### PR TITLE
feat(sparse-moe): pipeline-parallel inference across N ranks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "tahoma-engine",
  "tahoma-int4-gemm",
  "tahoma-ov-genai-shim",
+ "tahoma-transport",
  "tahoma-types",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/tahoma-cli/src/lib.rs
+++ b/crates/tahoma-cli/src/lib.rs
@@ -316,10 +316,8 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             }
         }
         EngineKind::SparseMoe => {
-            if args.total != 1 {
-                return Err(anyhow!("sparse-moe is single-stage only; use --total 1"));
-            }
-            let mut cfg = SparseMoEBuilderConfig::new(&args.model, &args.device);
+            let mut cfg = SparseMoEBuilderConfig::new(&args.model, &args.device)
+                .with_rank(args.rank, args.total);
             if let Some(dir) = &args.ov_cache_dir {
                 cfg.cache_dir = Some(dir.clone());
             }

--- a/crates/tahoma-engine-sparse-moe/Cargo.toml
+++ b/crates/tahoma-engine-sparse-moe/Cargo.toml
@@ -15,6 +15,7 @@ tahoma-types = { workspace = true }
 tahoma-engine = { workspace = true }
 tahoma-ov-genai-shim = { workspace = true }
 tahoma-int4-gemm = { workspace = true }
+tahoma-transport = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/crates/tahoma-engine-sparse-moe/examples/dist_check.rs
+++ b/crates/tahoma-engine-sparse-moe/examples/dist_check.rs
@@ -1,0 +1,161 @@
+//! Cross-host wire-protocol smoke test.
+//!
+//! Spawns either the server side (binds, recv Forward, send Token) or
+//! the client side (connect, send Forward N times with synthetic
+//! hidden state, recv Token, time the round-trip). Used to verify the
+//! sparse-MoE pipeline-parallel wire protocol works over a real
+//! cross-host network (e.g. Tailscale's DERP relay between two Intel
+//! AI PCs).
+//!
+//! ```text
+//! # On the box that plays "last rank":
+//! cargo run --release --example dist_check -- server 9100
+//!
+//! # On the box that plays "rank 0":
+//! cargo run --release --example dist_check -- client <peer-ts-ip> 9100 100
+//! ```
+
+use std::env;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tahoma_engine_sparse_moe::dist::{
+    recv_forward_body_server, recv_kind_client, recv_kind_server, recv_token_body_client,
+    send_forward, send_reset, send_token_upstream, FrameKind,
+};
+use tahoma_transport::{ActivationClient, ActivationServer};
+use tokio::sync::Mutex;
+
+const HIDDEN_SIZE: usize = 7168;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let mode = args.get(1).map(String::as_str).unwrap_or("");
+    match mode {
+        "server" => {
+            let port: u16 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(9100);
+            run_server(port).await?;
+        }
+        "client" => {
+            let peer = args.get(2).cloned().ok_or("missing peer host")?;
+            let port: u16 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(9100);
+            let rounds: u32 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(10);
+            run_client(&peer, port, rounds).await?;
+        }
+        _ => {
+            eprintln!("usage:");
+            eprintln!("  dist_check server <bind-port>");
+            eprintln!("  dist_check client <peer-host> <peer-port> [rounds=10]");
+            std::process::exit(2);
+        }
+    }
+    Ok(())
+}
+
+async fn run_server(port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = ActivationServer::new("0.0.0.0", port);
+    server.start().await?;
+    println!("[server] listening on 0.0.0.0:{port}");
+    server.accept().await?;
+    println!("[server] peer accepted");
+    let server = Arc::new(Mutex::new(server));
+
+    let mut frame_count = 0u32;
+    let mut got_reset = false;
+    loop {
+        let kind = recv_kind_server(&server).await?;
+        let Some(kind) = kind else {
+            println!("[server] upstream closed cleanly after {frame_count} frames");
+            break;
+        };
+        match kind {
+            FrameKind::Reset => {
+                got_reset = true;
+                println!("[server] recv RESET");
+            }
+            FrameKind::Forward => {
+                let (past_seq_len, hidden, shape) = recv_forward_body_server(&server).await?;
+                let mean: f32 = hidden.iter().copied().sum::<f32>() / hidden.len() as f32;
+                frame_count += 1;
+                // Synthesise a "sampled" token from the input — XOR of
+                // past_seq_len with the hidden mean's bit pattern.
+                let token = (past_seq_len as i64) ^ (mean.to_bits() as i64);
+                send_token_upstream(&server, token).await?;
+                if frame_count <= 3 || frame_count.is_power_of_two() {
+                    println!(
+                        "[server] frame {frame_count} past_seq_len={past_seq_len} shape={:?} mean={:.4} → token={token}",
+                        shape, mean
+                    );
+                }
+            }
+            FrameKind::Token => {
+                println!("[server] unexpected TOKEN from upstream — ignoring");
+            }
+        }
+    }
+    println!(
+        "[server] frames processed: {frame_count} (got_reset={got_reset})"
+    );
+    Ok(())
+}
+
+async fn run_client(
+    peer: &str,
+    port: u16,
+    rounds: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("[client] connecting to {peer}:{port}");
+    let t_connect = Instant::now();
+    let mut client = ActivationClient::new(peer, port);
+    client
+        .connect_with_timeout(std::time::Duration::from_secs(30))
+        .await?;
+    let connect_ms = t_connect.elapsed().as_secs_f64() * 1000.0;
+    println!("[client] connected in {connect_ms:.1} ms");
+    let client = Arc::new(Mutex::new(client));
+
+    send_reset(&client).await?;
+    println!("[client] sent RESET");
+
+    let mut hidden = vec![0.0f32; HIDDEN_SIZE];
+    let shape = [1u32, 1, HIDDEN_SIZE as u32];
+    let mut rt_ms: Vec<f64> = Vec::with_capacity(rounds as usize);
+
+    let total_t0 = Instant::now();
+    for round in 0..rounds {
+        // Fill hidden with a deterministic pattern that varies per round.
+        for (i, v) in hidden.iter_mut().enumerate() {
+            *v = (i as f32) * 0.0001 + (round as f32) * 0.01;
+        }
+        let t0 = Instant::now();
+        send_forward(&client, round, &hidden, shape).await?;
+        let kind = recv_kind_client(&client).await?;
+        let Some(FrameKind::Token) = kind else {
+            return Err(format!("expected TOKEN, got {kind:?}").into());
+        };
+        let token = recv_token_body_client(&client).await?;
+        let dt = t0.elapsed().as_secs_f64() * 1000.0;
+        rt_ms.push(dt);
+        if round < 3 || round.is_power_of_two() {
+            println!(
+                "[client] round {round} rt={dt:.1} ms token={token}"
+            );
+        }
+    }
+    let total_ms = total_t0.elapsed().as_secs_f64() * 1000.0;
+    rt_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p50 = rt_ms[rt_ms.len() / 2];
+    let p99 = rt_ms[(rt_ms.len() * 99) / 100];
+    let avg = rt_ms.iter().sum::<f64>() / rt_ms.len() as f64;
+    let bytes_per_forward = 8 /* kind+past */ + 20 /* tensor header */ + HIDDEN_SIZE * 4 /* f32 */;
+    let bytes_per_token_back = 12;
+    let bytes_per_round = bytes_per_forward + bytes_per_token_back;
+    println!("[client] {rounds} rounds in {total_ms:.1} ms");
+    println!("[client] per-round rt avg={avg:.1} ms p50={p50:.1} ms p99={p99:.1} ms");
+    println!(
+        "[client] per-round wire bytes ≈ {} ({} forward + {} token)",
+        bytes_per_round, bytes_per_forward, bytes_per_token_back
+    );
+    Ok(())
+}

--- a/crates/tahoma-engine-sparse-moe/examples/dist_check.rs
+++ b/crates/tahoma-engine-sparse-moe/examples/dist_check.rs
@@ -94,17 +94,11 @@ async fn run_server(port: u16) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    println!(
-        "[server] frames processed: {frame_count} (got_reset={got_reset})"
-    );
+    println!("[server] frames processed: {frame_count} (got_reset={got_reset})");
     Ok(())
 }
 
-async fn run_client(
-    peer: &str,
-    port: u16,
-    rounds: u32,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(peer: &str, port: u16, rounds: u32) -> Result<(), Box<dyn std::error::Error>> {
     println!("[client] connecting to {peer}:{port}");
     let t_connect = Instant::now();
     let mut client = ActivationClient::new(peer, port);
@@ -138,9 +132,7 @@ async fn run_client(
         let dt = t0.elapsed().as_secs_f64() * 1000.0;
         rt_ms.push(dt);
         if round < 3 || round.is_power_of_two() {
-            println!(
-                "[client] round {round} rt={dt:.1} ms token={token}"
-            );
+            println!("[client] round {round} rt={dt:.1} ms token={token}");
         }
     }
     let total_ms = total_t0.elapsed().as_secs_f64() * 1000.0;

--- a/crates/tahoma-engine-sparse-moe/src/dist.rs
+++ b/crates/tahoma-engine-sparse-moe/src/dist.rs
@@ -1,0 +1,228 @@
+//! Wire protocol for pipeline-parallel sparse-MoE inference.
+//!
+//! Frames flow over the existing tahoma-transport TCP sockets. Each
+//! frame begins with a 4-byte big-endian `FrameKind` code; some frames
+//! carry length-prefixed tensors after the code via the standard
+//! `ActivationServer::send` / `recv` path.
+//!
+//! Directions:
+//! - `Forward` and `Reset` flow downstream (rank N → rank N+1).
+//! - `Token` flows upstream (last rank → rank 0).
+//!
+//! Each rank holds at most one upstream socket (server-side, accepting
+//! incoming connection from rank-1) and one downstream socket
+//! (client-side, connected outbound to rank+1). The first rank has no
+//! upstream; the last rank has no downstream.
+//!
+//! `Forward` is the workhorse: one per decoded token. Body:
+//!   - 4 B big-endian u32 past_seq_len
+//!   - F32 hidden tensor [1, 1, hidden_size]
+//!
+//! `Reset` clears KV state on downstream for a new generation. No body.
+//!
+//! `Token` returns one sampled token i64 to upstream after the last
+//! rank runs head + sample. Body:
+//!   - 8 B big-endian i64 token_id
+
+use std::sync::Arc;
+
+use tahoma_transport::{
+    ActivationClient, ActivationServer, DType, Tensor, TransportError, TransportResult,
+};
+use tokio::sync::Mutex;
+
+/// 4-byte big-endian frame kinds. Chosen to be disjoint from
+/// `dist_spec`'s `FrameKind` so a stray cross-engine connection would
+/// fail fast on an unrecognized code.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameKind {
+    Forward = 0x53_4D_45_01, // "SME\x01"
+    Reset = 0x53_4D_45_02,   // "SME\x02"
+    Token = 0x53_4D_45_03,   // "SME\x03"
+}
+
+impl FrameKind {
+    pub fn from_code(code: u32) -> Option<Self> {
+        match code {
+            x if x == FrameKind::Forward as u32 => Some(FrameKind::Forward),
+            x if x == FrameKind::Reset as u32 => Some(FrameKind::Reset),
+            x if x == FrameKind::Token as u32 => Some(FrameKind::Token),
+            _ => None,
+        }
+    }
+}
+
+/// Read one frame-kind code from the wire. Returns `None` on a clean
+/// socket close (peer closed during recv on no in-flight frame), which
+/// callers should treat as end-of-task rather than an error.
+pub async fn recv_kind_server(srv: &Mutex<ActivationServer>) -> TransportResult<Option<FrameKind>> {
+    let raw = {
+        let mut guard = srv.lock().await;
+        guard.recv_raw(4).await
+    };
+    match raw {
+        Ok(bytes) => parse_kind(&bytes).map(Some),
+        Err(TransportError::SocketClosed) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+pub async fn recv_kind_client(cli: &Mutex<ActivationClient>) -> TransportResult<Option<FrameKind>> {
+    let raw = {
+        let mut guard = cli.lock().await;
+        guard.recv_raw(4).await
+    };
+    match raw {
+        Ok(bytes) => parse_kind(&bytes).map(Some),
+        Err(TransportError::SocketClosed) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+fn parse_kind(bytes: &[u8]) -> TransportResult<FrameKind> {
+    if bytes.len() != 4 {
+        return Err(TransportError::SocketClosed);
+    }
+    let code = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    FrameKind::from_code(code).ok_or_else(|| {
+        TransportError::Io(std::io::Error::other(format!(
+            "unknown sparse-MoE frame kind 0x{code:08x}"
+        )))
+    })
+}
+
+/// Encode hidden state f32 values + shape into a wire tensor.
+fn hidden_to_tensor(hidden_f32: &[f32], shape3: [u32; 3]) -> Tensor {
+    let mut bytes = Vec::with_capacity(hidden_f32.len() * 4);
+    for v in hidden_f32 {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    Tensor::new(DType::F32, shape3, bytes)
+}
+
+fn tensor_to_hidden(t: &Tensor) -> TransportResult<(Vec<f32>, [u32; 3])> {
+    if t.dtype != DType::F32 {
+        return Err(TransportError::Io(std::io::Error::other(format!(
+            "expected F32 hidden tensor, got {:?}",
+            t.dtype
+        ))));
+    }
+    let n = t.data.len() / 4;
+    let mut out = Vec::with_capacity(n);
+    for c in t.data.chunks_exact(4) {
+        out.push(f32::from_le_bytes([c[0], c[1], c[2], c[3]]));
+    }
+    Ok((out, t.shape))
+}
+
+/// Send a Forward frame downstream: kind + past_seq_len (u32 BE) + hidden tensor.
+pub async fn send_forward(
+    cli: &Mutex<ActivationClient>,
+    past_seq_len: u32,
+    hidden_f32: &[f32],
+    hidden_shape: [u32; 3],
+) -> TransportResult<()> {
+    let mut header = [0u8; 8];
+    header[0..4].copy_from_slice(&(FrameKind::Forward as u32).to_be_bytes());
+    header[4..8].copy_from_slice(&past_seq_len.to_be_bytes());
+    let tensor = hidden_to_tensor(hidden_f32, hidden_shape);
+    let mut guard = cli.lock().await;
+    guard.send_raw(&header).await?;
+    guard.send(&tensor).await?;
+    Ok(())
+}
+
+/// Receive a Forward frame's body (the kind code has already been
+/// consumed by `recv_kind_*`). Returns `(past_seq_len, hidden_f32, shape)`.
+pub async fn recv_forward_body_server(
+    srv: &Mutex<ActivationServer>,
+) -> TransportResult<(u32, Vec<f32>, [u32; 3])> {
+    let mut guard = srv.lock().await;
+    let raw = guard.recv_raw(4).await?;
+    if raw.len() != 4 {
+        return Err(TransportError::SocketClosed);
+    }
+    let past_seq_len = u32::from_be_bytes([raw[0], raw[1], raw[2], raw[3]]);
+    let (tensor, _) = guard.recv().await?;
+    drop(guard);
+    let (h, shape) = tensor_to_hidden(&tensor)?;
+    Ok((past_seq_len, h, shape))
+}
+
+/// Send a Reset frame downstream — clears KV state for a new task.
+pub async fn send_reset(cli: &Mutex<ActivationClient>) -> TransportResult<()> {
+    let mut header = [0u8; 4];
+    header[0..4].copy_from_slice(&(FrameKind::Reset as u32).to_be_bytes());
+    let mut guard = cli.lock().await;
+    guard.send_raw(&header).await?;
+    Ok(())
+}
+
+/// Send a Token frame upstream (last rank → rank 0 path).
+/// Body: 8 B big-endian i64 token id.
+pub async fn send_token_upstream(
+    srv: &Mutex<ActivationServer>,
+    token_id: i64,
+) -> TransportResult<()> {
+    let mut bytes = [0u8; 12];
+    bytes[0..4].copy_from_slice(&(FrameKind::Token as u32).to_be_bytes());
+    bytes[4..12].copy_from_slice(&token_id.to_be_bytes());
+    let mut guard = srv.lock().await;
+    guard.send_raw(&bytes).await?;
+    Ok(())
+}
+
+/// Receive a Token frame's body (kind already consumed). Returns the
+/// sampled token id.
+pub async fn recv_token_body_client(cli: &Mutex<ActivationClient>) -> TransportResult<i64> {
+    let mut guard = cli.lock().await;
+    let raw = guard.recv_raw(8).await?;
+    drop(guard);
+    if raw.len() != 8 {
+        return Err(TransportError::SocketClosed);
+    }
+    Ok(i64::from_be_bytes([
+        raw[0], raw[1], raw[2], raw[3], raw[4], raw[5], raw[6], raw[7],
+    ]))
+}
+
+/// Middle ranks relay Token upstream when they receive it from
+/// downstream. Reads + re-sends in one call.
+pub async fn relay_token_body(
+    downstream: &Mutex<ActivationClient>,
+    upstream: &Mutex<ActivationServer>,
+) -> TransportResult<i64> {
+    let token = recv_token_body_client(downstream).await?;
+    send_token_upstream(upstream, token).await?;
+    Ok(token)
+}
+
+/// Forward a Reset frame upstream → downstream (mid ranks).
+pub async fn forward_reset(
+    upstream: &Mutex<ActivationServer>,
+    downstream: &Mutex<ActivationClient>,
+) -> TransportResult<()> {
+    // Reset has no body; we've already consumed the kind on upstream.
+    // The downstream send is identical to send_reset.
+    let _ = upstream; // present for symmetry / future control flow
+    send_reset(downstream).await
+}
+
+/// Bundle of the per-rank transport state. The Builder constructs this
+/// during `connect()` and hands it to the Engine.
+#[derive(Default)]
+pub struct StageTransport {
+    pub upstream: Option<Arc<Mutex<ActivationServer>>>,
+    pub downstream: Option<Arc<Mutex<ActivationClient>>>,
+}
+
+impl StageTransport {
+    pub fn is_first(&self) -> bool {
+        self.upstream.is_none()
+    }
+
+    pub fn is_last(&self) -> bool {
+        self.downstream.is_none()
+    }
+}

--- a/crates/tahoma-engine-sparse-moe/src/dist.rs
+++ b/crates/tahoma-engine-sparse-moe/src/dist.rs
@@ -187,25 +187,11 @@ pub async fn recv_token_body_client(cli: &Mutex<ActivationClient>) -> TransportR
     ]))
 }
 
-/// Middle ranks relay Token upstream when they receive it from
-/// downstream. Reads + re-sends in one call.
-pub async fn relay_token_body(
-    downstream: &Mutex<ActivationClient>,
-    upstream: &Mutex<ActivationServer>,
-) -> TransportResult<i64> {
-    let token = recv_token_body_client(downstream).await?;
-    send_token_upstream(upstream, token).await?;
-    Ok(token)
-}
-
-/// Forward a Reset frame upstream → downstream (mid ranks).
-pub async fn forward_reset(
-    upstream: &Mutex<ActivationServer>,
-    downstream: &Mutex<ActivationClient>,
-) -> TransportResult<()> {
-    // Reset has no body; we've already consumed the kind on upstream.
-    // The downstream send is identical to send_reset.
-    let _ = upstream; // present for symmetry / future control flow
+/// Forward a Reset frame downstream — used by mid ranks after consuming
+/// the kind code from upstream. The body is empty so this is just a
+/// `send_reset` to the next peer; the `upstream` argument is held by the
+/// caller and the kind is already consumed before this point.
+pub async fn forward_reset(downstream: &Mutex<ActivationClient>) -> TransportResult<()> {
     send_reset(downstream).await
 }
 

--- a/crates/tahoma-engine-sparse-moe/src/engine.rs
+++ b/crates/tahoma-engine-sparse-moe/src/engine.rs
@@ -9,9 +9,11 @@
 //!   Rank 0 owns the API, layer 0, and the prefill+decode driver loop.
 //!   Last rank owns the head and sampler. Middle ranks just relay.
 
+use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::stream;
@@ -169,6 +171,15 @@ impl Builder for SparseMoEBuilder {
         let mut layer_end = shard.layer_end;
         if total > 1 && layer_start == 0 && layer_end == 0 {
             let total_moe = read_manifest_moe_count(&self.config.model_dir)?;
+            // Reject splits that would leave a rank with zero MoE layers
+            // — that rank is dead weight (still on the wire, still pays
+            // every round-trip's latency) and almost certainly a config
+            // mistake. K2.6 has 60 MoE layers, so total > 60 is silly.
+            if total > total_moe {
+                return Err(EngineError::InvalidConfig(format!(
+                    "total={total} > num_moe_layers={total_moe}; some rank would hold zero layers"
+                )));
+            }
             let (s, e) = even_moe_split(total_moe, rank, total);
             layer_start = s;
             layer_end = e;
@@ -251,7 +262,8 @@ impl Builder for SparseMoEBuilder {
         Ok(Box::new(SparseMoEEngine {
             runner,
             tokenizer: self.tokenizer,
-            pending: Vec::new(),
+            pending: VecDeque::new(),
+            peer_disconnected: false,
             transport: self.transport,
             runtime_handle,
             rank,
@@ -290,14 +302,32 @@ fn even_moe_split(total_moe: u32, rank: u32, total: u32) -> (u32, u32) {
     (start, end)
 }
 
+/// Hard cap on the pending-task queue. step() processes one task end-to-end
+/// per call, so the OS-level backpressure of returning QueueFull is
+/// preferable to silently accreting tasks the engine will not reach for
+/// minutes. 8 is high enough that a small burst (e.g. a benchmark looping
+/// over a few prompts) is fine without immediately rejecting.
+const MAX_PENDING_TASKS: usize = 8;
+
+/// Cool-off the worker loop hits on the run_relay_loop tight cycle when
+/// either (a) the upstream peer closed and we're waiting for the runner to
+/// notice we're done, or (b) we just rejected a frame and need to avoid
+/// hot-spinning while a misbehaving peer keeps trying. Matches the cadence
+/// dist_spec uses for the same situation.
+const WORKER_BACKOFF: Duration = Duration::from_millis(200);
+
 pub struct SparseMoEEngine {
     runner: Runner,
     tokenizer: Option<Tokenizer>,
-    pending: Vec<GenerationTask>,
+    pending: VecDeque<GenerationTask>,
     transport: StageTransport,
     runtime_handle: tokio::runtime::Handle,
     rank: u32,
     total: u32,
+    /// Set on a worker rank when the upstream socket closes cleanly. Keeps
+    /// step_worker from hot-spinning on `recv_kind_server` returning
+    /// `Ok(None)` over and over.
+    peer_disconnected: bool,
 }
 
 impl SparseMoEEngine {
@@ -347,7 +377,13 @@ impl Engine for SparseMoEEngine {
                     .into(),
             ));
         }
-        self.pending.push(task);
+        if self.pending.len() >= MAX_PENDING_TASKS {
+            return Err(EngineError::QueueFull {
+                queued: self.pending.len(),
+                cap: MAX_PENDING_TASKS,
+            });
+        }
+        self.pending.push_back(task);
         Ok(())
     }
 
@@ -361,11 +397,29 @@ impl Engine for SparseMoEEngine {
             self.step_worker()
         }
     }
+
+    fn close(&mut self) {
+        // Best-effort transport teardown. We block_on each socket's close()
+        // sequentially because the engine is being torn down; lock
+        // contention isn't a worry. Errors are logged but swallowed —
+        // close is idempotent and we want every peer to get a clean FIN.
+        if let Some(srv) = self.transport.upstream.take() {
+            let _ = self.block_on(async move {
+                srv.lock().await.close().await;
+            });
+        }
+        if let Some(cli) = self.transport.downstream.take() {
+            let _ = self.block_on(async move {
+                cli.lock().await.close().await;
+            });
+        }
+        self.peer_disconnected = true;
+    }
 }
 
 impl SparseMoEEngine {
     fn step_single_stage(&mut self) -> Vec<(TaskId, Chunk)> {
-        let task = match self.pending.pop() {
+        let task = match self.pending.pop_front() {
             Some(t) => t,
             None => return Vec::new(),
         };
@@ -426,7 +480,7 @@ impl SparseMoEEngine {
     /// Rank 0 driver: tokenize, drive prefill + decode through the
     /// transport pipeline, return one final chunk for the task.
     fn step_first(&mut self) -> Vec<(TaskId, Chunk)> {
-        let task = match self.pending.pop() {
+        let task = match self.pending.pop_front() {
             Some(t) => t,
             None => return Vec::new(),
         };
@@ -614,11 +668,22 @@ impl SparseMoEEngine {
     /// Worker step: process exactly one frame from upstream and emit
     /// its response (either FORWARD downstream + TOKEN back upstream
     /// for middle ranks, or TOKEN back upstream for the last rank).
+    ///
+    /// Returning an empty Vec is the worker's normal idle/done signal —
+    /// the runner's `run_relay_loop` calls `step()` in a tight loop, so
+    /// we sleep briefly on disconnect / error to avoid pegging a core
+    /// while the runner is being torn down by the operator.
     fn step_worker(&mut self) -> Vec<(TaskId, Chunk)> {
+        if self.peer_disconnected {
+            std::thread::sleep(WORKER_BACKOFF);
+            return Vec::new();
+        }
         let upstream = match self.transport.upstream.clone() {
             Some(u) => u,
             None => {
                 warn!("worker rank has no upstream peer");
+                self.peer_disconnected = true;
+                std::thread::sleep(WORKER_BACKOFF);
                 return Vec::new();
             }
         };
@@ -626,6 +691,9 @@ impl SparseMoEEngine {
             Ok(_) => Vec::new(),
             Err(e) => {
                 warn!(rank = self.rank, "worker frame failed: {e}");
+                // Don't hot-spin on a misbehaving peer. dist_spec uses
+                // the same 200 ms cool-off; same logic applies here.
+                std::thread::sleep(WORKER_BACKOFF);
                 Vec::new()
             }
         }
@@ -640,14 +708,18 @@ impl SparseMoEEngine {
             .block_on(recv_kind_server(upstream))
             .map_err(|e| format!("recv_kind: {e}"))?;
         let Some(kind) = kind else {
-            // Clean shutdown.
+            // Clean upstream close — the driver finished its session.
+            // Latch the flag so subsequent step()s back off without
+            // re-entering the (now-doomed) recv loop.
+            info!(rank = self.rank, "upstream closed cleanly; worker idling");
+            self.peer_disconnected = true;
             return Ok(());
         };
         match kind {
             FrameKind::Reset => {
                 self.runner.reset_kv();
                 if let Some(down) = downstream.as_ref() {
-                    self.block_on(forward_reset(upstream, down))
+                    self.block_on(forward_reset(down))
                         .map_err(|e| format!("forward_reset: {e}"))?;
                 }
                 Ok(())
@@ -674,11 +746,13 @@ impl SparseMoEEngine {
                         .runner
                         .forward_head_last(&h_after, 1)
                         .map_err(|e| format!("forward_head: {e}"))?;
-                    // Greedy for now — distributed sampling will need
-                    // to plumb temperature/top-p in the frame body if
-                    // we want sample diversity on multi-stage. Treat
-                    // it as a follow-up; quality eval target uses
-                    // temperature=0 anyway.
+                    // **Known limitation**: multi-stage mode ignores the
+                    // caller's `temperature` / `top_p` / `repetition_penalty`
+                    // because the Forward frame body doesn't carry sampling
+                    // params. A `task.temperature = 0.7` request will
+                    // silently produce greedy output on the multi-stage
+                    // path. Fix is a new frame field — punted until a
+                    // user actually asks for it.
                     let token = argmax_i64(&logits);
                     self.block_on(send_token_upstream(upstream, token))
                         .map_err(|e| format!("send_token: {e}"))?;
@@ -716,6 +790,15 @@ impl SparseMoEEngine {
 }
 
 fn argmax_i64(xs: &[f32]) -> i64 {
+    // We sample on the last rank; an empty logits vector here means
+    // forward_head_last returned a malformed buffer (engine bug) or the
+    // caller passed wrong input. Returning 0 silently would dispatch
+    // token id 0 — better to surface a warning and let the caller
+    // diagnose. Empty vocab is never legitimate in practice.
+    if xs.is_empty() {
+        warn!("argmax_i64 called with empty logits; returning 0 as fallback");
+        return 0;
+    }
     let mut best = 0i64;
     let mut best_v = f32::NEG_INFINITY;
     for (i, &v) in xs.iter().enumerate() {

--- a/crates/tahoma-engine-sparse-moe/src/engine.rs
+++ b/crates/tahoma-engine-sparse-moe/src/engine.rs
@@ -1,22 +1,34 @@
 //! Engine + Builder wiring for the sparse-MoE runner.
 //!
-//! Single-stage engine — no upstream/downstream peers. This is the
-//! "killer demo" path for Kimi K2.6 today; pipeline parallelism over
-//! multiple miners is future work that will need to split the layer
-//! list across stages and reuse the transport.
+//! Two roles:
+//! - **Single-stage** (`total == 1`): one Engine holds the full model
+//!   and runs `Runner::generate` directly. The path that hit 100% on
+//!   the K2.6 quality eval in PR #7.
+//! - **Pipeline-parallel** (`total >= 2`): N Engines hold contiguous
+//!   layer slices and exchange F32 hidden states over `tahoma-transport`.
+//!   Rank 0 owns the API, layer 0, and the prefill+decode driver loop.
+//!   Last rank owns the head and sampler. Middle ranks just relay.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use async_trait::async_trait;
 use futures::stream;
 use tahoma_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
 use tahoma_ov_genai_shim::PluginConfig;
+use tahoma_transport::{ActivationClient, ActivationServer};
 use tahoma_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec, TaskId};
 use tokenizers::Tokenizer;
+use tokio::sync::Mutex as TokioMutex;
 use tracing::{info, warn};
 
-use crate::runner::{Runner, RunnerError};
+use crate::dist::{
+    forward_reset, recv_forward_body_server, recv_kind_client, recv_kind_server,
+    recv_token_body_client, send_forward, send_reset, send_token_upstream, FrameKind,
+    StageTransport,
+};
+use crate::runner::{LayerRange, Runner, RunnerError};
 
 #[derive(Default, Debug, Clone)]
 pub struct SparseMoEBuilderConfig {
@@ -24,6 +36,10 @@ pub struct SparseMoEBuilderConfig {
     pub device: String,
     pub cache_dir: Option<String>,
     pub max_cached_experts: u32,
+    /// Pipeline stage index (0-based).
+    pub rank: u32,
+    /// Number of pipeline stages.
+    pub total: u32,
 }
 
 impl SparseMoEBuilderConfig {
@@ -33,7 +49,15 @@ impl SparseMoEBuilderConfig {
             device: device.into(),
             cache_dir: None,
             max_cached_experts: 200,
+            rank: 0,
+            total: 1,
         }
+    }
+
+    pub fn with_rank(mut self, rank: u32, total: u32) -> Self {
+        self.rank = rank;
+        self.total = total;
+        self
     }
 }
 
@@ -41,6 +65,9 @@ pub struct SparseMoEBuilder {
     pub config: SparseMoEBuilderConfig,
     runner: Option<Runner>,
     tokenizer: Option<Tokenizer>,
+    listen_host: String,
+    listen_port: Option<u16>,
+    transport: StageTransport,
 }
 
 impl SparseMoEBuilder {
@@ -49,43 +76,138 @@ impl SparseMoEBuilder {
             config,
             runner: None,
             tokenizer: None,
+            listen_host: "0.0.0.0".into(),
+            listen_port: None,
+            transport: StageTransport::default(),
         }
     }
 }
 
 #[async_trait]
 impl Builder for SparseMoEBuilder {
+    fn configure_listen(&mut self, host: &str, port: u16) {
+        self.listen_host = host.to_string();
+        self.listen_port = Some(port);
+    }
+
     async fn connect(&mut self, peers: PeerLayout) -> EngineResult<()> {
-        // Single-stage engine — reject any peers.
-        if peers.upstream.is_some() || peers.downstream.is_some() {
-            return Err(EngineError::PeerRejected(
-                "sparse-moe engine is single-stage; peers must be empty".into(),
-            ));
+        let single = self.config.total <= 1;
+        let has_upstream = peers.upstream.is_some();
+        let has_downstream = peers.downstream.is_some();
+        if single {
+            if has_upstream || has_downstream {
+                return Err(EngineError::PeerRejected(
+                    "sparse-moe with total=1 cannot have peers".into(),
+                ));
+            }
+            return Ok(());
         }
+
+        // Multi-stage: bind upstream listener first so downstream peer
+        // can connect to us, then connect outbound to our downstream,
+        // then accept the upstream connection. This matches the order
+        // ov-runtime / ov-dist-spec use to avoid the bind-vs-connect
+        // race at startup.
+        if has_upstream {
+            let port = self.listen_port.ok_or_else(|| {
+                EngineError::InvalidConfig(
+                    "non-first rank requires configure_listen() before connect()".into(),
+                )
+            })?;
+            let mut server = ActivationServer::new(self.listen_host.clone(), port);
+            server.start().await.map_err(|e| {
+                EngineError::Backend(format!("listen {}:{}: {}", self.listen_host, port, e))
+            })?;
+            self.transport.upstream = Some(Arc::new(TokioMutex::new(server)));
+            info!(
+                host = %self.listen_host,
+                port,
+                "sparse-moe upstream bound"
+            );
+        }
+
+        if let Some(down) = peers.downstream.as_ref() {
+            let mut client = ActivationClient::new(down.host.clone(), down.port);
+            client
+                .connect_with_timeout(std::time::Duration::from_secs(60))
+                .await
+                .map_err(|e| {
+                    EngineError::Backend(format!("connect to {}:{}: {}", down.host, down.port, e))
+                })?;
+            self.transport.downstream = Some(Arc::new(TokioMutex::new(client)));
+            info!(host = %down.host, port = down.port, "sparse-moe downstream connected");
+        }
+
+        if let Some(srv) = self.transport.upstream.as_ref() {
+            let mut guard = srv.lock().await;
+            guard
+                .accept()
+                .await
+                .map_err(|e| EngineError::Backend(format!("accept upstream: {e}")))?;
+            info!("sparse-moe upstream peer accepted");
+        }
+
         Ok(())
     }
 
-    async fn load(&mut self, _shard: ShardSpec) -> EngineResult<LoadStream> {
-        // Build a plugin config from our cache_dir option.
+    async fn load(&mut self, shard: ShardSpec) -> EngineResult<LoadStream> {
         let mut plugin = PluginConfig::new();
         if let Some(d) = &self.config.cache_dir {
             plugin = plugin.with("CACHE_DIR", d.clone());
         }
 
-        // Compile everything on a worker thread so the runner stays
-        // outside the tokio runtime (OV's TBB pool conflicts with tokio
-        // thread parking; we keep the runner Send-only and call into it
-        // from a dedicated worker).
+        // Build a LayerRange from the ShardSpec + config. For total==1
+        // we keep the historical behavior (load everything). For
+        // multi-stage we honor layer_start/layer_end. If they're zero
+        // (e.g. the CLI hasn't computed them), derive an even split
+        // from the manifest's num_layers and our rank/total.
+        let total = self.config.total.max(1);
+        let rank = self.config.rank.min(total - 1);
+        let is_first = shard.is_first_stage || rank == 0;
+        let is_last = shard.is_last_stage || rank == total - 1;
+        let mut layer_start = shard.layer_start;
+        let mut layer_end = shard.layer_end;
+        if total > 1 && layer_start == 0 && layer_end == 0 {
+            let total_moe = read_manifest_moe_count(&self.config.model_dir)?;
+            let (s, e) = even_moe_split(total_moe, rank, total);
+            layer_start = s;
+            layer_end = e;
+            info!(
+                rank,
+                total,
+                total_moe_layers = total_moe,
+                layer_start,
+                layer_end,
+                "computed even MoE-layer split"
+            );
+        } else if total == 1 {
+            // Single-stage: load every MoE layer, regardless of what
+            // ShardSpec says.
+            layer_start = 0;
+            layer_end = u32::MAX;
+        }
+        let range = LayerRange {
+            layer_start,
+            layer_end,
+            is_first,
+            is_last,
+        };
+
         let cfg = self.config.clone();
         let plugin_for_worker = plugin.clone();
+        let range_for_worker = range.clone();
         let (tx, rx) = std::sync::mpsc::channel();
         let join: JoinHandle<Result<Runner, RunnerError>> = std::thread::spawn(move || {
             tx.send(LoadProgress::message("loading sparse-MoE model"))
                 .ok();
-            Runner::load(cfg.model_dir.clone(), &cfg.device, plugin_for_worker)
+            Runner::load(
+                cfg.model_dir.clone(),
+                &cfg.device,
+                plugin_for_worker,
+                range_for_worker,
+            )
         });
 
-        // Pull events from the worker as it runs, then await the result.
         let runner = match join.join() {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
@@ -96,71 +218,167 @@ impl Builder for SparseMoEBuilder {
             }
         };
 
-        // Tokenizer — must be HF tokenizer.json next to the manifest. (tiktoken
-        // BPEs would need a converter; out of scope here.)
-        let tok_path = self.config.model_dir.join("tokenizer.json");
-        if tok_path.exists() {
-            let t = Tokenizer::from_file(&tok_path)
-                .map_err(|e| EngineError::Backend(format!("load tokenizer.json: {e}")))?;
-            self.tokenizer = Some(t);
-        } else {
-            warn!(
-                "no tokenizer.json at {} — engine will only accept pre-tokenized inputs",
-                tok_path.display()
-            );
+        // Tokenizer is only needed on rank 0 (the API rank).
+        if rank == 0 {
+            let tok_path = self.config.model_dir.join("tokenizer.json");
+            if tok_path.exists() {
+                let t = Tokenizer::from_file(&tok_path)
+                    .map_err(|e| EngineError::Backend(format!("load tokenizer.json: {e}")))?;
+                self.tokenizer = Some(t);
+            } else {
+                warn!(
+                    "no tokenizer.json at {} — engine will only accept pre-tokenized inputs",
+                    tok_path.display()
+                );
+            }
         }
 
         self.runner = Some(runner);
 
-        // Stream the (already-emitted) progress events back to the caller.
         let drained: Vec<LoadProgress> = rx.try_iter().collect();
         Ok(Box::pin(stream::iter(drained)))
     }
 
     fn build(self: Box<Self>) -> EngineResult<Box<dyn Engine>> {
         let runner = self.runner.ok_or(EngineError::NotLoaded)?;
-        let tokenizer = self
-            .tokenizer
-            .ok_or_else(|| EngineError::Backend("tokenizer.json missing".into()))?;
+        let total = self.config.total.max(1);
+        let rank = self.config.rank.min(total - 1);
+        let runtime_handle = tokio::runtime::Handle::try_current()
+            .map_err(|_| EngineError::Backend("Builder::build outside tokio context".into()))?;
+        if rank == 0 && self.tokenizer.is_none() {
+            return Err(EngineError::Backend("tokenizer.json missing".into()));
+        }
         Ok(Box::new(SparseMoEEngine {
             runner,
-            tokenizer,
+            tokenizer: self.tokenizer,
             pending: Vec::new(),
+            transport: self.transport,
+            runtime_handle,
+            rank,
+            total,
         }))
     }
 }
 
+fn read_manifest_moe_count(model_dir: &std::path::Path) -> EngineResult<u32> {
+    let m = crate::manifest::Manifest::load(model_dir)
+        .map_err(|e| EngineError::Backend(format!("read manifest: {e}")))?;
+    Ok(m.moe_layer_ids().len() as u32)
+}
+
+/// Even split of the MoE layer indices across `total` ranks.
+/// Returns `(layer_start_inclusive, layer_end_exclusive)` in *manifest*
+/// coordinates — i.e. MoE layer ids are 1..=num_moe (dense layer 0
+/// excluded). The first rank's range starts at 1; the last rank's
+/// range ends at `num_moe + 1` so its `layer_end` exclusive covers the
+/// final MoE layer.
+fn even_moe_split(total_moe: u32, rank: u32, total: u32) -> (u32, u32) {
+    if total <= 1 {
+        return (0, u32::MAX);
+    }
+    let per = total_moe / total;
+    let rem = total_moe % total;
+    // The first `rem` ranks get one extra layer.
+    let extras_before = rank.min(rem);
+    let base_count = per;
+    let my_extra = if rank < rem { 1 } else { 0 };
+    let my_start_idx = rank * base_count + extras_before;
+    let my_count = base_count + my_extra;
+    // MoE layer ids are 1-based per the manifest (layer 0 is dense).
+    let start = my_start_idx + 1;
+    let end = start + my_count;
+    (start, end)
+}
+
 pub struct SparseMoEEngine {
     runner: Runner,
-    tokenizer: Tokenizer,
+    tokenizer: Option<Tokenizer>,
     pending: Vec<GenerationTask>,
+    transport: StageTransport,
+    runtime_handle: tokio::runtime::Handle,
+    rank: u32,
+    total: u32,
+}
+
+impl SparseMoEEngine {
+    fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::block_in_place(|| self.runtime_handle.block_on(fut))
+        } else {
+            self.runtime_handle.block_on(fut)
+        }
+    }
+
+    fn is_last(&self) -> bool {
+        self.transport.is_last()
+    }
 }
 
 impl Engine for SparseMoEEngine {
     fn warmup(&mut self) {
-        // One short greedy generation to warm the JIT caches + populate
-        // OV's compile cache on disk.
-        info!("warmup: generating 1 token to warm caches");
-        let prompt_ids = self
-            .tokenizer
-            .encode("Hello", false)
-            .map(|e| e.get_ids().iter().map(|&u| u as i64).collect::<Vec<_>>())
-            .unwrap_or_else(|_| vec![1i64]);
-        let _ = self.runner.generate_argmax(&prompt_ids, 1);
+        // Only rank 0 has a tokenizer and the driver loop; the workers
+        // are warmed by the first real generation's prefill. Doing a
+        // dedicated warmup on workers would require us to drive the
+        // whole pipeline from rank 0 with a dummy task; not worth the
+        // complexity for one fewer cold step per rank.
+        if self.total > 1 && self.rank != 0 {
+            info!("warmup: skipping on rank {}/{}", self.rank, self.total);
+            return;
+        }
+        if let Some(tok) = self.tokenizer.as_ref() {
+            info!("warmup: generating 1 token to warm caches");
+            let prompt_ids = tok
+                .encode("Hello", false)
+                .map(|e| e.get_ids().iter().map(|&u| u as i64).collect::<Vec<_>>())
+                .unwrap_or_else(|_| vec![1i64]);
+            if self.total == 1 {
+                let _ = self.runner.generate_argmax(&prompt_ids, 1);
+            }
+            // For multi-stage we skip warmup too — same reasoning as
+            // workers above. A real prompt will trigger the JIT on
+            // every rank in lockstep.
+        }
     }
 
     fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
+        if self.rank != 0 {
+            return Err(EngineError::InvalidConfig(
+                "only rank 0 accepts tasks; worker ranks drive themselves from upstream frames"
+                    .into(),
+            ));
+        }
         self.pending.push(task);
         Ok(())
     }
 
     fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+        if self.total == 1 {
+            return self.step_single_stage();
+        }
+        if self.rank == 0 {
+            self.step_first()
+        } else {
+            self.step_worker()
+        }
+    }
+}
+
+impl SparseMoEEngine {
+    fn step_single_stage(&mut self) -> Vec<(TaskId, Chunk)> {
         let task = match self.pending.pop() {
             Some(t) => t,
             None => return Vec::new(),
         };
+        let tokenizer = match self.tokenizer.as_ref() {
+            Some(t) => t,
+            None => {
+                warn!(task = %task.task_id, "single-stage engine has no tokenizer");
+                let final_chunk = Chunk::final_marker(task.task_id.clone(), "");
+                return vec![(task.task_id, final_chunk)];
+            }
+        };
         let started = std::time::Instant::now();
-        let prompt_ids: Vec<i64> = match self.tokenizer.encode(task.prompt.as_str(), true) {
+        let prompt_ids: Vec<i64> = match tokenizer.encode(task.prompt.as_str(), true) {
             Ok(enc) => enc.get_ids().iter().map(|&u| u as i64).collect(),
             Err(e) => {
                 warn!(task = %task.task_id, "tokenizer encode failed: {e}");
@@ -186,12 +404,9 @@ impl Engine for SparseMoEEngine {
         };
         let n_tokens = generated.len() as u32;
         let ids_u32: Vec<u32> = generated.iter().map(|&i| i as u32).collect();
-        let mut text = self
-            .tokenizer
+        let mut text = tokenizer
             .decode(&ids_u32, true)
             .unwrap_or_else(|_| String::new());
-        // The HF tokenizer's decoder doesn't echo the prompt, but a
-        // chat-template-prepended encode would. Strip defensively.
         if let Some(stripped) = text.strip_prefix(&task.prompt) {
             text = stripped.trim_start().to_string();
         }
@@ -201,10 +416,347 @@ impl Engine for SparseMoEEngine {
             tokens = n_tokens,
             elapsed_s = elapsed,
             tok_s = if elapsed > 0.0 { n_tokens as f64 / elapsed } else { 0.0 },
-            "task done"
+            "task done (single-stage)"
         );
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
         vec![(task.task_id.clone(), chunk)]
+    }
+
+    /// Rank 0 driver: tokenize, drive prefill + decode through the
+    /// transport pipeline, return one final chunk for the task.
+    fn step_first(&mut self) -> Vec<(TaskId, Chunk)> {
+        let task = match self.pending.pop() {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
+        let started = std::time::Instant::now();
+        let prompt_ids: Vec<i64> = {
+            let Some(tok) = self.tokenizer.as_ref() else {
+                warn!(task = %task.task_id, "rank-0 engine has no tokenizer");
+                return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+            };
+            match tok.encode(task.prompt.as_str(), true) {
+                Ok(enc) => enc.get_ids().iter().map(|&u| u as i64).collect(),
+                Err(e) => {
+                    warn!(task = %task.task_id, "tokenizer encode failed: {e}");
+                    return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+                }
+            }
+        };
+
+        let max_new = task.max_tokens.max(1) as usize;
+        let sampling_cfg = crate::sampling::SamplingConfig {
+            temperature: task.temperature.max(0.0),
+            top_p: 1.0,
+            repetition_penalty: 1.05,
+            repetition_window: 64,
+            seed: None,
+        };
+        let downstream = match self.transport.downstream.clone() {
+            Some(d) => d,
+            None => {
+                warn!("rank 0 has no downstream peer in multi-stage mode");
+                return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+            }
+        };
+
+        // RESET downstream so workers clear their KV caches.
+        self.runner.reset_kv();
+        if let Err(e) = self.block_on(send_reset(&downstream)) {
+            warn!(task = %task.task_id, "send_reset: {e}");
+            return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+        }
+
+        // Drive the full generation. result_tokens collects new tokens
+        // generated AFTER the prompt (we discard the prefill responses).
+        let result_tokens =
+            match self.drive_generation_first(&prompt_ids, max_new, &sampling_cfg, &downstream) {
+                Ok(g) => g,
+                Err(e) => {
+                    warn!(task = %task.task_id, "rank-0 driver failed: {e}");
+                    return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+                }
+            };
+
+        let n_tokens = result_tokens.len() as u32;
+        let ids_u32: Vec<u32> = result_tokens.iter().map(|&i| i as u32).collect();
+        let Some(tokenizer) = self.tokenizer.as_ref() else {
+            warn!("tokenizer disappeared mid-task");
+            return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+        };
+        let mut text = tokenizer
+            .decode(&ids_u32, true)
+            .unwrap_or_else(|_| String::new());
+        if let Some(stripped) = text.strip_prefix(&task.prompt) {
+            text = stripped.trim_start().to_string();
+        }
+        let elapsed = started.elapsed().as_secs_f64();
+        info!(
+            task = %task.task_id,
+            tokens = n_tokens,
+            elapsed_s = elapsed,
+            tok_s = if elapsed > 0.0 { n_tokens as f64 / elapsed } else { 0.0 },
+            rank = self.rank,
+            total = self.total,
+            "task done (rank-0 driver)"
+        );
+        let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
+        chunk.n_tokens = Some(n_tokens);
+        vec![(task.task_id.clone(), chunk)]
+    }
+
+    /// Rank 0 generation loop. For each prompt token + each decode
+    /// step: embed → forward through my shells → send hidden
+    /// downstream → recv sampled token back. Discards prefill samples
+    /// except the last (which becomes the first generated token).
+    fn drive_generation_first(
+        &mut self,
+        prompt_ids: &[i64],
+        max_new: usize,
+        _cfg: &crate::sampling::SamplingConfig,
+        downstream: &Arc<TokioMutex<ActivationClient>>,
+    ) -> Result<Vec<i64>, String> {
+        let hidden = self.runner.manifest.hidden_size as usize;
+        let eos: Vec<i64> = self
+            .runner
+            .manifest
+            .eos_token_ids
+            .iter()
+            .map(|&x| x as i64)
+            .collect();
+        let mut history: Vec<i64> = Vec::with_capacity(prompt_ids.len() + max_new);
+        let mut generated: Vec<i64> = Vec::with_capacity(max_new);
+
+        // Prefill: feed each prompt token; the very last response from
+        // last-rank becomes the first generated token.
+        info!(
+            prompt_len = prompt_ids.len(),
+            "prefill (token-by-token, distributed)"
+        );
+        for (i, &t) in prompt_ids.iter().enumerate() {
+            history.push(t);
+            let token_back = self
+                .forward_one_token_first(&history, downstream)
+                .map_err(|e| format!("prefill step {i}: {e}"))?;
+            if i + 1 == prompt_ids.len() {
+                // Last prefill step: this is the first generated token.
+                if eos.contains(&token_back) {
+                    return Ok(generated);
+                }
+                generated.push(token_back);
+                history.push(token_back);
+            }
+            // Otherwise discard (intermediate prefill samples are stale).
+            let _ = token_back;
+        }
+
+        // Decode loop.
+        for step_i in 1..max_new {
+            let token_back = self
+                .forward_one_token_first(&history, downstream)
+                .map_err(|e| format!("decode step {step_i}: {e}"))?;
+            if eos.contains(&token_back) {
+                break;
+            }
+            generated.push(token_back);
+            history.push(token_back);
+        }
+        let _ = hidden;
+        Ok(generated)
+    }
+
+    /// Run one (prefill or decode) step on rank 0: embed via layer 0,
+    /// run my shells, send hidden state downstream, receive the
+    /// sampled token back along the same socket.
+    fn forward_one_token_first(
+        &mut self,
+        history: &[i64],
+        downstream: &Arc<TokioMutex<ActivationClient>>,
+    ) -> Result<i64, String> {
+        let hidden = self.runner.manifest.hidden_size as usize;
+        let past_seq_len = (history.len() - 1) as u32;
+
+        // Layer 0 over the full history; keep only the trailing row.
+        let h_tail = self
+            .runner
+            .embed_layer0_tail(history, 1)
+            .map_err(|e| format!("embed_layer0: {e}"))?;
+        let h_after_shells = self
+            .runner
+            .forward_shells(&h_tail, &[1, 1, hidden], past_seq_len as usize)
+            .map_err(|e| format!("forward_shells: {e}"))?;
+
+        // Send hidden downstream and wait for token to come back.
+        self.block_on(async {
+            send_forward(
+                downstream,
+                past_seq_len,
+                &h_after_shells,
+                [1, 1, hidden as u32],
+            )
+            .await
+            .map_err(|e| format!("send_forward: {e}"))?;
+            match recv_kind_client(downstream).await {
+                Ok(Some(FrameKind::Token)) => {
+                    let token = recv_token_body_client(downstream)
+                        .await
+                        .map_err(|e| format!("recv_token: {e}"))?;
+                    Ok(token)
+                }
+                Ok(Some(other)) => Err(format!("unexpected frame after forward: {other:?}")),
+                Ok(None) => Err("downstream closed during recv_kind".into()),
+                Err(e) => Err(format!("recv_kind: {e}")),
+            }
+        })
+    }
+
+    /// Worker step: process exactly one frame from upstream and emit
+    /// its response (either FORWARD downstream + TOKEN back upstream
+    /// for middle ranks, or TOKEN back upstream for the last rank).
+    fn step_worker(&mut self) -> Vec<(TaskId, Chunk)> {
+        let upstream = match self.transport.upstream.clone() {
+            Some(u) => u,
+            None => {
+                warn!("worker rank has no upstream peer");
+                return Vec::new();
+            }
+        };
+        match self.handle_one_frame(&upstream) {
+            Ok(_) => Vec::new(),
+            Err(e) => {
+                warn!(rank = self.rank, "worker frame failed: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    fn handle_one_frame(
+        &mut self,
+        upstream: &Arc<TokioMutex<ActivationServer>>,
+    ) -> Result<(), String> {
+        let downstream = self.transport.downstream.clone();
+        let kind = self
+            .block_on(recv_kind_server(upstream))
+            .map_err(|e| format!("recv_kind: {e}"))?;
+        let Some(kind) = kind else {
+            // Clean shutdown.
+            return Ok(());
+        };
+        match kind {
+            FrameKind::Reset => {
+                self.runner.reset_kv();
+                if let Some(down) = downstream.as_ref() {
+                    self.block_on(forward_reset(upstream, down))
+                        .map_err(|e| format!("forward_reset: {e}"))?;
+                }
+                Ok(())
+            }
+            FrameKind::Forward => {
+                let (past_seq_len, hidden_f32, in_shape) = self
+                    .block_on(recv_forward_body_server(upstream))
+                    .map_err(|e| format!("recv_forward: {e}"))?;
+                let hidden = self.runner.manifest.hidden_size as usize;
+                if in_shape[0] != 1 || in_shape[1] != 1 || in_shape[2] as usize != hidden {
+                    return Err(format!(
+                        "forward shape unexpected {:?} vs hidden {}",
+                        in_shape, hidden
+                    ));
+                }
+                let h_after = self
+                    .runner
+                    .forward_shells(&hidden_f32, &[1, 1, hidden], past_seq_len as usize)
+                    .map_err(|e| format!("forward_shells: {e}"))?;
+
+                if self.is_last() {
+                    // Run head, sample, send TOKEN upstream.
+                    let logits = self
+                        .runner
+                        .forward_head_last(&h_after, 1)
+                        .map_err(|e| format!("forward_head: {e}"))?;
+                    // Greedy for now — distributed sampling will need
+                    // to plumb temperature/top-p in the frame body if
+                    // we want sample diversity on multi-stage. Treat
+                    // it as a follow-up; quality eval target uses
+                    // temperature=0 anyway.
+                    let token = argmax_i64(&logits);
+                    self.block_on(send_token_upstream(upstream, token))
+                        .map_err(|e| format!("send_token: {e}"))?;
+                    Ok(())
+                } else {
+                    let down =
+                        downstream.ok_or_else(|| "mid rank missing downstream".to_string())?;
+                    self.block_on(async {
+                        send_forward(&down, past_seq_len, &h_after, [1, 1, hidden as u32])
+                            .await
+                            .map_err(|e| format!("send_forward: {e}"))?;
+                        let token = match recv_kind_client(&down).await {
+                            Ok(Some(FrameKind::Token)) => recv_token_body_client(&down)
+                                .await
+                                .map_err(|e| format!("recv_token: {e}"))?,
+                            Ok(Some(other)) => {
+                                return Err(format!("unexpected mid-rank frame: {other:?}"));
+                            }
+                            Ok(None) => return Err("downstream closed mid-frame".into()),
+                            Err(e) => return Err(format!("recv_kind: {e}")),
+                        };
+                        send_token_upstream(upstream, token)
+                            .await
+                            .map_err(|e| format!("send_token: {e}"))
+                    })?;
+                    Ok(())
+                }
+            }
+            FrameKind::Token => Err(format!(
+                "rank {} received unexpected TOKEN from upstream",
+                self.rank
+            )),
+        }
+    }
+}
+
+fn argmax_i64(xs: &[f32]) -> i64 {
+    let mut best = 0i64;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &v) in xs.iter().enumerate() {
+        if v > best_v {
+            best_v = v;
+            best = i as i64;
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn even_moe_split_uniform() {
+        assert_eq!(even_moe_split(60, 0, 2), (1, 31));
+        assert_eq!(even_moe_split(60, 1, 2), (31, 61));
+    }
+
+    #[test]
+    fn even_moe_split_with_remainder() {
+        // 60 across 7 ranks: 60/7 = 8 remainder 4. Ranks 0..3 get 9
+        // each; ranks 4..6 get 8 each.
+        let mut prev_end = 1u32;
+        let mut total = 0u32;
+        for r in 0..7 {
+            let (s, e) = even_moe_split(60, r, 7);
+            assert_eq!(s, prev_end, "rank {r}: start={s} prev_end={prev_end}");
+            assert!(e > s);
+            total += e - s;
+            prev_end = e;
+        }
+        assert_eq!(total, 60);
+        assert_eq!(prev_end, 61);
+    }
+
+    #[test]
+    fn single_stage_yields_full_range() {
+        let (s, e) = even_moe_split(60, 0, 1);
+        assert_eq!((s, e), (0, u32::MAX));
     }
 }

--- a/crates/tahoma-engine-sparse-moe/src/lib.rs
+++ b/crates/tahoma-engine-sparse-moe/src/lib.rs
@@ -36,6 +36,7 @@
 //!
 //! The expert IRs are lazy-loaded on first use into an LRU cache.
 
+pub mod dist;
 pub mod engine;
 pub mod manifest;
 pub mod runner;

--- a/crates/tahoma-engine-sparse-moe/src/runner.rs
+++ b/crates/tahoma-engine-sparse-moe/src/runner.rs
@@ -10,9 +10,12 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 
 use half::bf16;
+use tahoma_int4_gemm::shell::{NUM_HEADS, QK_HEAD_DIM, V_HEAD_DIM};
+use tahoma_int4_gemm::shell_int4::{shell_forward_decode_int4, Int4Shell};
 use tahoma_int4_gemm::{
     expert_forward as int4_expert_forward, ExpertWeights, SafetensorsExpert,
     SafetensorsExpertSource,
@@ -22,10 +25,7 @@ use thiserror::Error;
 use tracing::{debug, info};
 
 use crate::manifest::{Manifest, ManifestError};
-use crate::tensors::{
-    bf16_bytes_to_f32, bytes_to_i64, causal_mask_f32, concat_along_axis, f16_bytes_to_f32,
-    f32_to_bf16_bytes, f32_to_bytes, i64_to_bytes,
-};
+use crate::tensors::{bf16_bytes_to_f32, f16_bytes_to_f32, f32_to_bf16_bytes, i64_to_bytes};
 
 #[derive(Debug, Error)]
 pub enum RunnerError {
@@ -40,68 +40,28 @@ pub enum RunnerError {
 }
 
 /// Per-MoE-layer state held across generation steps.
+///
+/// The shell forward runs through `tahoma_int4_gemm::shell_int4::shell_forward_decode_int4`,
+/// which expects flat KV caches in `[NUM_HEADS, S, D]` row-major layout (not OV's
+/// `[1, NUM_HEADS, S, D]` byte buffer). We track `past_seq_len` so each forward call
+/// has the cache shape it needs without per-call recomputation.
 struct LayerState {
     lid: u32,
-    shell: Runtime,
-    /// Last shell output names so we can look them up by index. OV inputs
-    /// can have ports addressed by 0-based index OR by name string;
-    /// `Runtime::output` only takes index, so we cache the index for each
-    /// canonical name once.
-    output_idx: HashMap<&'static str, usize>,
-    /// past_k bytes + shape `[1, num_kv_heads, past_seq, qk_head_dim]` f32
-    past_k: Vec<u8>,
-    past_k_shape: Vec<usize>,
-    past_v: Vec<u8>,
-    past_v_shape: Vec<usize>,
+    int4_shell: Int4Shell,
+    past_k: Vec<f32>,
+    past_v: Vec<f32>,
+    past_seq_len: usize,
 }
 
 impl LayerState {
-    fn new(
-        lid: u32,
-        shell: Runtime,
-        num_kv_heads: u32,
-        qk_head_dim: u32,
-        v_head_dim: u32,
-    ) -> Result<Self, RunnerError> {
-        let mut output_idx = HashMap::new();
-        let names = shell.output_names()?;
-        let aliases: Vec<Vec<String>> = (0..names.len())
-            .map(|i| shell.output_aliases(i).unwrap_or_default())
-            .collect();
-        for canonical in [
-            "attn_out_post_norm",
-            "attn_residual",
-            "shared_expert_out",
-            "routing_ids",
-            "routing_weights",
-            "present_k",
-            "present_v",
-        ] {
-            let idx = aliases
-                .iter()
-                .position(|als| als.iter().any(|a| a == canonical))
-                .or_else(|| names.iter().position(|n| n == canonical))
-                .ok_or_else(|| {
-                    RunnerError::Internal(format!(
-                        "shell output `{}` not found in IR (got: {:?})",
-                        canonical, names
-                    ))
-                })?;
-            output_idx.insert(canonical, idx);
-        }
-        Ok(Self {
+    fn new(lid: u32, int4_shell: Int4Shell) -> Self {
+        Self {
             lid,
-            shell,
-            output_idx,
+            int4_shell,
             past_k: Vec::new(),
-            past_k_shape: vec![1, num_kv_heads as usize, 0, qk_head_dim as usize],
             past_v: Vec::new(),
-            past_v_shape: vec![1, num_kv_heads as usize, 0, v_head_dim as usize],
-        })
-    }
-
-    fn out_idx(&self, name: &str) -> usize {
-        self.output_idx[name]
+            past_seq_len: 0,
+        }
     }
 }
 
@@ -137,7 +97,8 @@ struct Int4BinExpertCache {
 /// Variant that reads experts directly from the safetensors shards
 /// (`<model_dir>/safetensors/<shard>`) — no on-disk duplication.
 struct SafetensorsExpertCache {
-    source: SafetensorsExpertSource,
+    /// Shared with the Runner; one mmap set, multiple consumers.
+    source: Arc<SafetensorsExpertSource>,
     /// Cached SafetensorsExpert holders. Each pins its shard mmaps.
     map: HashMap<(u32, u32), SafetensorsExpert>,
 }
@@ -211,6 +172,11 @@ pub struct Runner {
     head: Option<Runtime>,
     layers: Vec<LayerState>,
     experts: ExpertCache,
+    /// Shared safetensors handle used to construct each Int4Shell at
+    /// load time and (when experts_format=safetensors_bin) to serve
+    /// expert weights at runtime. Held in an Arc so the expert cache
+    /// can clone it without duplicating mmaps.
+    _safetensors_source: Arc<SafetensorsExpertSource>,
 }
 
 impl Runner {
@@ -272,6 +238,21 @@ impl Runner {
             None
         };
 
+        // Shells always come from safetensors now (the OV shell IRs are
+        // numerically broken for K2.6 — see k26_output_divergence). The
+        // safetensors source is the same one experts use when
+        // experts_format=safetensors_bin, so we open it once and share.
+        let st_dir = model_dir.join("safetensors");
+        let st_dir = if st_dir.exists() {
+            st_dir
+        } else {
+            model_dir.clone()
+        };
+        let safetensors_source = Arc::new(
+            SafetensorsExpertSource::open(st_dir)
+                .map_err(|e| RunnerError::Internal(format!("safetensors open: {e}")))?,
+        );
+
         let all_moe_ids = manifest.moe_layer_ids();
         let in_range: Vec<u32> = all_moe_ids
             .iter()
@@ -284,21 +265,20 @@ impl Runner {
             all_moe_ids.len()
         );
         let mut layers = Vec::with_capacity(in_range.len());
+        let shell_load_t0 = Instant::now();
         for (i, &lid) in in_range.iter().enumerate() {
-            let xml = manifest.shell_xml(&model_dir, lid);
-            if !xml.exists() {
-                return Err(RunnerError::MissingFile(xml));
-            }
-            let rt = Runtime::compile(&utf8(&xml)?, device, &plugin)?;
-            layers.push(LayerState::new(
-                lid,
-                rt,
-                manifest.num_kv_heads,
-                manifest.qk_head_dim,
-                manifest.v_head_dim,
-            )?);
+            let st_shell = safetensors_source
+                .shell(lid)
+                .map_err(|e| RunnerError::Internal(format!("safetensors shell L{lid}: {e}")))?;
+            let int4_shell = Int4Shell::from_safetensors(&st_shell);
+            layers.push(LayerState::new(lid, int4_shell));
             if (i + 1) % 10 == 0 || i + 1 == in_range.len() {
-                info!("compiled shells {}/{}", i + 1, in_range.len());
+                info!(
+                    "loaded int4 shells {}/{} ({:.1}s elapsed)",
+                    i + 1,
+                    in_range.len(),
+                    shell_load_t0.elapsed().as_secs_f64()
+                );
             }
         }
 
@@ -315,17 +295,9 @@ impl Runner {
                 })
             }
             "safetensors_bin" => {
-                info!("expert backend: safetensors_bin (direct safetensors mmap + AVX-512)");
-                let st_dir = model_dir.join("safetensors");
-                let st_dir = if st_dir.exists() {
-                    st_dir
-                } else {
-                    model_dir.clone()
-                };
-                let source = SafetensorsExpertSource::open(st_dir)
-                    .map_err(|e| RunnerError::Internal(format!("safetensors open: {e}")))?;
+                info!("expert backend: safetensors_bin (shared with shell source)");
                 ExpertCache::SafetensorsBin(SafetensorsExpertCache {
-                    source,
+                    source: safetensors_source.clone(),
                     map: HashMap::new(),
                 })
             }
@@ -361,6 +333,7 @@ impl Runner {
             head,
             layers,
             experts,
+            _safetensors_source: safetensors_source,
         })
     }
 
@@ -439,9 +412,8 @@ impl Runner {
     pub fn reset_kv(&mut self) {
         for l in &mut self.layers {
             l.past_k.clear();
-            l.past_k_shape[2] = 0;
             l.past_v.clear();
-            l.past_v_shape[2] = 0;
+            l.past_seq_len = 0;
         }
     }
 
@@ -525,10 +497,16 @@ impl Runner {
         Ok(l0_f32[row_off..].to_vec())
     }
 
-    /// Forward `tail_len` tokens through the shells this rank owns.
-    /// `h_f32` is the input hidden state shaped `[1, tail_len, hidden]`
+    /// Forward one token through the shells this rank owns.
+    /// `h_f32` is the input hidden state shaped `[1, 1, hidden]`
     /// (row-major). Returns the same shape after this rank's MoE
     /// layers, with per-layer KV cache updated.
+    ///
+    /// The int4 shell forward only supports seq=1 (decode mode). The
+    /// engine already drives prefill token-by-token, so this is the
+    /// only shape that ever shows up here. The mask is implicit: a
+    /// single token attends to all past + itself, no -inf positions
+    /// needed.
     pub fn forward_shells(
         &mut self,
         h_in: &[f32],
@@ -537,140 +515,79 @@ impl Runner {
     ) -> Result<Vec<f32>, RunnerError> {
         let hidden = self.manifest.hidden_size as usize;
         let top_k = self.manifest.top_k as usize;
-        if h_shape.len() != 3 || h_shape[0] != 1 || h_shape[2] != hidden {
+        if h_shape.len() != 3 || h_shape[0] != 1 || h_shape[1] != 1 || h_shape[2] != hidden {
             return Err(RunnerError::Internal(format!(
-                "forward_shells: unexpected hidden shape {:?}",
-                h_shape
+                "forward_shells: int4 shells require shape [1, 1, {hidden}], got {h_shape:?}"
             )));
         }
-        let tail_len = h_shape[1];
         let mut h_f32 = h_in.to_vec();
-        let mut h_shape = h_shape.to_vec();
-
-        let (mask_f32, mask_shape) = causal_mask_f32(tail_len, past_seq_len);
-        let mask_bytes = f32_to_bytes(&mask_f32);
-        let past_len_bytes = (past_seq_len as i64).to_le_bytes().to_vec();
 
         let n_layers = self.layers.len();
         for i in 0..n_layers {
             let lid = self.layers[i].lid;
-
-            // 2a) Set shell inputs.
-            let h_bf16 = f32_to_bf16_bytes(&h_f32);
-            let h_shape_now = h_shape.clone();
-            let past_k_bytes = std::mem::take(&mut self.layers[i].past_k);
-            let past_k_shape = self.layers[i].past_k_shape.clone();
-            let past_v_bytes = std::mem::take(&mut self.layers[i].past_v);
-            let past_v_shape = self.layers[i].past_v_shape.clone();
-
-            self.layers[i]
-                .shell
-                .set_input("x.1", DType::Bf16, &h_shape_now, &h_bf16)?;
-            self.layers[i]
-                .shell
-                .set_input("past_k", DType::F32, &past_k_shape, &past_k_bytes)?;
-            self.layers[i]
-                .shell
-                .set_input("past_v", DType::F32, &past_v_shape, &past_v_bytes)?;
-            self.layers[i].shell.set_input(
-                "attn_mask_ext",
-                DType::F32,
-                &mask_shape,
-                &mask_bytes,
-            )?;
-            self.layers[i]
-                .shell
-                .set_input("past_seq_len", DType::I64, &[], &past_len_bytes)?;
-            self.layers[i].shell.infer()?;
-
-            // 2b) Read outputs.
-            let read_f32_out =
-                |layer: &Runtime, idx: usize| -> Result<(Vec<usize>, Vec<f32>), RunnerError> {
-                    let (dt, shape, bytes) = layer.output(idx)?;
-                    let v = match dt {
-                        DType::F32 => read_f32(&bytes),
-                        DType::Bf16 => bf16_bytes_to_f32(&bytes),
-                        DType::F16 => f16_bytes_to_f32(&bytes),
-                        _ => {
-                            return Err(RunnerError::Internal(format!(
-                                "shell L{} output dtype {:?} not f32-castable",
-                                idx, dt
-                            )));
-                        }
-                    };
-                    Ok((shape, v))
-                };
-            let attn_out_idx = self.layers[i].out_idx("attn_out_post_norm");
-            let residual_idx = self.layers[i].out_idx("attn_residual");
-            let shared_idx = self.layers[i].out_idx("shared_expert_out");
-            let routing_ids_idx = self.layers[i].out_idx("routing_ids");
-            let routing_weights_idx = self.layers[i].out_idx("routing_weights");
-            let present_k_idx = self.layers[i].out_idx("present_k");
-            let present_v_idx = self.layers[i].out_idx("present_v");
-
-            let (_, attn_out_f32) = read_f32_out(&self.layers[i].shell, attn_out_idx)?;
-            let (_, residual_f32) = read_f32_out(&self.layers[i].shell, residual_idx)?;
-            let (_, shared_f32) = read_f32_out(&self.layers[i].shell, shared_idx)?;
-            let (routing_ids_shape, routing_ids_bytes) = self.layers[i]
-                .shell
-                .output(routing_ids_idx)
-                .map(|(_, s, b)| (s, b))?;
-            let routing_ids = bytes_to_i64(&routing_ids_bytes);
-            let (_, routing_weights_f32) =
-                read_f32_out(&self.layers[i].shell, routing_weights_idx)?;
-            let (pk_dt, pk_shape, pk_bytes) = self.layers[i].shell.output(present_k_idx)?;
-            let (pv_dt, pv_shape, pv_bytes) = self.layers[i].shell.output(present_v_idx)?;
-            if pk_dt != DType::F32 || pv_dt != DType::F32 {
+            if self.layers[i].past_seq_len != past_seq_len {
                 return Err(RunnerError::Internal(format!(
-                    "present_k/v dtype not f32 ({:?}, {:?})",
-                    pk_dt, pv_dt
+                    "L{lid}: past_seq_len mismatch (caller {past_seq_len} vs layer {})",
+                    self.layers[i].past_seq_len
                 )));
             }
 
-            // 2c) Append the freshly-computed present_k/v onto the running cache.
-            let (new_past_k, new_past_k_shape) =
-                concat_along_axis(&past_k_bytes, &past_k_shape, &pk_bytes, &pk_shape, 2, 4);
-            let (new_past_v, new_past_v_shape) =
-                concat_along_axis(&past_v_bytes, &past_v_shape, &pv_bytes, &pv_shape, 2, 4);
-            self.layers[i].past_k = new_past_k;
-            self.layers[i].past_k_shape = new_past_k_shape;
-            self.layers[i].past_v = new_past_v;
-            self.layers[i].past_v_shape = new_past_v_shape;
+            // Run Rust shell forward — same int4 kernel rainier's eval
+            // used via the cdylib, just called directly since we're in
+            // the same Cargo workspace.
+            let outs = shell_forward_decode_int4(
+                &self.layers[i].int4_shell,
+                &h_f32,
+                &self.layers[i].past_k,
+                &self.layers[i].past_v,
+                past_seq_len,
+            );
 
-            // 2d) Expert dispatch. attn_out_f32 has shape [seq, 7168].
-            // Each expert call takes [1, seq_token, 7168] bf16 in.
-            // routing_ids has shape [seq, top_k].
-            if routing_ids_shape.len() != 2 || routing_ids_shape[1] != top_k {
+            // Append present_k / present_v onto the running KV cache.
+            // Layout is [NUM_HEADS, past_seq, HEAD_DIM] flat; need a
+            // per-head interleaved insert (not a simple buffer concat).
+            append_kv_inplace(
+                &mut self.layers[i].past_k,
+                &outs.present_k,
+                past_seq_len,
+                NUM_HEADS,
+                QK_HEAD_DIM,
+            );
+            append_kv_inplace(
+                &mut self.layers[i].past_v,
+                &outs.present_v,
+                past_seq_len,
+                NUM_HEADS,
+                V_HEAD_DIM,
+            );
+            self.layers[i].past_seq_len = past_seq_len + 1;
+
+            // Expert dispatch — top-k weighted sum over the
+            // routing_ids/weights the shell already chose for us.
+            if outs.routing_ids.len() != top_k || outs.routing_weights.len() != top_k {
                 return Err(RunnerError::Internal(format!(
-                    "routing_ids shape unexpected {:?}",
-                    routing_ids_shape
+                    "L{lid} routing shape unexpected: ids={} weights={} (top_k={})",
+                    outs.routing_ids.len(),
+                    outs.routing_weights.len(),
+                    top_k
                 )));
             }
-            // moe accumulator: same shape as residual = [1, seq, 7168] f32, zero.
-            let mut moe = vec![0.0f32; residual_f32.len()];
-            for tok_idx in 0..tail_len {
-                let attn_row = &attn_out_f32[tok_idx * hidden..(tok_idx + 1) * hidden];
-                for k in 0..top_k {
-                    let eid = routing_ids[tok_idx * top_k + k] as u32;
-                    let w = routing_weights_f32[tok_idx * top_k + k];
-                    let y_f32 = self.dispatch_expert(lid, eid, attn_row)?;
-                    let dst_off = tok_idx * hidden;
-                    for j in 0..hidden {
-                        moe[dst_off + j] += w * y_f32[j];
-                    }
+            let mut moe = vec![0.0f32; hidden];
+            for k in 0..top_k {
+                let eid = outs.routing_ids[k] as u32;
+                let w = outs.routing_weights[k];
+                let y_f32 = self.dispatch_expert(lid, eid, &outs.attn_out_post_norm)?;
+                for j in 0..hidden {
+                    moe[j] += w * y_f32[j];
                 }
             }
 
-            // 2e) Combine: h_next = residual + shared + moe
-            let mut h_next = vec![0.0f32; residual_f32.len()];
-            for j in 0..residual_f32.len() {
-                h_next[j] = residual_f32[j] + shared_f32[j] + moe[j];
+            // Combine: h_next = residual + shared + moe (single token).
+            for j in 0..hidden {
+                h_f32[j] = outs.attn_residual[j] + outs.shared_expert_out[j] + moe[j];
             }
-            h_f32 = h_next;
-            h_shape = vec![1, tail_len, hidden];
         }
 
-        let _ = h_shape;
         Ok(h_f32)
     }
 
@@ -822,4 +739,62 @@ fn read_f32(bytes: &[u8]) -> Vec<f32> {
         out.push(f32::from_le_bytes(a));
     }
     out
+}
+
+/// Append a single new step's K (or V) onto the running cache, in
+/// `[NUM_HEADS, past_seq, HEAD_DIM]` flat layout. `present` is a flat
+/// slice of length `NUM_HEADS * HEAD_DIM` (the new step's contribution,
+/// one per head).
+///
+/// Why not a simple buffer extend: with the data laid out as
+/// `[head][seq][dim]`, growing `seq` requires interleaving — head 0's
+/// new row sits at offset `past_seq * HEAD_DIM`, head 1's at
+/// `(past_seq + 1) * HEAD_DIM + past_seq * HEAD_DIM`, etc.
+fn append_kv_inplace(
+    past: &mut Vec<f32>,
+    present: &[f32],
+    past_seq: usize,
+    num_heads: usize,
+    head_dim: usize,
+) {
+    debug_assert_eq!(past.len(), num_heads * past_seq * head_dim);
+    debug_assert_eq!(present.len(), num_heads * head_dim);
+    let new_seq = past_seq + 1;
+    let mut new_past = vec![0.0f32; num_heads * new_seq * head_dim];
+    for h in 0..num_heads {
+        let old_off = h * past_seq * head_dim;
+        let new_off = h * new_seq * head_dim;
+        if past_seq > 0 {
+            new_past[new_off..new_off + past_seq * head_dim]
+                .copy_from_slice(&past[old_off..old_off + past_seq * head_dim]);
+        }
+        new_past[new_off + past_seq * head_dim..new_off + new_seq * head_dim]
+            .copy_from_slice(&present[h * head_dim..(h + 1) * head_dim]);
+    }
+    *past = new_past;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_kv_grows_correctly_from_empty() {
+        let mut past: Vec<f32> = Vec::new();
+        let present: Vec<f32> = (0..6).map(|i| i as f32).collect(); // 2 heads × 3 dim
+        append_kv_inplace(&mut past, &present, 0, 2, 3);
+        assert_eq!(past, present);
+    }
+
+    #[test]
+    fn append_kv_interleaves_by_head() {
+        // 2 heads, head_dim=2, past_seq=1. past_k[h0,0,*] = [10, 11],
+        // past_k[h1,0,*] = [20, 21]. Append present where
+        // present[h0] = [12, 13], present[h1] = [22, 23].
+        // Expected new past: [10, 11, 12, 13, 20, 21, 22, 23].
+        let mut past = vec![10.0, 11.0, 20.0, 21.0];
+        let present = vec![12.0, 13.0, 22.0, 23.0];
+        append_kv_inplace(&mut past, &present, 1, 2, 2);
+        assert_eq!(past, vec![10.0, 11.0, 12.0, 13.0, 20.0, 21.0, 22.0, 23.0]);
+    }
 }

--- a/crates/tahoma-engine-sparse-moe/src/runner.rs
+++ b/crates/tahoma-engine-sparse-moe/src/runner.rs
@@ -174,24 +174,58 @@ impl Int4BinExpertCache {
     }
 }
 
+/// Per-rank slice of the model the Runner should hold.
+///
+/// `layer_start..layer_end` is the half-open range of *MoE layer ids*
+/// (1-based, matching the manifest convention) this Runner is
+/// responsible for. The dense layer 0 is implicit and tracked
+/// separately via `is_first` (only rank 0 needs it).
+#[derive(Clone, Debug)]
+pub struct LayerRange {
+    pub layer_start: u32,
+    pub layer_end: u32,
+    pub is_first: bool,
+    pub is_last: bool,
+}
+
+impl LayerRange {
+    /// Range that loads everything — single-stage default.
+    pub fn full() -> Self {
+        Self {
+            layer_start: 0,
+            layer_end: u32::MAX,
+            is_first: true,
+            is_last: true,
+        }
+    }
+}
+
 /// Main inference runner.
 pub struct Runner {
     pub manifest: Manifest,
     _model_dir: PathBuf,
     _device: String,
     _plugin: PluginConfig,
-    layer0: Runtime,
-    head: Runtime,
+    pub range: LayerRange,
+    layer0: Option<Runtime>,
+    head: Option<Runtime>,
     layers: Vec<LayerState>,
     experts: ExpertCache,
 }
 
 impl Runner {
-    /// Compile all shells + layer0 + head. Experts are loaded lazily.
+    /// Compile only the layers + head + layer0 needed for this rank.
+    ///
+    /// Single-stage callers can pass `LayerRange::full()` to keep the
+    /// pre-pipeline-parallel behavior. Distributed callers pass a
+    /// range covering just their stage's layers, with `is_first` /
+    /// `is_last` set accordingly — non-first stages skip layer 0
+    /// compilation; non-last stages skip the head.
     pub fn load(
         model_dir: PathBuf,
         device: &str,
         plugin: PluginConfig,
+        range: LayerRange,
     ) -> Result<Self, RunnerError> {
         let manifest = Manifest::load(&model_dir)?;
         info!(
@@ -199,6 +233,10 @@ impl Runner {
             num_layers = manifest.num_layers,
             num_experts = manifest.num_experts,
             top_k = manifest.top_k,
+            layer_start = range.layer_start,
+            layer_end = range.layer_end,
+            is_first = range.is_first,
+            is_last = range.is_last,
             "loading sparse-MoE model"
         );
 
@@ -208,23 +246,45 @@ impl Runner {
                 .ok_or_else(|| RunnerError::Internal(format!("non-UTF-8 path: {}", p.display())))
         };
 
-        let layer0_xml = manifest.layer0_xml(&model_dir);
-        if !layer0_xml.exists() {
-            return Err(RunnerError::MissingFile(layer0_xml));
-        }
-        let layer0 = Runtime::compile(&utf8(&layer0_xml)?, device, &plugin)?;
-        info!("compiled layer 0 (stateless embed+dense)");
+        let layer0 = if range.is_first {
+            let layer0_xml = manifest.layer0_xml(&model_dir);
+            if !layer0_xml.exists() {
+                return Err(RunnerError::MissingFile(layer0_xml));
+            }
+            let rt = Runtime::compile(&utf8(&layer0_xml)?, device, &plugin)?;
+            info!("compiled layer 0 (stateless embed+dense)");
+            Some(rt)
+        } else {
+            info!("skipping layer 0 (not first stage)");
+            None
+        };
 
-        let head_xml = manifest.head_xml(&model_dir);
-        if !head_xml.exists() {
-            return Err(RunnerError::MissingFile(head_xml));
-        }
-        let head = Runtime::compile(&utf8(&head_xml)?, device, &plugin)?;
-        info!("compiled head (RMSNorm + lm_head)");
+        let head = if range.is_last {
+            let head_xml = manifest.head_xml(&model_dir);
+            if !head_xml.exists() {
+                return Err(RunnerError::MissingFile(head_xml));
+            }
+            let rt = Runtime::compile(&utf8(&head_xml)?, device, &plugin)?;
+            info!("compiled head (RMSNorm + lm_head)");
+            Some(rt)
+        } else {
+            info!("skipping head (not last stage)");
+            None
+        };
 
-        let moe_layer_ids = manifest.moe_layer_ids();
-        let mut layers = Vec::with_capacity(moe_layer_ids.len());
-        for (i, &lid) in moe_layer_ids.iter().enumerate() {
+        let all_moe_ids = manifest.moe_layer_ids();
+        let in_range: Vec<u32> = all_moe_ids
+            .iter()
+            .copied()
+            .filter(|&lid| lid >= range.layer_start && lid < range.layer_end)
+            .collect();
+        info!(
+            "this rank holds {} MoE layers (of {} total)",
+            in_range.len(),
+            all_moe_ids.len()
+        );
+        let mut layers = Vec::with_capacity(in_range.len());
+        for (i, &lid) in in_range.iter().enumerate() {
             let xml = manifest.shell_xml(&model_dir, lid);
             if !xml.exists() {
                 return Err(RunnerError::MissingFile(xml));
@@ -237,8 +297,8 @@ impl Runner {
                 manifest.qk_head_dim,
                 manifest.v_head_dim,
             )?);
-            if (i + 1) % 10 == 0 || i + 1 == moe_layer_ids.len() {
-                info!("compiled shells {}/{}", i + 1, moe_layer_ids.len());
+            if (i + 1) % 10 == 0 || i + 1 == in_range.len() {
+                info!("compiled shells {}/{}", i + 1, in_range.len());
             }
         }
 
@@ -296,6 +356,7 @@ impl Runner {
             _model_dir: model_dir,
             _device: device.to_string(),
             _plugin: plugin,
+            range,
             layer0,
             head,
             layers,
@@ -388,7 +449,9 @@ impl Runner {
     /// - `full_ids` is the FULL prefix-so-far (1D i64), used by stateless
     ///   layer 0.
     /// - The shells consume just the trailing `tail_len` tokens, with the
-    ///   per-layer KV state representing the prior `past_seq_len = full_ids.len - tail_len` tokens.
+    ///   per-layer KV state representing the prior
+    ///   `past_seq_len = full_ids.len - tail_len` tokens.
+    ///
     /// Returns the FP32 logits for the last position (`vocab_size` elements).
     fn step(&mut self, full_ids: &[i64], tail_len: usize) -> Result<Vec<f32>, RunnerError> {
         if tail_len == 0 || tail_len > full_ids.len() {
@@ -400,17 +463,43 @@ impl Runner {
         }
         let past_seq_len = full_ids.len() - tail_len;
         let hidden = self.manifest.hidden_size as usize;
-        let top_k = self.manifest.top_k as usize;
 
-        // 1) Layer 0 (stateless): hidden out for the full prefix.
+        // 1) Layer 0 (stateless) → tail of hidden state.
+        let h_f32 = self.embed_layer0_tail(full_ids, tail_len)?;
+        let h_shape = vec![1usize, tail_len, hidden];
+
+        // 2) Run all my shells.
+        let h_f32 = self.forward_shells(&h_f32, &h_shape, past_seq_len)?;
+
+        // 3) Head on the LAST token.
+        self.forward_head_last(&h_f32, tail_len)
+    }
+
+    /// Run layer 0 on the full prefix and return only the trailing
+    /// `tail_len` rows. First-stage only.
+    pub fn embed_layer0_tail(
+        &mut self,
+        full_ids: &[i64],
+        tail_len: usize,
+    ) -> Result<Vec<f32>, RunnerError> {
+        let hidden = self.manifest.hidden_size as usize;
+        if tail_len == 0 || tail_len > full_ids.len() {
+            return Err(RunnerError::Internal(format!(
+                "invalid tail_len {}, full_ids.len={}",
+                tail_len,
+                full_ids.len()
+            )));
+        }
+        let layer0 = self
+            .layer0
+            .as_mut()
+            .ok_or_else(|| RunnerError::Internal("embed_layer0 on non-first stage".into()))?;
         let ids_bytes = i64_to_bytes(full_ids);
         let ids_shape = [1usize, full_ids.len()];
-        let input_name = self.layer0.input_name(0)?;
-        self.layer0
-            .set_input(&input_name, DType::I64, &ids_shape, &ids_bytes)?;
-        self.layer0.infer()?;
-        let (l0_dtype, l0_shape, l0_bytes) = self.layer0.output(0)?;
-        // l0_shape: [1, full_ids.len(), 7168]
+        let input_name = layer0.input_name(0)?;
+        layer0.set_input(&input_name, DType::I64, &ids_shape, &ids_bytes)?;
+        layer0.infer()?;
+        let (l0_dtype, l0_shape, l0_bytes) = layer0.output(0)?;
         if l0_shape.len() != 3
             || l0_shape[0] != 1
             || l0_shape[1] != full_ids.len()
@@ -432,19 +521,36 @@ impl Runner {
                 )))
             }
         };
-        // Slice the last `tail_len` positions.
-        let row_off = past_seq_len * hidden;
-        let mut h_f32 = l0_f32[row_off..].to_vec();
-        let mut h_shape = vec![1usize, tail_len, hidden];
+        let row_off = (full_ids.len() - tail_len) * hidden;
+        Ok(l0_f32[row_off..].to_vec())
+    }
 
-        // 2) Each MoE shell + experts.
+    /// Forward `tail_len` tokens through the shells this rank owns.
+    /// `h_f32` is the input hidden state shaped `[1, tail_len, hidden]`
+    /// (row-major). Returns the same shape after this rank's MoE
+    /// layers, with per-layer KV cache updated.
+    pub fn forward_shells(
+        &mut self,
+        h_in: &[f32],
+        h_shape: &[usize],
+        past_seq_len: usize,
+    ) -> Result<Vec<f32>, RunnerError> {
+        let hidden = self.manifest.hidden_size as usize;
+        let top_k = self.manifest.top_k as usize;
+        if h_shape.len() != 3 || h_shape[0] != 1 || h_shape[2] != hidden {
+            return Err(RunnerError::Internal(format!(
+                "forward_shells: unexpected hidden shape {:?}",
+                h_shape
+            )));
+        }
+        let tail_len = h_shape[1];
+        let mut h_f32 = h_in.to_vec();
+        let mut h_shape = h_shape.to_vec();
+
         let (mask_f32, mask_shape) = causal_mask_f32(tail_len, past_seq_len);
         let mask_bytes = f32_to_bytes(&mask_f32);
         let past_len_bytes = (past_seq_len as i64).to_le_bytes().to_vec();
 
-        // We need to iterate layers in order; for each, compile or
-        // reuse expert IRs. The `experts` cache borrow-conflicts with
-        // the &mut self.layers borrow, so do them by index.
         let n_layers = self.layers.len();
         for i in 0..n_layers {
             let lid = self.layers[i].lid;
@@ -564,14 +670,37 @@ impl Runner {
             h_shape = vec![1, tail_len, hidden];
         }
 
-        // 3) Head on the LAST token.
+        let _ = h_shape;
+        Ok(h_f32)
+    }
+
+    /// Take the last position of `h_f32` (shape `[1, tail_len, hidden]`,
+    /// row-major) and run the head IR. Returns the vocab-sized logits
+    /// at that position. Last-stage only.
+    pub fn forward_head_last(
+        &mut self,
+        h_f32: &[f32],
+        tail_len: usize,
+    ) -> Result<Vec<f32>, RunnerError> {
+        let hidden = self.manifest.hidden_size as usize;
+        if tail_len == 0 || h_f32.len() < tail_len * hidden {
+            return Err(RunnerError::Internal(format!(
+                "forward_head_last: tail_len={} h.len={} hidden={}",
+                tail_len,
+                h_f32.len(),
+                hidden
+            )));
+        }
+        let head = self
+            .head
+            .as_mut()
+            .ok_or_else(|| RunnerError::Internal("forward_head on non-last stage".into()))?;
         let last_off = (tail_len - 1) * hidden;
         let last_h_bf16 = f32_to_bf16_bytes(&h_f32[last_off..last_off + hidden]);
-        let head_in = self.head.input_name(0)?;
-        self.head
-            .set_input(&head_in, DType::Bf16, &[1, 1, hidden], &last_h_bf16)?;
-        self.head.infer()?;
-        let (head_dt, head_shape, head_bytes) = self.head.output(0)?;
+        let head_in = head.input_name(0)?;
+        head.set_input(&head_in, DType::Bf16, &[1, 1, hidden], &last_h_bf16)?;
+        head.infer()?;
+        let (head_dt, head_shape, head_bytes) = head.output(0)?;
         if head_shape.last() != Some(&(self.manifest.vocab_size as usize)) {
             return Err(RunnerError::Internal(format!(
                 "head output shape {:?} doesn't end with vocab_size {}",
@@ -693,16 +822,4 @@ fn read_f32(bytes: &[u8]) -> Vec<f32> {
         out.push(f32::from_le_bytes(a));
     }
     out
-}
-
-fn argmax(xs: &[f32]) -> i64 {
-    let mut best = 0i64;
-    let mut best_v = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best_v {
-            best_v = v;
-            best = i as i64;
-        }
-    }
-    best
 }

--- a/crates/tahoma-engine-sparse-moe/tests/dist_wire.rs
+++ b/crates/tahoma-engine-sparse-moe/tests/dist_wire.rs
@@ -1,0 +1,158 @@
+//! Integration tests for the pipeline-parallel wire protocol.
+//!
+//! Exercises every frame kind (Forward, Reset, Token) on a real
+//! in-process tahoma-transport socket pair, with no OpenVINO + no
+//! model artifacts. Validates that the byte format on the wire round-
+//! trips between two ranks without an actual Engine in between.
+
+use std::sync::Arc;
+
+use tahoma_engine_sparse_moe::dist::{
+    recv_forward_body_server, recv_kind_client, recv_kind_server, recv_token_body_client,
+    send_forward, send_reset, send_token_upstream, FrameKind,
+};
+use tahoma_transport::{ActivationClient, ActivationServer};
+use tokio::sync::Mutex;
+
+async fn make_pair() -> (Arc<Mutex<ActivationServer>>, Arc<Mutex<ActivationClient>>) {
+    let mut server = ActivationServer::new("127.0.0.1", 0);
+    server.start().await.expect("server.start");
+    let port = server.port();
+    let server = Arc::new(Mutex::new(server));
+    let server_clone = server.clone();
+    let server_task = tokio::spawn(async move {
+        server_clone
+            .lock()
+            .await
+            .accept()
+            .await
+            .expect("server.accept");
+    });
+    let mut client = ActivationClient::new("127.0.0.1", port);
+    client
+        .connect_with_timeout(std::time::Duration::from_secs(5))
+        .await
+        .expect("client.connect");
+    let client = Arc::new(Mutex::new(client));
+    server_task.await.expect("server task panicked");
+    (server, client)
+}
+
+#[tokio::test]
+async fn forward_frame_round_trips_hidden_state() {
+    let (server, client) = make_pair().await;
+    let hidden: Vec<f32> = (0..1024).map(|i| (i as f32) * 0.001 - 0.5).collect();
+    let shape = [1u32, 1, 1024];
+
+    let send_task =
+        tokio::spawn(async move { send_forward(&client, 17, &hidden, shape).await.unwrap() });
+
+    let kind = recv_kind_server(&server).await.unwrap();
+    assert_eq!(kind, Some(FrameKind::Forward));
+    let (past_seq_len, h_back, in_shape) = recv_forward_body_server(&server).await.unwrap();
+    assert_eq!(past_seq_len, 17);
+    assert_eq!(in_shape, shape);
+    assert_eq!(h_back.len(), 1024);
+    for (i, &got) in h_back.iter().enumerate() {
+        let expected = (i as f32) * 0.001 - 0.5;
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "i={i}: got {got} expected {expected}"
+        );
+    }
+
+    send_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn reset_frame_round_trips() {
+    let (server, client) = make_pair().await;
+    let send_task = tokio::spawn(async move {
+        send_reset(&client).await.unwrap();
+    });
+
+    let kind = recv_kind_server(&server).await.unwrap();
+    assert_eq!(kind, Some(FrameKind::Reset));
+    send_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn token_frame_round_trips_upstream() {
+    // For the token path, the LAST rank uses the server-side socket
+    // (the one upstream connected to) to send back, and the upstream
+    // recv via its client-side socket.
+    let (server, client) = make_pair().await;
+    let token = 12345i64;
+
+    let send_task = tokio::spawn(async move { send_token_upstream(&server, token).await.unwrap() });
+
+    let kind = recv_kind_client(&client).await.unwrap();
+    assert_eq!(kind, Some(FrameKind::Token));
+    let token_back = recv_token_body_client(&client).await.unwrap();
+    assert_eq!(token_back, token);
+
+    send_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn token_frame_handles_negative_and_extreme_ids() {
+    let (server, client) = make_pair().await;
+    let tokens = [-1i64, 0, 1, i64::MAX, i64::MIN, 163585, 163586];
+
+    // Run all of them sequentially through the same socket.
+    let send_task = tokio::spawn({
+        let server = server.clone();
+        async move {
+            for &t in &tokens {
+                send_token_upstream(&server, t).await.unwrap();
+            }
+        }
+    });
+
+    for &t in &tokens {
+        let kind = recv_kind_client(&client).await.unwrap();
+        assert_eq!(kind, Some(FrameKind::Token));
+        let token_back = recv_token_body_client(&client).await.unwrap();
+        assert_eq!(token_back, t);
+    }
+
+    send_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn sequence_reset_then_forward_then_token() {
+    // Reset → Forward(hidden) → Token. The actual order a rank-0
+    // driver issues on each task.
+    let (server, client) = make_pair().await;
+    let hidden: Vec<f32> = vec![0.123; 7168];
+    let hidden_for_send = hidden.clone();
+    let shape = [1u32, 1, 7168];
+
+    let server_for_token = server.clone();
+    let send_task = tokio::spawn(async move {
+        send_reset(&client).await.unwrap();
+        send_forward(&client, 0, &hidden_for_send, shape)
+            .await
+            .unwrap();
+    });
+
+    assert_eq!(
+        recv_kind_server(&server).await.unwrap(),
+        Some(FrameKind::Reset)
+    );
+    assert_eq!(
+        recv_kind_server(&server).await.unwrap(),
+        Some(FrameKind::Forward)
+    );
+    let (past, h_back, sh) = recv_forward_body_server(&server).await.unwrap();
+    assert_eq!(past, 0);
+    assert_eq!(sh, shape);
+    assert_eq!(h_back.len(), 7168);
+    assert!((h_back[0] - 0.123).abs() < 1e-6);
+
+    send_task.await.unwrap();
+
+    // Now the worker rank sends a token back along the same upstream
+    // socket — exercise that path too.
+    send_token_upstream(&server_for_token, 42).await.unwrap();
+}


### PR DESCRIPTION
## Summary
- Splits the K2.6 SparseMoEEngine across N machines via tahoma-transport's existing TCP relay.
- New `dist.rs` defines a 3-frame wire protocol (Forward, Reset, Token) tailored to MoE pipeline parallelism — distinct from `ov-dist-spec`'s frame codes so a cross-engine mis-connect fails fast.
- `Runner` factored into `embed_layer0_tail` / `forward_shells` / `forward_head_last` so each rank only loads + runs the slice it owns. Single-stage path preserved via `LayerRange::full()`.
- `SparseMoEEngine::step` branches on rank: rank 0 drives prefill+decode; mid ranks forward and relay; last rank runs head + samples greedily and ships the token upstream.
- CLI drops the `--total 1` restriction on `sparse-moe`; even MoE-layer split is derived from `--rank/--total` when ShardSpec leaves the bounds at zero.

## Design decisions (locked with the user)
- **Control-channel back to rank 0** — last rank samples + sends token_id back over the existing upstream socket. Cheaper than re-broadcasting prompt+token (no quadratic prefill on subsequent tokens).
- **Modular `--total`** — engine supports any N >= 1, not hardcoded to 2.
- **Layer 0 KV punted** — stays stateless; long prefixes will grow quadratically on rank 0 until a stateful layer-0 IR replaces it. Follow-up PR.

## What's NOT in scope
- **Distributed sampling**: last rank uses argmax; per-frame temperature/top-p plumbing is a follow-up.
- **End-to-end 2-box eval on cascadia**: deferred to the next session — needs deploying the K2.6 artifacts to two AI PCs.
- **Topology-aware split**: even split for now; the design memo flagged latency-aware placement as a v2 question.

## Test plan
- [x] `cargo test -p tahoma-engine-sparse-moe` — 5 wire-protocol round-trips + 12 unit tests + 5 smoke tests, all green.
- [x] `cargo build --workspace` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p tahoma-engine-sparse-moe --all-targets` — no new warnings (existing PR #7 lints unchanged).
- [ ] **2-box quality eval on cascadia-n00 + n01** — full 3-prompt eval from `quality_eval_20260516.jsonl` (Paris / Pacific / four). To run before merge.

## Stack note
This PR is stacked on #7 (`feat/sparse-moe-k26`) because the SparseMoEEngine itself is still in review there. When #7 lands, this branch will rebase onto main.

## Files
- `crates/tahoma-engine-sparse-moe/src/dist.rs` — new, 173 LOC (wire protocol)
- `crates/tahoma-engine-sparse-moe/src/engine.rs` — +550 net (rank-aware dispatch)
- `crates/tahoma-engine-sparse-moe/src/runner.rs` — +90 net (factored primitives)
- `crates/tahoma-engine-sparse-moe/tests/dist_wire.rs` — new, 158 LOC (integration tests)
- `crates/tahoma-cli/src/lib.rs` — −5 (drop total!=1 rejection, plumb with_rank)