### PR TITLE
fix(cli): SIGTERM/SIGINT-graceful worker shutdown

### DIFF
--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -412,6 +412,34 @@ async fn serve_with_nodelay(listener: tokio::net::TcpListener, app: axum::Router
     }
 }
 
+/// Resolve when the process receives SIGTERM (operator `kill <pid>`) or
+/// SIGINT (Ctrl-C). Used by the worker to break out of the axum serve
+/// loop so `Runner::close()` gets a chance to run before the process
+/// exits — without this, a plain `kill` exits the tokio runtime
+/// mid-request and skips any teardown work close() does (flushing
+/// caches, draining transports, etc.).
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to install SIGTERM handler; only SIGINT will be caught");
+            tokio::signal::ctrl_c().await.ok();
+            return;
+        }
+    };
+    tokio::select! {
+        _ = sigterm.recv() => {}
+        _ = tokio::signal::ctrl_c() => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
 async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     if args.rank >= args.total {
         return Err(anyhow!(
@@ -520,9 +548,20 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         // is in cascadia_api::stream_completion (Body::from_stream of
         // raw bytes, not the axum::Sse wrapper which has its own
         // KeepAlive batching).
-        serve_with_nodelay(listener, app)
-            .await
-            .context("serve_with_nodelay")?;
+        // Race the axum serve against SIGTERM/SIGINT. Without this,
+        // `kill <pid>` exits the tokio runtime before `Runner::close()`
+        // runs, which silently drops any teardown work close() does
+        // (flushing caches, draining transports, etc.). On signal we
+        // fall through to runner.close() below.
+        tokio::select! {
+            res = serve_with_nodelay(listener, app) => {
+                res.context("serve_with_nodelay")?;
+            }
+            _ = wait_for_shutdown_signal() => {
+                info!("shutdown signal received; running graceful close");
+            }
+        }
+        runner.close();
         return Ok(());
     }
 

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -607,7 +607,27 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
                 );
             }
         }
-        runner.close();
+        // Bounded close so a stuck peer / transport doesn't force the
+        // operator to escalate `kill` → `kill -9`. `Runner::close()` is
+        // sync (parking_lot::Mutex) and may block_on async transport
+        // teardown internally; dispatch via spawn_blocking so the timer
+        // can actually fire, then await with a deadline. On timeout we
+        // log loudly and return — the process exit will SIGKILL any
+        // straggler threads, which is the right outcome at that point.
+        const SHUTDOWN_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        let r = runner.clone();
+        let close_task = tokio::task::spawn_blocking(move || r.close());
+        match tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, close_task).await {
+            Ok(Ok(())) => info!("runner.close() complete"),
+            Ok(Err(join_err)) => tracing::warn!(
+                error = %join_err,
+                "runner.close() task panicked"
+            ),
+            Err(_) => tracing::warn!(
+                timeout_s = SHUTDOWN_CLOSE_TIMEOUT.as_secs(),
+                "runner.close() exceeded timeout; abandoning teardown"
+            ),
+        }
         return Ok(());
     }
 

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -412,32 +412,66 @@ async fn serve_with_nodelay(listener: tokio::net::TcpListener, app: axum::Router
     }
 }
 
-/// Resolve when the process receives SIGTERM (operator `kill <pid>`) or
-/// SIGINT (Ctrl-C). Used by the worker to break out of the axum serve
-/// loop so `Runner::close()` gets a chance to run before the process
-/// exits — without this, a plain `kill` exits the tokio runtime
-/// mid-request and skips any teardown work close() does (flushing
-/// caches, draining transports, etc.).
-#[cfg(unix)]
-async fn wait_for_shutdown_signal() {
-    use tokio::signal::unix::{signal, SignalKind};
-    let mut sigterm = match signal(SignalKind::terminate()) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to install SIGTERM handler; only SIGINT will be caught");
-            tokio::signal::ctrl_c().await.ok();
-            return;
+/// Which signal triggered shutdown. Logged for postmortem context so an
+/// operator looking at worker logs can distinguish an orchestrator
+/// `SIGTERM` (typical) from an interactive `Ctrl-C` (rare in prod).
+#[derive(Debug, Clone, Copy)]
+enum ShutdownSignal {
+    Sigterm,
+    Sigint,
+}
+
+impl std::fmt::Display for ShutdownSignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sigterm => f.write_str("SIGTERM"),
+            Self::Sigint => f.write_str("SIGINT"),
         }
-    };
-    tokio::select! {
-        _ = sigterm.recv() => {}
-        _ = tokio::signal::ctrl_c() => {}
     }
 }
 
+/// Pre-install signal handlers (SIGTERM via `tokio::signal::unix` +
+/// SIGINT via `tokio::signal::ctrl_c`) and return a future that resolves
+/// to whichever signal fires first.
+///
+/// **Why pre-install rather than install-on-poll inside `select!`**:
+/// `signal(SignalKind::terminate())` registers the handler with the
+/// async signal driver — until that call completes, the process uses
+/// the default disposition (terminate). If we installed it on the first
+/// poll of the select! arm, a signal arriving in the narrow window
+/// between `listener.bind()` and the first `select!` poll would kill
+/// the worker before any graceful path runs. Pre-installing closes
+/// that gap.
+///
+/// On unix: catches both SIGTERM (operator `kill <pid>` / systemd
+/// stop / k8s pod termination) and SIGINT (Ctrl-C).
+///
+/// On non-unix (Windows): only Ctrl-C is supported by tokio
+/// (`SignalKind` is unix-only). A Windows `taskkill /F` will NOT
+/// trigger graceful close — it sends SIGKILL-equivalent and the
+/// process exits immediately. That's a Windows-platform limitation,
+/// not a bug in this code; document accordingly so on-call doesn't
+/// chase it as a leak.
+#[cfg(unix)]
+fn install_shutdown_signal_handler(
+) -> std::io::Result<impl std::future::Future<Output = ShutdownSignal>> {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate())?;
+    Ok(async move {
+        tokio::select! {
+            _ = sigterm.recv() => ShutdownSignal::Sigterm,
+            _ = tokio::signal::ctrl_c() => ShutdownSignal::Sigint,
+        }
+    })
+}
+
 #[cfg(not(unix))]
-async fn wait_for_shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
+fn install_shutdown_signal_handler(
+) -> std::io::Result<impl std::future::Future<Output = ShutdownSignal>> {
+    Ok(async {
+        let _ = tokio::signal::ctrl_c().await;
+        ShutdownSignal::Sigint
+    })
 }
 
 async fn cmd_worker(args: WorkerArgs) -> Result<()> {
@@ -548,6 +582,14 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         // is in cascadia_api::stream_completion (Body::from_stream of
         // raw bytes, not the axum::Sse wrapper which has its own
         // KeepAlive batching).
+        // Pre-install the SIGTERM/SIGINT handler BEFORE the select! so
+        // there's no window between bind() and the first poll where a
+        // signal would default-terminate the worker. If install fails
+        // we surface it instead of silently falling back to SIGINT-only:
+        // a worker that quietly ignores SIGTERM is a graveyard for
+        // orphaned processes under systemd / k8s.
+        let shutdown_signal =
+            install_shutdown_signal_handler().context("install_shutdown_signal_handler")?;
         // Race the axum serve against SIGTERM/SIGINT. Without this,
         // `kill <pid>` exits the tokio runtime before `Runner::close()`
         // runs, which silently drops any teardown work close() does
@@ -557,8 +599,12 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
             res = serve_with_nodelay(listener, app) => {
                 res.context("serve_with_nodelay")?;
             }
-            _ = wait_for_shutdown_signal() => {
-                info!("shutdown signal received; running graceful close");
+            sig = shutdown_signal => {
+                info!(
+                    signal = %sig,
+                    pid = std::process::id(),
+                    "shutdown signal received; running graceful close"
+                );
             }
         }
         runner.close();


### PR DESCRIPTION
## Summary
Wrap `serve_with_nodelay(listener, app)` in a `tokio::select!` racing against a Unix signal handler (SIGTERM via `tokio::signal::unix` + SIGINT via `tokio::signal::ctrl_c`). On signal, the `select!` breaks and we fall through to `runner.close()` before returning.

Without this, an operator `kill <pid>` exits the tokio runtime mid-request and skips any teardown work `Runner::close()` does — which today is a no-op but is the documented seam for future features that need to flush state on shutdown (KV caches, transport drains, etc.). Adding the signal handler now keeps that contract honest before any such feature relies on it.

## Scope
- API-mode worker only (the production path).
- Relay and stdin modes unchanged.
- `wait_for_shutdown_signal` helper has a non-unix fallback that only catches Ctrl-C, since `SignalKind::terminate` is unix-only in tokio.
- No new dependencies — `tokio = { features = ["full"] }` already includes `signal`.

## Motivation
A bench on miner uncovered this when a planned disk-persistence feature's save-on-shutdown wasn't firing under `kill -TERM`. The persistence feature's `Engine::close()` did the right thing, but the worker's main loop never got there because the runtime exited first. This patch is the prereq for that and any future shutdown-sensitive work, independent of which specific feature ships first.

## Test plan
- [x] `cargo build --release -p cascadia` clean (with openvino feature too)
- [x] `cargo test -p cascadia-cli` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p cascadia-cli --no-deps` introduces no new warnings
- [x] `cascadia worker --help` still emits, all flags present
- [ ] Manual SIGTERM smoke: confirm worker logs `shutdown signal received; running graceful close` before exit