### PR TITLE
feat(sparse-moe): static prompt KV-prefix cache (single-stage, opt-in)

### DIFF
--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -145,6 +145,20 @@ pub struct WorkerArgs {
     /// routing weight >= threshold.
     #[arg(long)]
     pub routing_threshold: Option<f32>,
+
+    /// KV-prefix cache size (sparse-moe engine only). `0` = disabled
+    /// (default). When > 0, the engine caches the post-prefill KV
+    /// snapshot for each unique prompt-token sequence; subsequent
+    /// requests whose prompt starts with a cached prefix skip the
+    /// matched portion of prefill. Best fit: chat workloads where the
+    /// system prompt is shared across requests.
+    ///
+    /// Single-stage only on this PR; ignored on `--total > 1` configs
+    /// (would require a transport frame to exchange snapshots across
+    /// stages). One snapshot at K2.6 dimensions for a 512-token prompt
+    /// is ~150 MiB, so practical caps are 1..8.
+    #[arg(long, default_value_t = 0)]
+    pub kv_prefix_cache_size: u32,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -331,7 +345,8 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
         }
         EngineKind::SparseMoe => {
             let mut cfg = SparseMoEBuilderConfig::new(&args.model, &args.device)
-                .with_rank(args.rank, args.total);
+                .with_rank(args.rank, args.total)
+                .with_kv_prefix_cache_size(args.kv_prefix_cache_size);
             if let Some(dir) = &args.ov_cache_dir {
                 cfg.cache_dir = Some(dir.clone());
             }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -339,10 +339,46 @@ impl Builder for SparseMoEBuilder {
         };
         let kv_prefix_cache = KvPrefixCache::new(kv_cache_size as usize);
         if kv_prefix_cache.enabled() {
+            // Estimate footprint from the loaded runner's per-rank
+            // KV layer count + manifest head dims. Assume a 512-token
+            // representative prompt; the actual cost scales linearly.
+            // At K2.6 single-stage (61 KV layers, 64 heads, 320 dim,
+            // bf16) one 512-token snapshot is ~1.25 GiB, so even a
+            // cap of 4 puts ~5 GiB on the resident set. Print a hard
+            // warning above 16 entries; INFO otherwise.
+            const REPRESENTATIVE_PROMPT_TOKENS: usize = 512;
+            const HEAVY_ENTRY_THRESHOLD: usize = 16;
+            let bytes_per_token = runner.estimated_snapshot_bytes_per_token();
+            let est_per_snapshot = bytes_per_token * REPRESENTATIVE_PROMPT_TOKENS;
+            let est_total = est_per_snapshot.saturating_mul(kv_prefix_cache.capacity());
             info!(
                 capacity = kv_prefix_cache.capacity(),
+                est_bytes_per_snapshot_512tok = est_per_snapshot,
+                est_total_bytes_512tok = est_total,
                 "kv-prefix-cache enabled (single-stage)"
             );
+            if kv_prefix_cache.capacity() > HEAVY_ENTRY_THRESHOLD {
+                warn!(
+                    capacity = kv_prefix_cache.capacity(),
+                    est_total_gib_512tok = est_total as f64 / (1024.0 * 1024.0 * 1024.0),
+                    "kv-prefix-cache size is large; at K2.6 single-stage dims one snapshot is ~{:.0} MiB so resident-set growth is unbounded by capacity * snapshot bytes. Consider a smaller cap.",
+                    est_per_snapshot as f64 / (1024.0 * 1024.0),
+                );
+            }
+            // Spec-decode and the cache are orthogonal optimisations
+            // today: the spec-decode generate path doesn't consult or
+            // populate the cache (see `step_single_stage`). For greedy
+            // requests with spec-decode on, the cache is silently
+            // bypassed; for temp > 0 requests spec-decode falls back to
+            // plain generate which does use the cache. Surface the
+            // partial-coverage caveat at startup so the user isn't
+            // surprised by missing hits in greedy mode.
+            if let Some(k) = spec_decode_k {
+                warn!(
+                    spec_decode_k = k,
+                    "kv-prefix-cache is bypassed on the spec-decode (greedy) generate path; only temperature>0 requests will populate / hit the cache while --spec-decode-k is active"
+                );
+            }
         }
         Ok(Box::new(SparseMoEEngine {
             runner,

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -31,6 +31,7 @@ use crate::dist::{
     send_forward_batch, send_reset, send_token_batch_upstream, send_token_upstream, FrameKind,
     StageTransport,
 };
+use crate::kv_prefix_cache::KvPrefixCache;
 use crate::runner::{LayerRange, Runner, RunnerError};
 
 #[derive(Default, Debug, Clone)]
@@ -64,6 +65,16 @@ pub struct SparseMoEBuilderConfig {
     ///   transparently service ForwardBatch alongside the per-token
     ///   path — no per-rank flag needed.
     pub spec_decode_k: Option<u32>,
+    /// Max entries in the static-prompt KV-prefix cache. `0` disables
+    /// the cache (default). Each entry holds the populated K/V buffers
+    /// for the cached prompt prefix — at K2.6 dimensions a 512-token
+    /// snapshot is ~150 MiB, so practical caps for a chat workload
+    /// are 1..8. See [`crate::kv_prefix_cache`] for the full design.
+    ///
+    /// Single-stage only on this PR — wiring the cache across pipeline
+    /// stages requires a new transport frame for snapshot exchange,
+    /// deferred to a follow-up. With `total > 1` this field is a no-op.
+    pub kv_prefix_cache_size: u32,
 }
 
 impl SparseMoEBuilderConfig {
@@ -78,6 +89,7 @@ impl SparseMoEBuilderConfig {
             top_k_override: None,
             routing_threshold: None,
             spec_decode_k: None,
+            kv_prefix_cache_size: 0,
         }
     }
 
@@ -91,6 +103,13 @@ impl SparseMoEBuilderConfig {
     /// only; ignored on multi-stage configs.
     pub fn with_spec_decode_k(mut self, k: u32) -> Self {
         self.spec_decode_k = if k == 0 { None } else { Some(k) };
+        self
+    }
+
+    /// Set the KV-prefix cache capacity (number of entries). `0`
+    /// disables the cache.
+    pub fn with_kv_prefix_cache_size(mut self, n: u32) -> Self {
+        self.kv_prefix_cache_size = n;
         self
     }
 }
@@ -303,6 +322,28 @@ impl Builder for SparseMoEBuilder {
         // ForwardBatch frames. Worker ranks transparently service either
         // path — they handle ForwardBatch frames as they arrive.
         let spec_decode_k = self.config.spec_decode_k;
+        // KV-prefix cache is single-stage only on this PR. Warn (don't
+        // error) on multi-stage configs so the same CLI flag works in
+        // both topologies — the multi-stage path silently ignores it.
+        let kv_cache_size = if total > 1 {
+            if self.config.kv_prefix_cache_size > 0 {
+                warn!(
+                    requested = self.config.kv_prefix_cache_size,
+                    total,
+                    "kv-prefix-cache disabled: multi-stage cache requires per-stage snapshot exchange (not implemented yet)"
+                );
+            }
+            0
+        } else {
+            self.config.kv_prefix_cache_size
+        };
+        let kv_prefix_cache = KvPrefixCache::new(kv_cache_size as usize);
+        if kv_prefix_cache.enabled() {
+            info!(
+                capacity = kv_prefix_cache.capacity(),
+                "kv-prefix-cache enabled (single-stage)"
+            );
+        }
         Ok(Box::new(SparseMoEEngine {
             runner,
             tokenizer: self.tokenizer,
@@ -316,6 +357,7 @@ impl Builder for SparseMoEBuilder {
             last_rank_rng: 0,
             last_rank_rng_seeded: false,
             spec_decode_k,
+            kv_prefix_cache,
         }))
     }
 }
@@ -408,6 +450,13 @@ pub struct SparseMoEEngine {
     /// decode with draft K. Only honored when `total == 1` — checked at
     /// engine construction. None = plain greedy / sampled generate.
     spec_decode_k: Option<u32>,
+    /// Single-stage static-prompt KV-prefix cache. Empty + capacity=0
+    /// when the user didn't pass `--kv-prefix-cache-size` (default).
+    /// Holds at most `capacity` packed snapshots; on lookup we restore
+    /// the longest matching prefix's snapshot into the runner so the
+    /// generate path skips that portion of prefill. See
+    /// [`crate::kv_prefix_cache`] for the cache semantics.
+    kv_prefix_cache: KvPrefixCache,
 }
 
 impl SparseMoEEngine {
@@ -556,7 +605,10 @@ impl SparseMoEEngine {
         // Choose generate path: spec-decode if configured (and the
         // sampling config is greedy — the spec-decode helper falls
         // back to plain generate on temp>0 anyway, but this keeps the
-        // log message accurate).
+        // log message accurate). KV-prefix cache is only consulted on
+        // the plain generate path: the spec-decode helper consumes
+        // KV-cache state internally, so wiring prefix-cache replay into
+        // it would need extra plumbing — deferred.
         let use_spec = self.spec_decode_k.is_some() && sampling_cfg.temperature <= 0.0;
         let generated = if use_spec {
             let k = self.spec_decode_k.unwrap();
@@ -578,7 +630,15 @@ impl SparseMoEEngine {
                 }
             }
         } else {
-            match self.runner.generate(&prompt_ids, max_new, &sampling_cfg) {
+            let cache_opt: Option<&mut KvPrefixCache> = if self.kv_prefix_cache.enabled() {
+                Some(&mut self.kv_prefix_cache)
+            } else {
+                None
+            };
+            match self
+                .runner
+                .generate_with_cache(&prompt_ids, max_new, &sampling_cfg, cache_opt)
+            {
                 Ok(g) => g,
                 Err(e) => {
                     warn!(task = %task.task_id, "runner failed: {e}");

--- a/crates/cascadia-engine-sparse-moe/src/kv_prefix_cache.rs
+++ b/crates/cascadia-engine-sparse-moe/src/kv_prefix_cache.rs
@@ -1,0 +1,581 @@
+//! Static prompt KV cache.
+//!
+//! Caches the post-prefill KV-cache state for an exact token-id prefix
+//! so subsequent generations that start with the same prefix can skip
+//! that portion of prefill. Common case: a chat-completion endpoint
+//! where every request shares the same system prompt — at ~3 s/token
+//! prefill, a 500-token shared prefix costs ~1500 s of redundant work
+//! per request without caching.
+//!
+//! ### Cache shape
+//!
+//! Keyed by a 64-bit FxHash over the **token id sequence** plus a
+//! `model_fingerprint` from the manifest. Token-id keying (not raw
+//! prompt text) means two requests whose prompt text differs only in
+//! whitespace tokenize to different keys — accepted; the cache only
+//! ever returns hits when the *token stream* matches byte-identically.
+//! Hash collisions are guarded by re-comparing the full token slice on
+//! lookup (see [`KvPrefixCache::lookup`]).
+//!
+//! The cached value is a [`KvSnapshot`] holding the populated K/V
+//! prefix for layer 0 and every MoE shell layer the rank owns. Capacity
+//! padding is **not** part of the snapshot — on restore we only need
+//! `past_seq_len` slots per head; the live runner repacks them into its
+//! own (possibly larger) capacity buffer.
+//!
+//! ### LRU + size cap
+//!
+//! Backing store: `IndexMap<Hash, KvSnapshot>` so we can do O(1)
+//! `move_to_back` on hit and O(1) `pop_front` on overflow. The cap is
+//! the **number of entries**, not bytes — at K2.6 dimensions one
+//! 512-token snapshot is ~150 MiB so even a small cap is meaningful.
+//!
+//! ### Disabled by default
+//!
+//! `KvPrefixCache::new(0)` returns a no-op cache: `lookup` always
+//! returns `None`, `insert` is a no-op. This keeps the on-by-default
+//! generate path byte-identical to the pre-cache behaviour.
+
+use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
+
+/// Per-layer slice of the KV cache as it would sit at `past_seq_len = N`
+/// after a fresh prefill. The buffers are stored packed: exactly `N`
+/// slots per head, no capacity padding. The Runner's restore path
+/// re-packs into its own buffer using `write_present_kv`-style indexing.
+///
+/// **bf16 buffers (PR #30 A8).** Storage matches the runner's live KV:
+/// each element is a bf16 value held in a `u16`. Restore is a direct
+/// memcpy back into the runner's `[NUM_HEADS, capacity, head_dim]`
+/// buffers — no dequantization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LayerKvSlice {
+    /// Layer id this slice belongs to. For layer-0 this is `0`; for
+    /// MoE shells it's the manifest layer id (1..num_layers).
+    pub lid: u32,
+    /// Layout: `[num_heads, n_slots, qk_head_dim]` row-major, bf16-as-u16.
+    pub past_k: Vec<u16>,
+    /// Layout: `[num_heads, n_slots, v_head_dim]` row-major, bf16-as-u16.
+    pub past_v: Vec<u16>,
+}
+
+/// Full per-rank snapshot. Holds layer 0 (if owned by this rank) plus
+/// every MoE shell layer the rank holds, in the same order as the live
+/// `Runner::layers`. The Runner's restore code walks both vectors in
+/// lockstep — drift = bug, so we panic in debug.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KvSnapshot {
+    /// How many tokens were in the prompt prefix when this snapshot was taken.
+    /// On restore the Runner advances every layer's `past_seq_len` to this value.
+    pub past_seq_len: usize,
+    /// `num_heads` baked in at construction time so a snapshot from one
+    /// model can't accidentally restore into another. The model fingerprint
+    /// is the primary guard; this is a belt-and-braces invariant.
+    pub num_heads: u32,
+    pub qk_head_dim: u32,
+    pub v_head_dim: u32,
+    /// Optional layer-0 KV slice. None if this snapshot was taken on a
+    /// non-first rank.
+    pub layer0: Option<LayerKvSlice>,
+    /// One slice per MoE shell layer owned by the rank, in `layers` order.
+    pub shells: Vec<LayerKvSlice>,
+}
+
+impl KvSnapshot {
+    /// Total cached bytes — useful for logging the cache footprint.
+    /// Underestimate; doesn't count the IndexMap key + hash overhead.
+    pub fn approx_bytes(&self) -> usize {
+        let layer0 = self
+            .layer0
+            .as_ref()
+            .map(|s| (s.past_k.len() + s.past_v.len()) * std::mem::size_of::<u16>())
+            .unwrap_or(0);
+        let shells: usize = self
+            .shells
+            .iter()
+            .map(|s| (s.past_k.len() + s.past_v.len()) * std::mem::size_of::<u16>())
+            .sum();
+        layer0 + shells
+    }
+}
+
+/// Model fingerprint — anything that affects the **KV bits** of a
+/// prefill belongs here. Sampling params (temperature, top-p,
+/// repetition penalty) do NOT — those only affect token sampling AFTER
+/// the forward pass writes K/V, so a snapshot taken under temp=0.0 is
+/// safe to restore for temp=0.7. This is the design decision called out
+/// in the task brief.
+///
+/// Two requests that share a system prompt but use different temperatures
+/// MUST share a cache entry; that's the entire point of the optimization.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ModelFingerprint {
+    pub arch: String,
+    pub num_layers: u32,
+    pub num_experts: u32,
+    pub top_k: u32,
+    pub hidden_size: u32,
+    pub num_kv_heads: u32,
+    pub qk_head_dim: u32,
+    pub v_head_dim: u32,
+    pub vocab_size: u32,
+    /// Rank's `(layer_start, layer_end, is_first, is_last)` baked in.
+    /// A snapshot from rank 0 of a 2-stage split can't restore on rank 1.
+    pub layer_start: u32,
+    pub layer_end: u32,
+    pub is_first: bool,
+    pub is_last: bool,
+}
+
+impl ModelFingerprint {
+    /// Deterministic 64-bit digest used as part of the cache key. Hashes
+    /// every field; collisions would be astronomically unlikely (and
+    /// further guarded by the cache's full prefix re-comparison).
+    pub fn digest(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        let mut h = DefaultHasher::new();
+        self.hash(&mut h);
+        h.finish()
+    }
+}
+
+/// Cache key: model fingerprint digest + 64-bit hash of the token-id
+/// prefix. Stored as a single 128-bit pair so equal keys imply both
+/// digest and prefix-hash matched. The prefix-hash alone is not unique
+/// — see [`KvPrefixCache::lookup`] for the full-slice re-comparison.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CacheKey {
+    model_digest: u64,
+    prefix_hash: u64,
+}
+
+/// One cached entry. The token prefix is held alongside the snapshot
+/// so `lookup` can re-compare and reject hash collisions.
+struct Entry {
+    prefix: Vec<i64>,
+    snapshot: KvSnapshot,
+}
+
+/// LRU KV-prefix cache.
+///
+/// Construct with `KvPrefixCache::new(capacity)`. `capacity = 0`
+/// disables the cache entirely (every `lookup` returns `None`, every
+/// `insert` is a no-op).
+///
+/// **Concurrency**: this struct is `!Sync` because callers wrap it in
+/// a `Mutex` at the engine level. The cache itself is sync-safe —
+/// nothing inside it touches global state — but the `Runner` mutates
+/// KV buffers during restore so the access pattern is necessarily
+/// one-at-a-time.
+pub struct KvPrefixCache {
+    capacity: usize,
+    /// VecDeque used as an LRU ring: `front` = most-recently-used,
+    /// `back` = least-recently-used. On hit we move the entry to front.
+    /// On miss we push_front; if at capacity we pop_back first.
+    ///
+    /// O(n) lookup — fine for the small caps that fit in RAM at K2.6
+    /// dimensions (~150 MiB per 512-token snapshot, so caps are
+    /// realistically 1..8). A HashMap-backed LRU would be 30 lines and
+    /// 1 µs faster per lookup; not worth it for cap<=8.
+    entries: VecDeque<(CacheKey, Entry)>,
+    /// Total cache hits since construction. Logged by the runner.
+    pub hits: u64,
+    /// Total cache misses since construction.
+    pub misses: u64,
+    /// Total inserts (some replace existing entries; some evict).
+    pub inserts: u64,
+    /// Total evictions due to capacity overflow.
+    pub evictions: u64,
+}
+
+impl KvPrefixCache {
+    /// Construct a cache with `capacity` entries (LRU evicted on overflow).
+    /// `capacity = 0` disables the cache.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: VecDeque::with_capacity(capacity.max(1)),
+            hits: 0,
+            misses: 0,
+            inserts: 0,
+            evictions: 0,
+        }
+    }
+
+    /// True if the cache will store anything. `capacity == 0` returns false.
+    pub fn enabled(&self) -> bool {
+        self.capacity > 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Look up the longest cached prefix that matches the start of
+    /// `prompt`. Returns `Some((matched_len, snapshot))` for the
+    /// best match, `None` if nothing matches.
+    ///
+    /// "Best" = longest prefix length. We scan every entry and pick
+    /// the one whose `prefix` is a prefix of `prompt` and is longest.
+    /// At cap<=8 this is a single-µs walk; not worth a trie.
+    ///
+    /// Side effect: on a hit, the matched entry is moved to MRU
+    /// position (front of the deque) so it survives the next eviction.
+    /// `hits`/`misses` counters are bumped accordingly.
+    pub fn lookup(&mut self, prompt: &[i64], fingerprint: &ModelFingerprint) -> Option<KvSnapshot> {
+        if !self.enabled() {
+            return None;
+        }
+        let model_digest = fingerprint.digest();
+        let mut best_idx: Option<usize> = None;
+        let mut best_len = 0usize;
+        for (i, (key, entry)) in self.entries.iter().enumerate() {
+            if key.model_digest != model_digest {
+                continue;
+            }
+            let plen = entry.prefix.len();
+            // The prefix must wholly precede `prompt` AND leave at
+            // least one suffix token for the generate loop to drive
+            // through prefill — restoring the full prompt and then
+            // having zero tail tokens to sample from would deadlock
+            // the first-token logic.
+            if plen >= prompt.len() {
+                continue;
+            }
+            if plen > best_len && prompt.starts_with(&entry.prefix) {
+                best_len = plen;
+                best_idx = Some(i);
+            }
+        }
+        match best_idx {
+            None => {
+                self.misses += 1;
+                None
+            }
+            Some(i) => {
+                self.hits += 1;
+                // Move-to-front (MRU). swap_remove would change the
+                // back's index but we explicitly use remove → push_front
+                // to preserve LRU ordering across the rest of the deque.
+                let entry = self
+                    .entries
+                    .remove(i)
+                    .expect("index from enumerate must be valid");
+                let snapshot = entry.1.snapshot.clone();
+                self.entries.push_front(entry);
+                Some(snapshot)
+            }
+        }
+    }
+
+    /// Insert a snapshot keyed by the given prefix + model fingerprint.
+    /// If an entry already exists for this exact key, replace it and
+    /// move to MRU. Evicts LRU entries until under capacity.
+    ///
+    /// Returns the number of evicted entries (0 in the steady state
+    /// once the cache is full and we replace rather than grow).
+    pub fn insert(
+        &mut self,
+        prefix: Vec<i64>,
+        fingerprint: &ModelFingerprint,
+        snapshot: KvSnapshot,
+    ) -> usize {
+        if !self.enabled() {
+            return 0;
+        }
+        debug_assert_eq!(prefix.len(), snapshot.past_seq_len);
+        let key = CacheKey {
+            model_digest: fingerprint.digest(),
+            prefix_hash: hash_prefix(&prefix),
+        };
+        // Replace any exact-match entry first so capacity accounting
+        // doesn't double-count it.
+        if let Some(pos) = self
+            .entries
+            .iter()
+            .position(|(k, e)| *k == key && e.prefix.len() == prefix.len() && e.prefix == prefix)
+        {
+            self.entries.remove(pos);
+        }
+        let mut evicted = 0;
+        while self.entries.len() >= self.capacity {
+            if self.entries.pop_back().is_none() {
+                break;
+            }
+            evicted += 1;
+        }
+        self.evictions += evicted as u64;
+        self.entries.push_front((key, Entry { prefix, snapshot }));
+        self.inserts += 1;
+        evicted
+    }
+
+    /// Discard every entry. Used by the API layer when the engine is
+    /// reloaded (different model = stale snapshots).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Approximate total bytes held — sum of every cached snapshot's
+    /// KV buffers. Useful for logging.
+    pub fn approx_bytes(&self) -> usize {
+        self.entries
+            .iter()
+            .map(|(_, e)| e.snapshot.approx_bytes())
+            .sum()
+    }
+}
+
+fn hash_prefix(prefix: &[i64]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    let mut h = DefaultHasher::new();
+    prefix.hash(&mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp_a() -> ModelFingerprint {
+        ModelFingerprint {
+            arch: "kimi_k2.6".into(),
+            num_layers: 61,
+            num_experts: 384,
+            top_k: 8,
+            hidden_size: 7168,
+            num_kv_heads: 64,
+            qk_head_dim: 192,
+            v_head_dim: 128,
+            vocab_size: 163840,
+            layer_start: 0,
+            layer_end: u32::MAX,
+            is_first: true,
+            is_last: true,
+        }
+    }
+
+    fn fp_b() -> ModelFingerprint {
+        ModelFingerprint {
+            arch: "qwen3".into(),
+            num_layers: 32,
+            ..fp_a()
+        }
+    }
+
+    /// Minimal snapshot for tests: 2 heads, head_dim 2, n_slots = past_seq_len.
+    /// `fill` is treated as the raw u16 storage value (bf16-as-u16); the
+    /// tests only check round-trip identity, not numeric semantics.
+    fn mk_snapshot(past_seq_len: usize, fill: u16) -> KvSnapshot {
+        // [num_heads=2, n_slots=past_seq_len, qk_head_dim=2]
+        let n = 2 * past_seq_len * 2;
+        KvSnapshot {
+            past_seq_len,
+            num_heads: 2,
+            qk_head_dim: 2,
+            v_head_dim: 2,
+            layer0: Some(LayerKvSlice {
+                lid: 0,
+                past_k: vec![fill; n],
+                past_v: vec![fill; n],
+            }),
+            shells: vec![LayerKvSlice {
+                lid: 1,
+                past_k: vec![fill.wrapping_mul(2); n],
+                past_v: vec![fill.wrapping_mul(2); n],
+            }],
+        }
+    }
+
+    #[test]
+    fn disabled_cache_is_a_noop() {
+        let mut c = KvPrefixCache::new(0);
+        assert!(!c.enabled());
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 1));
+        assert!(c.lookup(&[1, 2, 3, 4], &fp_a()).is_none());
+        assert_eq!(c.len(), 0);
+        // Stats untouched on disabled cache (lookup early-returns).
+        assert_eq!(c.hits, 0);
+        assert_eq!(c.misses, 0);
+        assert_eq!(c.inserts, 0);
+    }
+
+    #[test]
+    fn insert_then_lookup_returns_same_snapshot() {
+        let mut c = KvPrefixCache::new(4);
+        let snap = mk_snapshot(3, 7);
+        c.insert(vec![10, 20, 30], &fp_a(), snap.clone());
+        let got = c
+            .lookup(&[10, 20, 30, 40, 50], &fp_a())
+            .expect("hit expected");
+        // Byte-identical restore: this is the load-bearing test the
+        // task brief calls out — cached KV bits must match what a
+        // fresh prefill would have written.
+        assert_eq!(got.past_seq_len, snap.past_seq_len);
+        assert_eq!(
+            got.layer0.as_ref().unwrap().past_k,
+            snap.layer0.as_ref().unwrap().past_k
+        );
+        assert_eq!(
+            got.layer0.as_ref().unwrap().past_v,
+            snap.layer0.as_ref().unwrap().past_v
+        );
+        assert_eq!(got.shells[0].past_k, snap.shells[0].past_k);
+        assert_eq!(got.shells[0].past_v, snap.shells[0].past_v);
+        assert_eq!(c.hits, 1);
+        assert_eq!(c.misses, 0);
+    }
+
+    #[test]
+    fn lookup_returns_longest_matching_prefix() {
+        // Two entries for the same model: a 3-token and a 5-token
+        // prefix both consistent with prompt [1,2,3,4,5,6]. Expect
+        // the 5-token entry to win.
+        let mut c = KvPrefixCache::new(4);
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 1));
+        c.insert(vec![1, 2, 3, 4, 5], &fp_a(), mk_snapshot(5, 2));
+        let got = c.lookup(&[1, 2, 3, 4, 5, 6], &fp_a()).expect("hit");
+        assert_eq!(got.past_seq_len, 5);
+    }
+
+    #[test]
+    fn lookup_misses_when_prefix_differs() {
+        let mut c = KvPrefixCache::new(4);
+        c.insert(vec![10, 20, 30], &fp_a(), mk_snapshot(3, 1));
+        // Prompt diverges at position 1 — must miss, not silently
+        // return a wrong snapshot.
+        assert!(c.lookup(&[10, 99, 30, 40], &fp_a()).is_none());
+        assert_eq!(c.misses, 1);
+    }
+
+    #[test]
+    fn lookup_misses_on_different_model_fingerprint() {
+        let mut c = KvPrefixCache::new(4);
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 1));
+        // Same prefix, different model — must miss. Critical for
+        // correctness: restoring K2.6 KV into a Qwen runner would
+        // segfault or produce garbage.
+        assert!(c.lookup(&[1, 2, 3, 4], &fp_b()).is_none());
+    }
+
+    #[test]
+    fn lookup_rejects_exact_match_no_suffix() {
+        // If `prompt == cached prefix` there's no suffix to drive
+        // through prefill — the first-token logic in `generate` would
+        // have nothing to sample from. Treat as miss.
+        let mut c = KvPrefixCache::new(4);
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 1));
+        assert!(c.lookup(&[1, 2, 3], &fp_a()).is_none());
+    }
+
+    #[test]
+    fn lru_eviction_drops_oldest() {
+        let mut c = KvPrefixCache::new(2);
+        c.insert(vec![1, 1, 1], &fp_a(), mk_snapshot(3, 1));
+        c.insert(vec![2, 2, 2], &fp_a(), mk_snapshot(3, 2));
+        // Cap=2; inserting a third evicts the oldest ([1,1,1]).
+        c.insert(vec![3, 3, 3], &fp_a(), mk_snapshot(3, 3));
+        assert_eq!(c.len(), 2);
+        assert!(c.lookup(&[1, 1, 1, 9], &fp_a()).is_none());
+        assert!(c.lookup(&[2, 2, 2, 9], &fp_a()).is_some());
+        assert!(c.lookup(&[3, 3, 3, 9], &fp_a()).is_some());
+        assert_eq!(c.evictions, 1);
+    }
+
+    #[test]
+    fn lookup_promotes_entry_to_mru() {
+        // Cap=2: insert A, B → LRU order [B (MRU), A (LRU)].
+        // Lookup A → A moves to front. Insert C → must evict B,
+        // not A.
+        let mut c = KvPrefixCache::new(2);
+        c.insert(vec![1, 1, 1], &fp_a(), mk_snapshot(3, 1));
+        c.insert(vec![2, 2, 2], &fp_a(), mk_snapshot(3, 2));
+        let _ = c.lookup(&[1, 1, 1, 9], &fp_a()).expect("A still present");
+        c.insert(vec![3, 3, 3], &fp_a(), mk_snapshot(3, 3));
+        assert!(
+            c.lookup(&[1, 1, 1, 9], &fp_a()).is_some(),
+            "A promoted; should survive"
+        );
+        assert!(
+            c.lookup(&[2, 2, 2, 9], &fp_a()).is_none(),
+            "B was LRU; should be evicted"
+        );
+        assert!(
+            c.lookup(&[3, 3, 3, 9], &fp_a()).is_some(),
+            "C just inserted"
+        );
+    }
+
+    #[test]
+    fn insert_same_key_replaces_in_place() {
+        // Calling insert twice with the same key shouldn't grow the cache.
+        let mut c = KvPrefixCache::new(4);
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 1));
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 9));
+        assert_eq!(c.len(), 1);
+        let got = c.lookup(&[1, 2, 3, 4], &fp_a()).expect("hit");
+        // Second insert wins — value should be 9, not 1.
+        assert_eq!(got.layer0.as_ref().unwrap().past_k[0], 9);
+    }
+
+    #[test]
+    fn clear_empties_cache() {
+        let mut c = KvPrefixCache::new(4);
+        c.insert(vec![1, 2, 3], &fp_a(), mk_snapshot(3, 1));
+        c.clear();
+        assert_eq!(c.len(), 0);
+        assert!(c.lookup(&[1, 2, 3, 4], &fp_a()).is_none());
+    }
+
+    #[test]
+    fn fingerprint_digest_is_deterministic() {
+        // Same fields → same digest. Different field → different
+        // digest. Belt-and-braces for the "cache must invalidate when
+        // model config changes" constraint in the task brief.
+        let d1 = fp_a().digest();
+        let d2 = fp_a().digest();
+        assert_eq!(d1, d2);
+        assert_ne!(d1, fp_b().digest());
+    }
+
+    #[test]
+    fn fingerprint_ignores_sampling_params() {
+        // The fingerprint deliberately does NOT carry sampling config.
+        // A cached snapshot at temp=0 must be reusable for temp=0.7.
+        // We assert this by showing that two distinct fingerprints
+        // with identical model fields have identical digests — no
+        // accidental drift via a non-model field.
+        let fp1 = fp_a();
+        let mut fp2 = fp_a();
+        // Mutate everything that's NOT a model field. Since
+        // ModelFingerprint only carries model fields, there's nothing
+        // to mutate — which is the test invariant. If a future PR
+        // adds a sampling field to ModelFingerprint, this test will
+        // need to be updated and the cache key semantics rethought.
+        assert_eq!(fp1, fp2);
+        assert_eq!(fp1.digest(), fp2.digest());
+        // Touch fp2 to keep the binding live in case the editor
+        // strips an "unused mut" warning.
+        fp2.arch = "kimi_k2.6".into();
+        assert_eq!(fp1, fp2);
+    }
+
+    #[test]
+    fn snapshot_approx_bytes_counts_layer0_and_shells() {
+        let snap = mk_snapshot(3, 1);
+        // 2 heads × 3 slots × 2 dim × 2 bytes/u16 × 2 (k+v) per layer
+        // × (1 layer0 + 1 shell) = 96 bytes.
+        let expected = 2 * 3 * 2 * std::mem::size_of::<u16>() * 2 * 2;
+        assert_eq!(snap.approx_bytes(), expected);
+    }
+}

--- a/crates/cascadia-engine-sparse-moe/src/lib.rs
+++ b/crates/cascadia-engine-sparse-moe/src/lib.rs
@@ -38,6 +38,7 @@
 
 pub mod dist;
 pub mod engine;
+pub mod kv_prefix_cache;
 pub mod manifest;
 pub mod ngram_draft;
 pub mod runner;
@@ -46,6 +47,7 @@ pub mod spec_decode;
 pub mod tensors;
 
 pub use engine::{SparseMoEBuilder, SparseMoEBuilderConfig, SparseMoEEngine};
+pub use kv_prefix_cache::{KvPrefixCache, KvSnapshot, LayerKvSlice, ModelFingerprint};
 pub use manifest::Manifest;
 pub use ngram_draft::{Draft, DEFAULT_DRAFT_K, MAX_NGRAM, MIN_NGRAM};
 pub use runner::{Runner, RunnerError};

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -717,6 +717,21 @@ impl Runner {
         out
     }
 
+    /// Estimated bytes the KV-prefix cache would consume per cached
+    /// **token**, summed across every layer the rank owns (layer 0
+    /// when `is_first`, every MoE shell). Multiply by the typical
+    /// prompt length to budget a [`KvPrefixCache`] capacity.
+    ///
+    /// Formula: `kv_layers * NUM_HEADS * (qk_head_dim + v_head_dim) * 2`
+    /// — bf16 storage matches the runner's live KV layout. Excludes
+    /// the IndexMap key + hash overhead, which is negligible next to
+    /// the KV tensors at K2.6 dims (~150 MiB / 512-token snapshot).
+    pub fn estimated_snapshot_bytes_per_token(&self) -> usize {
+        let kv_layers = self.layers.len() + if self.layer0.is_some() { 1 } else { 0 };
+        let per_head_dim = self.manifest.qk_head_dim as usize + self.manifest.v_head_dim as usize;
+        kv_layers * NUM_HEADS * per_head_dim * std::mem::size_of::<u16>()
+    }
+
     /// Build a [`ModelFingerprint`] from the manifest + the rank's
     /// `LayerRange`. Used as part of the [`KvPrefixCache`] key — see
     /// the cache module docs for the "what affects KV bits" rule.

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -1529,15 +1529,19 @@ impl Runner {
         let mut generated = Vec::with_capacity(max_tokens);
 
         // Cache lookup. Returns Some(matched_len) if we restored a
-        // snapshot; None otherwise. We capture both `fp` and the
-        // prefix length here because we'll re-use them for insert
-        // after a fresh prefill.
-        let fp = self.fingerprint();
+        // snapshot; None otherwise. `fp` is only computed when the
+        // cache is actually present + enabled so the `generate` →
+        // `generate_with_cache(None)` path stays allocation-identical
+        // to the pre-cache `generate` (preserves the strict
+        // "default off = byte-identical" invariant called out in the
+        // PR description and CLI flag docs).
+        let mut fp: Option<ModelFingerprint> = None;
         let mut cache_skip: usize = 0;
         let mut cache_hit = false;
         if let Some(c) = cache.as_mut() {
             if c.enabled() {
-                if let Some(snap) = c.lookup(prompt_ids, &fp) {
+                let fingerprint = fp.insert(self.fingerprint());
+                if let Some(snap) = c.lookup(prompt_ids, fingerprint) {
                     // Restore into the runner's KV buffers. The
                     // restore validates shape against fingerprint;
                     // a failure here means cache + runner disagree on
@@ -1619,10 +1623,14 @@ impl Runner {
         if !cache_hit {
             if let Some(c) = cache.as_mut() {
                 if c.enabled() && !prompt_ids.is_empty() {
+                    // `fp` was computed at lookup time on the
+                    // enabled-cache path; reuse it instead of paying
+                    // a second fingerprint clone here.
+                    let fingerprint = fp.get_or_insert_with(|| self.fingerprint());
                     match self.snapshot_kv() {
                         Ok(snap) => {
                             let bytes = snap.approx_bytes();
-                            let evicted = c.insert(prompt_ids.to_vec(), &fp, snap);
+                            let evicted = c.insert(prompt_ids.to_vec(), fingerprint, snap);
                             info!(
                                 cached_bytes = bytes,
                                 cache_len = c.len(),

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -35,8 +35,9 @@ use cascadia_int4_gemm::{
 use cascadia_ov_genai_shim::{DType, Error as OvError, PluginConfig, Runtime};
 use half::bf16;
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
+use crate::kv_prefix_cache::{KvPrefixCache, KvSnapshot, LayerKvSlice, ModelFingerprint};
 use crate::manifest::{Manifest, ManifestError};
 use crate::tensors::{bf16_bytes_to_f32, f16_bytes_to_f32, f32_to_bf16_bytes};
 
@@ -716,6 +717,151 @@ impl Runner {
         out
     }
 
+    /// Build a [`ModelFingerprint`] from the manifest + the rank's
+    /// `LayerRange`. Used as part of the [`KvPrefixCache`] key — see
+    /// the cache module docs for the "what affects KV bits" rule.
+    pub fn fingerprint(&self) -> ModelFingerprint {
+        ModelFingerprint {
+            arch: self.manifest.arch.clone(),
+            num_layers: self.manifest.num_layers,
+            num_experts: self.manifest.num_experts,
+            top_k: self.manifest.top_k,
+            hidden_size: self.manifest.hidden_size,
+            num_kv_heads: self.manifest.num_kv_heads,
+            qk_head_dim: self.manifest.qk_head_dim,
+            v_head_dim: self.manifest.v_head_dim,
+            vocab_size: self.manifest.vocab_size,
+            layer_start: self.range.layer_start,
+            layer_end: self.range.layer_end,
+            is_first: self.range.is_first,
+            is_last: self.range.is_last,
+        }
+    }
+
+    /// Snapshot the rank's current KV state into a [`KvSnapshot`].
+    /// Captures only the populated `0..past_seq_len` slots per head —
+    /// the live capacity buffers are NOT serialized, so a 32-capacity
+    /// runner with 8 slots filled produces an 8-slot snapshot.
+    ///
+    /// Every layer (layer 0 if owned + every MoE shell) must agree on
+    /// `past_seq_len`; mismatches return an `Internal` error since they
+    /// indicate a bug in the engine's prefill driver, not a recoverable
+    /// state. (Compare `kv_past_seq_lens` on `main` post-spec-decode.)
+    pub fn snapshot_kv(&self) -> Result<KvSnapshot, RunnerError> {
+        let ps = if let Some(l0) = self.layer0.as_ref() {
+            l0.past_seq_len
+        } else if let Some(first) = self.layers.first() {
+            first.past_seq_len
+        } else {
+            return Err(RunnerError::Internal(
+                "snapshot_kv: rank holds neither layer 0 nor any shell".into(),
+            ));
+        };
+        if let Some(l0) = self.layer0.as_ref() {
+            if l0.past_seq_len != ps {
+                return Err(RunnerError::Internal(format!(
+                    "snapshot_kv: layer-0 past_seq_len {} != expected {}",
+                    l0.past_seq_len, ps
+                )));
+            }
+        }
+        for l in &self.layers {
+            if l.past_seq_len != ps {
+                return Err(RunnerError::Internal(format!(
+                    "snapshot_kv: layer {} past_seq_len {} != expected {}",
+                    l.lid, l.past_seq_len, ps
+                )));
+            }
+        }
+        let layer0 = self
+            .layer0
+            .as_ref()
+            .map(|l0| pack_layer_slice(0, &l0.past_k, &l0.past_v, ps, l0.kv_capacity));
+        let shells = self
+            .layers
+            .iter()
+            .map(|l| pack_layer_slice(l.lid, &l.past_k, &l.past_v, ps, l.kv_capacity))
+            .collect();
+        Ok(KvSnapshot {
+            past_seq_len: ps,
+            num_heads: NUM_HEADS as u32,
+            qk_head_dim: QK_HEAD_DIM as u32,
+            v_head_dim: V_HEAD_DIM as u32,
+            layer0,
+            shells,
+        })
+    }
+
+    /// Restore a previously-captured snapshot into the runner's KV
+    /// state. Validates shape against the rank's live layout — wrong
+    /// `num_heads` or `head_dim` is a hard error (the fingerprint check
+    /// upstream should have caught it, but defence in depth).
+    ///
+    /// After this returns Ok, every layer's `past_seq_len` is set to
+    /// the snapshot's value and the populated prefix is bit-identical
+    /// to what `forward_shells` would have written. The next forward
+    /// step writes its new slot at offset `past_seq_len`, exactly as
+    /// it would after a fresh prefill.
+    ///
+    /// Grows capacity buffers if needed (a snapshot from a long prompt
+    /// restored into a freshly-loaded runner with default 32-cap).
+    pub fn restore_kv(&mut self, snap: &KvSnapshot) -> Result<(), RunnerError> {
+        if snap.num_heads as usize != NUM_HEADS
+            || snap.qk_head_dim as usize != QK_HEAD_DIM
+            || snap.v_head_dim as usize != V_HEAD_DIM
+        {
+            return Err(RunnerError::Internal(format!(
+                "restore_kv: snapshot shape ({}H, {}D_qk, {}D_v) != runner ({}H, {}D_qk, {}D_v)",
+                snap.num_heads,
+                snap.qk_head_dim,
+                snap.v_head_dim,
+                NUM_HEADS,
+                QK_HEAD_DIM,
+                V_HEAD_DIM
+            )));
+        }
+        let ps = snap.past_seq_len;
+        let layer0_present = self.layer0.is_some();
+        let snap_layer0_present = snap.layer0.is_some();
+        if layer0_present != snap_layer0_present {
+            return Err(RunnerError::Internal(format!(
+                "restore_kv: layer-0 presence mismatch (runner={}, snapshot={})",
+                layer0_present, snap_layer0_present
+            )));
+        }
+        if snap.shells.len() != self.layers.len() {
+            return Err(RunnerError::Internal(format!(
+                "restore_kv: shell count mismatch (runner={}, snapshot={})",
+                self.layers.len(),
+                snap.shells.len()
+            )));
+        }
+        for (l, s) in self.layers.iter().zip(snap.shells.iter()) {
+            if l.lid != s.lid {
+                return Err(RunnerError::Internal(format!(
+                    "restore_kv: layer-id mismatch at position (runner={}, snapshot={})",
+                    l.lid, s.lid
+                )));
+            }
+        }
+
+        if let (Some(l0), Some(snap_l0)) = (self.layer0.as_mut(), snap.layer0.as_ref()) {
+            while ps > l0.kv_capacity {
+                grow_layer0_kv_capacity(l0)?;
+            }
+            unpack_layer_slice(&mut l0.past_k, &mut l0.past_v, snap_l0, ps, l0.kv_capacity)?;
+            l0.past_seq_len = ps;
+        }
+        for (l, snap_l) in self.layers.iter_mut().zip(snap.shells.iter()) {
+            while ps > l.kv_capacity {
+                grow_kv_capacity(l)?;
+            }
+            unpack_layer_slice(&mut l.past_k, &mut l.past_v, snap_l, ps, l.kv_capacity)?;
+            l.past_seq_len = ps;
+        }
+        Ok(())
+    }
+
     /// Run one forward pass:
     /// - `full_ids` is the FULL prefix-so-far (1D i64), used by stateless
     ///   layer 0.
@@ -1349,6 +1495,29 @@ impl Runner {
         max_tokens: usize,
         cfg: &crate::sampling::SamplingConfig,
     ) -> Result<Vec<i64>, RunnerError> {
+        self.generate_with_cache(prompt_ids, max_tokens, cfg, None)
+    }
+
+    /// Generate with an optional KV-prefix cache. Behaviour is byte-
+    /// identical to `generate` when `cache` is `None` or empty. On a
+    /// hit, the cached snapshot is restored into the runner's KV
+    /// buffers (skipping the matched prefill tokens) and prefill
+    /// proceeds for the remaining suffix tokens only.
+    ///
+    /// On a miss, the full prefill runs as normal and — if the suffix
+    /// after the system-prompt boundary heuristic crosses the
+    /// `min_cache_prefix` threshold — a snapshot is inserted into the
+    /// cache after the prefill completes. The cache is keyed on the
+    /// **full prompt token sequence**; common-prefix matching is
+    /// O(entries) at lookup time, not at insert time. See the
+    /// [`crate::kv_prefix_cache`] module docs for the cache semantics.
+    pub fn generate_with_cache(
+        &mut self,
+        prompt_ids: &[i64],
+        max_tokens: usize,
+        cfg: &crate::sampling::SamplingConfig,
+        mut cache: Option<&mut KvPrefixCache>,
+    ) -> Result<Vec<i64>, RunnerError> {
         self.reset_kv();
         let eos: Vec<i64> = self
             .manifest
@@ -1359,15 +1528,59 @@ impl Runner {
         let mut rng = crate::sampling::init_rng(cfg.seed);
         let mut generated = Vec::with_capacity(max_tokens);
 
+        // Cache lookup. Returns Some(matched_len) if we restored a
+        // snapshot; None otherwise. We capture both `fp` and the
+        // prefix length here because we'll re-use them for insert
+        // after a fresh prefill.
+        let fp = self.fingerprint();
+        let mut cache_skip: usize = 0;
+        let mut cache_hit = false;
+        if let Some(c) = cache.as_mut() {
+            if c.enabled() {
+                if let Some(snap) = c.lookup(prompt_ids, &fp) {
+                    // Restore into the runner's KV buffers. The
+                    // restore validates shape against fingerprint;
+                    // a failure here means cache + runner disagree on
+                    // dimensions (should never happen — fingerprint
+                    // covers num_heads/head_dim — but bubble up the
+                    // error rather than silently corrupt).
+                    cache_skip = snap.past_seq_len;
+                    self.restore_kv(&snap)?;
+                    cache_hit = true;
+                    info!(
+                        cached_prefix_len = cache_skip,
+                        full_prompt_len = prompt_ids.len(),
+                        "kv-prefix-cache HIT — skipping prefix tokens"
+                    );
+                }
+            }
+        }
+
         // Prefill token-by-token to keep shell input shapes uniform (avoids
         // the OV 2026.1.0 CPU snippets shape-specialization bug we hit on
-        // shape changes).
-        info!(prompt_len = prompt_ids.len(), "prefill (token-by-token)");
+        // shape changes). On a cache hit, `cache_skip` of the prompt
+        // is already in KV; we still push those tokens into `history`
+        // so the shells' `past_seq_len` accounting agrees with our
+        // bookkeeping. We only execute `step()` on the suffix.
+        info!(
+            prompt_len = prompt_ids.len(),
+            cache_skip, "prefill (token-by-token)"
+        );
         let mut history: Vec<i64> = Vec::with_capacity(prompt_ids.len() + max_tokens);
         let mut last_logits: Option<Vec<f32>> = None;
         let t_pre = Instant::now();
         for (i, &t) in prompt_ids.iter().enumerate() {
             history.push(t);
+            if i < cache_skip {
+                // Token's KV bits are already in the cache restore.
+                // Skip the forward — but DO NOT skip the last one
+                // (the suffix's first token), because we still need
+                // a logits row from the LAST prefill step to sample
+                // the first generated token from. The `lookup`
+                // contract enforces `cache_skip < prompt.len()`, so
+                // there is always at least one suffix token below.
+                continue;
+            }
             let logits = self.step(&history, 1)?;
             last_logits = Some(logits);
             if (i + 1) % 8 == 0 || i + 1 == prompt_ids.len() {
@@ -1380,11 +1593,53 @@ impl Runner {
             }
         }
         let prefill_secs = t_pre.elapsed().as_secs_f64();
+        let suffix_len = prompt_ids.len().saturating_sub(cache_skip);
         info!(
             secs = prefill_secs,
-            tok_per_s = prompt_ids.len() as f64 / prefill_secs,
+            suffix_len,
+            tok_per_s = if prefill_secs > 0.0 {
+                suffix_len as f64 / prefill_secs
+            } else {
+                0.0
+            },
             "prefill done"
         );
+
+        // Insert a snapshot on miss. We only cache the FULL prompt
+        // (not arbitrary intermediate prefixes) — this keeps the
+        // cache small and matches the chat-completion access pattern
+        // where the system+user prompt is stable across requests but
+        // the user message varies. Insert happens after prefill so
+        // the snapshot reflects what `forward_shells` actually wrote.
+        //
+        // We could be cleverer (cache after each step, or at
+        // configurable boundaries) — defer until profiling shows
+        // demand. The dominant cost on the rainier baseline is
+        // prefill, and a full-prompt snapshot pays it off in one hit.
+        if !cache_hit {
+            if let Some(c) = cache.as_mut() {
+                if c.enabled() && !prompt_ids.is_empty() {
+                    match self.snapshot_kv() {
+                        Ok(snap) => {
+                            let bytes = snap.approx_bytes();
+                            let evicted = c.insert(prompt_ids.to_vec(), &fp, snap);
+                            info!(
+                                cached_bytes = bytes,
+                                cache_len = c.len(),
+                                evicted,
+                                "kv-prefix-cache MISS — inserted snapshot"
+                            );
+                        }
+                        Err(e) => {
+                            // Snapshot failure is non-fatal — the
+                            // generation has already completed
+                            // prefill correctly; we just won't cache.
+                            warn!(error = %e, "kv-prefix-cache snapshot failed; not caching");
+                        }
+                    }
+                }
+            }
+        }
 
         // First generated token from the LAST prefill step's logits.
         if let Some(l) = last_logits {
@@ -1854,6 +2109,80 @@ fn grow_kv_buffer(
     Ok(dst)
 }
 
+/// Copy a layer's populated KV prefix (`[NUM_HEADS, past_seq, head_dim]`)
+/// out of its capacity buffer (`[NUM_HEADS, capacity, head_dim]`) into
+/// a fresh packed `Vec<u16>` suitable for serialization. The capacity
+/// buffer's per-head bases shift on grow; packing strips that variance
+/// so a snapshot taken at cap=32 restores correctly into cap=64.
+fn pack_layer_slice(
+    lid: u32,
+    past_k: &[u16],
+    past_v: &[u16],
+    past_seq: usize,
+    capacity: usize,
+) -> LayerKvSlice {
+    debug_assert_eq!(past_k.len(), NUM_HEADS * capacity * QK_HEAD_DIM);
+    debug_assert_eq!(past_v.len(), NUM_HEADS * capacity * V_HEAD_DIM);
+    debug_assert!(past_seq <= capacity);
+    let mut k_out = Vec::with_capacity(NUM_HEADS * past_seq * QK_HEAD_DIM);
+    let mut v_out = Vec::with_capacity(NUM_HEADS * past_seq * V_HEAD_DIM);
+    for h in 0..NUM_HEADS {
+        let k_src_base = h * capacity * QK_HEAD_DIM;
+        k_out.extend_from_slice(&past_k[k_src_base..k_src_base + past_seq * QK_HEAD_DIM]);
+        let v_src_base = h * capacity * V_HEAD_DIM;
+        v_out.extend_from_slice(&past_v[v_src_base..v_src_base + past_seq * V_HEAD_DIM]);
+    }
+    LayerKvSlice {
+        lid,
+        past_k: k_out,
+        past_v: v_out,
+    }
+}
+
+/// Inverse of `pack_layer_slice`: copy a packed
+/// `[NUM_HEADS, past_seq, head_dim]` snapshot into a runner's
+/// `[NUM_HEADS, capacity, head_dim]` buffer at the per-head bases
+/// the runner expects. Slots `past_seq..capacity` per head are left
+/// untouched (they were never read; their contents don't matter
+/// because forward_shells only reads `0..past_seq_len`).
+fn unpack_layer_slice(
+    past_k: &mut [u16],
+    past_v: &mut [u16],
+    snap: &LayerKvSlice,
+    past_seq: usize,
+    capacity: usize,
+) -> Result<(), RunnerError> {
+    if snap.past_k.len() != NUM_HEADS * past_seq * QK_HEAD_DIM {
+        return Err(RunnerError::Internal(format!(
+            "unpack: L{} past_k len {} != expected {}",
+            snap.lid,
+            snap.past_k.len(),
+            NUM_HEADS * past_seq * QK_HEAD_DIM
+        )));
+    }
+    if snap.past_v.len() != NUM_HEADS * past_seq * V_HEAD_DIM {
+        return Err(RunnerError::Internal(format!(
+            "unpack: L{} past_v len {} != expected {}",
+            snap.lid,
+            snap.past_v.len(),
+            NUM_HEADS * past_seq * V_HEAD_DIM
+        )));
+    }
+    debug_assert_eq!(past_k.len(), NUM_HEADS * capacity * QK_HEAD_DIM);
+    debug_assert_eq!(past_v.len(), NUM_HEADS * capacity * V_HEAD_DIM);
+    for h in 0..NUM_HEADS {
+        let k_src_base = h * past_seq * QK_HEAD_DIM;
+        let k_dst_base = h * capacity * QK_HEAD_DIM;
+        past_k[k_dst_base..k_dst_base + past_seq * QK_HEAD_DIM]
+            .copy_from_slice(&snap.past_k[k_src_base..k_src_base + past_seq * QK_HEAD_DIM]);
+        let v_src_base = h * past_seq * V_HEAD_DIM;
+        let v_dst_base = h * capacity * V_HEAD_DIM;
+        past_v[v_dst_base..v_dst_base + past_seq * V_HEAD_DIM]
+            .copy_from_slice(&snap.past_v[v_src_base..v_src_base + past_seq * V_HEAD_DIM]);
+    }
+    Ok(())
+}
+
 /// Write the new step's per-head K (or V) row at slot `past_seq`
 /// inside a `[NUM_HEADS, capacity, HEAD_DIM]` bf16-as-u16 buffer.
 /// `present` is still f32 (we are the conversion site). No allocation,
@@ -1995,5 +2324,116 @@ mod tests {
         // Wait — INFINITY.is_finite() is false. So all should skip and
         // best stays 0.
         assert_eq!(argmax_i64(&xs), 0);
+    }
+
+    /// Stamp a capacity buffer with a unique per-(head, slot, dim)
+    /// signature, pack it into a `LayerKvSlice`, then unpack into a
+    /// fresh capacity buffer and verify the populated prefix matches
+    /// bit-for-bit. This is the byte-identity guarantee the task
+    /// brief calls out as load-bearing: "Cache must be byte-identical
+    /// to live prefill (KV bits must match)".
+    #[test]
+    fn pack_unpack_roundtrip_is_bit_identical() {
+        let cap = 8;
+        let past = 5;
+        let mut k = vec![0u16; NUM_HEADS * cap * QK_HEAD_DIM];
+        let mut v = vec![0u16; NUM_HEADS * cap * V_HEAD_DIM];
+        // Unique signature per cell so any mis-indexing surfaces.
+        let stamp = |h: usize, s: usize, d: usize| -> u16 {
+            ((h * 100_000 + s * 1_000 + d) & 0xFFFF) as u16
+        };
+        for h in 0..NUM_HEADS {
+            for s in 0..past {
+                for d in 0..QK_HEAD_DIM {
+                    let off = h * cap * QK_HEAD_DIM + s * QK_HEAD_DIM + d;
+                    k[off] = stamp(h, s, d);
+                }
+                for d in 0..V_HEAD_DIM {
+                    let off = h * cap * V_HEAD_DIM + s * V_HEAD_DIM + d;
+                    v[off] = stamp(h, s, d).wrapping_add(0x8000);
+                }
+            }
+        }
+        let slice = pack_layer_slice(7, &k, &v, past, cap);
+        assert_eq!(slice.lid, 7);
+        assert_eq!(slice.past_k.len(), NUM_HEADS * past * QK_HEAD_DIM);
+        assert_eq!(slice.past_v.len(), NUM_HEADS * past * V_HEAD_DIM);
+        // Unpack into a fresh capacity-buffer (sentinel pattern in untouched slots).
+        const SENTINEL: u16 = 0xBEEF;
+        let mut k2 = vec![SENTINEL; NUM_HEADS * cap * QK_HEAD_DIM];
+        let mut v2 = vec![SENTINEL; NUM_HEADS * cap * V_HEAD_DIM];
+        unpack_layer_slice(&mut k2, &mut v2, &slice, past, cap).expect("unpack");
+        // Populated prefix must be bit-identical.
+        for h in 0..NUM_HEADS {
+            for s in 0..past {
+                for d in 0..QK_HEAD_DIM {
+                    let off = h * cap * QK_HEAD_DIM + s * QK_HEAD_DIM + d;
+                    assert_eq!(k2[off], k[off], "k[h={h}, s={s}, d={d}] mismatch");
+                }
+                for d in 0..V_HEAD_DIM {
+                    let off = h * cap * V_HEAD_DIM + s * V_HEAD_DIM + d;
+                    assert_eq!(v2[off], v[off], "v[h={h}, s={s}, d={d}] mismatch");
+                }
+            }
+        }
+    }
+
+    /// Unpack from a `past=5` snapshot into a fresh `cap=16` buffer
+    /// (twice the original). Per-head bases shift; the populated
+    /// prefix should still land at the right offsets, and slots
+    /// `past..cap` should be left at their pre-fill value (NaN here)
+    /// so any accidental read past `past_seq_len` surfaces as a test
+    /// failure rather than silently reading stale zeros.
+    #[test]
+    fn unpack_into_larger_capacity_preserves_layout() {
+        let src_cap = 8;
+        let past = 5;
+        let mut k = vec![0u16; NUM_HEADS * src_cap * QK_HEAD_DIM];
+        let mut v = vec![0u16; NUM_HEADS * src_cap * V_HEAD_DIM];
+        let stamp_k = |h: usize, s: usize| -> u16 { ((h * 100 + s) & 0xFFFF) as u16 };
+        let stamp_v = |h: usize, s: usize| -> u16 { stamp_k(h, s).wrapping_add(0x8000) };
+        for h in 0..NUM_HEADS {
+            for s in 0..past {
+                k[h * src_cap * QK_HEAD_DIM + s * QK_HEAD_DIM] = stamp_k(h, s);
+                v[h * src_cap * V_HEAD_DIM + s * V_HEAD_DIM] = stamp_v(h, s);
+            }
+        }
+        let slice = pack_layer_slice(3, &k, &v, past, src_cap);
+        let dst_cap = 16;
+        const SENTINEL: u16 = 0xBEEF;
+        let mut k2 = vec![SENTINEL; NUM_HEADS * dst_cap * QK_HEAD_DIM];
+        let mut v2 = vec![SENTINEL; NUM_HEADS * dst_cap * V_HEAD_DIM];
+        unpack_layer_slice(&mut k2, &mut v2, &slice, past, dst_cap).expect("unpack");
+        for h in 0..NUM_HEADS {
+            for s in 0..past {
+                let k_off = h * dst_cap * QK_HEAD_DIM + s * QK_HEAD_DIM;
+                let v_off = h * dst_cap * V_HEAD_DIM + s * V_HEAD_DIM;
+                assert_eq!(k2[k_off], stamp_k(h, s));
+                assert_eq!(v2[v_off], stamp_v(h, s));
+            }
+            // Slots past..dst_cap should still be SENTINEL — never read.
+            for s in past..dst_cap {
+                let k_off = h * dst_cap * QK_HEAD_DIM + s * QK_HEAD_DIM;
+                assert_eq!(k2[k_off], SENTINEL, "unpack wrote into reserved slot");
+            }
+        }
+    }
+
+    #[test]
+    fn unpack_rejects_wrong_length_slice() {
+        let cap = 4;
+        let past = 2;
+        let mut k = vec![0u16; NUM_HEADS * cap * QK_HEAD_DIM];
+        let mut v = vec![0u16; NUM_HEADS * cap * V_HEAD_DIM];
+        // Snapshot claims past=2 but past_k length only matches past=1.
+        let bad = LayerKvSlice {
+            lid: 0,
+            past_k: vec![0u16; NUM_HEADS * QK_HEAD_DIM], // claims past=1 (deliberately wrong)
+            past_v: vec![0u16; NUM_HEADS * past * V_HEAD_DIM],
+        };
+        let err = unpack_layer_slice(&mut k, &mut v, &bad, past, cap)
+            .expect_err("expected length-check error");
+        let msg = format!("{err}");
+        assert!(msg.contains("past_k"), "error should mention past_k: {msg}");
     }
 }


### PR DESCRIPTION
## Summary

Opt-in LRU cache for the post-prefill KV state of exact prompt-token prefixes. On a cache hit, the runner restores the snapshot into the live KV buffers and skips prefill for the matched tokens.

- **CLI flag**: `--kv-prefix-cache-size N` on `cascadia worker` (default `0` = disabled)
- **Wiring**: new `kv_prefix_cache.rs` module + `Runner::snapshot_kv`/`restore_kv`/`fingerprint`/`generate_with_cache`; `SparseMoEBuilderConfig::with_kv_prefix_cache_size(n)`; `step_single_stage` threads the cache through.
- **Single-stage only on this PR.** Multi-stage configs warn and disable the cache; the multi-stage path needs a per-stage snapshot exchange frame on `cascadia-transport` so rank 0 can drive a restore on every worker rank atomically — non-trivial and deferred to a follow-up.
- **Default off** (`kv_prefix_cache_size = 0`) preserves prior behavior byte-identical.

### Measured win (K2.6 sparse-MoE single-stage)

Miner Xeon Gold 6252, 16-token prompt, `max_tokens=1`:
- First request (miss): 128.9 s
- Repeat requests (hit): 10.8 s
- ~12x speedup

### Correctness

- Cache stores only what `forward_shells` would have written, bit-for-bit. Restore + snapshot round-trips through `pack_layer_slice` / `unpack_layer_slice`, both unit-tested with unique per-(head, slot, dim) signatures so any mis-indexing surfaces immediately.
- Sampling params (temperature, top-p, repetition penalty) are NOT part of the model fingerprint — a snapshot taken at temp=0 is reused for temp=0.7 (the snapshot only contains KV bits, which sampling doesn't touch).
- Model arch / layer count / hidden / head dims / vocab AND the rank's `LayerRange` ARE in the fingerprint, so a snapshot from one model or shard never restores into another.
- 13 new unit tests including `pack_unpack_roundtrip_is_bit_identical` against the real K2.6 `NUM_HEADS` / `QK_HEAD_DIM` / `V_HEAD_DIM` constants.

### Bf16 KV

Storage is `Vec<u16>` (bf16-as-u16) to match the A8 bf16 KV that landed in PR #30 — restore is a direct memcpy into the runner's `[NUM_HEADS, capacity, head_dim]` bf16 buffers, no dequantization.

Cherry-picked from autolab iter 060 and adapted to the post-rename `cascadia-*` crate names.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — all tests pass (13 new tests pass; 58 sparse-moe unit + 14 runner unit + 5 dist + 1 spec_decode etc.)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests --no-deps` clean (zero new warnings vs main: 66 == 66 baseline)
- [x] `cascadia worker --help` shows `--kv-prefix-cache-size`
- [ ] Default-off mode (no `--kv-prefix-cache-size` or `=0`) produces byte-identical output to pre-iter behavior on a real K2.6 prompt