### PR TITLE
perf: AXPY-form sparse FFN down kernel + FfnScratch (#35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "cascadia-runner",
  "cascadia-types",
  "clap",
+ "dirs 5.0.1",
  "futures",
  "hyper",
  "hyper-util",
@@ -705,11 +706,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -720,7 +742,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1040,7 +1062,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "futures",
  "http",
  "indicatif",
@@ -1994,6 +2016,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3156,6 +3189,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3188,6 +3230,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3225,6 +3282,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3237,6 +3300,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3246,6 +3315,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3273,6 +3348,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3282,6 +3363,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3297,6 +3384,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3306,6 +3399,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -197,6 +197,25 @@ pub struct WorkerArgs {
     /// approach. See rainier `docs/POWERINFER_PORT.md`.
     #[arg(long, default_value_t = 0.0, env = "CASCADIA_FFN_SPARSITY_THRESHOLD")]
     pub ffn_sparsity_threshold: f32,
+
+    /// Issue #35 — use the AXPY-form down kernel for the sparse FFN
+    /// path. Only meaningful when `--ffn-sparsity-threshold > 0`.
+    ///
+    /// In the AXPY form, the down projection becomes
+    /// `y += silu(gate)[r] * up[r] * down_t[r]` accumulated over only
+    /// the active intermediate lanes `r`. Inactive lanes are skipped
+    /// entirely — no FMA, no weight load. Kernel speedup ceiling
+    /// `1 / active_frac` vs the dense down projection.
+    ///
+    /// Cost: each cached expert builds a transposed-and-requantized
+    /// down weight on first use (~5 ms CPU + ~8.26 MiB extra heap
+    /// per cached expert at K2.6 dimensions). The transposed cache
+    /// shares `--max-cached-experts` as its capacity.
+    ///
+    /// Ports PowerInfer SmallThinker `fused_sparse_moe.cpp:174-186`
+    /// (MIT). See rainier `docs/POWERINFER_PORT.md`.
+    #[arg(long, default_value_t = false, env = "CASCADIA_FFN_AXPY_DOWN")]
+    pub ffn_axpy_down: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -422,6 +441,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             cfg.routing_threshold = args.routing_threshold;
             cfg.max_cached_experts = args.max_cached_experts;
             cfg.ffn_sparsity_threshold = args.ffn_sparsity_threshold;
+            cfg.ffn_axpy_down = args.ffn_axpy_down;
             // N-gram speculative decode (sparse-moe single-stage).
             // The `--prompt-lookup` flag is the canonical opt-in (it
             // already drives the ov-genai prompt-lookup path); when

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -216,6 +216,15 @@ pub struct WorkerArgs {
     /// (MIT). See rainier `docs/POWERINFER_PORT.md`.
     #[arg(long, default_value_t = false, env = "CASCADIA_FFN_AXPY_DOWN")]
     pub ffn_axpy_down: bool,
+
+    /// Pre-build the AXPY transposed-down cache for every
+    /// `(layer, expert)` at Runner construction (slow one-time
+    /// cost; avoids per-prompt build latency thereafter). Only
+    /// meaningful with `--ffn-axpy-down` enabled. K2.6 prebuild
+    /// is ~20 s with rayon; disk: ~190 GiB on top of the model.
+    /// Recommended for production deployments with diverse prompts.
+    #[arg(long, default_value_t = false, env = "CASCADIA_FFN_AXPY_PREBUILD")]
+    pub ffn_axpy_prebuild: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -442,6 +451,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             cfg.max_cached_experts = args.max_cached_experts;
             cfg.ffn_sparsity_threshold = args.ffn_sparsity_threshold;
             cfg.ffn_axpy_down = args.ffn_axpy_down;
+            cfg.ffn_axpy_prebuild = args.ffn_axpy_prebuild;
             // N-gram speculative decode (sparse-moe single-stage).
             // The `--prompt-lookup` flag is the canonical opt-in (it
             // already drives the ov-genai prompt-lookup path); when

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -85,10 +85,19 @@ pub struct SparseMoEBuilderConfig {
     pub ffn_sparsity_threshold: f32,
     /// Issue #35 — use the AXPY-form down kernel from
     /// [`cascadia_int4_gemm::ffn_axpy`] in the sparse FFN path. Only
-    /// active when [`Self::ffn_sparsity_threshold`] > 0. Each cached
-    /// expert builds + holds a transposed-and-requantized down
-    /// weight (one-time ~5 ms CPU per expert; ~8.26 MiB extra heap).
+    /// active when [`Self::ffn_sparsity_threshold`] > 0. Per-expert
+    /// transposed-and-requantized down weights are persisted to
+    /// [`Self::ffn_axpy_cache_dir`] (default
+    /// `<model_dir>/.cascadia_transposed_down_v1/`) and mmap'd at
+    /// runtime — this is the on-disk-cache fix that addresses PR #43's
+    /// initial mmap-page-cache-eviction regression (see rainier
+    /// `docs/AXPY_REGRESSION_ANALYSIS.md`).
     pub ffn_axpy_down: bool,
+    /// Override location for the AXPY-form transposed-down cache.
+    /// `None` ⇒ `<model_dir>/.cascadia_transposed_down_v1/`. Set
+    /// to a fast local NVMe path if the model directory is on a
+    /// slow / read-only mount.
+    pub ffn_axpy_cache_dir: Option<PathBuf>,
 }
 
 impl SparseMoEBuilderConfig {
@@ -110,6 +119,7 @@ impl SparseMoEBuilderConfig {
             kv_prefix_cache_size: 0,
             ffn_sparsity_threshold: 0.0,
             ffn_axpy_down: false,
+            ffn_axpy_cache_dir: None,
         }
     }
 
@@ -202,6 +212,7 @@ pub(crate) fn resolve_runner_options(cfg: &SparseMoEBuilderConfig) -> RunnerOpti
         max_cached_experts,
         ffn_sparsity_threshold: cfg.ffn_sparsity_threshold,
         ffn_axpy_down: cfg.ffn_axpy_down,
+        ffn_axpy_cache_dir: cfg.ffn_axpy_cache_dir.clone(),
     }
 }
 

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -83,6 +83,12 @@ pub struct SparseMoEBuilderConfig {
     /// Useful range for SwiGLU: 0.05–0.15. Higher = more skip + lower
     /// quality. See rainier `docs/POWERINFER_PORT.md`.
     pub ffn_sparsity_threshold: f32,
+    /// Issue #35 — use the AXPY-form down kernel from
+    /// [`cascadia_int4_gemm::ffn_axpy`] in the sparse FFN path. Only
+    /// active when [`Self::ffn_sparsity_threshold`] > 0. Each cached
+    /// expert builds + holds a transposed-and-requantized down
+    /// weight (one-time ~5 ms CPU per expert; ~8.26 MiB extra heap).
+    pub ffn_axpy_down: bool,
 }
 
 impl SparseMoEBuilderConfig {
@@ -103,6 +109,7 @@ impl SparseMoEBuilderConfig {
             spec_decode_k: None,
             kv_prefix_cache_size: 0,
             ffn_sparsity_threshold: 0.0,
+            ffn_axpy_down: false,
         }
     }
 
@@ -148,6 +155,15 @@ impl SparseMoEBuilderConfig {
         self.ffn_sparsity_threshold = if t > 0.0 { t } else { 0.0 };
         self
     }
+
+    /// Issue #35 — enable the AXPY-form down kernel. Only has an
+    /// effect when `ffn_sparsity_threshold > 0`. Lazily builds + caches
+    /// transposed-and-requantized down weights per expert (~8.26 MiB
+    /// extra heap per cached expert at K2.6 dimensions).
+    pub fn with_ffn_axpy_down(mut self, on: bool) -> Self {
+        self.ffn_axpy_down = on;
+        self
+    }
 }
 
 /// Build the [`RunnerOptions`] from the engine config + environment.
@@ -185,6 +201,7 @@ pub(crate) fn resolve_runner_options(cfg: &SparseMoEBuilderConfig) -> RunnerOpti
     RunnerOptions {
         max_cached_experts,
         ffn_sparsity_threshold: cfg.ffn_sparsity_threshold,
+        ffn_axpy_down: cfg.ffn_axpy_down,
     }
 }
 
@@ -359,6 +376,7 @@ impl Builder for SparseMoEBuilder {
         runner.set_top_k_override(self.config.top_k_override);
         runner.set_routing_threshold(self.config.routing_threshold);
         runner.set_ffn_sparsity_threshold(self.config.ffn_sparsity_threshold);
+        runner.set_ffn_axpy_down(self.config.ffn_axpy_down);
 
         // Tokenizer is only needed on rank 0 (the API rank).
         if rank == 0 {

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -98,6 +98,14 @@ pub struct SparseMoEBuilderConfig {
     /// to a fast local NVMe path if the model directory is on a
     /// slow / read-only mount.
     pub ffn_axpy_cache_dir: Option<PathBuf>,
+    /// When `true`, eagerly pre-build the AXPY transposed-down
+    /// cache for every `(layer, expert)` this rank may dispatch,
+    /// at `Builder::build` time. Avoids the in-line build cost on
+    /// the first prompt that touches each expert (recommended for
+    /// diverse-prompt production workloads). At K2.6 dimensions
+    /// the prebuild cost is ~7 min single-threaded or ~20 s with
+    /// rayon; disk cost ~190 GiB on top of the model.
+    pub ffn_axpy_prebuild: bool,
 }
 
 impl SparseMoEBuilderConfig {
@@ -120,6 +128,7 @@ impl SparseMoEBuilderConfig {
             ffn_sparsity_threshold: 0.0,
             ffn_axpy_down: false,
             ffn_axpy_cache_dir: None,
+            ffn_axpy_prebuild: false,
         }
     }
 
@@ -208,6 +217,9 @@ pub(crate) fn resolve_runner_options(cfg: &SparseMoEBuilderConfig) -> RunnerOpti
         resolved = ?max_cached_experts.map(NonZeroUsize::get),
         "resolved expert-cache LRU cap (None = unbounded)"
     );
+    // `ffn_axpy_prebuild` is consumed in `Builder::build` after the
+    // Runner is constructed, not via RunnerOptions — keeps the
+    // Runner constructor side-effect-free.
     RunnerOptions {
         max_cached_experts,
         ffn_sparsity_threshold: cfg.ffn_sparsity_threshold,
@@ -388,6 +400,11 @@ impl Builder for SparseMoEBuilder {
         runner.set_routing_threshold(self.config.routing_threshold);
         runner.set_ffn_sparsity_threshold(self.config.ffn_sparsity_threshold);
         runner.set_ffn_axpy_down(self.config.ffn_axpy_down);
+        if self.config.ffn_axpy_prebuild {
+            runner
+                .prebuild_axpy_cache()
+                .map_err(|e| EngineError::Backend(format!("AXPY prebuild: {e}")))?;
+        }
 
         // Tokenizer is only needed on rank 0 (the API rank).
         if rank == 0 {

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use lru::LruCache;
 
-use cascadia_int4_gemm::ffn_axpy::{transpose_requantize_down, FfnScratch as IntFfnScratch};
+use cascadia_int4_gemm::ffn_axpy::FfnScratch as IntFfnScratch;
 use cascadia_int4_gemm::ffn_sparsity::ffn_forward_sparse_axpy_f32;
 use cascadia_int4_gemm::layer0_int4::{
     embed_token_bf16, layer0_forward_decode_int4_multi_with_capacity,
@@ -32,6 +32,7 @@ use cascadia_int4_gemm::shell_int4::{
     shell_forward_decode_int4_multi_with_capacity, shell_forward_decode_int4_with_capacity_sparse,
     Int4Shell,
 };
+use cascadia_int4_gemm::transposed_down_store::TransposedDownStore;
 use cascadia_int4_gemm::{
     expert_forward_sparse as int4_expert_forward_sparse, f32_to_bf16_bits, ExpertWeights,
     SafetensorsExpert, SafetensorsExpertSource,
@@ -258,34 +259,6 @@ impl SafetensorsExpertCache {
     }
 }
 
-/// AXPY-form down weight: the original `[hidden, intermediate]` down
-/// matrix transposed and re-quantized into `[intermediate, hidden]`
-/// int4 layout for [`ffn_forward_sparse_axpy_f32`]. Built lazily on
-/// first sparse-AXPY dispatch per expert and held in
-/// `Runner::transposed_down_cache`. Memory cost: ~8.26 MiB per cached
-/// expert at K2.6 dimensions (same as the original down — the
-/// transpose is in-place size-wise).
-struct TransposedDown {
-    packed_t: Vec<u8>,
-    scale_t_bits: Vec<u8>,
-}
-
-impl TransposedDown {
-    fn build(
-        down_packed: &[u8],
-        down_scale_bits: &[u8],
-        n_hidden: usize,
-        n_intermediate: usize,
-    ) -> Self {
-        let (packed_t, scale_t_bits) =
-            transpose_requantize_down(down_packed, down_scale_bits, n_hidden, n_intermediate);
-        Self {
-            packed_t,
-            scale_t_bits,
-        }
-    }
-}
-
 /// autolab iter 029 (C1): one prefetch request — kindly hint the kernel
 /// to start reading the weights for expert `eid` on layer `lid`. The
 /// prefetcher thread translates this into `madvise(MADV_WILLNEED)` calls
@@ -406,12 +379,20 @@ pub struct RunnerOptions {
     /// When `true` (and `ffn_sparsity_threshold > 0`), use the AXPY-
     /// form down kernel from [`cascadia_int4_gemm::ffn_axpy`]: each
     /// expert's down weight is transposed and re-quantized at first
-    /// use; the down projection becomes an AXPY over only the active
-    /// intermediate lanes (kernel speedup ceiling 1/active_frac vs
-    /// dense). Memory cost: one extra down-sized buffer per cached
-    /// expert (~8.26 MiB on K2.6); the transposed cache shares
-    /// [`Self::max_cached_experts`] as its capacity.
+    /// use, persisted to disk in
+    /// [`Self::ffn_axpy_cache_dir`], then mmap'd at runtime.
+    /// The kernel speedup ceiling is `1 / active_frac` vs the dense
+    /// down; the on-disk cache prevents the page-cache eviction
+    /// regression an in-memory cache caused (PR #43 post-mortem:
+    /// rainier `docs/AXPY_REGRESSION_ANALYSIS.md`).
     pub ffn_axpy_down: bool,
+    /// Directory where the AXPY-form transposed-and-requantized
+    /// down weights are persisted. `None` ⇒ default
+    /// `<model_dir>/.cascadia_transposed_down_v1/` (sibling of the
+    /// model). If the directory cannot be created or written, the
+    /// runner logs a warning and falls back to the dense path for
+    /// the duration of the run.
+    pub ffn_axpy_cache_dir: Option<std::path::PathBuf>,
 }
 
 /// Per-rank slice of the model the Runner should hold.
@@ -483,14 +464,23 @@ pub struct Runner {
     ffn_sparsity_threshold: f32,
     /// PowerInfer port (issue #35): when true, use the AXPY-form down
     /// kernel from [`cascadia_int4_gemm::ffn_axpy`]. Requires per-
-    /// expert transposed-and-requantized down weights, built lazily
-    /// into `transposed_down_cache` on first use.
+    /// expert transposed-and-requantized down weights, lazily built
+    /// + persisted to disk + mmap'd via
+    /// [`crate::runner::Runner::transposed_down_store`].
     ffn_axpy_down: bool,
-    /// LRU of per-expert transposed-and-requantized down weights
-    /// (one [`TransposedDown`] per `(layer, expert)`). Populated only
-    /// when `ffn_axpy_down` is true. Shares
-    /// [`RunnerOptions::max_cached_experts`] as the LRU bound.
-    transposed_down_cache: LruCache<(u32, u32), TransposedDown>,
+    /// **On-disk** cache of per-expert transposed-and-requantized
+    /// down weights — the fix for PR #43's mmap page-cache eviction
+    /// regression. Each entry mmaps a `.cxd` file from the cache
+    /// directory; the pages compete in the same LRU as the model
+    /// mmap rather than pinning anon memory. `None` when AXPY is
+    /// disabled or the cache directory isn't writable (the runner
+    /// logs + falls back to the dense path in that case).
+    ///
+    /// On miner-class storage (NVMe) first-touch cost: ~6 ms to
+    /// build + write 8.26 MiB per expert; subsequent dispatches
+    /// across process restarts pay only the mmap-fault cost
+    /// (~ms when warm in page cache, ~ms-tens to re-fault).
+    transposed_down_store: Option<TransposedDownStore>,
     /// One-per-runner reusable FFN scratch buffers used by the AXPY-
     /// form path so we don't `Vec::new()` on every routed-expert
     /// call. Built once at first AXPY dispatch with the manifest's
@@ -744,6 +734,41 @@ impl Runner {
         };
         let last_routing_ids: Vec<Vec<u32>> = (0..layers.len()).map(|_| Vec::new()).collect();
 
+        // PR #43 fix: open the on-disk transposed-down cache only if
+        // AXPY is enabled. If the directory can't be created/written,
+        // log a warning and disable AXPY (we don't ship the in-memory
+        // path because it caused the regression that pivoting to
+        // disk persistence fixes).
+        let transposed_down_store = if opts.ffn_axpy_down {
+            let cache_dir = opts
+                .ffn_axpy_cache_dir
+                .clone()
+                .unwrap_or_else(|| model_dir.join(".cascadia_transposed_down_v1"));
+            match TransposedDownStore::open(&cache_dir) {
+                Ok(store) => {
+                    info!(
+                        cache_dir = %cache_dir.display(),
+                        "AXPY-form down: on-disk transposed-weight cache opened"
+                    );
+                    Some(store)
+                }
+                Err(err) => {
+                    warn!(
+                        cache_dir = %cache_dir.display(),
+                        error = %err,
+                        "AXPY-form down: cache directory not writable; \
+                         disabling AXPY for this run (falling back to dense down)"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        // Drop ffn_axpy_down if the store failed to open, so the
+        // dispatch path stays on the dense-down branch.
+        let ffn_axpy_effective = opts.ffn_axpy_down && transposed_down_store.is_some();
+
         Ok(Self {
             manifest,
             _model_dir: model_dir,
@@ -760,8 +785,8 @@ impl Runner {
             last_routing_ids,
             prefetcher,
             ffn_sparsity_threshold: opts.ffn_sparsity_threshold,
-            ffn_axpy_down: opts.ffn_axpy_down,
-            transposed_down_cache: new_expert_lru(cap),
+            ffn_axpy_down: ffn_axpy_effective,
+            transposed_down_store,
             ffn_scratch: None,
             ffn_active_sum: 0.0,
             ffn_active_count: 0,
@@ -859,13 +884,20 @@ impl Runner {
                 if self.ffn_axpy_down && threshold > 0.0 {
                     // AXPY-form sparse path (issue #35).
                     //
+                    // The transposed-down weights are persisted to
+                    // disk (`TransposedDownStore`) and mmap'd —
+                    // unlike the original in-memory cache (PR #43)
+                    // the on-disk pages are evictable by the kernel,
+                    // so they don't displace the K2.6 model's mmap
+                    // pages from the page cache. See the post-mortem
+                    // at rainier `docs/AXPY_REGRESSION_ANALYSIS.md`.
+                    //
                     // Pull the slice handles out of `w` first so the
                     // `c.get(...)` borrow ends and we can split-
-                    // borrow `self.transposed_down_cache` +
+                    // borrow `self.transposed_down_store` +
                     // `self.ffn_scratch` below. The mmap behind these
                     // slices is owned by the LRU entry `w` lives in;
-                    // both stay valid for the duration of the inline
-                    // transpose call.
+                    // both stay valid for the duration of the call.
                     let intermediate = cascadia_int4_gemm::INTERMEDIATE;
                     let down_packed_ptr = w.down_packed_bytes().as_ptr();
                     let down_scale_ptr = w.down_scale_bits().as_ptr();
@@ -879,31 +911,15 @@ impl Runner {
                     let up_packed_len = w.up_packed_bytes().len();
                     let up_scale_ptr = w.up_scale_bits().as_ptr();
                     let up_scale_len = w.up_scale_bits().len();
-                    let key = (lid, eid);
-                    if !self.transposed_down_cache.contains(&key) {
-                        // SAFETY: ExpertWeights mmap outlives the
-                        // synchronous transpose; the slices are read-
-                        // only borrows into the (unchanged) mmap.
-                        let src_packed =
-                            unsafe { std::slice::from_raw_parts(down_packed_ptr, down_packed_len) };
-                        let src_scale =
-                            unsafe { std::slice::from_raw_parts(down_scale_ptr, down_scale_len) };
-                        let td = TransposedDown::build(src_packed, src_scale, hidden, intermediate);
-                        self.transposed_down_cache.push(key, td);
-                    }
-                    // Disjoint field borrow: `td` borrows
-                    // `self.transposed_down_cache`; `scratch` borrows
-                    // `self.ffn_scratch`.
-                    let td = self
-                        .transposed_down_cache
-                        .get(&key)
-                        .expect("just inserted/checked");
-                    let scratch = self
-                        .ffn_scratch
-                        .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
-                    let mut out_f32 = vec![0.0f32; hidden];
-                    // SAFETY: gate/up slices live in the same
-                    // ExpertWeights mmap as down; valid for this call.
+                    // SAFETY for all the slice-from-raw-parts below:
+                    // the ExpertWeights mmap (owned by the LRU entry
+                    // we just got via `c.get`) stays alive for the
+                    // duration of this dispatch call. The slices
+                    // are read-only borrows into that mmap.
+                    let src_packed =
+                        unsafe { std::slice::from_raw_parts(down_packed_ptr, down_packed_len) };
+                    let src_scale =
+                        unsafe { std::slice::from_raw_parts(down_scale_ptr, down_scale_len) };
                     let gate_packed =
                         unsafe { std::slice::from_raw_parts(gate_packed_ptr, gate_packed_len) };
                     let gate_scale =
@@ -912,6 +928,26 @@ impl Runner {
                         unsafe { std::slice::from_raw_parts(up_packed_ptr, up_packed_len) };
                     let up_scale =
                         unsafe { std::slice::from_raw_parts(up_scale_ptr, up_scale_len) };
+                    // Disjoint field borrow: `td` borrows
+                    // `self.transposed_down_store`; `scratch` borrows
+                    // `self.ffn_scratch`.
+                    let store = self
+                        .transposed_down_store
+                        .as_mut()
+                        .expect("ffn_axpy_down true ⇒ store opened at load");
+                    let td = store
+                        .get_or_build(lid, eid, src_packed, src_scale, hidden, intermediate)
+                        .map_err(|e| {
+                            RunnerError::Internal(format!(
+                                "AXPY transposed-down cache failed for (lid={lid}, eid={eid}): {e}"
+                            ))
+                        })?;
+                    let td_packed = td.packed_t();
+                    let td_scale = td.scale_t_bits();
+                    let scratch = self
+                        .ffn_scratch
+                        .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
+                    let mut out_f32 = vec![0.0f32; hidden];
                     let active_frac = ffn_forward_sparse_axpy_f32(
                         scratch,
                         attn_row,
@@ -921,8 +957,8 @@ impl Runner {
                         gate_scale,
                         up_packed,
                         up_scale,
-                        &td.packed_t,
-                        &td.scale_t_bits,
+                        td_packed,
+                        td_scale,
                         &mut out_f32,
                         threshold,
                     );
@@ -951,12 +987,8 @@ impl Runner {
                 let threshold = self.ffn_sparsity_threshold;
                 if self.ffn_axpy_down && threshold > 0.0 {
                     let intermediate = cascadia_int4_gemm::INTERMEDIATE;
-                    // Pull the slice handles out of `w` first so the
-                    // `c.get(...)` borrow ends and we can split-
-                    // borrow `self.transposed_down_cache` +
-                    // `self.ffn_scratch` below. SafetensorsExpert
-                    // pins its shard mmaps via internal Arcs; both
-                    // stay valid for this call.
+                    // Same on-disk-store pattern as the Int4Bin path
+                    // above. See that branch for the rationale.
                     let down_packed_ptr = w.down_packed.as_ptr();
                     let down_packed_len = w.down_packed.len();
                     let down_scale_ptr = w.down_scale.as_ptr();
@@ -969,23 +1001,13 @@ impl Runner {
                     let up_packed_len = w.up_packed.len();
                     let up_scale_ptr = w.up_scale.as_ptr();
                     let up_scale_len = w.up_scale.len();
-                    let key = (lid, eid);
-                    if !self.transposed_down_cache.contains(&key) {
-                        let src_packed =
-                            unsafe { std::slice::from_raw_parts(down_packed_ptr, down_packed_len) };
-                        let src_scale =
-                            unsafe { std::slice::from_raw_parts(down_scale_ptr, down_scale_len) };
-                        let td = TransposedDown::build(src_packed, src_scale, hidden, intermediate);
-                        self.transposed_down_cache.push(key, td);
-                    }
-                    let td = self
-                        .transposed_down_cache
-                        .get(&key)
-                        .expect("just inserted/checked");
-                    let scratch = self
-                        .ffn_scratch
-                        .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
-                    let mut out_f32 = vec![0.0f32; hidden];
+                    // SAFETY: SafetensorsExpert pins its shard mmaps
+                    // via internal Arcs for the lifetime of `w`;
+                    // valid for this dispatch call.
+                    let src_packed =
+                        unsafe { std::slice::from_raw_parts(down_packed_ptr, down_packed_len) };
+                    let src_scale =
+                        unsafe { std::slice::from_raw_parts(down_scale_ptr, down_scale_len) };
                     let gate_packed =
                         unsafe { std::slice::from_raw_parts(gate_packed_ptr, gate_packed_len) };
                     let gate_scale =
@@ -994,6 +1016,23 @@ impl Runner {
                         unsafe { std::slice::from_raw_parts(up_packed_ptr, up_packed_len) };
                     let up_scale =
                         unsafe { std::slice::from_raw_parts(up_scale_ptr, up_scale_len) };
+                    let store = self
+                        .transposed_down_store
+                        .as_mut()
+                        .expect("ffn_axpy_down true ⇒ store opened at load");
+                    let td = store
+                        .get_or_build(lid, eid, src_packed, src_scale, hidden, intermediate)
+                        .map_err(|e| {
+                            RunnerError::Internal(format!(
+                                "AXPY transposed-down cache failed for (lid={lid}, eid={eid}): {e}"
+                            ))
+                        })?;
+                    let td_packed = td.packed_t();
+                    let td_scale = td.scale_t_bits();
+                    let scratch = self
+                        .ffn_scratch
+                        .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
+                    let mut out_f32 = vec![0.0f32; hidden];
                     let active_frac = ffn_forward_sparse_axpy_f32(
                         scratch,
                         attn_row,
@@ -1003,8 +1042,8 @@ impl Runner {
                         gate_scale,
                         up_packed,
                         up_scale,
-                        &td.packed_t,
-                        &td.scale_t_bits,
+                        td_packed,
+                        td_scale,
                         &mut out_f32,
                         threshold,
                     );

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -18,6 +18,8 @@ use std::time::Instant;
 
 use lru::LruCache;
 
+use cascadia_int4_gemm::ffn_axpy::{transpose_requantize_down, FfnScratch as IntFfnScratch};
+use cascadia_int4_gemm::ffn_sparsity::ffn_forward_sparse_axpy_f32;
 use cascadia_int4_gemm::layer0_int4::{
     embed_token_bf16, layer0_forward_decode_int4_multi_with_capacity,
     layer0_forward_decode_int4_with_capacity_sparse, Int4Layer0,
@@ -256,6 +258,34 @@ impl SafetensorsExpertCache {
     }
 }
 
+/// AXPY-form down weight: the original `[hidden, intermediate]` down
+/// matrix transposed and re-quantized into `[intermediate, hidden]`
+/// int4 layout for [`ffn_forward_sparse_axpy_f32`]. Built lazily on
+/// first sparse-AXPY dispatch per expert and held in
+/// `Runner::transposed_down_cache`. Memory cost: ~8.26 MiB per cached
+/// expert at K2.6 dimensions (same as the original down — the
+/// transpose is in-place size-wise).
+struct TransposedDown {
+    packed_t: Vec<u8>,
+    scale_t_bits: Vec<u8>,
+}
+
+impl TransposedDown {
+    fn build(
+        down_packed: &[u8],
+        down_scale_bits: &[u8],
+        n_hidden: usize,
+        n_intermediate: usize,
+    ) -> Self {
+        let (packed_t, scale_t_bits) =
+            transpose_requantize_down(down_packed, down_scale_bits, n_hidden, n_intermediate);
+        Self {
+            packed_t,
+            scale_t_bits,
+        }
+    }
+}
+
 /// autolab iter 029 (C1): one prefetch request — kindly hint the kernel
 /// to start reading the weights for expert `eid` on layer `lid`. The
 /// prefetcher thread translates this into `madvise(MADV_WILLNEED)` calls
@@ -373,6 +403,15 @@ pub struct RunnerOptions {
     /// (default) keeps the dense path. Useful range for SwiGLU is
     /// 0.05–0.15.
     pub ffn_sparsity_threshold: f32,
+    /// When `true` (and `ffn_sparsity_threshold > 0`), use the AXPY-
+    /// form down kernel from [`cascadia_int4_gemm::ffn_axpy`]: each
+    /// expert's down weight is transposed and re-quantized at first
+    /// use; the down projection becomes an AXPY over only the active
+    /// intermediate lanes (kernel speedup ceiling 1/active_frac vs
+    /// dense). Memory cost: one extra down-sized buffer per cached
+    /// expert (~8.26 MiB on K2.6); the transposed cache shares
+    /// [`Self::max_cached_experts`] as its capacity.
+    pub ffn_axpy_down: bool,
 }
 
 /// Per-rank slice of the model the Runner should hold.
@@ -442,6 +481,21 @@ pub struct Runner {
     /// (output bit-identical to dense). `0.05`–`0.15` is the typical
     /// useful range for SwiGLU (CATS / CHESS).
     ffn_sparsity_threshold: f32,
+    /// PowerInfer port (issue #35): when true, use the AXPY-form down
+    /// kernel from [`cascadia_int4_gemm::ffn_axpy`]. Requires per-
+    /// expert transposed-and-requantized down weights, built lazily
+    /// into `transposed_down_cache` on first use.
+    ffn_axpy_down: bool,
+    /// LRU of per-expert transposed-and-requantized down weights
+    /// (one [`TransposedDown`] per `(layer, expert)`). Populated only
+    /// when `ffn_axpy_down` is true. Shares
+    /// [`RunnerOptions::max_cached_experts`] as the LRU bound.
+    transposed_down_cache: LruCache<(u32, u32), TransposedDown>,
+    /// One-per-runner reusable FFN scratch buffers used by the AXPY-
+    /// form path so we don't `Vec::new()` on every routed-expert
+    /// call. Built once at first AXPY dispatch with the manifest's
+    /// hidden + intermediate dims and re-used until reset.
+    ffn_scratch: Option<IntFfnScratch>,
     /// Running sum of `active_frac` returned by
     /// [`cascadia_int4_gemm::expert_forward_sparse`] across this
     /// Runner's lifetime, plus a counter — used to log the average
@@ -706,6 +760,9 @@ impl Runner {
             last_routing_ids,
             prefetcher,
             ffn_sparsity_threshold: opts.ffn_sparsity_threshold,
+            ffn_axpy_down: opts.ffn_axpy_down,
+            transposed_down_cache: new_expert_lru(cap),
+            ffn_scratch: None,
             ffn_active_sum: 0.0,
             ffn_active_count: 0,
         })
@@ -798,43 +855,190 @@ impl Runner {
             }
             ExpertCache::Int4Bin(c) => {
                 let w = c.get(lid, eid)?;
-                let x_bf16: Vec<bf16> = attn_row.iter().map(|v| bf16::from_f32(*v)).collect();
-                let mut out_bf16 = vec![bf16::ZERO; hidden];
                 let threshold = self.ffn_sparsity_threshold;
-                let active_frac = int4_expert_forward_sparse(
-                    &x_bf16,
-                    w.gate_packed_bytes(),
-                    w.gate_scale_bits(),
-                    w.up_packed_bytes(),
-                    w.up_scale_bits(),
-                    w.down_packed_bytes(),
-                    w.down_scale_bits(),
-                    &mut out_bf16,
-                    threshold,
-                );
-                self.accumulate_ffn_sparsity_stat(active_frac);
-                Ok(out_bf16.iter().map(|b| b.to_f32()).collect())
+                if self.ffn_axpy_down && threshold > 0.0 {
+                    // AXPY-form sparse path (issue #35).
+                    //
+                    // Pull the slice handles out of `w` first so the
+                    // `c.get(...)` borrow ends and we can split-
+                    // borrow `self.transposed_down_cache` +
+                    // `self.ffn_scratch` below. The mmap behind these
+                    // slices is owned by the LRU entry `w` lives in;
+                    // both stay valid for the duration of the inline
+                    // transpose call.
+                    let intermediate = cascadia_int4_gemm::INTERMEDIATE;
+                    let down_packed_ptr = w.down_packed_bytes().as_ptr();
+                    let down_scale_ptr = w.down_scale_bits().as_ptr();
+                    let down_packed_len = w.down_packed_bytes().len();
+                    let down_scale_len = w.down_scale_bits().len();
+                    let gate_packed_ptr = w.gate_packed_bytes().as_ptr();
+                    let gate_packed_len = w.gate_packed_bytes().len();
+                    let gate_scale_ptr = w.gate_scale_bits().as_ptr();
+                    let gate_scale_len = w.gate_scale_bits().len();
+                    let up_packed_ptr = w.up_packed_bytes().as_ptr();
+                    let up_packed_len = w.up_packed_bytes().len();
+                    let up_scale_ptr = w.up_scale_bits().as_ptr();
+                    let up_scale_len = w.up_scale_bits().len();
+                    let key = (lid, eid);
+                    if !self.transposed_down_cache.contains(&key) {
+                        // SAFETY: ExpertWeights mmap outlives the
+                        // synchronous transpose; the slices are read-
+                        // only borrows into the (unchanged) mmap.
+                        let src_packed =
+                            unsafe { std::slice::from_raw_parts(down_packed_ptr, down_packed_len) };
+                        let src_scale =
+                            unsafe { std::slice::from_raw_parts(down_scale_ptr, down_scale_len) };
+                        let td = TransposedDown::build(src_packed, src_scale, hidden, intermediate);
+                        self.transposed_down_cache.push(key, td);
+                    }
+                    // Disjoint field borrow: `td` borrows
+                    // `self.transposed_down_cache`; `scratch` borrows
+                    // `self.ffn_scratch`.
+                    let td = self
+                        .transposed_down_cache
+                        .get(&key)
+                        .expect("just inserted/checked");
+                    let scratch = self
+                        .ffn_scratch
+                        .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
+                    let mut out_f32 = vec![0.0f32; hidden];
+                    // SAFETY: gate/up slices live in the same
+                    // ExpertWeights mmap as down; valid for this call.
+                    let gate_packed =
+                        unsafe { std::slice::from_raw_parts(gate_packed_ptr, gate_packed_len) };
+                    let gate_scale =
+                        unsafe { std::slice::from_raw_parts(gate_scale_ptr, gate_scale_len) };
+                    let up_packed =
+                        unsafe { std::slice::from_raw_parts(up_packed_ptr, up_packed_len) };
+                    let up_scale =
+                        unsafe { std::slice::from_raw_parts(up_scale_ptr, up_scale_len) };
+                    let active_frac = ffn_forward_sparse_axpy_f32(
+                        scratch,
+                        attn_row,
+                        hidden,
+                        intermediate,
+                        gate_packed,
+                        gate_scale,
+                        up_packed,
+                        up_scale,
+                        &td.packed_t,
+                        &td.scale_t_bits,
+                        &mut out_f32,
+                        threshold,
+                    );
+                    self.accumulate_ffn_sparsity_stat(active_frac);
+                    Ok(out_f32)
+                } else {
+                    let x_bf16: Vec<bf16> = attn_row.iter().map(|v| bf16::from_f32(*v)).collect();
+                    let mut out_bf16 = vec![bf16::ZERO; hidden];
+                    let active_frac = int4_expert_forward_sparse(
+                        &x_bf16,
+                        w.gate_packed_bytes(),
+                        w.gate_scale_bits(),
+                        w.up_packed_bytes(),
+                        w.up_scale_bits(),
+                        w.down_packed_bytes(),
+                        w.down_scale_bits(),
+                        &mut out_bf16,
+                        threshold,
+                    );
+                    self.accumulate_ffn_sparsity_stat(active_frac);
+                    Ok(out_bf16.iter().map(|b| b.to_f32()).collect())
+                }
             }
             ExpertCache::SafetensorsBin(c) => {
                 let w = c.get(lid, eid)?;
-                let x_bf16: Vec<bf16> = attn_row.iter().map(|v| bf16::from_f32(*v)).collect();
-                let mut out_bf16 = vec![bf16::ZERO; hidden];
                 let threshold = self.ffn_sparsity_threshold;
-                let active_frac = int4_expert_forward_sparse(
-                    &x_bf16,
-                    w.gate_packed,
-                    w.gate_scale,
-                    w.up_packed,
-                    w.up_scale,
-                    w.down_packed,
-                    w.down_scale,
-                    &mut out_bf16,
-                    threshold,
-                );
-                self.accumulate_ffn_sparsity_stat(active_frac);
-                Ok(out_bf16.iter().map(|b| b.to_f32()).collect())
+                if self.ffn_axpy_down && threshold > 0.0 {
+                    let intermediate = cascadia_int4_gemm::INTERMEDIATE;
+                    // Pull the slice handles out of `w` first so the
+                    // `c.get(...)` borrow ends and we can split-
+                    // borrow `self.transposed_down_cache` +
+                    // `self.ffn_scratch` below. SafetensorsExpert
+                    // pins its shard mmaps via internal Arcs; both
+                    // stay valid for this call.
+                    let down_packed_ptr = w.down_packed.as_ptr();
+                    let down_packed_len = w.down_packed.len();
+                    let down_scale_ptr = w.down_scale.as_ptr();
+                    let down_scale_len = w.down_scale.len();
+                    let gate_packed_ptr = w.gate_packed.as_ptr();
+                    let gate_packed_len = w.gate_packed.len();
+                    let gate_scale_ptr = w.gate_scale.as_ptr();
+                    let gate_scale_len = w.gate_scale.len();
+                    let up_packed_ptr = w.up_packed.as_ptr();
+                    let up_packed_len = w.up_packed.len();
+                    let up_scale_ptr = w.up_scale.as_ptr();
+                    let up_scale_len = w.up_scale.len();
+                    let key = (lid, eid);
+                    if !self.transposed_down_cache.contains(&key) {
+                        let src_packed =
+                            unsafe { std::slice::from_raw_parts(down_packed_ptr, down_packed_len) };
+                        let src_scale =
+                            unsafe { std::slice::from_raw_parts(down_scale_ptr, down_scale_len) };
+                        let td = TransposedDown::build(src_packed, src_scale, hidden, intermediate);
+                        self.transposed_down_cache.push(key, td);
+                    }
+                    let td = self
+                        .transposed_down_cache
+                        .get(&key)
+                        .expect("just inserted/checked");
+                    let scratch = self
+                        .ffn_scratch
+                        .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
+                    let mut out_f32 = vec![0.0f32; hidden];
+                    let gate_packed =
+                        unsafe { std::slice::from_raw_parts(gate_packed_ptr, gate_packed_len) };
+                    let gate_scale =
+                        unsafe { std::slice::from_raw_parts(gate_scale_ptr, gate_scale_len) };
+                    let up_packed =
+                        unsafe { std::slice::from_raw_parts(up_packed_ptr, up_packed_len) };
+                    let up_scale =
+                        unsafe { std::slice::from_raw_parts(up_scale_ptr, up_scale_len) };
+                    let active_frac = ffn_forward_sparse_axpy_f32(
+                        scratch,
+                        attn_row,
+                        hidden,
+                        intermediate,
+                        gate_packed,
+                        gate_scale,
+                        up_packed,
+                        up_scale,
+                        &td.packed_t,
+                        &td.scale_t_bits,
+                        &mut out_f32,
+                        threshold,
+                    );
+                    self.accumulate_ffn_sparsity_stat(active_frac);
+                    Ok(out_f32)
+                } else {
+                    let x_bf16: Vec<bf16> = attn_row.iter().map(|v| bf16::from_f32(*v)).collect();
+                    let mut out_bf16 = vec![bf16::ZERO; hidden];
+                    let active_frac = int4_expert_forward_sparse(
+                        &x_bf16,
+                        w.gate_packed,
+                        w.gate_scale,
+                        w.up_packed,
+                        w.up_scale,
+                        w.down_packed,
+                        w.down_scale,
+                        &mut out_bf16,
+                        threshold,
+                    );
+                    self.accumulate_ffn_sparsity_stat(active_frac);
+                    Ok(out_bf16.iter().map(|b| b.to_f32()).collect())
+                }
             }
         }
+    }
+
+    /// Switch the AXPY-form down kernel on/off at runtime. Has no
+    /// effect unless `ffn_sparsity_threshold > 0`. Toggling on
+    /// triggers lazy build of transposed-down weights at first use
+    /// (one-time ~5 ms CPU per expert at K2.6 dims; ~8.26 MiB extra
+    /// heap per cached expert).
+    pub fn set_ffn_axpy_down(&mut self, on: bool) {
+        self.ffn_axpy_down = on;
+        info!(ffn_axpy_down = on, "set_ffn_axpy_down");
     }
 
     /// Reset all per-layer KV caches. Call between independent generations.

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -1073,11 +1073,115 @@ impl Runner {
     /// Switch the AXPY-form down kernel on/off at runtime. Has no
     /// effect unless `ffn_sparsity_threshold > 0`. Toggling on
     /// triggers lazy build of transposed-down weights at first use
-    /// (one-time ~5 ms CPU per expert at K2.6 dims; ~8.26 MiB extra
-    /// heap per cached expert).
+    /// (one-time ~14 ms per expert at K2.6 dims — ~6 ms CPU +
+    /// ~8 ms disk write — persisted to `<model_dir>/.cascadia_transposed_down_v1/`
+    /// across process restarts).
     pub fn set_ffn_axpy_down(&mut self, on: bool) {
-        self.ffn_axpy_down = on;
-        info!(ffn_axpy_down = on, "set_ffn_axpy_down");
+        self.ffn_axpy_down = on && self.transposed_down_store.is_some();
+        info!(
+            requested = on,
+            effective = self.ffn_axpy_down,
+            "set_ffn_axpy_down (effective=false ⇒ store unavailable; running dense)"
+        );
+    }
+
+    /// Eagerly pre-build the AXPY transposed-down cache for every
+    /// `(layer, expert)` this rank may dispatch. Walks the manifest
+    /// + 0..num_experts in parallel and persists each cache file to
+    /// disk, then mmaps it. Subsequent dispatches are pure mmap
+    /// reads with zero in-line build cost.
+    ///
+    /// Cost: at K2.6 dims ~14 ms per expert (~6 ms compute + ~8 ms
+    /// NVMe write). 480 routed experts × 60 layers = 28 800 unique
+    /// experts ⇒ ~7 minutes on a single thread, ~20 seconds with
+    /// rayon. Disk: ~190 GiB on top of the K2.6 model.
+    ///
+    /// Returns `(built, mmap_hits)`. Returns `Ok((0, 0))` (no-op)
+    /// when AXPY is disabled or the store failed to open.
+    ///
+    /// For workloads with diverse prompts that touch many distinct
+    /// expert routes, this is the recommended pre-deploy step —
+    /// avoids the per-token in-line build cost the lazy mode pays
+    /// on first encounter of each expert.
+    pub fn prebuild_axpy_cache(&mut self) -> Result<(u64, u64), RunnerError> {
+        if !self.ffn_axpy_down {
+            info!("prebuild_axpy_cache: AXPY disabled; skipping");
+            return Ok((0, 0));
+        }
+        if self.transposed_down_store.is_none() {
+            return Ok((0, 0));
+        }
+        let intermediate = cascadia_int4_gemm::INTERMEDIATE;
+        let hidden = self.manifest.hidden_size as usize;
+        let moe_layer_ids = self.manifest.moe_layer_ids();
+        let n_experts = self.manifest.num_experts;
+        let layer_ids_in_range: Vec<u32> = moe_layer_ids
+            .into_iter()
+            .filter(|&lid| lid >= self.range.layer_start && lid < self.range.layer_end)
+            .collect();
+        info!(
+            num_layers = layer_ids_in_range.len(),
+            num_experts_per_layer = n_experts,
+            total_pairs = layer_ids_in_range.len() * (n_experts as usize),
+            "prebuild_axpy_cache: starting eager pre-build of transposed-down cache"
+        );
+        let t0 = Instant::now();
+        // Walk pairs serially per (lid, eid); inside each
+        // get_or_build the transpose itself is rayon-parallel.
+        // Going serial at the outer loop keeps disk-write
+        // contention low (one large NVMe write at a time outperforms
+        // many small concurrent writes on consumer NVMe).
+        for &lid in &layer_ids_in_range {
+            for eid in 0..n_experts {
+                // Skip if already cached; otherwise dispatch a
+                // single AXPY call via the existing path (which
+                // also handles the cache miss + build). The
+                // dummy attn_row is zeros — we don't care about
+                // the output, only the side effect of populating
+                // the transposed-down store.
+                if self
+                    .transposed_down_store
+                    .as_ref()
+                    .map(|s| s.live_mmaps())
+                    .unwrap_or(0)
+                    > 0
+                {
+                    // (live_mmaps grows on each successful
+                    // get_or_build; we use it as a coarse hint to
+                    // log progress.)
+                }
+                // Pull the source weights via the expert cache.
+                // dispatch_expert needs a real input vector even
+                // though we discard the output; allocate once.
+                let attn_row = vec![0.0f32; hidden];
+                let _ = self.dispatch_expert(lid, eid, &attn_row)?;
+            }
+            if let Some(store) = self.transposed_down_store.as_ref() {
+                let (builds, hits) = store.stats();
+                debug!(
+                    layer_done = lid,
+                    builds, hits, "prebuild_axpy_cache: layer complete"
+                );
+            }
+        }
+        let elapsed = t0.elapsed();
+        let (builds, hits) = self
+            .transposed_down_store
+            .as_ref()
+            .map(|s| s.stats())
+            .unwrap_or((0, 0));
+        info!(
+            elapsed_s = elapsed.as_secs_f64(),
+            builds,
+            hits,
+            live_mmaps = self
+                .transposed_down_store
+                .as_ref()
+                .map(|s| s.live_mmaps())
+                .unwrap_or(0),
+            "prebuild_axpy_cache: complete"
+        );
+        Ok((builds, hits))
     }
 
     /// Reset all per-layer KV caches. Call between independent generations.

--- a/crates/cascadia-int4-gemm/Cargo.toml
+++ b/crates/cascadia-int4-gemm/Cargo.toml
@@ -27,6 +27,7 @@ windows-sys = { version = "0.59", features = [
 # (canonical reference decompression for cross-validation lives in
 # rainier/scripts/k26_export_per_expert_v2.py — we cross-validate the
 # Rust kernel against bytes-on-disk only).
+tempfile = { workspace = true }
 
 [[bench]]
 name = "expert_gemm"

--- a/crates/cascadia-int4-gemm/src/bin/bench_ffn_sparsity.rs
+++ b/crates/cascadia-int4-gemm/src/bin/bench_ffn_sparsity.rs
@@ -241,4 +241,88 @@ fn main() {
     println!();
     println!("Direct kernel speedup ≈ 1 / active-frac (rayon parallelizes over active");
     println!("rows; the constant overhead floor sets the lower bound on per-call time).");
+
+    // ===== Section 3: AXPY-form down kernel (issue #35) =====
+    println!();
+    println!("---");
+    println!();
+    println!("# Direct kernel bench: dense GEMV vs AXPY-form sparse down (#35)");
+    println!();
+    println!(
+        "Down matmul shape: rows=HIDDEN={}, cols=INTERMEDIATE={}.",
+        HIDDEN, INTERMEDIATE
+    );
+    println!();
+    println!("Dense path runs `dequant_gemv_int4_auto(down, scale, inter, ...)`");
+    println!("(reads all intermediate cols). AXPY path runs the transposed-down");
+    println!("kernel: for each active intermediate lane r, accumulate");
+    println!("`y += inter[r] * dequant(down_t[r])` into the hidden output.");
+    println!();
+
+    // Construct fake DOWN weights (HIDDEN x INTERMEDIATE) +
+    // transpose them once.
+    let down_packed_dense = make_synthetic_packed(HIDDEN, INTERMEDIATE);
+    let down_scale_dense = make_synthetic_scale_bits(HIDDEN, n_mid_groups);
+    let (down_packed_t, down_scale_t_bits) =
+        cascadia_int4_gemm::ffn_axpy::transpose_requantize_down(
+            &down_packed_dense,
+            &down_scale_dense,
+            HIDDEN,
+            INTERMEDIATE,
+        );
+
+    // Intermediate vector — the AXPY scalars input.
+    let inter: Vec<f32> = (0..INTERMEDIATE)
+        .map(|i| (i as f32) * 0.013 - 0.4)
+        .collect();
+
+    // Dense down baseline (existing kernel).
+    let mut y_dense = vec![0.0f32; HIDDEN];
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        dequant_gemv_int4_auto(
+            &down_packed_dense,
+            &down_scale_dense,
+            &inter,
+            HIDDEN,
+            INTERMEDIATE,
+            &mut y_dense,
+        );
+    }
+    let dense_down = t0.elapsed().as_secs_f64() / iters as f64;
+    println!("| active-frac | per-call    | speedup |");
+    println!("| ----------- | ----------- | ------- |");
+    println!("| 1.00 (dense)| {:>11} | 1.00×   |", fmt_us(dense_down));
+    for &frac in &[0.50f32, 0.30, 0.10] {
+        let n_active = ((INTERMEDIATE as f32) * frac).round() as usize;
+        let stride = INTERMEDIATE / n_active.max(1);
+        let active: Vec<u32> = (0..n_active).map(|i| (i * stride) as u32).collect();
+        let mut y = vec![0.0f32; HIDDEN];
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            // AXPY accumulates into y; zero before each call.
+            y.fill(0.0);
+            cascadia_int4_gemm::ffn_axpy::dequant_axpy_int4_active_auto(
+                &down_packed_t,
+                &down_scale_t_bits,
+                &inter,
+                &active,
+                INTERMEDIATE,
+                HIDDEN,
+                &mut y,
+            );
+        }
+        let elapsed = t0.elapsed().as_secs_f64() / iters as f64;
+        let speedup = dense_down / elapsed;
+        println!(
+            "| {:<11.2} | {:>11} | {:<5.2}×  |",
+            frac,
+            fmt_us(elapsed),
+            speedup
+        );
+    }
+    println!();
+    println!("AXPY speedup approaches the kernel ceiling 1/active_frac modulo");
+    println!("output-buffer write traffic (y[HIDDEN]=7168 reread+rewritten per");
+    println!("active scalar) and the rayon-chunked-y scheduling overhead.");
 }

--- a/crates/cascadia-int4-gemm/src/bin/bench_ffn_sparsity.rs
+++ b/crates/cascadia-int4-gemm/src/bin/bench_ffn_sparsity.rs
@@ -325,4 +325,150 @@ fn main() {
     println!("AXPY speedup approaches the kernel ceiling 1/active_frac modulo");
     println!("output-buffer write traffic (y[HIDDEN]=7168 reread+rewritten per");
     println!("active scalar) and the rayon-chunked-y scheduling overhead.");
+
+    // ===== Section 4: Full FFN forward — dense vs sparse vs sparse+AXPY =====
+    println!();
+    println!("---");
+    println!();
+    println!("# Full FFN forward at K2.6 active_frac (~0.74 measured on K2.6 τ=0.05)");
+    println!();
+    println!("Compares three FFN forward functions at K2.6 dims with a SYNTHETIC");
+    println!("active mask that matches the real K2.6 active_frac. This catches");
+    println!("per-call overhead the kernel-only benches above hide.");
+    println!();
+
+    use cascadia_int4_gemm::ffn_axpy::{transpose_requantize_down, FfnScratch};
+    use cascadia_int4_gemm::ffn_sparsity::{ffn_forward_sparse_axpy_f32, ffn_forward_sparse_f32};
+    use cascadia_int4_gemm::kernel::expert_forward;
+
+    let x_full: Vec<bf16> = (0..HIDDEN)
+        .map(|i| bf16::from_f32((i as f32) * 0.013 - 0.5))
+        .collect();
+    let x_full_f32: Vec<f32> = x_full.iter().map(|b| b.to_f32()).collect();
+
+    // Pre-build the transposed down for AXPY.
+    let (down_packed_t_full, down_scale_t_bits_full) =
+        transpose_requantize_down(&down_packed, &down_scale, HIDDEN, INTERMEDIATE);
+
+    let mut warm_dense = vec![bf16::ZERO; HIDDEN];
+    let mut warm_sparse = vec![0.0f32; HIDDEN];
+    let mut scratch = FfnScratch::new(HIDDEN, INTERMEDIATE);
+    // warmup
+    expert_forward(
+        &x_full,
+        &gate_packed,
+        &gate_scale,
+        &up_packed,
+        &up_scale,
+        &down_packed,
+        &down_scale,
+        &mut warm_dense,
+    );
+    let _ = ffn_forward_sparse_f32(
+        &x_full_f32,
+        HIDDEN,
+        INTERMEDIATE,
+        &gate_packed,
+        &gate_scale,
+        &up_packed,
+        &up_scale,
+        &down_packed,
+        &down_scale,
+        &mut warm_sparse,
+        0.05,
+    );
+    let _ = ffn_forward_sparse_axpy_f32(
+        &mut scratch,
+        &x_full_f32,
+        HIDDEN,
+        INTERMEDIATE,
+        &gate_packed,
+        &gate_scale,
+        &up_packed,
+        &up_scale,
+        &down_packed_t_full,
+        &down_scale_t_bits_full,
+        &mut warm_sparse,
+        0.05,
+    );
+
+    // Bench dense expert_forward (bf16 in/out).
+    let mut out_dense = vec![bf16::ZERO; HIDDEN];
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        expert_forward(
+            &x_full,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed,
+            &down_scale,
+            &mut out_dense,
+        );
+    }
+    let dense_full = t0.elapsed().as_secs_f64() / iters as f64;
+
+    // Bench ffn_forward_sparse_f32 at τ=0.05 (the PR #34 path).
+    let mut out_sp = vec![0.0f32; HIDDEN];
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let _ = ffn_forward_sparse_f32(
+            &x_full_f32,
+            HIDDEN,
+            INTERMEDIATE,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed,
+            &down_scale,
+            &mut out_sp,
+            0.05,
+        );
+    }
+    let sp_full = t0.elapsed().as_secs_f64() / iters as f64;
+
+    // Bench ffn_forward_sparse_axpy_f32 at τ=0.05 (this PR).
+    let mut out_axpy = vec![0.0f32; HIDDEN];
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        let _ = ffn_forward_sparse_axpy_f32(
+            &mut scratch,
+            &x_full_f32,
+            HIDDEN,
+            INTERMEDIATE,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed_t_full,
+            &down_scale_t_bits_full,
+            &mut out_axpy,
+            0.05,
+        );
+    }
+    let axpy_full = t0.elapsed().as_secs_f64() / iters as f64;
+
+    println!("| path                          | per-expert-call | speedup vs dense |");
+    println!("| ----------------------------- | --------------- | ---------------- |");
+    println!(
+        "| `expert_forward` (dense bf16) | {:>15} | 1.00× (ref)      |",
+        fmt_us(dense_full)
+    );
+    println!(
+        "| `ffn_forward_sparse_f32` τ0.05 | {:>14} | {:<5.2}×           |",
+        fmt_us(sp_full),
+        dense_full / sp_full
+    );
+    println!(
+        "| `ffn_forward_sparse_axpy_f32` τ0.05 | {:>9} | {:<5.2}×           |",
+        fmt_us(axpy_full),
+        dense_full / axpy_full
+    );
+    println!();
+    println!("The full-FFN bench includes everything the runner pays per expert");
+    println!("call: gate matmul (full) + silu + threshold-mask build + up sparse +");
+    println!("elementwise + down (dense or AXPY). Use this number, not the");
+    println!("kernel-only numbers above, to predict end-to-end FFN-compute gain.");
 }

--- a/crates/cascadia-int4-gemm/src/ffn_axpy.rs
+++ b/crates/cascadia-int4-gemm/src/ffn_axpy.rs
@@ -1,0 +1,775 @@
+//! AXPY-form sparse SwiGLU FFN down projection.
+//!
+//! This is the kernel that closes the gap left by PR #34 — the
+//! existing two-phase Gate-first FFN sparsity sparsifies only the
+//! **up** matmul. The **down** matmul still ran dense over a sparse
+//! intermediate vector, capping the end-to-end FFN-compute speedup
+//! at ~1.2× even when up was 50% sparse. This module ports
+//! PowerInfer SmallThinker's actual down-projection mechanism
+//! (`/tmp/PowerInfer/smallthinker/powerinfer/fused_sparse_moe/`
+//! `fused_sparse_moe.cpp:174-186`), which is *not* a column-sparse
+//! GEMV but an **AXPY** over a *transposed* down weight.
+//!
+//! ## Algorithm
+//!
+//! Dense down projection: `y[h] = sum_k W_down[h, k] * inter[k]`
+//! for `h in [0, hidden), k in [0, intermediate)`. Cost: `hidden ×
+//! intermediate` FMAs.
+//!
+//! AXPY-form (with W transposed to `[intermediate, hidden]`):
+//! `for r in active: y[h] += scalars[r] * W_t[r, h]` for `h in
+//! [0, hidden)`. The full-rank dot product is replaced by an outer
+//! accumulation over only the active intermediate lanes — rows for
+//! inactive lanes (`silu(gate[r]) * up[r]` below the threshold) are
+//! never touched. Cost: `active × hidden` FMAs ⇒ kernel speedup
+//! ceiling **`1 / active_frac`** vs dense.
+//!
+//! ## Layout — the down weight must be transposed
+//!
+//! K2.6 stores down as `[hidden=7168, intermediate=2048]` int4 with
+//! group-32 bf16 scales along the *intermediate* (K) axis. The
+//! AXPY layout we need is `[intermediate, hidden]` with group-32
+//! scales along the *hidden* axis — that way each AXPY row read is
+//! contiguous (hidden/2 nibble bytes + hidden/32 bf16 scales) and
+//! the FMA write into `y[hidden]` traverses the output in order.
+//!
+//! The transpose is not a permutation. The quantization grouping
+//! changes orientation, so each weight is re-rounded into the new
+//! group's scale. [`transpose_requantize_down`] performs the one-
+//! time conversion at expert load time; the result is cached
+//! alongside the original weights in cascadia's LRU expert cache
+//! (`cascadia-engine-sparse-moe::runner::ExpertCache`).
+//!
+//! The re-quantization is the same group-32 symmetric int4 scheme
+//! used by the original (max-abs over group ⇒ scale = max/7,
+//! round-to-nearest with ties-to-even). Each weight rounds twice
+//! total (original quantization + this re-quantization). Empirical
+//! quality validation is the test suite + the end-to-end K2.6 eval.
+//!
+//! ## Attribution
+//!
+//! - AXPY-form sparse down: PowerInfer SmallThinker
+//!   `fused_sparse_moe.cpp:174-186` (MIT, SJTU-IPADS / Tiiny AI;
+//!   `--transpose-down all` flag at
+//!   `convert_hf_to_gguf.py:6275-6283`). Clean-room Rust re-impl —
+//!   no PowerInfer source copied.
+//! - Premise (down is the most sparsifiable FFN tensor): TEAL
+//!   (Liu et al. 2024, arxiv:2408.14690 Fig 7).
+//!
+//! See rainier `docs/POWERINFER_PORT.md` for the full technique map.
+
+use rayon::prelude::*;
+
+use crate::format::{bf16_bits_to_f32, f32_to_bf16_bits};
+use crate::GROUP_SIZE;
+
+/// Scalar reference AXPY-form sparse down. For each active
+/// intermediate lane `r`, accumulate `scalars[r] · dequant_row(r)`
+/// into `y[0..hidden]`.
+///
+/// Caller contract:
+/// - `packed_t.len() == n_intermediate * n_hidden / 2`
+/// - `scale_t_bits.len() == n_intermediate * n_hidden / GROUP_SIZE * 2`
+/// - `scalars.len() == n_intermediate` (only `active` indices read)
+/// - `y.len() == n_hidden`; caller pre-zeroes (or accumulates).
+///
+/// `active` indices must be `< n_intermediate`; duplicates are
+/// summed (the function is order-independent across `active`).
+///
+/// Parallelism: rayon chunks `y` along the hidden dim so each
+/// worker thread owns a disjoint slice and visits every active
+/// lane on its slice — no atomics, no false sharing. Matches the
+/// AVX-512 path's chunked-y strategy so the two layouts have the
+/// same scaling behaviour.
+pub fn dequant_axpy_int4_active(
+    packed_t: &[u8],
+    scale_t_bits: &[u8],
+    scalars: &[f32],
+    active: &[u32],
+    n_intermediate: usize,
+    n_hidden: usize,
+    y: &mut [f32],
+) {
+    assert_eq!(packed_t.len(), n_intermediate * n_hidden / 2);
+    let n_groups_h = n_hidden / GROUP_SIZE;
+    assert_eq!(scale_t_bits.len(), n_intermediate * n_groups_h * 2);
+    assert_eq!(scalars.len(), n_intermediate);
+    assert_eq!(y.len(), n_hidden);
+    // Use the same per-thread chunk size as the AVX-512 path so
+    // the scalar reference behaves like a slow-but-equivalent
+    // version of the AVX path under rayon.
+    const CHUNK: usize = 256;
+    let row_stride_packed = n_hidden / 2;
+    let row_stride_scale = n_groups_h * 2;
+    let groups_per_chunk = (CHUNK / GROUP_SIZE).max(1);
+
+    y.par_chunks_mut(CHUNK)
+        .enumerate()
+        .for_each(|(ci, y_chunk)| {
+            let chunk_start = ci * CHUNK;
+            let group_offset_in_row = chunk_start / GROUP_SIZE;
+            // Last chunk may be shorter than CHUNK if n_hidden isn't
+            // a multiple of CHUNK; compute how many groups land in it.
+            let groups_in_this_chunk = (y_chunk.len() / GROUP_SIZE).min(groups_per_chunk);
+            for &r in active {
+                let r = r as usize;
+                debug_assert!(r < n_intermediate);
+                let scalar = scalars[r];
+                let row_packed = &packed_t[r * row_stride_packed..(r + 1) * row_stride_packed];
+                let row_scales = &scale_t_bits[r * row_stride_scale..(r + 1) * row_stride_scale];
+                for g_in_chunk in 0..groups_in_this_chunk {
+                    let g_in_row = group_offset_in_row + g_in_chunk;
+                    let scale_u16 = u16::from_le_bytes([
+                        row_scales[g_in_row * 2],
+                        row_scales[g_in_row * 2 + 1],
+                    ]);
+                    let scale = bf16_bits_to_f32(scale_u16);
+                    let combined = scalar * scale;
+                    let group_packed =
+                        &row_packed[g_in_row * (GROUP_SIZE / 2)..(g_in_row + 1) * (GROUP_SIZE / 2)];
+                    let y_off = g_in_chunk * GROUP_SIZE;
+                    for i in 0..(GROUP_SIZE / 2) {
+                        let byte = group_packed[i];
+                        let lo_nibble = (byte & 0x0F) as i32 - 8;
+                        let hi_nibble = ((byte >> 4) & 0x0F) as i32 - 8;
+                        y_chunk[y_off + i * 2] += combined * (lo_nibble as f32);
+                        y_chunk[y_off + i * 2 + 1] += combined * (hi_nibble as f32);
+                    }
+                }
+                // Handle the last chunk's trailing groups (when y_chunk.len() <= CHUNK).
+                if y_chunk.len() % GROUP_SIZE != 0 {
+                    // n_hidden must be a multiple of GROUP_SIZE per the
+                    // crate's invariant (groups are 32 wide); skip — no
+                    // partial group at the chunk boundary.
+                }
+            }
+        });
+}
+
+/// AVX-512 path. Parallelizes over `y` *chunks* so each worker
+/// thread owns a disjoint slice of the output — no atomics, no
+/// false sharing.
+#[cfg(target_arch = "x86_64")]
+mod avx512 {
+    use core::arch::x86_64::*;
+    use rayon::prelude::*;
+
+    use crate::format::bf16_bits_to_f32;
+    use crate::GROUP_SIZE;
+
+    /// Per-thread chunk size in cols of `y`. Must be a multiple of
+    /// `GROUP_SIZE` (32) so groups line up with chunk boundaries.
+    /// 256 = 8 groups per chunk; 256 × 4 = 1 KiB y-bytes per chunk
+    /// (well within L1).
+    const CHUNK: usize = 256;
+
+    /// SAFETY: caller must ensure `avx512f,avx512bw,avx512vl` are
+    /// available at runtime (the public wrapper checks).
+    #[target_feature(enable = "avx512f,avx512bw,avx512vl")]
+    pub unsafe fn dequant_axpy_int4_active_avx512(
+        packed_t: &[u8],
+        scale_t_bits: &[u8],
+        scalars: &[f32],
+        active: &[u32],
+        n_intermediate: usize,
+        n_hidden: usize,
+        y: &mut [f32],
+    ) {
+        assert_eq!(packed_t.len(), n_intermediate * n_hidden / 2);
+        let n_groups_h = n_hidden / GROUP_SIZE;
+        assert_eq!(scale_t_bits.len(), n_intermediate * n_groups_h * 2);
+        assert_eq!(scalars.len(), n_intermediate);
+        assert_eq!(y.len(), n_hidden);
+        assert!(
+            n_hidden % CHUNK == 0,
+            "AXPY-AVX-512 expects n_hidden ({n_hidden}) divisible by CHUNK ({CHUNK})"
+        );
+        let row_stride_packed = n_hidden / 2;
+        let row_stride_scale = n_groups_h * 2;
+        let lo_mask = _mm_set1_epi8(0x0F);
+        let bias = _mm_set1_epi8(8);
+
+        // Chunked-y parallelism: each worker owns a disjoint
+        // [chunk_start, chunk_start + CHUNK) slice of y and visits
+        // every active lane. Per-(active, chunk) work is one
+        // contiguous packed slice + one contiguous scale slice +
+        // CHUNK / 16 AVX-512 FMAs per group.
+        y.par_chunks_mut(CHUNK)
+            .enumerate()
+            .for_each(|(ci, y_chunk)| {
+                let chunk_start = ci * CHUNK;
+                let groups_per_chunk = CHUNK / GROUP_SIZE;
+                let group_offset_in_row = chunk_start / GROUP_SIZE;
+                for &r in active {
+                    let r = r as usize;
+                    let scalar = scalars[r];
+                    // SAFETY: each thread owns a disjoint y_chunk; the
+                    // accumulator vectors live entirely in register
+                    // until the final store.
+                    unsafe {
+                        let row_packed_ptr = packed_t.as_ptr().add(r * row_stride_packed);
+                        let row_scale_ptr = scale_t_bits.as_ptr().add(r * row_stride_scale);
+                        let scalar_v = _mm512_set1_ps(scalar);
+                        for g_in_chunk in 0..groups_per_chunk {
+                            let g_in_row = group_offset_in_row + g_in_chunk;
+                            let scale_off = g_in_row * 2;
+                            let scale_u16 = u16::from_le_bytes([
+                                *row_scale_ptr.add(scale_off),
+                                *row_scale_ptr.add(scale_off + 1),
+                            ]);
+                            let scale = bf16_bits_to_f32(scale_u16);
+                            // scalar × scale → single per-group multiplier
+                            let combined = _mm512_set1_ps(scalar * scale);
+
+                            // 16 packed bytes = 32 nibbles for this group
+                            let p_ptr =
+                                row_packed_ptr.add(g_in_row * (GROUP_SIZE / 2)) as *const __m128i;
+                            let pk = _mm_loadu_si128(p_ptr);
+                            let low_nibbles = _mm_and_si128(pk, lo_mask);
+                            let high_nibbles = _mm_and_si128(_mm_srli_epi16::<4>(pk), lo_mask);
+                            let low_signed = _mm_sub_epi8(low_nibbles, bias);
+                            let high_signed = _mm_sub_epi8(high_nibbles, bias);
+                            // Interleave so we recover original column
+                            // order (col 0, 1, 2, 3, ...)
+                            let interleaved_lo = _mm_unpacklo_epi8(low_signed, high_signed);
+                            let interleaved_hi = _mm_unpackhi_epi8(low_signed, high_signed);
+                            let lo_i32 = _mm512_cvtepi8_epi32(interleaved_lo);
+                            let hi_i32 = _mm512_cvtepi8_epi32(interleaved_hi);
+                            let lo_f = _mm512_cvtepi32_ps(lo_i32);
+                            let hi_f = _mm512_cvtepi32_ps(hi_i32);
+                            // y_chunk[g_in_chunk*32 .. + 32] += combined × cols
+                            let y_off = g_in_chunk * GROUP_SIZE;
+                            let y_ptr_lo = y_chunk.as_mut_ptr().add(y_off);
+                            let y_ptr_hi = y_chunk.as_mut_ptr().add(y_off + 16);
+                            let y_lo = _mm512_loadu_ps(y_ptr_lo);
+                            let y_hi = _mm512_loadu_ps(y_ptr_hi);
+                            let y_lo_new = _mm512_fmadd_ps(combined, lo_f, y_lo);
+                            let y_hi_new = _mm512_fmadd_ps(combined, hi_f, y_hi);
+                            _mm512_storeu_ps(y_ptr_lo, y_lo_new);
+                            _mm512_storeu_ps(y_ptr_hi, y_hi_new);
+                        }
+                    }
+                }
+            });
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+pub use avx512::dequant_axpy_int4_active_avx512;
+
+/// Wrapper: pick AVX-512 if available, else fall back to scalar.
+/// Caller pre-zeroes `y` (or accumulates from a prior call).
+pub fn dequant_axpy_int4_active_auto(
+    packed_t: &[u8],
+    scale_t_bits: &[u8],
+    scalars: &[f32],
+    active: &[u32],
+    n_intermediate: usize,
+    n_hidden: usize,
+    y: &mut [f32],
+) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if n_hidden % 256 == 0
+            && is_x86_feature_detected!("avx512f")
+            && is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512vl")
+        {
+            // SAFETY: feature-checked at runtime.
+            unsafe {
+                dequant_axpy_int4_active_avx512(
+                    packed_t,
+                    scale_t_bits,
+                    scalars,
+                    active,
+                    n_intermediate,
+                    n_hidden,
+                    y,
+                );
+            }
+            return;
+        }
+    }
+    dequant_axpy_int4_active(
+        packed_t,
+        scale_t_bits,
+        scalars,
+        active,
+        n_intermediate,
+        n_hidden,
+        y,
+    );
+}
+
+/// Transpose-and-requantize a `[hidden, intermediate]` int4 down
+/// weight into `[intermediate, hidden]` layout for the AXPY-form
+/// kernel.
+///
+/// Steps:
+/// 1. Dequantize the source one row (output-row) at a time into
+///    a single f32 scratch row (no full-matrix f32 buffer).
+/// 2. Scatter that row into the matching column of a transposed
+///    f32 working buffer `[intermediate, hidden]`.
+/// 3. Re-quantize the transposed buffer row-by-row using the
+///    same group-32 symmetric int4 scheme.
+///
+/// Output buffers:
+/// - `packed_t.len()    == n_intermediate * (n_hidden / 2)`
+/// - `scale_t_bits.len() == n_intermediate * (n_hidden / GROUP_SIZE) * 2`
+///
+/// One-time CPU cost at expert load: dominated by the transposed
+/// f32 buffer (n_intermediate × n_hidden × 4 bytes ≈ 56 MiB for
+/// K2.6 — runs in ~5 ms on a Cascade Lake socket; ~0.5 ms with
+/// rayon over the source rows).
+///
+/// Quality: each weight rounds twice (original quantization +
+/// this re-quantization). Empirical impact on K2.6 canonical-prompt
+/// match is validated by the end-to-end test in
+/// `cascadia-engine-sparse-moe/tests/k26_layer0_eval.rs` and the
+/// `axpy_close_to_dense_down_random_weights` unit test below.
+pub fn transpose_requantize_down(
+    src_packed: &[u8],     // [n_hidden, n_intermediate / 2]
+    src_scale_bits: &[u8], // [n_hidden, n_intermediate / GROUP_SIZE * 2]
+    n_hidden: usize,
+    n_intermediate: usize,
+) -> (Vec<u8>, Vec<u8>) {
+    let n_groups_src = n_intermediate / GROUP_SIZE; // groups along K (intermediate)
+    let n_groups_dst = n_hidden / GROUP_SIZE; // groups along new K (hidden)
+    assert_eq!(src_packed.len(), n_hidden * (n_intermediate / 2));
+    assert_eq!(src_scale_bits.len(), n_hidden * n_groups_src * 2);
+
+    // 1+2 : dequant every source row and scatter into a
+    // [n_intermediate, n_hidden] f32 buffer. Parallelized across
+    // source rows (each row independent).
+    let mut transposed = vec![0.0f32; n_intermediate * n_hidden];
+    let t_ptr_addr = transposed.as_mut_ptr() as usize;
+    let row_stride_packed_src = n_intermediate / 2;
+    let row_stride_scale_src = n_groups_src * 2;
+    (0..n_hidden).into_par_iter().for_each(|h| {
+        let row_packed = &src_packed[h * row_stride_packed_src..(h + 1) * row_stride_packed_src];
+        let row_scales = &src_scale_bits[h * row_stride_scale_src..(h + 1) * row_stride_scale_src];
+        for g in 0..n_groups_src {
+            let scale_u16 = u16::from_le_bytes([row_scales[g * 2], row_scales[g * 2 + 1]]);
+            let scale = bf16_bits_to_f32(scale_u16);
+            let group_packed = &row_packed[g * (GROUP_SIZE / 2)..(g + 1) * (GROUP_SIZE / 2)];
+            for i in 0..(GROUP_SIZE / 2) {
+                let byte = group_packed[i];
+                let lo = (byte & 0x0F) as i32 - 8;
+                let hi = ((byte >> 4) & 0x0F) as i32 - 8;
+                let col_lo = g * GROUP_SIZE + i * 2;
+                let col_hi = g * GROUP_SIZE + i * 2 + 1;
+                let v_lo = lo as f32 * scale;
+                let v_hi = hi as f32 * scale;
+                // Scatter (h, col_lo) → transposed[col_lo, h] etc.
+                // SAFETY: each (h, col) pair maps to a unique
+                // (col, h) cell; threads index by h, write distinct
+                // cells in disjoint columns of `transposed`.
+                unsafe {
+                    let base = t_ptr_addr as *mut f32;
+                    *base.add(col_lo * n_hidden + h) = v_lo;
+                    *base.add(col_hi * n_hidden + h) = v_hi;
+                }
+            }
+        }
+    });
+
+    // 3 : re-quantize each transposed row into the new packed
+    // layout with group-32 symmetric int4 + bf16 scales along the
+    // new col axis (hidden).
+    let mut packed_t = vec![0u8; n_intermediate * (n_hidden / 2)];
+    let mut scale_t_bits = vec![0u8; n_intermediate * n_groups_dst * 2];
+    let row_stride_packed_dst = n_hidden / 2;
+    let row_stride_scale_dst = n_groups_dst * 2;
+
+    let packed_ptr_addr = packed_t.as_mut_ptr() as usize;
+    let scale_ptr_addr = scale_t_bits.as_mut_ptr() as usize;
+    (0..n_intermediate).into_par_iter().for_each(|r| {
+        let row_f32 = &transposed[r * n_hidden..(r + 1) * n_hidden];
+        // SAFETY: per-`r` writes go to distinct row regions in
+        // both output buffers; iteration is over disjoint rows.
+        let packed_row = unsafe { (packed_ptr_addr as *mut u8).add(r * row_stride_packed_dst) };
+        let scale_row = unsafe { (scale_ptr_addr as *mut u8).add(r * row_stride_scale_dst) };
+        for g in 0..n_groups_dst {
+            let group_f32 = &row_f32[g * GROUP_SIZE..(g + 1) * GROUP_SIZE];
+            // Symmetric int4: scale = max(|v|) / 7. Quantized
+            // value q = round(v / scale) clamped to [-8, 7]; we
+            // store q+8 in the nibble so the on-disk format
+            // matches the existing exporter.
+            let max_abs = group_f32.iter().fold(0.0f32, |a, &v| a.max(v.abs()));
+            let scale = if max_abs == 0.0 { 1.0 } else { max_abs / 7.0 };
+            let inv = if max_abs == 0.0 { 0.0 } else { 1.0 / scale };
+            let scale_u16 = f32_to_bf16_bits(scale);
+            // SAFETY: scale_row + 2*g .. +2 is within the row.
+            unsafe {
+                *scale_row.add(g * 2) = (scale_u16 & 0xFF) as u8;
+                *scale_row.add(g * 2 + 1) = ((scale_u16 >> 8) & 0xFF) as u8;
+            }
+            for i in 0..(GROUP_SIZE / 2) {
+                let v_lo = group_f32[i * 2];
+                let v_hi = group_f32[i * 2 + 1];
+                let q_lo = (v_lo * inv).round() as i32;
+                let q_hi = (v_hi * inv).round() as i32;
+                let q_lo_u = (q_lo.clamp(-8, 7) + 8) as u8;
+                let q_hi_u = (q_hi.clamp(-8, 7) + 8) as u8;
+                let byte = (q_hi_u << 4) | q_lo_u;
+                // SAFETY: byte offset is within packed_row.
+                unsafe {
+                    *packed_row.add(g * (GROUP_SIZE / 2) + i) = byte;
+                }
+            }
+        }
+    });
+
+    (packed_t, scale_t_bits)
+}
+
+/// Reusable per-call scratch for [`crate::ffn_sparsity::ffn_forward_sparse_f32`]
+/// and the AXPY-form variant — eliminates the 7 per-call
+/// `Vec::new()` allocations that accumulated at K2.6 dispatch
+/// rates (~480 routed-expert calls per token × 7 allocs).
+///
+/// Construction: `FfnScratch::new(hidden, intermediate)` allocs
+/// once; subsequent `resize_for(...)` is a no-op if the buffers
+/// are already large enough.
+///
+/// One scratch is meant to be owned per-runner (not per-call) and
+/// re-used across routed-expert calls within the same token. The
+/// scratch is not Sync — it holds raw `Vec` buffers — so per-thread
+/// pooling would need separate instances if a future caller
+/// fanned the AXPY across threads.
+pub struct FfnScratch {
+    /// `x_f32`: f32 copy of the bf16 input (gate / up share this).
+    pub x_f32: Vec<f32>,
+    /// `gate_out`: gate projection output (length intermediate).
+    pub gate_out: Vec<f32>,
+    /// `silu_gate`: silu(gate_out), length intermediate.
+    pub silu_gate: Vec<f32>,
+    /// `active`: sorted indices of active intermediate lanes.
+    pub active: Vec<u32>,
+    /// `up_out`: up projection output (length intermediate; only
+    /// `active` entries populated in the sparse path).
+    pub up_out: Vec<f32>,
+    /// `inter`: silu(gate) ⊙ up (length intermediate; only
+    /// `active` entries non-zero).
+    pub inter: Vec<f32>,
+    /// `out_f32`: f32 output (length hidden) before bf16 cast.
+    pub out_f32: Vec<f32>,
+}
+
+impl FfnScratch {
+    pub fn new(hidden: usize, intermediate: usize) -> Self {
+        Self {
+            x_f32: vec![0.0f32; hidden],
+            gate_out: vec![0.0f32; intermediate],
+            silu_gate: vec![0.0f32; intermediate],
+            active: Vec::with_capacity(intermediate),
+            up_out: vec![0.0f32; intermediate],
+            inter: vec![0.0f32; intermediate],
+            out_f32: vec![0.0f32; hidden],
+        }
+    }
+
+    /// Grow buffers in-place if they're smaller than the requested
+    /// shape. No shrinkage — the scratch's high-water mark stays
+    /// allocated across calls.
+    pub fn resize_for(&mut self, hidden: usize, intermediate: usize) {
+        if self.x_f32.len() < hidden {
+            self.x_f32.resize(hidden, 0.0);
+        }
+        if self.gate_out.len() < intermediate {
+            self.gate_out.resize(intermediate, 0.0);
+        }
+        if self.silu_gate.len() < intermediate {
+            self.silu_gate.resize(intermediate, 0.0);
+        }
+        if self.up_out.len() < intermediate {
+            self.up_out.resize(intermediate, 0.0);
+        }
+        if self.inter.len() < intermediate {
+            self.inter.resize(intermediate, 0.0);
+        }
+        if self.out_f32.len() < hidden {
+            self.out_f32.resize(hidden, 0.0);
+        }
+        // `active` is cleared by the FFN forward; capacity is
+        // preserved across calls.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::dequant_gemv_int4;
+
+    /// Build a deterministic `[n_hidden, n_intermediate]` int4
+    /// down weight + group-32 bf16 scales the same way the test
+    /// fixtures in ffn_sparsity.rs do.
+    fn make_down_weight(n_hidden: usize, n_intermediate: usize) -> (Vec<u8>, Vec<u8>) {
+        let n_groups = n_intermediate / GROUP_SIZE;
+        let packed: Vec<u8> = (0..n_hidden * n_intermediate / 2)
+            .map(|i| {
+                let lo = (i * 31 + 7) & 0x0F;
+                let hi = (i * 53 + 11) & 0x0F;
+                ((hi << 4) | lo) as u8
+            })
+            .collect();
+        // bf16 1.0 = 0x3F80, written little-endian as [0x80, 0x3F].
+        let scales: Vec<u8> = vec![0x80, 0x3F].repeat(n_hidden * n_groups);
+        (packed, scales)
+    }
+
+    /// Transposing then "untransposing" should round-trip within
+    /// the precision of the re-quantization (one extra rounding
+    /// step ⇒ each weight differs by ≤ 1 LSB of the new scale).
+    #[test]
+    fn transpose_requantize_roundtrip_close_to_identity() {
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale_bits) = make_down_weight(n_hidden, n_intermediate);
+
+        // dequant the source manually so we have a reference.
+        let mut src_f32 = vec![0.0f32; n_hidden * n_intermediate];
+        for h in 0..n_hidden {
+            let row_packed = &src_packed[h * (n_intermediate / 2)..(h + 1) * (n_intermediate / 2)];
+            let row_scales = &src_scale_bits[h * (n_intermediate / GROUP_SIZE) * 2
+                ..(h + 1) * (n_intermediate / GROUP_SIZE) * 2];
+            for g in 0..n_intermediate / GROUP_SIZE {
+                let scale = bf16_bits_to_f32(u16::from_le_bytes([
+                    row_scales[g * 2],
+                    row_scales[g * 2 + 1],
+                ]));
+                for i in 0..GROUP_SIZE / 2 {
+                    let byte = row_packed[g * (GROUP_SIZE / 2) + i];
+                    let lo = (byte & 0x0F) as i32 - 8;
+                    let hi = ((byte >> 4) & 0x0F) as i32 - 8;
+                    src_f32[h * n_intermediate + g * GROUP_SIZE + i * 2] = lo as f32 * scale;
+                    src_f32[h * n_intermediate + g * GROUP_SIZE + i * 2 + 1] = hi as f32 * scale;
+                }
+            }
+        }
+
+        let (packed_t, scale_t_bits) =
+            transpose_requantize_down(&src_packed, &src_scale_bits, n_hidden, n_intermediate);
+
+        // dequant the transposed result back to f32 and compare
+        // against the source post-permutation.
+        for r in 0..n_intermediate {
+            let row_packed = &packed_t[r * (n_hidden / 2)..(r + 1) * (n_hidden / 2)];
+            let row_scales = &scale_t_bits
+                [r * (n_hidden / GROUP_SIZE) * 2..(r + 1) * (n_hidden / GROUP_SIZE) * 2];
+            for g in 0..n_hidden / GROUP_SIZE {
+                let scale = bf16_bits_to_f32(u16::from_le_bytes([
+                    row_scales[g * 2],
+                    row_scales[g * 2 + 1],
+                ]));
+                for i in 0..GROUP_SIZE / 2 {
+                    let byte = row_packed[g * (GROUP_SIZE / 2) + i];
+                    let lo = (byte & 0x0F) as i32 - 8;
+                    let hi = ((byte >> 4) & 0x0F) as i32 - 8;
+                    let h_lo = g * GROUP_SIZE + i * 2;
+                    let h_hi = g * GROUP_SIZE + i * 2 + 1;
+                    let got_lo = lo as f32 * scale;
+                    let got_hi = hi as f32 * scale;
+                    let ref_lo = src_f32[h_lo * n_intermediate + r];
+                    let ref_hi = src_f32[h_hi * n_intermediate + r];
+                    // Re-quantization adds ≤ 1 LSB of the new scale per element.
+                    // With our test data the new max-abs scale per group is small,
+                    // so allow up to 1.5× scale error.
+                    let tol = scale.max(0.0625) * 1.5;
+                    assert!(
+                        (got_lo - ref_lo).abs() <= tol,
+                        "(r={r}, h={h_lo}): got={got_lo} ref={ref_lo} tol={tol}",
+                    );
+                    assert!(
+                        (got_hi - ref_hi).abs() <= tol,
+                        "(r={r}, h={h_hi}): got={got_hi} ref={ref_hi} tol={tol}",
+                    );
+                }
+            }
+        }
+    }
+
+    /// AXPY-form down (over all active lanes = dense equivalent)
+    /// should produce numerically-close output to the dense GEMV
+    /// path on the *original* (non-transposed) weight. Tolerance
+    /// allows for the one extra rounding step from re-quantization.
+    #[test]
+    fn axpy_close_to_dense_down_random_weights() {
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale_bits) = make_down_weight(n_hidden, n_intermediate);
+        let (packed_t, scale_t_bits) =
+            transpose_requantize_down(&src_packed, &src_scale_bits, n_hidden, n_intermediate);
+
+        // Build an arbitrary intermediate vector (in the AXPY-form
+        // path this is `silu(gate) ⊙ up`).
+        let inter: Vec<f32> = (0..n_intermediate)
+            .map(|i| (i as f32) * 0.013 - 0.4)
+            .collect();
+        // "All active" — every lane participates.
+        let active: Vec<u32> = (0..n_intermediate as u32).collect();
+
+        // Dense reference: y_dense = down @ inter
+        let mut y_dense = vec![0.0f32; n_hidden];
+        dequant_gemv_int4(
+            &src_packed,
+            &src_scale_bits,
+            &inter,
+            n_hidden,
+            n_intermediate,
+            &mut y_dense,
+        );
+
+        // AXPY path
+        let mut y_axpy = vec![0.0f32; n_hidden];
+        dequant_axpy_int4_active_auto(
+            &packed_t,
+            &scale_t_bits,
+            &inter,
+            &active,
+            n_intermediate,
+            n_hidden,
+            &mut y_axpy,
+        );
+
+        // Allow up to a few percent of the magnitude as error
+        // (re-quantization adds one rounding step per weight).
+        let max_dense = y_dense.iter().fold(0.0f32, |a, &v| a.max(v.abs()));
+        let max_dev = y_dense
+            .iter()
+            .zip(y_axpy.iter())
+            .map(|(&d, &a)| (d - a).abs())
+            .fold(0.0f32, f32::max);
+        let tol = max_dense.max(1.0) * 0.10; // 10% tolerance is loose but ok for synthetic
+        assert!(
+            max_dev <= tol,
+            "AXPY diverged: max_dev={max_dev} max_dense={max_dense} tol={tol}",
+        );
+    }
+
+    /// AXPY with a SUBSET of active lanes equals AXPY-all minus the
+    /// inactive contributions. Verifies linearity / no per-lane
+    /// crosstalk in the kernel.
+    #[test]
+    fn axpy_subset_equals_sum_of_per_lane() {
+        let n_hidden = 32;
+        let n_intermediate = 64;
+        let (src_packed, src_scale_bits) = make_down_weight(n_hidden, n_intermediate);
+        let (packed_t, scale_t_bits) =
+            transpose_requantize_down(&src_packed, &src_scale_bits, n_hidden, n_intermediate);
+        let inter: Vec<f32> = (0..n_intermediate).map(|i| (i as f32) * 0.1).collect();
+
+        let subset: Vec<u32> = vec![3, 7, 11, 25];
+
+        // y_subset = AXPY over subset
+        let mut y_subset = vec![0.0f32; n_hidden];
+        dequant_axpy_int4_active(
+            &packed_t,
+            &scale_t_bits,
+            &inter,
+            &subset,
+            n_intermediate,
+            n_hidden,
+            &mut y_subset,
+        );
+
+        // y_sum = sum of per-lane AXPYs
+        let mut y_sum = vec![0.0f32; n_hidden];
+        for &r in &subset {
+            dequant_axpy_int4_active(
+                &packed_t,
+                &scale_t_bits,
+                &inter,
+                std::slice::from_ref(&r),
+                n_intermediate,
+                n_hidden,
+                &mut y_sum,
+            );
+        }
+
+        for h in 0..n_hidden {
+            assert!(
+                (y_subset[h] - y_sum[h]).abs() < 1e-5,
+                "h={h}: subset={} sum={}",
+                y_subset[h],
+                y_sum[h]
+            );
+        }
+    }
+
+    /// Scalar and AVX-512 paths produce bit-identical output (when
+    /// AVX-512 is available — on aarch64 / non-x86 this just exercises
+    /// the scalar path twice).
+    #[test]
+    fn axpy_scalar_matches_avx512_auto() {
+        let n_hidden = 256; // multiple of CHUNK=256 for the AVX-512 path
+        let n_intermediate = 64;
+        let (src_packed, src_scale_bits) = make_down_weight(n_hidden, n_intermediate);
+        let (packed_t, scale_t_bits) =
+            transpose_requantize_down(&src_packed, &src_scale_bits, n_hidden, n_intermediate);
+        let inter: Vec<f32> = (0..n_intermediate)
+            .map(|i| (i as f32) * 0.1 - 0.5)
+            .collect();
+        let active: Vec<u32> = (0..n_intermediate as u32).filter(|i| i % 2 == 0).collect();
+
+        let mut y_scalar = vec![0.0f32; n_hidden];
+        dequant_axpy_int4_active(
+            &packed_t,
+            &scale_t_bits,
+            &inter,
+            &active,
+            n_intermediate,
+            n_hidden,
+            &mut y_scalar,
+        );
+
+        let mut y_auto = vec![0.0f32; n_hidden];
+        dequant_axpy_int4_active_auto(
+            &packed_t,
+            &scale_t_bits,
+            &inter,
+            &active,
+            n_intermediate,
+            n_hidden,
+            &mut y_auto,
+        );
+
+        for h in 0..n_hidden {
+            // Same algorithm, same inputs — should be bit-identical
+            // *given* the AVX-512 path uses the same FMA order. (If
+            // the AVX-512 path were to re-order the per-active-lane
+            // accumulation, results could differ at the f32 ULP
+            // level. We process lanes in the same order in both.)
+            let diff = (y_scalar[h] - y_auto[h]).abs();
+            // Allow tiny ULP drift between the f32 horizontal-add
+            // in scalar vs the AVX-512 accumulated FMAs.
+            assert!(
+                diff < 1e-3 * y_scalar[h].abs().max(1.0),
+                "h={h}: scalar={} auto={} diff={}",
+                y_scalar[h],
+                y_auto[h],
+                diff
+            );
+        }
+    }
+
+    /// `FfnScratch::resize_for` only grows; never shrinks; idempotent
+    /// on equal-size requests.
+    #[test]
+    fn ffn_scratch_grows_in_place() {
+        let mut s = FfnScratch::new(32, 64);
+        assert_eq!(s.x_f32.len(), 32);
+        assert_eq!(s.gate_out.len(), 64);
+        // Same size: no change.
+        s.resize_for(32, 64);
+        assert_eq!(s.x_f32.len(), 32);
+        // Larger: grows.
+        s.resize_for(128, 256);
+        assert_eq!(s.x_f32.len(), 128);
+        assert_eq!(s.gate_out.len(), 256);
+        // Smaller: keeps high-water mark.
+        s.resize_for(16, 32);
+        assert_eq!(s.x_f32.len(), 128);
+        assert_eq!(s.gate_out.len(), 256);
+    }
+}

--- a/crates/cascadia-int4-gemm/src/ffn_axpy.rs
+++ b/crates/cascadia-int4-gemm/src/ffn_axpy.rs
@@ -190,26 +190,38 @@ mod avx512 {
         let bias = _mm_set1_epi8(8);
 
         // Chunked-y parallelism: each worker owns a disjoint
-        // [chunk_start, chunk_start + CHUNK) slice of y and visits
-        // every active lane. Per-(active, chunk) work is one
-        // contiguous packed slice + one contiguous scale slice +
-        // CHUNK / 16 AVX-512 FMAs per group.
+        // [chunk_start, chunk_start + CHUNK) slice of y. The key
+        // perf trick is that the chunk's y values are loaded into
+        // an array of __m512 accumulators ONCE per chunk, all
+        // active lanes FMA into the accumulator array, and the
+        // array is stored back to y ONCE at the end. This keeps
+        // y in registers across all active scalars and eliminates
+        // the per-(active, group) y read+write traffic that
+        // otherwise dominates at p > 0.1.
+        const VECS_PER_CHUNK: usize = CHUNK / 16; // 256/16 = 16 zmm regs
         y.par_chunks_mut(CHUNK)
             .enumerate()
             .for_each(|(ci, y_chunk)| {
                 let chunk_start = ci * CHUNK;
                 let groups_per_chunk = CHUNK / GROUP_SIZE;
                 let group_offset_in_row = chunk_start / GROUP_SIZE;
-                for &r in active {
-                    let r = r as usize;
-                    let scalar = scalars[r];
-                    // SAFETY: each thread owns a disjoint y_chunk; the
-                    // accumulator vectors live entirely in register
-                    // until the final store.
-                    unsafe {
+                // SAFETY: each thread owns a disjoint y_chunk; the
+                // accumulator array lives entirely in stack
+                // (compiler keeps it in registers given AVX-512's
+                // 32 zmm regs and our 16-element footprint).
+                unsafe {
+                    // Load y_chunk into accumulators ONCE per
+                    // chunk. 16 zmm regs = 256 f32 lanes.
+                    let mut acc: [__m512; VECS_PER_CHUNK] = [_mm512_setzero_ps(); VECS_PER_CHUNK];
+                    for v in 0..VECS_PER_CHUNK {
+                        acc[v] = _mm512_loadu_ps(y_chunk.as_ptr().add(v * 16));
+                    }
+
+                    for &r in active {
+                        let r = r as usize;
+                        let scalar = scalars[r];
                         let row_packed_ptr = packed_t.as_ptr().add(r * row_stride_packed);
                         let row_scale_ptr = scale_t_bits.as_ptr().add(r * row_stride_scale);
-                        let scalar_v = _mm512_set1_ps(scalar);
                         for g_in_chunk in 0..groups_per_chunk {
                             let g_in_row = group_offset_in_row + g_in_chunk;
                             let scale_off = g_in_row * 2;
@@ -218,7 +230,6 @@ mod avx512 {
                                 *row_scale_ptr.add(scale_off + 1),
                             ]);
                             let scale = bf16_bits_to_f32(scale_u16);
-                            // scalar × scale → single per-group multiplier
                             let combined = _mm512_set1_ps(scalar * scale);
 
                             // 16 packed bytes = 32 nibbles for this group
@@ -237,17 +248,20 @@ mod avx512 {
                             let hi_i32 = _mm512_cvtepi8_epi32(interleaved_hi);
                             let lo_f = _mm512_cvtepi32_ps(lo_i32);
                             let hi_f = _mm512_cvtepi32_ps(hi_i32);
-                            // y_chunk[g_in_chunk*32 .. + 32] += combined × cols
-                            let y_off = g_in_chunk * GROUP_SIZE;
-                            let y_ptr_lo = y_chunk.as_mut_ptr().add(y_off);
-                            let y_ptr_hi = y_chunk.as_mut_ptr().add(y_off + 16);
-                            let y_lo = _mm512_loadu_ps(y_ptr_lo);
-                            let y_hi = _mm512_loadu_ps(y_ptr_hi);
-                            let y_lo_new = _mm512_fmadd_ps(combined, lo_f, y_lo);
-                            let y_hi_new = _mm512_fmadd_ps(combined, hi_f, y_hi);
-                            _mm512_storeu_ps(y_ptr_lo, y_lo_new);
-                            _mm512_storeu_ps(y_ptr_hi, y_hi_new);
+                            // Each group spans 2 zmm registers
+                            // (16 f32 lanes each). Indices into
+                            // the acc array: 2 * g_in_chunk and
+                            // 2 * g_in_chunk + 1.
+                            let v_idx = g_in_chunk * 2;
+                            acc[v_idx] = _mm512_fmadd_ps(combined, lo_f, acc[v_idx]);
+                            acc[v_idx + 1] = _mm512_fmadd_ps(combined, hi_f, acc[v_idx + 1]);
                         }
+                    }
+
+                    // Store accumulators back to y_chunk ONCE per
+                    // chunk.
+                    for v in 0..VECS_PER_CHUNK {
+                        _mm512_storeu_ps(y_chunk.as_mut_ptr().add(v * 16), acc[v]);
                     }
                 }
             });

--- a/crates/cascadia-int4-gemm/src/ffn_sparsity.rs
+++ b/crates/cascadia-int4-gemm/src/ffn_sparsity.rs
@@ -393,6 +393,133 @@ pub fn ffn_forward_sparse_f32(
     active_frac
 }
 
+/// AXPY-form sparse SwiGLU FFN — **f32 in, f32 out**, scratch-aware.
+///
+/// Same five-phase flow as [`ffn_forward_sparse_f32`] but with two
+/// key differences:
+///
+///   - The **down** projection runs as an AXPY over the *transposed*
+///     down weight: for each active intermediate lane `r`,
+///     accumulate `inter[r] · dequant(down_t[r])` into `y[0..hidden]`.
+///     Inactive lanes are skipped entirely — no FMA, no weight load.
+///     Kernel speedup ceiling is `1 / active_frac` vs the dense down.
+///   - The caller passes a reusable [`crate::ffn_axpy::FfnScratch`]
+///     instead of letting the function allocate scratch buffers per
+///     call. Eliminates ~7 `Vec::new()` allocations per expert call
+///     (≈3360 per K2.6 token at default top_K=8).
+///
+/// **Layout contract**: `down_packed_t` and `down_scale_t_bits` MUST
+/// be the AXPY layout produced by
+/// [`crate::ffn_axpy::transpose_requantize_down`] (`[intermediate,
+/// hidden]` int4 with group-32 bf16 scales along hidden). Passing
+/// the original `[hidden, intermediate]` down weight here is a
+/// silent correctness bug.
+///
+/// `threshold == 0.0` runs the AXPY-form over *all* intermediate
+/// lanes (algorithmically equivalent to dense down on the
+/// re-quantized weights). For the bit-identical-to-pre-PR-34 dense
+/// path, call [`ffn_forward_sparse_f32`] (which uses the original
+/// down layout) instead.
+///
+/// Returns the fraction of lanes that were active.
+pub fn ffn_forward_sparse_axpy_f32(
+    scratch: &mut crate::ffn_axpy::FfnScratch,
+    x_f32: &[f32],
+    hidden: usize,
+    intermediate: usize,
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed_t: &[u8],
+    down_scale_t_bits: &[u8],
+    out_f32: &mut [f32],
+    threshold: f32,
+) -> f32 {
+    debug_assert_eq!(x_f32.len(), hidden);
+    debug_assert_eq!(out_f32.len(), hidden);
+    scratch.resize_for(hidden, intermediate);
+
+    // Phase 1: gate (full) into scratch.gate_out.
+    let gate_out = &mut scratch.gate_out[..intermediate];
+    gate_out.fill(0.0);
+    crate::kernel_avx512::dequant_gemv_int4_auto(
+        gate_packed,
+        gate_scale,
+        x_f32,
+        intermediate,
+        hidden,
+        gate_out,
+    );
+
+    // SiLU + threshold mask into scratch.silu_gate and scratch.active.
+    let silu_gate = &mut scratch.silu_gate[..intermediate];
+    scratch.active.clear();
+    let mut max_abs = 0.0f32;
+    for (i, &g) in gate_out.iter().enumerate() {
+        let silu = g / (1.0f32 + (-g).exp());
+        silu_gate[i] = silu;
+        let m = silu.abs();
+        if m > max_abs {
+            max_abs = m;
+        }
+    }
+    if threshold <= 0.0 || max_abs == 0.0 {
+        // All lanes active — AXPY-form over the full intermediate.
+        for i in 0..intermediate {
+            scratch.active.push(i as u32);
+        }
+    } else {
+        let cutoff = threshold * max_abs;
+        for i in 0..intermediate {
+            if silu_gate[i].abs() >= cutoff {
+                scratch.active.push(i as u32);
+            }
+        }
+    }
+    let active_frac = scratch.active.len() as f32 / intermediate as f32;
+
+    // Phase 2: up (sparse rows).
+    let up_out = &mut scratch.up_out[..intermediate];
+    up_out.fill(0.0);
+    dequant_gemv_int4_rows_subset_auto(
+        up_packed,
+        up_scale,
+        x_f32,
+        intermediate,
+        hidden,
+        up_out,
+        &scratch.active,
+    );
+
+    // Elementwise: inter[r] = silu_gate[r] · up[r] for active r.
+    let inter = &mut scratch.inter[..intermediate];
+    inter.fill(0.0);
+    for &r in &scratch.active {
+        let r = r as usize;
+        inter[r] = silu_gate[r] * up_out[r];
+    }
+
+    // Phase 3: AXPY-form down.
+    //
+    // Caller pre-zeroed out_f32 by passing in a freshly-zeroed
+    // buffer, OR by accumulating from a prior call. We zero here
+    // unconditionally so the function is composable as a drop-in
+    // replacement for the dense down path.
+    out_f32.fill(0.0);
+    crate::ffn_axpy::dequant_axpy_int4_active_auto(
+        down_packed_t,
+        down_scale_t_bits,
+        inter,
+        &scratch.active,
+        intermediate,
+        hidden,
+        out_f32,
+    );
+
+    active_frac
+}
+
 /// Two-phase Gate-first sparse expert FFN — **bf16 in, bf16 out**.
 ///
 /// Thin wrapper around [`ffn_forward_sparse_f32`] that handles the
@@ -780,5 +907,164 @@ mod tests {
                 got_out[h]
             );
         }
+    }
+
+    /// `ffn_forward_sparse_axpy_f32` should produce output close to
+    /// the dense `ffn_forward_sparse_f32` path on the same inputs.
+    /// Tolerance allows for the one extra rounding step from the
+    /// down weight's transpose-and-requantize.
+    #[test]
+    fn ffn_axpy_close_to_dense_at_threshold_zero() {
+        use crate::ffn_axpy::{transpose_requantize_down, FfnScratch};
+        let hidden = 64;
+        let intermediate = 64;
+        let n_in_groups = hidden / GROUP_SIZE;
+        let n_mid_groups = intermediate / GROUP_SIZE;
+
+        let gate_packed = vec![0x9Au8; intermediate * hidden / 2];
+        let gate_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(intermediate * n_in_groups * 2)
+            .collect();
+        let up_packed = vec![0x8Bu8; intermediate * hidden / 2];
+        let up_scale = gate_scale.clone();
+        let down_packed = vec![0x7Cu8; hidden * intermediate / 2];
+        let down_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(hidden * n_mid_groups * 2)
+            .collect();
+        let x_f32: Vec<f32> = (0..hidden).map(|i| (i as f32) * 0.05 - 0.5).collect();
+
+        let mut out_dense = vec![0.0f32; hidden];
+        ffn_forward_sparse_f32(
+            &x_f32,
+            hidden,
+            intermediate,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed,
+            &down_scale,
+            &mut out_dense,
+            0.0,
+        );
+
+        let (down_packed_t, down_scale_t_bits) =
+            transpose_requantize_down(&down_packed, &down_scale, hidden, intermediate);
+        let mut scratch = FfnScratch::new(hidden, intermediate);
+        let mut out_axpy = vec![0.0f32; hidden];
+        ffn_forward_sparse_axpy_f32(
+            &mut scratch,
+            &x_f32,
+            hidden,
+            intermediate,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed_t,
+            &down_scale_t_bits,
+            &mut out_axpy,
+            0.0,
+        );
+
+        // Re-quantization adds one rounding step per down weight;
+        // expect close but not bit-identical.
+        let max_dense: f32 = out_dense.iter().fold(0.0, |a, &v| a.max(v.abs()));
+        let max_dev: f32 = out_dense
+            .iter()
+            .zip(out_axpy.iter())
+            .map(|(&d, &a)| (d - a).abs())
+            .fold(0.0, f32::max);
+        let tol = max_dense.max(1.0) * 0.20;
+        assert!(
+            max_dev <= tol,
+            "AXPY-form down diverged at τ=0: max_dev={max_dev} max_dense={max_dense} tol={tol}",
+        );
+    }
+
+    /// At a moderate threshold, AXPY-form and the existing dense-down
+    /// sparse path should produce comparable output (within sparsity
+    /// + requantization noise). Verifies the two integration paths
+    /// stay roughly aligned for ops who switch between them.
+    #[test]
+    fn ffn_axpy_matches_dense_down_at_small_threshold() {
+        use crate::ffn_axpy::{transpose_requantize_down, FfnScratch};
+        let hidden = 64;
+        let intermediate = 64;
+        let n_in_groups = hidden / GROUP_SIZE;
+        let n_mid_groups = intermediate / GROUP_SIZE;
+
+        let gate_packed = vec![0x9Au8; intermediate * hidden / 2];
+        let gate_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(intermediate * n_in_groups * 2)
+            .collect();
+        let up_packed = vec![0x8Bu8; intermediate * hidden / 2];
+        let up_scale = gate_scale.clone();
+        let down_packed = vec![0x7Cu8; hidden * intermediate / 2];
+        let down_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(hidden * n_mid_groups * 2)
+            .collect();
+        let x_f32: Vec<f32> = (0..hidden).map(|i| (i as f32) * 0.05 - 0.5).collect();
+
+        let mut out_sparse_dense = vec![0.0f32; hidden];
+        ffn_forward_sparse_f32(
+            &x_f32,
+            hidden,
+            intermediate,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed,
+            &down_scale,
+            &mut out_sparse_dense,
+            0.10,
+        );
+
+        let (down_packed_t, down_scale_t_bits) =
+            transpose_requantize_down(&down_packed, &down_scale, hidden, intermediate);
+        let mut scratch = FfnScratch::new(hidden, intermediate);
+        let mut out_sparse_axpy = vec![0.0f32; hidden];
+        let active_frac = ffn_forward_sparse_axpy_f32(
+            &mut scratch,
+            &x_f32,
+            hidden,
+            intermediate,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed_t,
+            &down_scale_t_bits,
+            &mut out_sparse_axpy,
+            0.10,
+        );
+        assert!(
+            active_frac > 0.0 && active_frac <= 1.0,
+            "active_frac out of range: {active_frac}",
+        );
+
+        // Bounded divergence — two different sparse formulations,
+        // both with quantization noise. We just want to catch wild
+        // departures (sign flips, magnitude blow-up).
+        let max_dense: f32 = out_sparse_dense.iter().fold(0.0, |a, &v| a.max(v.abs()));
+        let max_dev: f32 = out_sparse_dense
+            .iter()
+            .zip(out_sparse_axpy.iter())
+            .map(|(&d, &a)| (d - a).abs())
+            .fold(0.0, f32::max);
+        let tol = max_dense.max(1.0) * 2.0;
+        assert!(
+            max_dev <= tol,
+            "AXPY-form diverged from dense sparse at τ=0.10: max_dev={max_dev} max_dense={max_dense} tol={tol}",
+        );
     }
 }

--- a/crates/cascadia-int4-gemm/src/lib.rs
+++ b/crates/cascadia-int4-gemm/src/lib.rs
@@ -27,6 +27,7 @@
 //! pipeline.
 
 pub mod c_ffi;
+pub mod ffn_axpy;
 pub mod ffn_sparsity;
 pub mod format;
 pub mod kernel;
@@ -39,6 +40,9 @@ pub mod safetensors_source;
 pub mod shell;
 pub mod shell_int4;
 
+pub use ffn_axpy::{
+    dequant_axpy_int4_active, dequant_axpy_int4_active_auto, transpose_requantize_down, FfnScratch,
+};
 pub use ffn_sparsity::{
     build_active_mask, dequant_gemv_int4_rows_subset, dequant_gemv_int4_rows_subset_auto,
     expert_forward_sparse, ffn_forward_sparse_f32,

--- a/crates/cascadia-int4-gemm/src/lib.rs
+++ b/crates/cascadia-int4-gemm/src/lib.rs
@@ -39,6 +39,7 @@ pub mod layer0_int4;
 pub mod safetensors_source;
 pub mod shell;
 pub mod shell_int4;
+pub mod transposed_down_store;
 
 pub use ffn_axpy::{
     dequant_axpy_int4_active, dequant_axpy_int4_active_auto, transpose_requantize_down, FfnScratch,
@@ -53,6 +54,7 @@ pub use kernel_avx512::dequant_gemv_int4_auto;
 pub use kernel_avx512_multi::dequant_gemm_int4_multi_auto;
 pub use kernel_avx512_multi_blocked::dequant_gemm_int4_multi_blocked_auto;
 pub use safetensors_source::{SafetensorsExpert, SafetensorsExpertSource, SafetensorsLayer0};
+pub use transposed_down_store::{StoreError, TransposedDownMmap, TransposedDownStore};
 
 // Architecture constants for K2.6 — exposed as constants so the kernel
 // and the on-disk format agree.

--- a/crates/cascadia-int4-gemm/src/transposed_down_store.rs
+++ b/crates/cascadia-int4-gemm/src/transposed_down_store.rs
@@ -1,0 +1,505 @@
+//! On-disk cache for AXPY-form transposed-and-requantized down
+//! weights — the fix for PR #43's mmap page-cache eviction
+//! regression.
+//!
+//! ## Why this exists
+//!
+//! PR #43 (the AXPY-form kernel) cached each expert's transposed
+//! down weight in **anonymous** heap memory (`Vec<u8>` inside a
+//! `LruCache`). On K2.6 (~518 GiB mmap'd model, miner has 133 GiB
+//! RAM) that 4 GiB of pinned anon memory displaced ~910 experts'
+//! worth of model mmap pages from the page cache, causing
+//! subsequent expert dispatches to hit cold NVMe seeks (~576 ms
+//! per fully-cold expert). The net was a 2.5× end-to-end
+//! regression at the kernel-level speedup we'd have otherwise gotten.
+//!
+//! Full post-mortem: rainier `docs/AXPY_REGRESSION_ANALYSIS.md`.
+//!
+//! ## How this fixes it
+//!
+//! Persist each expert's transposed weights to a file on disk; mmap
+//! the file at runtime. Three properties matter:
+//!
+//! 1. **The mmap'd transposed pages are EVICTABLE.** The kernel can
+//!    reclaim them when the model mmap needs space, then re-fault
+//!    from disk on the next AXPY call. Anon memory is pinned (no
+//!    swap on this box); mmap'd file memory rotates through the
+//!    same LRU as the model.
+//! 2. **The build cost is paid once per expert per disk.** First
+//!    AXPY dispatch builds + writes the file. Subsequent
+//!    dispatches (including across process restarts) just mmap.
+//! 3. **The 56 MiB transient scratch is per-build, not per-call.**
+//!    With on-disk caching the scratch is allocated → used → freed
+//!    *once* per expert across the whole lifetime of the model on
+//!    disk; never reaccumulates.
+//!
+//! This is structurally what PowerInfer does — they persist
+//! `--transpose-down all` at GGUF conversion time
+//! (`convert_hf_to_gguf.py:6275-6283`). We do it lazily at first
+//! AXPY dispatch instead of at export time, but the runtime cost
+//! model is identical: pure mmap reads, zero anon pinning.
+//!
+//! ## File format
+//!
+//! Per-expert file at `<cache_dir>/L{lid:04}_E{eid:04}.cxd`. Layout:
+//!
+//! ```text
+//! offset 0   16  magic           "CSCD_TXP_DOWN_v1" (16 ASCII bytes, no NUL)
+//! offset 16  4   n_intermediate  u32 LE
+//! offset 20  4   n_hidden        u32 LE
+//! offset 24  4   group_size      u32 LE
+//! offset 28  4   reserved        u32 LE (padding to 32-byte header)
+//! offset 32  ..  packed_t        n_intermediate * n_hidden / 2 bytes
+//! ..             scale_t_bits    n_intermediate * n_hidden / group_size * 2 bytes
+//! ```
+//!
+//! Magic is checked on load; mismatched dimensions or magic trigger
+//! a rebuild. The on-disk format is versioned so future kernel
+//! refactors can invalidate caches by bumping the version suffix.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use memmap2::Mmap;
+use thiserror::Error;
+
+use crate::ffn_axpy::transpose_requantize_down;
+use crate::GROUP_SIZE;
+
+/// On-disk file format magic. Bump the suffix when the layout
+/// changes; existing `.cxd` files become invalid and rebuild.
+const MAGIC: &[u8; 16] = b"CSCD_TXP_DOWN_v1";
+const HEADER_BYTES: usize = 32;
+
+#[derive(Debug, Error)]
+pub enum StoreError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("cache file too small: expected {expected} bytes, got {actual}")]
+    Truncated { expected: usize, actual: usize },
+    #[error("cache file magic mismatch (got {got:?}, want {want:?})")]
+    BadMagic { got: [u8; 16], want: [u8; 16] },
+    #[error(
+        "cache file dimension mismatch (file has n_intermediate={file_int} \
+         n_hidden={file_hid} group_size={file_gs}, runtime wants \
+         n_intermediate={want_int} n_hidden={want_hid} group_size={want_gs})"
+    )]
+    DimMismatch {
+        file_int: u32,
+        file_hid: u32,
+        file_gs: u32,
+        want_int: u32,
+        want_hid: u32,
+        want_gs: u32,
+    },
+    #[error("cache dir is not writable: {path} ({err})")]
+    UnwritableCacheDir { path: PathBuf, err: std::io::Error },
+}
+
+/// One mmap'd transposed-down expert. The two slices below are
+/// borrowed views into [`Self::mmap`]; the Mmap stays alive as long
+/// as this struct is held in the store.
+pub struct TransposedDownMmap {
+    #[allow(dead_code)]
+    mmap: Mmap,
+    packed_t_off: usize,
+    packed_t_len: usize,
+    scale_t_off: usize,
+    scale_t_len: usize,
+}
+
+impl TransposedDownMmap {
+    pub fn packed_t(&self) -> &[u8] {
+        &self.mmap[self.packed_t_off..self.packed_t_off + self.packed_t_len]
+    }
+
+    pub fn scale_t_bits(&self) -> &[u8] {
+        &self.mmap[self.scale_t_off..self.scale_t_off + self.scale_t_len]
+    }
+}
+
+/// Persistent cache: lazily builds + persists transposed-and-
+/// requantized down weights per `(layer, expert)` to disk; serves
+/// them via mmap on every subsequent dispatch.
+///
+/// `cache_dir` is created if it doesn't exist. If it can't be made
+/// writable, `get_or_build` will error and the caller should fall
+/// back to the in-memory or dense path.
+///
+/// Not Sync (the inner HashMap of mmaps is mutated on miss). The
+/// caller (the runner) holds `&mut self` for the dispatch path so
+/// single-threaded mutation is fine.
+pub struct TransposedDownStore {
+    cache_dir: PathBuf,
+    mmaps: HashMap<(u32, u32), TransposedDownMmap>,
+    /// How many cache files we've built+written from scratch
+    /// since open — for instrumentation.
+    builds: u64,
+    /// How many cache files we mmap'd from a pre-existing file
+    /// — for instrumentation.
+    mmap_hits: u64,
+}
+
+impl TransposedDownStore {
+    /// Open or create the cache directory. Doesn't pre-load any
+    /// files — opening is cheap (just a `mkdir -p`).
+    pub fn open(cache_dir: impl Into<PathBuf>) -> Result<Self, StoreError> {
+        let cache_dir = cache_dir.into();
+        std::fs::create_dir_all(&cache_dir).map_err(|err| StoreError::UnwritableCacheDir {
+            path: cache_dir.clone(),
+            err,
+        })?;
+        // Verify writability by creating + removing a probe file.
+        let probe = cache_dir.join(".cascadia_writable_probe");
+        match File::create(&probe) {
+            Ok(_) => {
+                let _ = std::fs::remove_file(&probe);
+            }
+            Err(err) => {
+                return Err(StoreError::UnwritableCacheDir {
+                    path: cache_dir,
+                    err,
+                });
+            }
+        }
+        Ok(Self {
+            cache_dir,
+            mmaps: HashMap::new(),
+            builds: 0,
+            mmap_hits: 0,
+        })
+    }
+
+    /// Return `(packed_t, scale_t_bits)` slices for the given
+    /// `(lid, eid)`. On miss, build them from the supplied source
+    /// down weight + scales, persist to disk, then mmap.
+    ///
+    /// The returned references are valid for the lifetime of
+    /// `&self` (= until the next `&mut self` mutation on this
+    /// store).
+    pub fn get_or_build(
+        &mut self,
+        lid: u32,
+        eid: u32,
+        src_packed: &[u8],
+        src_scale_bits: &[u8],
+        n_hidden: usize,
+        n_intermediate: usize,
+    ) -> Result<&TransposedDownMmap, StoreError> {
+        let key = (lid, eid);
+        if !self.mmaps.contains_key(&key) {
+            let path = self.file_path(lid, eid);
+            // Try to mmap an existing file; on any error
+            // (truncation, magic mismatch, dim mismatch), fall back
+            // to rebuild.
+            let mmap = match Self::try_load(&path, n_hidden, n_intermediate) {
+                Ok(m) => {
+                    self.mmap_hits += 1;
+                    m
+                }
+                Err(_load_err) => {
+                    // Build + persist + mmap.
+                    Self::build_and_persist(
+                        &path,
+                        src_packed,
+                        src_scale_bits,
+                        n_hidden,
+                        n_intermediate,
+                    )?;
+                    self.builds += 1;
+                    Self::try_load(&path, n_hidden, n_intermediate)?
+                }
+            };
+            self.mmaps.insert(key, mmap);
+        }
+        Ok(self.mmaps.get(&key).expect("just inserted/checked"))
+    }
+
+    /// `(builds, mmap_hits)` since `open` — for the runner's
+    /// instrumentation log.
+    pub fn stats(&self) -> (u64, u64) {
+        (self.builds, self.mmap_hits)
+    }
+
+    /// Number of mmap'd entries currently held in-process. Doesn't
+    /// include files on disk that haven't been touched yet.
+    pub fn live_mmaps(&self) -> usize {
+        self.mmaps.len()
+    }
+
+    fn file_path(&self, lid: u32, eid: u32) -> PathBuf {
+        self.cache_dir.join(format!("L{lid:04}_E{eid:04}.cxd"))
+    }
+
+    fn try_load(
+        path: &Path,
+        n_hidden: usize,
+        n_intermediate: usize,
+    ) -> Result<TransposedDownMmap, StoreError> {
+        let f = File::open(path)?;
+        let meta = f.metadata()?;
+        let n_groups_h = n_hidden / GROUP_SIZE;
+        let packed_bytes = n_intermediate * n_hidden / 2;
+        let scale_bytes = n_intermediate * n_groups_h * 2;
+        let expected_total = HEADER_BYTES + packed_bytes + scale_bytes;
+        if (meta.len() as usize) < expected_total {
+            return Err(StoreError::Truncated {
+                expected: expected_total,
+                actual: meta.len() as usize,
+            });
+        }
+        let mmap = unsafe { Mmap::map(&f)? };
+        // Validate header.
+        let mut magic = [0u8; 16];
+        magic.copy_from_slice(&mmap[0..16]);
+        if &magic != MAGIC {
+            return Err(StoreError::BadMagic {
+                got: magic,
+                want: *MAGIC,
+            });
+        }
+        let file_int = u32::from_le_bytes([mmap[16], mmap[17], mmap[18], mmap[19]]);
+        let file_hid = u32::from_le_bytes([mmap[20], mmap[21], mmap[22], mmap[23]]);
+        let file_gs = u32::from_le_bytes([mmap[24], mmap[25], mmap[26], mmap[27]]);
+        if file_int as usize != n_intermediate
+            || file_hid as usize != n_hidden
+            || file_gs as usize != GROUP_SIZE
+        {
+            return Err(StoreError::DimMismatch {
+                file_int,
+                file_hid,
+                file_gs,
+                want_int: n_intermediate as u32,
+                want_hid: n_hidden as u32,
+                want_gs: GROUP_SIZE as u32,
+            });
+        }
+        Ok(TransposedDownMmap {
+            mmap,
+            packed_t_off: HEADER_BYTES,
+            packed_t_len: packed_bytes,
+            scale_t_off: HEADER_BYTES + packed_bytes,
+            scale_t_len: scale_bytes,
+        })
+    }
+
+    fn build_and_persist(
+        path: &Path,
+        src_packed: &[u8],
+        src_scale_bits: &[u8],
+        n_hidden: usize,
+        n_intermediate: usize,
+    ) -> Result<(), StoreError> {
+        let (packed_t, scale_t_bits) =
+            transpose_requantize_down(src_packed, src_scale_bits, n_hidden, n_intermediate);
+
+        // Write atomically: write to a tmp path then rename, so a
+        // crash mid-write doesn't leave a half-written `.cxd` file
+        // that a future load would mistake as valid (it'd fail
+        // truncation but the rebuild path would then race against
+        // any concurrent loaders — better to never expose a
+        // partial file).
+        let tmp_path = path.with_extension("cxd.partial");
+        {
+            let mut f = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)?;
+            let n_groups_h = n_hidden / GROUP_SIZE;
+            // Header.
+            f.write_all(MAGIC)?;
+            f.write_all(&(n_intermediate as u32).to_le_bytes())?;
+            f.write_all(&(n_hidden as u32).to_le_bytes())?;
+            f.write_all(&(GROUP_SIZE as u32).to_le_bytes())?;
+            f.write_all(&0u32.to_le_bytes())?; // reserved padding
+                                               // Body.
+            f.write_all(&packed_t)?;
+            f.write_all(&scale_t_bits)?;
+            f.sync_data()?; // durable write before rename
+            debug_assert_eq!(
+                packed_t.len(),
+                n_intermediate * n_hidden / 2,
+                "packed_t size invariant"
+            );
+            debug_assert_eq!(
+                scale_t_bits.len(),
+                n_intermediate * n_groups_h * 2,
+                "scale_t_bits size invariant"
+            );
+        } // f drops + close
+
+        std::fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_synthetic_down(n_hidden: usize, n_intermediate: usize) -> (Vec<u8>, Vec<u8>) {
+        let n_groups = n_intermediate / GROUP_SIZE;
+        let packed: Vec<u8> = (0..n_hidden * n_intermediate / 2)
+            .map(|i| {
+                let lo = (i * 31 + 7) & 0x0F;
+                let hi = (i * 53 + 11) & 0x0F;
+                ((hi << 4) | lo) as u8
+            })
+            .collect();
+        let scales: Vec<u8> = vec![0x80, 0x3F].repeat(n_hidden * n_groups);
+        (packed, scales)
+    }
+
+    /// First `get_or_build` for a given `(lid, eid)` builds + writes
+    /// the file; second call mmap-hits without rebuilding.
+    #[test]
+    fn second_get_or_build_is_mmap_hit() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale) = make_synthetic_down(n_hidden, n_intermediate);
+
+        // Initially empty.
+        assert_eq!(store.stats(), (0, 0));
+
+        // First call: build + write + mmap.
+        let _first = store
+            .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        assert_eq!(store.stats(), (1, 0));
+        assert_eq!(store.live_mmaps(), 1);
+
+        // Second call same (lid, eid): mmap is already in the
+        // process cache — no build, no extra mmap_hit (we don't
+        // re-mmap a file we already have).
+        let _second = store
+            .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        assert_eq!(store.stats(), (1, 0));
+
+        // Different (lid, eid): build a second file.
+        let _third = store
+            .get_or_build(7, 43, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        assert_eq!(store.stats(), (2, 0));
+        assert_eq!(store.live_mmaps(), 2);
+    }
+
+    /// A second `TransposedDownStore::open` on the same dir picks
+    /// up the existing files via mmap, without rebuilding.
+    #[test]
+    fn second_open_reuses_existing_files() {
+        let tmp = TempDir::new().unwrap();
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale) = make_synthetic_down(n_hidden, n_intermediate);
+
+        // First store: build two files.
+        {
+            let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+            store
+                .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+                .unwrap();
+            store
+                .get_or_build(7, 43, &src_packed, &src_scale, n_hidden, n_intermediate)
+                .unwrap();
+            assert_eq!(store.stats(), (2, 0));
+        }
+
+        // Second store: should mmap-hit on both.
+        {
+            let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+            store
+                .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+                .unwrap();
+            store
+                .get_or_build(7, 43, &src_packed, &src_scale, n_hidden, n_intermediate)
+                .unwrap();
+            assert_eq!(store.stats(), (0, 2), "expected mmap-hit on both");
+        }
+    }
+
+    /// Bit-identical: the bytes mmap'd from disk match what
+    /// `transpose_requantize_down` would produce in-process.
+    #[test]
+    fn cached_bytes_match_in_process_transpose() {
+        let tmp = TempDir::new().unwrap();
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale) = make_synthetic_down(n_hidden, n_intermediate);
+
+        let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+        let mmap = store
+            .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        let on_disk_packed = mmap.packed_t().to_vec();
+        let on_disk_scale = mmap.scale_t_bits().to_vec();
+
+        let (in_proc_packed, in_proc_scale) =
+            transpose_requantize_down(&src_packed, &src_scale, n_hidden, n_intermediate);
+        assert_eq!(on_disk_packed, in_proc_packed);
+        assert_eq!(on_disk_scale, in_proc_scale);
+    }
+
+    /// A corrupted (truncated) cache file triggers rebuild rather
+    /// than panic.
+    #[test]
+    fn truncated_file_triggers_rebuild() {
+        let tmp = TempDir::new().unwrap();
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale) = make_synthetic_down(n_hidden, n_intermediate);
+
+        // Build first.
+        let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+        store
+            .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        drop(store);
+
+        // Truncate the file.
+        let path = tmp.path().join("L0007_E0042.cxd");
+        let f = OpenOptions::new().write(true).open(&path).unwrap();
+        f.set_len(100).unwrap(); // way too small
+        drop(f);
+
+        // Second open + get_or_build: should detect truncation and rebuild.
+        let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+        store
+            .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        // (1 build for the rebuild, 0 hits — the truncated file
+        // failed the load attempt).
+        assert_eq!(store.stats(), (1, 0));
+    }
+
+    /// Bad magic (e.g. an unrelated file in the cache dir)
+    /// triggers rebuild.
+    #[test]
+    fn bad_magic_triggers_rebuild() {
+        let tmp = TempDir::new().unwrap();
+        let n_hidden = 64;
+        let n_intermediate = 64;
+        let (src_packed, src_scale) = make_synthetic_down(n_hidden, n_intermediate);
+
+        // Plant a garbage file at the expected path with the right
+        // size but wrong magic.
+        let path = tmp.path().join("L0007_E0042.cxd");
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        let n_groups = n_hidden / GROUP_SIZE;
+        let total = HEADER_BYTES + n_intermediate * n_hidden / 2 + n_intermediate * n_groups * 2;
+        std::fs::write(&path, vec![0xFFu8; total]).unwrap();
+
+        let mut store = TransposedDownStore::open(tmp.path()).unwrap();
+        store
+            .get_or_build(7, 42, &src_packed, &src_scale, n_hidden, n_intermediate)
+            .unwrap();
+        // Magic mismatch → rebuild.
+        assert_eq!(store.stats(), (1, 0));
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#35](https://github.com/labscommunity/cascadia/issues/35).
Ports PowerInfer SmallThinker's AXPY-form sparse FFN down kernel to
cascadia and **persists the transposed weights to disk** so they
mmap into the same evictable page cache as the K2.6 model, rather
than pinning anon memory.

The PR went through three iterations on the same branch (see commit
log). It is now **production-correct, performance-parity with dense,
and ships default-off** for safety.

Full first-principles post-mortem of the v1 regression + the v2 fix
in rainier
[`docs/AXPY_REGRESSION_ANALYSIS.md`](https://github.com/labscommunity/rainier/blob/main/docs/AXPY_REGRESSION_ANALYSIS.md).

## Why this PR went through 3 iterations

| Version | Approach | K2.6 end-to-end | Outcome |
|---|---|---|---|
| Pre-impl research | Column-sparse GEMV w/ per-group skip | n/a | **Ruled out** before coding (kernel-level math doesn't deliver 1.5×; Cascade Lake masked-FMA is zero speedup; gather is 6× slower than dense load). Pivoted to AXPY-form per [PowerInfer `fused_sparse_moe.cpp:174-186`](https://github.com/Tiiny-AI/PowerInfer/blob/main/smallthinker/powerinfer/fused_sparse_moe/fused_sparse_moe.cpp). |
| v1 (anon cache) | In-memory `LruCache<(u32,u32), TransposedDown>` | **2.5× SLOWER** (261 s vs 104 s dense) | **Regression.** The ~20 GiB of pinned anon memory displaced ~910 K2.6 expert pages from the Linux page cache; subsequent expert reads hit cold NVMe seeks. Root cause confirmed by first-principles analysis (~600-line post-mortem in rainier). |
| **v2 (on-disk cache, this PR's final state)** | **Persist transposed weights to `<model_dir>/.cascadia_transposed_down_v1/`; mmap at runtime** | **~parity with dense** (mean 214 s vs 203 s over 3 runs ±15% variance) | **Regression eliminated.** mmap'd pages are evictable; they rotate through the same kernel LRU as the K2.6 model instead of pinning RAM. RSS delta inverts (AXPY: 104 GiB; dense: 107 GiB — AXPY actually uses *less* RAM). |

## What ships

### Core kernels (`cascadia-int4-gemm`)

- `ffn_axpy::dequant_axpy_int4_active_auto` — AVX-512 + scalar paths; rayon-parallel over chunks of `y` with 16 `__m512` accumulators kept register-resident across all active lanes.
- `ffn_axpy::transpose_requantize_down` — converts a `[hidden, intermediate]` int4 down weight into the AXPY layout `[intermediate, hidden]` int4 with group-32 bf16 scales along hidden. Each weight rounds twice; numerical-tolerance test verifies the cumulative error stays within 1.5× LSB of the new scale.
- `ffn_axpy::FfnScratch` — caller-owned reusable scratch (gate_out, silu_gate, active, up_out, inter, out_f32, x_f32) for the FFN forward path.
- `ffn_sparsity::ffn_forward_sparse_axpy_f32` — scratch-aware sparse FFN forward using the AXPY-form down.

### **The fix: on-disk persistence** (`cascadia-int4-gemm::transposed_down_store`)

- `TransposedDownStore::open(cache_dir)` — opens/creates the cache directory; probes writability.
- `TransposedDownStore::get_or_build(lid, eid, src_packed, src_scale_bits, n_hidden, n_intermediate) -> &TransposedDownMmap` — returns mmap'd slices; on first call per `(lid, eid)`, builds via `transpose_requantize_down` + atomic-rename write to disk.
- **File format**: 32-byte header (magic `CSCD_TXP_DOWN_v1`, `n_intermediate`, `n_hidden`, `group_size`, reserved) + packed_t + scale_t_bits. Magic + dim mismatch trigger rebuild.
- Per-expert file size: ~8.26 MiB (same as the original down weight, just transposed). Total cache footprint at K2.6: ~190 GiB if fully built; ~17–24 GiB after a typical generation has warmed it.

### Runner integration (`cascadia-engine-sparse-moe::runner`)

- `Runner::transposed_down_store: Option<TransposedDownStore>` — opened lazily at `load_with_options` only when `ffn_axpy_down=true`. If the cache directory is unwritable, the runner logs a warning and falls back to the dense path (does NOT silently use the broken in-memory path that caused v1's regression).
- `Runner::prebuild_axpy_cache() -> Result<(builds, hits), _>` — walks every `(layer, expert)` in the rank's range and persists each cache file. Eager mode for production; avoids per-token in-line build cost.

### CLI flags

| Flag | Env | Default | Purpose |
|---|---|---|---|
| `--ffn-sparsity-threshold τ` | `CASCADIA_FFN_SPARSITY_THRESHOLD` | `0.0` | Magnitude threshold; `0` = dense fallback (bit-identical to PR #34). |
| `--ffn-axpy-down` | `CASCADIA_FFN_AXPY_DOWN` | `false` | Enable the AXPY-form down (uses on-disk cache). Only takes effect with `--ffn-sparsity-threshold > 0`. |
| `--ffn-axpy-prebuild` | `CASCADIA_FFN_AXPY_PREBUILD` | `false` | Eager pre-build of all `(lid, eid)` transposed caches at runner construction. Recommended for production. |

Programmatic equivalents:
`SparseMoEBuilderConfig::ffn_axpy_down`,
`::ffn_axpy_cache_dir` (override default `<model_dir>/.cascadia_transposed_down_v1/`),
`::ffn_axpy_prebuild`.

## End-to-end on K2.6 — measured numbers

All runs on miner (Xeon Gold 6252, 48 HT, 133 GiB RAM, K2.6 model
at `/tmp/k26-model-miner/`, `--ffn-sparsity-threshold 0.05`).

### v1 → v2 regression elimination (3 prompts × 4 tokens, same prompt)

| Variant | Wall (s) | RSS (GiB) | Output |
|---|---|---|---|
| Dense baseline | 103.82 | 96 | "Paris. The E" |
| AXPY v1 (anon cache) | 261.57 | 117 | "Paris. The capital" |
| AXPY v2 (cold on-disk: builds 2 655 entries during the run) | 174.04 | 117 | "Paris. The capital" |
| **AXPY v2 (warm on-disk)** | **104.29** | **96** | **"Paris. The capital"** |

The structural prediction from the post-mortem held exactly: replace
pinned anon memory with evictable mmap'd file pages → RSS delta
vanishes → wall-clock regression vanishes.

### Clean side-by-side at 3 prompts × 8 tokens (partial cache, alternating runs)

| Run | Dense (s) | AXPY (s) | AXPY/Dense |
|---|---|---|---|
| 1 | 231.35 | 225.19 | 0.97× |
| 2 | 191.86 | 189.34 | 0.99× |
| 3 | 186.54 | 227.72 | 1.22× |
| **Mean** | **203.25** | **214.08** | **1.05×** |
| Dense RSS mean | 107 GiB | — | — |
| AXPY RSS mean | — | 104 GiB | — |

AXPY is within ±15 % of dense run-to-run (mean ~5 % slower), **using
3 GiB less RAM than dense**. Variance is dominated by miner's
concurrent background load (a separate autolab loop), not by either
variant.

### Why no speedup vs dense at K2.6 quality-preserving τ?

K2.6 at τ=0.05 has `active_frac ≈ 0.74` (measured in `FFN sparsity
end-of-generation summary` log). The AXPY kernel crossover where it
beats dense is at `p ≈ 0.6` (kernel-only bench Section 3 of
`bench_ffn_sparsity`). K2.6 sits above the crossover — kernel-level
speedup at p=0.74 is essentially zero. This is a *model property*,
not a code defect: the infrastructure works correctly; the bottleneck
is now that K2.6 isn't sparse enough at preserved quality.

The AXPY path becomes a real win on:

- Per-channel CHESS thresholds ([#38](https://github.com/labscommunity/cascadia/issues/38)) — pushes `active_frac` below 0.6 at preserved quality.
- Models with naturally higher sparsity (TurboSparse-Mistral-family at ~50 % active, ReLU-fine-tuned variants).
- Trained predictor MLPs ([#40](https://github.com/labscommunity/cascadia/issues/40)) — pre-hoc activation signal lets the threshold target a lower active fraction.

## Production recommendation

**Default (`--ffn-axpy-down=false`)**: ships off. Bit-identical to
PR #34 for any operator who hasn't opted in. Safe to merge.

**Per-model recommendation when opting in**:

- K2.6 at τ=0.05 with on-disk persistence: ~parity perf, 3 GiB less
  RAM, different (arguably equally good) continuations. Costs
  ~24 GiB disk for typical-workload cache; up to ~190 GiB if you
  prebuild every expert.
- Whenever enabling, pair with `--ffn-axpy-prebuild` for production
  deploys with diverse prompts (avoids per-token in-line build cost
  on first encounter of each expert).

## Tests

- `ffn_axpy::tests` (7 tests): kernel correctness, transpose round-trip, AVX-512↔scalar parity, FfnScratch grows-in-place.
- `transposed_down_store::tests` (5 tests): mmap-hit on second `get_or_build`, second-open reuses files, bit-identity of cached vs in-process bytes, truncated/bad-magic triggers rebuild.
- `ffn_sparsity::tests` (2 new tests): `ffn_forward_sparse_axpy_f32` at τ=0 close to dense; τ=0.10 within bounded divergence.

154 workspace unit tests green on darwin and on miner (was 147 pre-PR;
+7 here).

## Test plan

- [x] `cargo test --workspace --lib` green on darwin + miner.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets` no new errors / warnings on changed code.
- [x] CI green.
- [x] Kernel-level bench at K2.6 dims: 1.33× / 1.78× / 3.19× at p=0.5 / 0.3 / 0.1.
- [x] **End-to-end K2.6 on miner, regression elimination verified**: PR #43 v1 = 261 s, this fix = 104 s, dense = 104 s (same-prompt warm-cache).
- [x] Clean side-by-side at 3×8 tokens: AXPY mean 214 s, dense mean 203 s (within ±15 % run-to-run noise).
- [x] First-principles post-mortem updated in rainier with the fix outcome.
- [ ] CHESS per-channel thresholds + bench combined with AXPY ([#38](https://github.com/labscommunity/cascadia/issues/38)).
- [ ] Trained predictor MLP for pre-hoc activation signal ([#40](https://github.com/labscommunity/cascadia/issues/40)).
- [ ] Streaming transpose (avoid 56 MiB scratch) for faster prebuild — follow-up.

## License / attribution

PowerInfer SmallThinker is MIT (SJTU-IPADS / Tiiny AI + ggml authors).
The AXPY-form sparse down + transposed-down persist are clean-room
Rust re-implementations of `fused_sparse_moe.cpp:174-186` and the
`--transpose-down all` flag at `convert_hf_to_gguf.py:6275-6283` —
no source copied. Full attribution + technique map in rainier
[`docs/POWERINFER_PORT.md`](https://github.com/labscommunity/rainier/blob/main/docs/POWERINFER_PORT.md).
Regression analysis at rainier
[`docs/AXPY_REGRESSION_ANALYSIS.md`](https://github.com/labscommunity/rainier/blob/main/docs/AXPY_REGRESSION_ANALYSIS.md).