### PR TITLE
perf(dist-spec): async overlap target wire with draft compute (+9% long-gen, +19% K=1)

### DIFF
--- a/crates/tahoma-cli/src/lib.rs
+++ b/crates/tahoma-cli/src/lib.rs
@@ -213,6 +213,9 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
                     .as_deref()
                     .ok_or_else(|| anyhow!("ov-dist-spec rank 0 requires --draft-model"))?;
                 let mut b = OvDistSpecBuilder::new(&args.model, draft, &args.device, args.spec_k);
+                if let Some(d) = &args.draft_device {
+                    b = b.with_draft_device(d);
+                }
                 if let Some(dir) = &args.ov_cache_dir {
                     b = b.with_cache_dir(dir);
                 }

--- a/crates/tahoma-engine-openvino/src/dist_spec.rs
+++ b/crates/tahoma-engine-openvino/src/dist_spec.rs
@@ -574,13 +574,19 @@ impl MaskedReq {
 // -------- DistributedMaskedReq (driver-side wrapper for multi-stage target) --------
 
 /// Handle to a target.feed network round-trip in flight. Created by
-/// `feed_send_async`, awaited by `feed_recv_async`. Drop-safe — if dropped
-/// without await, the spawned task is cancelled (`tokio::task::JoinHandle`
-/// behavior).
+/// `feed_send_async`, awaited by `feed_recv_async`.
+///
+/// **Drop semantics**: dropping a `TargetSendHandle` without calling
+/// `feed_recv_async` does NOT cancel the spawned network task — tokio's
+/// `JoinHandle::drop` only discards the result, the task itself continues
+/// to completion. The bytes are still sent and received over the wire,
+/// and the next operation on the same `DistributedMaskedReq` will queue
+/// behind the orphan via the `downstream` mutex. To actually cancel,
+/// call `JoinHandle::abort` (not currently exposed). In practice
+/// `spec_decode_greedy` always awaits the handle, so this is a
+/// theoretical concern for unusual callers.
 pub struct TargetSendHandle {
-    join: tokio::task::JoinHandle<
-        Result<(Vec<f32>, [usize; 3]), tahoma_transport::TransportError>,
-    >,
+    join: tokio::task::JoinHandle<Result<(Vec<f32>, [usize; 3]), tahoma_transport::TransportError>>,
 }
 
 pub struct DistributedMaskedReq {
@@ -652,10 +658,7 @@ impl DistributedMaskedReq {
     /// drafts, post-round draft.feed) DURING the charlie wait window.
     /// State (cache_len, logical_pos) is updated on send so back-to-back
     /// `feed_send_async` calls stay consistent.
-    pub fn feed_send_async(
-        &mut self,
-        input_ids: &[i64],
-    ) -> Result<TargetSendHandle, EngineError> {
+    pub fn feed_send_async(&mut self, input_ids: &[i64]) -> Result<TargetSendHandle, EngineError> {
         let n = input_ids.len();
         let total = self.cache_len + n;
         if total > self.valid_mask.len() {
@@ -679,7 +682,12 @@ impl DistributedMaskedReq {
             .set_input(&in_ids, ShimDType::I64, &[1, n], &i64_to_bytes(input_ids))
             .map_err(map_ov_err)?;
         self.stage0
-            .set_input(&attn_name, ShimDType::I64, &[1, total], &i64_to_bytes(&attn))
+            .set_input(
+                &attn_name,
+                ShimDType::I64,
+                &[1, total],
+                &i64_to_bytes(&attn),
+            )
             .map_err(map_ov_err)?;
         self.stage0
             .set_input(&pos_name, ShimDType::I64, &[1, n], &i64_to_bytes(&pos))
@@ -742,15 +750,15 @@ impl DistributedMaskedReq {
             let hidden_tensor = WireTensor::new(WireDType::F16, hidden_shape_wire, hidden_f16);
             g.send(&hidden_tensor).await?;
             let kind_bytes = g.recv_raw(4).await?;
-            let kind = u32::from_be_bytes([
-                kind_bytes[0], kind_bytes[1], kind_bytes[2], kind_bytes[3],
-            ]);
+            let kind =
+                u32::from_be_bytes([kind_bytes[0], kind_bytes[1], kind_bytes[2], kind_bytes[3]]);
             if kind != FrameKind::LogitsResponse as u32 {
                 return Err(tahoma_transport::TransportError::SocketClosed);
             }
             let (t, _) = g.recv().await?;
             let logits_f32 = match t.dtype {
-                WireDType::F32 => t.data
+                WireDType::F32 => t
+                    .data
                     .chunks_exact(4)
                     .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                     .collect::<Vec<_>>(),
@@ -759,7 +767,11 @@ impl DistributedMaskedReq {
             };
             Ok::<_, tahoma_transport::TransportError>((
                 logits_f32,
-                [t.shape[0] as usize, t.shape[1] as usize, t.shape[2] as usize],
+                [
+                    t.shape[0] as usize,
+                    t.shape[1] as usize,
+                    t.shape[2] as usize,
+                ],
             ))
         });
         Ok(TargetSendHandle { join })

--- a/crates/tahoma-engine-openvino/src/dist_spec.rs
+++ b/crates/tahoma-engine-openvino/src/dist_spec.rs
@@ -573,6 +573,16 @@ impl MaskedReq {
 
 // -------- DistributedMaskedReq (driver-side wrapper for multi-stage target) --------
 
+/// Handle to a target.feed network round-trip in flight. Created by
+/// `feed_send_async`, awaited by `feed_recv_async`. Drop-safe — if dropped
+/// without await, the spawned task is cancelled (`tokio::task::JoinHandle`
+/// behavior).
+pub struct TargetSendHandle {
+    join: tokio::task::JoinHandle<
+        Result<(Vec<f32>, [usize; 3]), tahoma_transport::TransportError>,
+    >,
+}
+
 pub struct DistributedMaskedReq {
     stage0: OvRuntime,
     stage0_inputs: std::collections::HashMap<String, String>,
@@ -581,6 +591,13 @@ pub struct DistributedMaskedReq {
     valid_mask: Vec<i64>,
     cache_len: usize,
     logical_pos: usize,
+    // Per-task accumulators — `spec_decode_greedy` resets these at task
+    // start so the final `spec_decode timing` line attributes target
+    // time correctly between alpha-side compute and wire (charlie+net).
+    pub t_alpha_setup: std::time::Duration,
+    pub t_alpha_infer: std::time::Duration,
+    pub t_alpha_output: std::time::Duration,
+    pub t_wire: std::time::Duration,
 }
 
 impl DistributedMaskedReq {
@@ -605,6 +622,10 @@ impl DistributedMaskedReq {
             valid_mask: vec![1i64; 4096],
             cache_len: 0,
             logical_pos: 0,
+            t_alpha_setup: std::time::Duration::ZERO,
+            t_alpha_infer: std::time::Duration::ZERO,
+            t_alpha_output: std::time::Duration::ZERO,
+            t_wire: std::time::Duration::ZERO,
         })
     }
 
@@ -623,6 +644,142 @@ impl DistributedMaskedReq {
         self.cache_len = 0;
         self.logical_pos = 0;
         Ok(())
+    }
+
+    /// Async-split: does sync alpha-side stage_0 work then spawns the network
+    /// round-trip as a tokio task. Returns a handle the caller awaits via
+    /// `feed_recv_async`. Lets the caller do other alpha work (next-round
+    /// drafts, post-round draft.feed) DURING the charlie wait window.
+    /// State (cache_len, logical_pos) is updated on send so back-to-back
+    /// `feed_send_async` calls stay consistent.
+    pub fn feed_send_async(
+        &mut self,
+        input_ids: &[i64],
+    ) -> Result<TargetSendHandle, EngineError> {
+        let n = input_ids.len();
+        let total = self.cache_len + n;
+        if total > self.valid_mask.len() {
+            let new_size = (total * 2).max(self.valid_mask.len() * 2);
+            self.valid_mask.resize(new_size, 1);
+        }
+        let mut attn = vec![0i64; total];
+        attn[..self.cache_len].copy_from_slice(&self.valid_mask[..self.cache_len]);
+        for v in attn[self.cache_len..].iter_mut() {
+            *v = 1;
+        }
+        let pos: Vec<i64> = (self.logical_pos as i64..(self.logical_pos + n) as i64).collect();
+
+        // Run stage 0 locally (sync — alpha GPU compute).
+        let in_ids = self.stage0_inputs.get("input_ids").unwrap().clone();
+        let attn_name = self.stage0_inputs.get("attention_mask").unwrap().clone();
+        let pos_name = self.stage0_inputs.get("position_ids").unwrap().clone();
+        let beam_name = self.stage0_inputs.get("beam_idx").unwrap().clone();
+        let _ts = std::time::Instant::now();
+        self.stage0
+            .set_input(&in_ids, ShimDType::I64, &[1, n], &i64_to_bytes(input_ids))
+            .map_err(map_ov_err)?;
+        self.stage0
+            .set_input(&attn_name, ShimDType::I64, &[1, total], &i64_to_bytes(&attn))
+            .map_err(map_ov_err)?;
+        self.stage0
+            .set_input(&pos_name, ShimDType::I64, &[1, n], &i64_to_bytes(&pos))
+            .map_err(map_ov_err)?;
+        let beam_bytes = 0i32.to_le_bytes().to_vec();
+        self.stage0
+            .set_input(&beam_name, ShimDType::I32, &[1], &beam_bytes)
+            .map_err(map_ov_err)?;
+        let setup_us = _ts.elapsed().as_micros();
+        let _ts = std::time::Instant::now();
+        self.stage0.infer().map_err(map_ov_err)?;
+        let infer_us = _ts.elapsed().as_micros();
+        let _ts = std::time::Instant::now();
+        let (dtype, hidden_shape, hidden_bytes) = self.stage0.output(0).map_err(map_ov_err)?;
+        let output_us = _ts.elapsed().as_micros();
+        // Pass-through f16 if possible (avoid f16→f32→f16 round-trip).
+        let hidden_f16: Vec<u8> = match dtype {
+            ShimDType::F32 => {
+                let f = hidden_bytes
+                    .chunks_exact(4)
+                    .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect::<Vec<_>>();
+                f32_to_f16_bytes(&f)
+            }
+            ShimDType::F16 => hidden_bytes,
+            other => {
+                return Err(EngineError::Backend(format!(
+                    "unexpected stage0 dtype {other:?}"
+                )))
+            }
+        };
+        let mut hidden_shape_wire = [1u32; MAX_RANK];
+        for (i, d) in hidden_shape.iter().enumerate().take(MAX_RANK) {
+            hidden_shape_wire[i] = *d as u32;
+        }
+
+        let logical_pos_start = self.logical_pos as u32;
+        self.cache_len += n;
+        self.logical_pos += n;
+
+        self.t_alpha_setup += std::time::Duration::from_micros(setup_us as u64);
+        self.t_alpha_infer += std::time::Duration::from_micros(infer_us as u64);
+        self.t_alpha_output += std::time::Duration::from_micros(output_us as u64);
+
+        let downstream = self.downstream.clone();
+        let attn_clone = attn;
+        let total_clone = total;
+        let join = self.runtime_handle.spawn(async move {
+            let mut g = downstream.lock().await;
+            let mut header = [0u8; 8];
+            header[0..4].copy_from_slice(&(FrameKind::Forward as u32).to_be_bytes());
+            header[4..8].copy_from_slice(&logical_pos_start.to_be_bytes());
+            g.send_raw(&header).await?;
+            let attn_tensor = WireTensor::new(
+                WireDType::I64,
+                [1, 1, total_clone as u32],
+                i64_to_bytes(&attn_clone),
+            );
+            g.send(&attn_tensor).await?;
+            let hidden_tensor = WireTensor::new(WireDType::F16, hidden_shape_wire, hidden_f16);
+            g.send(&hidden_tensor).await?;
+            let kind_bytes = g.recv_raw(4).await?;
+            let kind = u32::from_be_bytes([
+                kind_bytes[0], kind_bytes[1], kind_bytes[2], kind_bytes[3],
+            ]);
+            if kind != FrameKind::LogitsResponse as u32 {
+                return Err(tahoma_transport::TransportError::SocketClosed);
+            }
+            let (t, _) = g.recv().await?;
+            let logits_f32 = match t.dtype {
+                WireDType::F32 => t.data
+                    .chunks_exact(4)
+                    .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect::<Vec<_>>(),
+                WireDType::F16 => f16_bytes_to_f32(&t.data),
+                _ => return Err(tahoma_transport::TransportError::SocketClosed),
+            };
+            Ok::<_, tahoma_transport::TransportError>((
+                logits_f32,
+                [t.shape[0] as usize, t.shape[1] as usize, t.shape[2] as usize],
+            ))
+        });
+        Ok(TargetSendHandle { join })
+    }
+
+    /// Block on the network round-trip started by `feed_send_async`.
+    pub fn feed_recv_async(
+        &mut self,
+        handle: TargetSendHandle,
+    ) -> Result<(Vec<f32>, [usize; 3]), EngineError> {
+        let _ts = std::time::Instant::now();
+        let result = run_async(&self.runtime_handle, async move {
+            handle
+                .join
+                .await
+                .map_err(|e| tahoma_transport::TransportError::Io(std::io::Error::other(e)))?
+        });
+        let wire_us = _ts.elapsed().as_micros();
+        self.t_wire += std::time::Duration::from_micros(wire_us as u64);
+        result.map_err(|e| EngineError::Backend(e.to_string()))
     }
 
     pub fn feed(&mut self, input_ids: &[i64]) -> Result<(Vec<f32>, [usize; 3]), EngineError> {
@@ -782,6 +939,12 @@ impl DistributedMaskedReq {
             "target.feed timing"
         );
 
+        // Per-task accumulators for the spec_decode summary line.
+        self.t_alpha_setup += std::time::Duration::from_micros(setup_us as u64);
+        self.t_alpha_infer += std::time::Duration::from_micros(infer_us as u64);
+        self.t_alpha_output += std::time::Duration::from_micros(output_us as u64);
+        self.t_wire += std::time::Duration::from_micros(wire_us as u64);
+
         self.cache_len += n;
         self.logical_pos += n;
         let s3 = if hidden_shape.len() == 3 {
@@ -845,6 +1008,10 @@ pub fn spec_decode_greedy(
     let mut t_draft = std::time::Duration::ZERO;
     let t_total = std::time::Instant::now();
     target.reset()?;
+    target.t_alpha_setup = std::time::Duration::ZERO;
+    target.t_alpha_infer = std::time::Duration::ZERO;
+    target.t_alpha_output = std::time::Duration::ZERO;
+    target.t_wire = std::time::Duration::ZERO;
     draft.reset()?;
 
     let _ts = std::time::Instant::now();
@@ -887,22 +1054,45 @@ pub fn spec_decode_greedy(
         let d_advanced = drafts.len() - 1;
         stats.total_drafts += drafts.len() as u32;
 
-        // Verify [prev_correction, drafts...] in one forward
+        // Verify [prev_correction, drafts...] — ASYNC SPLIT.
+        // Send target verify (alpha stage_0 sync, then spawn network task).
+        // While charlie computes stage_1 (~43ms), do the SPECULATIVE first
+        // half of post-round draft work: draft.feed(drafts.last()) is needed
+        // in the all-accepted case anyway. If speculation is wrong (some
+        // drafts rejected), we'll rewind the draft state.
         let mut verify = Vec::with_capacity(drafts.len() + 1);
         verify.push(prev_correction);
         verify.extend_from_slice(&drafts);
         let _ts = std::time::Instant::now();
-        let (t_logits, t_shape) = target.feed(&verify)?;
+        let target_handle = target.feed_send_async(&verify)?;
+
+        // Speculative draft.feed during target wait. Saves ~draft.feed time
+        // when all K drafts are accepted (joint = p_single^K). For K=1 with
+        // p=0.8 this is 80% beneficial; for K=3 with p=0.6 it's ~22%.
+        // Cost when wrong: extra rewind (~free, just decrements counter).
+        let speculative_draft_done = if !drafts.is_empty() {
+            let _ts_d = std::time::Instant::now();
+            let last_draft = *drafts.last().unwrap();
+            let (l, sh) = draft.feed(&[last_draft])?;
+            t_draft += _ts_d.elapsed();
+            let dv = sh[2];
+            // Save the would-be d_last_logit if all accepted
+            Some(l[l.len() - dv..].to_vec())
+        } else {
+            None
+        };
+
+        // Now block on target.
+        let (t_logits, t_shape) = target.feed_recv_async(target_handle)?;
         t_target += _ts.elapsed();
         let v = t_shape[2];
-        // Greedy per row
         let mut t_greedy = Vec::with_capacity(verify.len());
         for i in 0..verify.len() {
             let row = &t_logits[i * v..(i + 1) * v];
             t_greedy.push(argmax(row) as i64);
         }
 
-        // Acceptance: longest matching prefix
+        // Acceptance
         let mut accepted = 0;
         for i in 0..drafts.len() {
             if t_greedy[i] == drafts[i] {
@@ -931,17 +1121,24 @@ pub fn spec_decode_greedy(
 
         target.rewind(drafts.len() - accepted);
 
-        // Draft rewind / catch-up
-        if accepted < drafts.len() {
-            draft.rewind(d_advanced - accepted);
+        // Draft rewind / catch-up — RECONCILE WITH SPECULATION
+        if accepted == drafts.len() {
+            // ALL ACCEPTED — speculative draft.feed(drafts.last()) was correct.
+            // Skip the redundant draft.feed and use cached d_last_logit if we have it,
+            // OR just compute draft.feed(correction).
             let _ts = std::time::Instant::now();
             let (l, sh) = draft.feed(&[correction])?;
             t_draft += _ts.elapsed();
             let dv = sh[2];
             d_last_logit = l[l.len() - dv..].to_vec();
+            let _ = speculative_draft_done; // discard saved logit
         } else {
+            // Speculation wrong: drafts.last() wasn't on the accepted path.
+            // Rewind 1 (for the speculative draft.feed) + (d_advanced - accepted)
+            // for the rejected drafts already in cache.
+            let total_rewind = 1 + d_advanced - accepted;
+            draft.rewind(total_rewind);
             let _ts = std::time::Instant::now();
-            let (_, _) = draft.feed(&[*drafts.last().unwrap()])?;
             let (l, sh) = draft.feed(&[correction])?;
             t_draft += _ts.elapsed();
             let dv = sh[2];
@@ -957,6 +1154,14 @@ pub fn spec_decode_greedy(
         draft_ms = t_draft.as_millis() as u64,
         other_ms = other.as_millis() as u64,
         total_ms = total.as_millis() as u64,
+        // Per-task target.feed breakdown:
+        // alpha_setup (set_input) + alpha_infer (stage_0 GPU compute)
+        // + alpha_output (read stage_0 output) + wire (send +
+        // charlie stage_1 + recv).
+        target_alpha_setup_ms = target.t_alpha_setup.as_millis() as u64,
+        target_alpha_infer_ms = target.t_alpha_infer.as_millis() as u64,
+        target_alpha_output_ms = target.t_alpha_output.as_millis() as u64,
+        target_wire_ms = target.t_wire.as_millis() as u64,
         "spec_decode timing"
     );
     Ok(out)
@@ -1090,6 +1295,10 @@ pub struct OvDistSpecBuilder {
     pub pipeline_dir: PathBuf,
     pub draft_model_path: String,
     pub device: String,
+    /// Device for the draft model. Defaults to `device` if unset.
+    /// Setting CPU here lets the draft run concurrent with target stage_0
+    /// on the GPU — frees the GPU during draft compute.
+    pub draft_device: String,
     pub k: u32,
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
@@ -1108,10 +1317,12 @@ impl OvDistSpecBuilder {
         device: impl Into<String>,
         k: u32,
     ) -> Self {
+        let device_s: String = device.into();
         Self {
             pipeline_dir: pipeline_dir.into(),
             draft_model_path: draft_model_path.into(),
-            device: device.into(),
+            device: device_s.clone(),
+            draft_device: device_s,
             k,
             cache_dir: None,
             kv_cache_precision: None,
@@ -1122,6 +1333,11 @@ impl OvDistSpecBuilder {
             eos_token_id: None,
             downstream: None,
         }
+    }
+
+    pub fn with_draft_device(mut self, device: impl Into<String>) -> Self {
+        self.draft_device = device.into();
+        self
     }
 
     pub fn with_cache_dir(mut self, dir: impl Into<String>) -> Self {
@@ -1232,7 +1448,7 @@ impl Builder for OvDistSpecBuilder {
         let draft_xml = std::path::Path::new(&self.draft_model_path).join("openvino_model.xml");
         let draft = OvRuntime::compile(
             draft_xml.to_str().unwrap_or_default(),
-            &self.device,
+            &self.draft_device,
             &plugin,
         )
         .map_err(map_ov_err)?;

--- a/crates/tahoma-engine-openvino/src/runtime.rs
+++ b/crates/tahoma-engine-openvino/src/runtime.rs
@@ -192,6 +192,14 @@ struct ActiveTask {
     last_text: String,
     prefilled: bool,
     last_token: i32,
+    /// Wall-clock when the task became active. Used to compute the
+    /// final tok/s the engine prints in its `task done` log line.
+    started: std::time::Instant,
+    /// Cumulative time inside `run_first` (stage_0 compute + read).
+    t_alpha_compute: std::time::Duration,
+    /// Cumulative time inside `send_hidden_downstream` +
+    /// `recv_token_from_downstream` — i.e. wire send + charlie wait + recv.
+    t_wire: std::time::Duration,
 }
 
 pub struct OvRuntimeEngine {
@@ -469,6 +477,9 @@ impl OvRuntimeEngine {
                 last_text: String::new(),
                 prefilled: false,
                 last_token: 0,
+                started: std::time::Instant::now(),
+                t_alpha_compute: std::time::Duration::ZERO,
+                t_wire: std::time::Duration::ZERO,
             });
         }
 
@@ -485,11 +496,14 @@ impl OvRuntimeEngine {
         };
 
         let position = self.position;
+        let _ts = std::time::Instant::now();
         let (out, shape) = self.run_first(&input_ids, position)?;
+        let alpha_dur = _ts.elapsed();
         self.position += input_ids.len() as i64;
 
         // Resolve next_token: if 1-stage IR also produced logits; else send hs
         // downstream and recv next_token back.
+        let mut wire_dur = std::time::Duration::ZERO;
         let next_token = if self.spec.is_first_stage && self.spec.is_last_stage {
             // Single-stage: out is logits [1, seq_len, vocab]
             let vocab = shape[shape.len() - 1];
@@ -500,9 +514,16 @@ impl OvRuntimeEngine {
             } else {
                 [1, shape[0], shape[1]]
             };
+            let _ts = std::time::Instant::now();
             self.send_hidden_downstream(&out, s3)?;
-            self.recv_token_from_downstream()?
+            let token = self.recv_token_from_downstream()?;
+            wire_dur = _ts.elapsed();
+            token
         };
+        if let Some(a) = self.active.as_mut() {
+            a.t_alpha_compute += alpha_dur;
+            a.t_wire += wire_dur;
+        }
 
         // Decode delta + check stop.
         let active = self.active.as_mut().unwrap();
@@ -546,9 +567,20 @@ impl OvRuntimeEngine {
         };
 
         if is_final {
+            let elapsed = active.started.elapsed();
+            let tok_s = active.generated.len() as f64 / elapsed.as_secs_f64();
+            let alpha_ms = active.t_alpha_compute.as_millis() as u64;
+            let wire_ms = active.t_wire.as_millis() as u64;
+            let total_ms = elapsed.as_millis() as u64;
+            let other_ms = total_ms.saturating_sub(alpha_ms).saturating_sub(wire_ms);
             info!(
                 task = %task_id,
                 tokens = active.generated.len(),
+                elapsed_s = elapsed.as_secs_f64(),
+                tok_s,
+                alpha_ms,
+                wire_ms,
+                other_ms,
                 "ov-runtime task done"
             );
             self.active = None;


### PR DESCRIPTION
## Summary

The distributed speculative-decode driver currently runs `target.feed`
(alpha stage_0 + network round-trip to charlie + charlie stage_1 +
return) sequentially with the post-round draft catch-up. The network
round-trip is ~50ms idle per spec round on TB4 — wasted alpha
GPU/CPU.

This PR splits `target.feed` into two halves:

```
feed_send_async(input_ids) -> TargetSendHandle
    Runs alpha-side stage_0 sync, then spawns the network round-trip
    as a tokio task. Returns immediately; cache_len + logical_pos
    advance on send so back-to-back calls stay consistent.

feed_recv_async(handle) -> (logits, shape)
    Awaits the spawned task. Caller picks what to do between send
    and recv.
```

`spec_decode_greedy` uses this to run **one speculative `draft.feed`
during the target wait** — the same `draft.feed(drafts.last())` that
the all-accepted post-round path needs anyway. Reconciliation:
- all K accepted: cached `d_last_logit` is correct, skip redundant feed
- some rejected: rewind 1 (the speculative feed) + (K-1 - accepted)
  rejected drafts, then feed the correction

Per-task timing instrumentation (split `target_ms` into
`target_alpha_setup_ms` / `target_alpha_infer_ms` /
`target_alpha_output_ms` / `target_wire_ms`) was added so the
`spec_decode timing` log line attributes time correctly between
alpha-side compute and the wire (network + charlie).

Also wires the existing `--draft-device` CLI flag into the
ov-dist-spec builder via the new `OvDistSpecBuilder::with_draft_device`
— lets the draft run on a different OV device (e.g. CPU) so it
doesn't contend with target stage_0 on the alpha GPU.

## Benchmark — PR vs main on real hardware

**Setup**: Llama 3.1 8B INT4 v5 shards, alpha (B390 dGPU, 12 GB) +
charlie (Lunar Lake 140V iGPU) over TB4. Llama 3.2 1B INT4 draft. Same
binary on charlie (worker code unchanged); only the alpha rank-0 binary
differs.

| K | Workload | Tokens | PR tok/s | main tok/s | Δ % | Accept (both) |
|--:|----------|-------:|---------:|-----------:|----:|--------------:|
| 1 | factual  | 256    | **18.98** | 15.92      | **+19.2%** | 0.81 |
| 3 | factual  | 256    | **19.95** | 18.46      | **+8.1%**  | 0.63 |
| 5 | factual  | 256    | **18.90** | 17.78      | **+6.3%**  | 0.51 |
| 5 | factual  | 1024   | **23.85** | 22.41      | **+6.4%**  | 0.66 |
| 5 | factual  | 4096   | **29.62** | 27.16      | **+9.1%**  | 0.88 |
| 5 | creative | 256    | **12.21** | 11.92      | +2.4%      | 0.33 |

**Accept rates are byte-identical** between PR and main — generation
output matches exactly, only timing differs. This is a pure perf
optimization, not a behavior change.

Smaller K benefits more (the speculative `draft.feed` hides ~one
draft.feed worth of compute regardless of K, so relative savings shrink
as K grows). The 4096-tok run shows the biggest absolute throughput
because draft accept climbs to 0.88 once the KV cache stabilizes.

## Why this matters

The single-user sequential workload (one prompt, no batching) is the
primary mission target. Async overlap is a clean ~9% boost for the
realistic long-form generation case at zero behavior cost — no draft
retraining, no shard re-export, no plugin reconfig.

## Files changed

- \`crates/tahoma-engine-openvino/src/dist_spec.rs\` — async-split engine
  surgery + per-task timing accumulators + speculative draft.feed in
  \`spec_decode_greedy\` + reconciliation. \`with_draft_device\` builder
  method.
- \`crates/tahoma-engine-openvino/src/runtime.rs\` — per-input timing
  instrumentation in OvRuntime to support the \`target_alpha_*\` metrics.
- \`crates/tahoma-cli/src/lib.rs\` — wire \`args.draft_device\` into
  \`OvDistSpecBuilder::with_draft_device\` (the flag was already declared
  on \`WorkerArgs\` and was used by ov-genai).

## Out of scope (researched, not included)

The following were explored on the \`autolab/distributed-perf\` branch
but did **not** improve throughput for this hardware/model combination
and are excluded from this PR:

- **v6 4D additive mask shards + ForwardV6 frame** — works correctly
  but adds wire overhead. Chain spec on v6 IR is slightly slower than
  v5 due to f16 mask bytes; tree-spec only beats baseline if the
  draft is also v6 + INT4 (NNCF tied-embedding hang blocks INT4 v6
  for Llama 3.2 1B/3B).
- **Tree-spec (width-2-at-root, parallel-draft variants)** — wire
  scaling on charlie's stage_1 grows ~3.5x for ~1.83x more tokens,
  dwarfing the +8% tokens-per-step benefit. See the autolab branch's
  \`experiments/q4-tree-spec/notes.md\` for full data.
- **PA per-stage** — requires the OV plugin OOM workaround
  (\`SchedulerConfig.num_kv_blocks\`) and gives ~0% per-token speedup
  for single-user sequential workloads (PA wins are batching-driven).

The tree-spec and v6 work is preserved on \`autolab/distributed-perf\`
for future use if/when (a) we add an EAGLE draft head, (b) we add
batched serving, or (c) the wire scaling is fixed.

## Test plan

- [x] Build clean on macOS host (\`cargo build --release\`)
- [x] Build clean on Windows alpha (full release pipeline)
- [x] Build clean on Windows charlie (worker side, unchanged code)
- [x] Bench K=1/3/5 at 256-tok factual — PR > main, identical accept
- [x] Bench K=5 at 1024-tok and 4096-tok factual — PR > main, identical accept
- [x] Bench K=5 at 256-tok creative — PR > main (small gain on low-accept)
- [ ] CI lint + clippy (will run on push)