### PR TITLE
perf: per-channel CHESS FFN sparsity thresholds (#38)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "rayon",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -225,6 +225,31 @@ pub struct WorkerArgs {
     /// Recommended for production deployments with diverse prompts.
     #[arg(long, default_value_t = false, env = "CASCADIA_FFN_AXPY_PREBUILD")]
     pub ffn_axpy_prebuild: bool,
+
+    /// Issue #38 (CHESS) — load per-channel FFN sparsity thresholds
+    /// from this JSON file (produced by the `calibrate_ffn_thresholds`
+    /// tool). Takes precedence over `--ffn-sparsity-threshold` for
+    /// any layer covered by the file; uncovered layers fall back to
+    /// the scalar value.
+    ///
+    /// Per-channel τ typically achieves 2× the sparsity-at-quality of
+    /// a single global τ — some channels reliably dominate the
+    /// magnitude distribution, others are reliably negligible. See
+    /// `docs/perf/CHESS_PER_CHANNEL.md` for the calibration workflow.
+    #[arg(long, env = "CASCADIA_FFN_SPARSITY_THRESHOLDS_FILE")]
+    pub ffn_sparsity_thresholds_file: Option<std::path::PathBuf>,
+
+    /// Issue #38 (CHESS) — capture per-(layer, channel) `silu(gate)`
+    /// histograms during routed expert calls and dump them to this
+    /// directory on shutdown. Feed the dump into
+    /// `calibrate_ffn_thresholds` to produce a per-channel threshold
+    /// file. Only effective when `--ffn-axpy-down` is also on (the
+    /// non-AXPY path doesn't surface `silu(gate)` to the runner).
+    ///
+    /// Memory cost: 60 layers × 2048 channels × 128 bins × 4 B
+    /// ≈ 60 MiB resident on K2.6 single-stage; bounded.
+    #[arg(long, env = "CASCADIA_FFN_SPARSITY_CAPTURE_DIR")]
+    pub ffn_sparsity_capture_dir: Option<std::path::PathBuf>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -452,6 +477,18 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             cfg.ffn_sparsity_threshold = args.ffn_sparsity_threshold;
             cfg.ffn_axpy_down = args.ffn_axpy_down;
             cfg.ffn_axpy_prebuild = args.ffn_axpy_prebuild;
+            cfg.ffn_sparsity_thresholds_file = args.ffn_sparsity_thresholds_file.clone();
+            cfg.ffn_sparsity_capture_dir = args.ffn_sparsity_capture_dir.clone();
+            // Issue #38: capture surfaces silu(gate) via the AXPY
+            // scratch — if the user asked to capture but didn't ask
+            // for AXPY, warn (the capture will silently be empty
+            // because the non-AXPY path doesn't expose silu(gate)).
+            if args.ffn_sparsity_capture_dir.is_some() && !args.ffn_axpy_down {
+                tracing::warn!(
+                    "--ffn-sparsity-capture-dir requires --ffn-axpy-down to surface silu(gate); \
+                     capture will be empty without it"
+                );
+            }
             // N-gram speculative decode (sparse-moe single-stage).
             // The `--prompt-lookup` flag is the canonical opt-in (it
             // already drives the ov-genai prompt-lookup path); when

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -106,6 +106,21 @@ pub struct SparseMoEBuilderConfig {
     /// the prebuild cost is ~7 min single-threaded or ~20 s with
     /// rayon; disk cost ~190 GiB on top of the model.
     pub ffn_axpy_prebuild: bool,
+    /// Issue #38 (CHESS) — load per-channel FFN sparsity thresholds
+    /// from this file. The file is produced by the
+    /// `calibrate_ffn_thresholds` bin from a capture run. `None`
+    /// (default) keeps the scalar [`Self::ffn_sparsity_threshold`]
+    /// behaviour. When set, the per-channel τ vector takes precedence
+    /// over the scalar τ for any layer covered by the file.
+    pub ffn_sparsity_thresholds_file: Option<PathBuf>,
+    /// Issue #38 (CHESS) — when set, record per-(layer, channel)
+    /// `|silu(gate[c])| / max_j |silu(gate[j])|` histograms during
+    /// every routed expert call. The histograms are dumped to this
+    /// directory on engine close. Used as input to
+    /// `calibrate_ffn_thresholds`. `None` (default) disables capture.
+    /// Only meaningful while the AXPY-form path is active — the
+    /// non-AXPY (bf16 boundary) path doesn't surface `silu(gate)`.
+    pub ffn_sparsity_capture_dir: Option<PathBuf>,
 }
 
 impl SparseMoEBuilderConfig {
@@ -129,6 +144,8 @@ impl SparseMoEBuilderConfig {
             ffn_axpy_down: false,
             ffn_axpy_cache_dir: None,
             ffn_axpy_prebuild: false,
+            ffn_sparsity_thresholds_file: None,
+            ffn_sparsity_capture_dir: None,
         }
     }
 
@@ -225,6 +242,8 @@ pub(crate) fn resolve_runner_options(cfg: &SparseMoEBuilderConfig) -> RunnerOpti
         ffn_sparsity_threshold: cfg.ffn_sparsity_threshold,
         ffn_axpy_down: cfg.ffn_axpy_down,
         ffn_axpy_cache_dir: cfg.ffn_axpy_cache_dir.clone(),
+        ffn_sparsity_thresholds_file: cfg.ffn_sparsity_thresholds_file.clone(),
+        ffn_sparsity_capture_dir: cfg.ffn_sparsity_capture_dir.clone(),
     }
 }
 
@@ -718,6 +737,22 @@ impl Engine for SparseMoEEngine {
     }
 
     fn close(&mut self) {
+        // Issue #38: dump the gate-capture histograms before tearing
+        // down the runner. A clean shutdown (SIGTERM via
+        // cascadia-cli's graceful-shutdown wiring) thus persists
+        // calibration data without further user action.
+        match self.runner.dump_gate_capture() {
+            Ok((0, _)) => {}
+            Ok((n_layers, total_samples)) => {
+                info!(
+                    n_layers,
+                    total_samples, "dumped FFN gate-capture histograms (CHESS calibration)"
+                );
+            }
+            Err(e) => {
+                warn!("failed to dump gate-capture histograms on close: {e}");
+            }
+        }
         // Best-effort transport teardown. We block_on each socket's close()
         // sequentially because the engine is being torn down; lock
         // contention isn't a worry. Errors are logged but swallowed —

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -2405,11 +2405,21 @@ impl Runner {
         // of generation so the operator can see what fraction of FFN
         // lanes were actually active under the chosen threshold. Logged
         // at info level so it shows up without RUST_LOG tuning, but
-        // skipped silently when the threshold is 0.0 (no sparsity).
-        if self.ffn_sparsity_threshold > 0.0 {
+        // skipped silently when both the scalar threshold and the
+        // per-channel thresholds are inactive (no sparsity at all). The
+        // per-channel check is needed for issue #38: when the only
+        // sparsity signal is the loaded thresholds file, `ffn_sparsity_threshold`
+        // stays at 0.0 but the dispatcher still runs the sparse path.
+        if self.ffn_sparsity_threshold > 0.0 || self.ffn_sparsity_thresholds.is_some() {
             let (cached_experts, expert_evictions) = self.experts.lru_stats();
+            let per_channel_layers = self
+                .ffn_sparsity_thresholds
+                .as_ref()
+                .map(|t| t.n_layers())
+                .unwrap_or(0);
             info!(
                 ffn_sparsity_threshold = self.ffn_sparsity_threshold,
+                ffn_per_channel_layers = per_channel_layers,
                 ffn_active_fraction = self.ffn_active_fraction(),
                 routed_expert_calls = self.ffn_active_count,
                 cached_experts,

--- a/crates/cascadia-engine-sparse-moe/src/runner.rs
+++ b/crates/cascadia-engine-sparse-moe/src/runner.rs
@@ -19,7 +19,6 @@ use std::time::Instant;
 use lru::LruCache;
 
 use cascadia_int4_gemm::ffn_axpy::FfnScratch as IntFfnScratch;
-use cascadia_int4_gemm::ffn_sparsity::ffn_forward_sparse_axpy_f32;
 use cascadia_int4_gemm::layer0_int4::{
     embed_token_bf16, layer0_forward_decode_int4_multi_with_capacity,
     layer0_forward_decode_int4_with_capacity_sparse, Int4Layer0,
@@ -393,6 +392,21 @@ pub struct RunnerOptions {
     /// runner logs a warning and falls back to the dense path for
     /// the duration of the run.
     pub ffn_axpy_cache_dir: Option<std::path::PathBuf>,
+    /// Issue #38 — load per-channel FFN sparsity thresholds (the CHESS
+    /// extension to global-τ) from a JSON file produced by the
+    /// `calibrate_ffn_thresholds` tool. `None` (default) keeps the
+    /// global-τ / dense behaviour. When set, the per-channel τ
+    /// vector takes precedence over `ffn_sparsity_threshold` for any
+    /// layer present in the file; layers not in the file fall back
+    /// to the global-τ value.
+    pub ffn_sparsity_thresholds_file: Option<std::path::PathBuf>,
+    /// Issue #38 — when set, record per-layer-per-channel
+    /// `|silu(gate[c])| / max_j |silu(gate[j])|` histograms during
+    /// every expert dispatch and dump them to this directory on
+    /// engine close. The histogram dump is fed into
+    /// `calibrate_ffn_thresholds` to compute per-channel τ values.
+    /// `None` (default) disables capture.
+    pub ffn_sparsity_capture_dir: Option<std::path::PathBuf>,
 }
 
 /// Per-rank slice of the model the Runner should hold.
@@ -492,6 +506,19 @@ pub struct Runner {
     /// active-lane fraction without polluting hot-path logging.
     ffn_active_sum: f64,
     ffn_active_count: u64,
+    /// Issue #38 — per-channel FFN sparsity thresholds loaded from
+    /// disk at startup. `None` ⇒ fall back to the scalar
+    /// [`Self::ffn_sparsity_threshold`] for every layer. When set,
+    /// the dispatcher prefers the per-channel τ vector for any
+    /// layer covered by the file.
+    ffn_sparsity_thresholds: Option<Arc<cascadia_int4_gemm::PerChannelThresholds>>,
+    /// Issue #38 — when `Some`, record `silu(gate)` distributions
+    /// per (layer, channel) into this state for offline calibration.
+    /// Dumped to disk on engine close. Capture is silently no-op'd
+    /// for the dense FFN path (we don't compute silu(gate) there) and
+    /// the dense-down sparse path — only the AXPY-form path exposes
+    /// silu(gate) via its scratch.
+    gate_capture: Option<Arc<cascadia_int4_gemm::GateCaptureState>>,
 }
 
 impl Runner {
@@ -769,6 +796,53 @@ impl Runner {
         // dispatch path stays on the dense-down branch.
         let ffn_axpy_effective = opts.ffn_axpy_down && transposed_down_store.is_some();
 
+        // Issue #38: load per-channel thresholds, if a file was
+        // requested. Verify shape; fail-loud on mismatch (a runner
+        // built with the wrong intermediate dim is a config error,
+        // not a runtime fallback).
+        let intermediate = cascadia_int4_gemm::INTERMEDIATE;
+        let ffn_sparsity_thresholds = match opts.ffn_sparsity_thresholds_file.as_ref() {
+            None => None,
+            Some(path) => {
+                let loaded = cascadia_int4_gemm::PerChannelThresholds::load(path).map_err(|e| {
+                    RunnerError::Internal(format!(
+                        "load FFN sparsity thresholds from {}: {e}",
+                        path.display()
+                    ))
+                })?;
+                loaded.verify_for_intermediate(intermediate).map_err(|e| {
+                    RunnerError::Internal(format!(
+                        "thresholds file {} mismatches model intermediate: {e}",
+                        path.display(),
+                    ))
+                })?;
+                info!(
+                    path = %path.display(),
+                    model_id = loaded.model_id,
+                    n_layers = loaded.n_layers(),
+                    target_active_frac = loaded.target_active_frac,
+                    calibration_n_tokens = loaded.calibration_n_tokens,
+                    "loaded per-channel FFN sparsity thresholds (CHESS)"
+                );
+                Some(Arc::new(loaded))
+            }
+        };
+
+        // Issue #38: capture state. We only allocate the histograms
+        // for layers this rank owns (memory ≈ layers × 2048 × 128
+        // bins × 4 B; at K2.6 single-stage that's 60 × 1 MiB =
+        // 60 MiB, easily worth the calibration value).
+        let gate_capture = opts.ffn_sparsity_capture_dir.as_ref().map(|dir| {
+            info!(
+                capture_dir = %dir.display(),
+                "FFN sparsity gate-capture mode enabled (CHESS calibration)"
+            );
+            Arc::new(cascadia_int4_gemm::GateCaptureState::new(
+                dir.clone(),
+                intermediate,
+            ))
+        });
+
         Ok(Self {
             manifest,
             _model_dir: model_dir,
@@ -790,6 +864,8 @@ impl Runner {
             ffn_scratch: None,
             ffn_active_sum: 0.0,
             ffn_active_count: 0,
+            ffn_sparsity_thresholds,
+            gate_capture,
         })
     }
 
@@ -881,7 +957,16 @@ impl Runner {
             ExpertCache::Int4Bin(c) => {
                 let w = c.get(lid, eid)?;
                 let threshold = self.ffn_sparsity_threshold;
-                if self.ffn_axpy_down && threshold > 0.0 {
+                // Issue #38: per-channel thresholds (CHESS) override
+                // the scalar τ for any layer covered by the loaded
+                // file. Resolve here so the dispatch path below sees
+                // a single `mode: SparsityMode` value.
+                let per_channel: Option<&[f32]> = self
+                    .ffn_sparsity_thresholds
+                    .as_ref()
+                    .and_then(|t| t.get(lid));
+                let sparse_active = per_channel.is_some() || threshold > 0.0;
+                if self.ffn_axpy_down && sparse_active {
                     // AXPY-form sparse path (issue #35).
                     //
                     // The transposed-down weights are persisted to
@@ -944,40 +1029,69 @@ impl Runner {
                         })?;
                     let td_packed = td.packed_t();
                     let td_scale = td.scale_t_bits();
+                    // Capture state is an Arc — clone before borrowing
+                    // `self.ffn_scratch` so we can dispatch into it and
+                    // still record from `scratch.silu_gate` without
+                    // re-borrowing `self`.
+                    let gate_capture = self.gate_capture.clone();
                     let scratch = self
                         .ffn_scratch
                         .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
                     let mut out_f32 = vec![0.0f32; hidden];
-                    let active_frac = ffn_forward_sparse_axpy_f32(
-                        scratch,
-                        attn_row,
-                        hidden,
-                        intermediate,
-                        gate_packed,
-                        gate_scale,
-                        up_packed,
-                        up_scale,
-                        td_packed,
-                        td_scale,
-                        &mut out_f32,
-                        threshold,
-                    );
+                    let mode = match per_channel {
+                        Some(τ) => cascadia_int4_gemm::SparsityMode::PerChannel(τ),
+                        None => cascadia_int4_gemm::SparsityMode::Global(threshold),
+                    };
+                    let active_frac =
+                        cascadia_int4_gemm::ffn_sparsity::ffn_forward_sparse_axpy_f32_mode(
+                            scratch,
+                            attn_row,
+                            hidden,
+                            intermediate,
+                            gate_packed,
+                            gate_scale,
+                            up_packed,
+                            up_scale,
+                            td_packed,
+                            td_scale,
+                            &mut out_f32,
+                            mode,
+                        );
+                    if let Some(cap) = gate_capture {
+                        let silu = &scratch.silu_gate[..intermediate];
+                        let max_abs = silu.iter().fold(0.0f32, |a, &v| a.max(v.abs()));
+                        cap.record(lid, silu, max_abs);
+                    }
+                    // End of scratch borrow — now safe to re-borrow self.
                     self.accumulate_ffn_sparsity_stat(active_frac);
                     Ok(out_f32)
                 } else {
                     let x_bf16: Vec<bf16> = attn_row.iter().map(|v| bf16::from_f32(*v)).collect();
                     let mut out_bf16 = vec![bf16::ZERO; hidden];
-                    let active_frac = int4_expert_forward_sparse(
-                        &x_bf16,
-                        w.gate_packed_bytes(),
-                        w.gate_scale_bits(),
-                        w.up_packed_bytes(),
-                        w.up_scale_bits(),
-                        w.down_packed_bytes(),
-                        w.down_scale_bits(),
-                        &mut out_bf16,
-                        threshold,
-                    );
+                    let active_frac = match per_channel {
+                        Some(τ) => cascadia_int4_gemm::expert_forward_sparse_per_channel(
+                            &x_bf16,
+                            w.gate_packed_bytes(),
+                            w.gate_scale_bits(),
+                            w.up_packed_bytes(),
+                            w.up_scale_bits(),
+                            w.down_packed_bytes(),
+                            w.down_scale_bits(),
+                            &mut out_bf16,
+                            τ,
+                        ),
+                        None => int4_expert_forward_sparse(
+                            &x_bf16,
+                            w.gate_packed_bytes(),
+                            w.gate_scale_bits(),
+                            w.up_packed_bytes(),
+                            w.up_scale_bits(),
+                            w.down_packed_bytes(),
+                            w.down_scale_bits(),
+                            &mut out_bf16,
+                            threshold,
+                        ),
+                    };
                     self.accumulate_ffn_sparsity_stat(active_frac);
                     Ok(out_bf16.iter().map(|b| b.to_f32()).collect())
                 }
@@ -985,7 +1099,12 @@ impl Runner {
             ExpertCache::SafetensorsBin(c) => {
                 let w = c.get(lid, eid)?;
                 let threshold = self.ffn_sparsity_threshold;
-                if self.ffn_axpy_down && threshold > 0.0 {
+                let per_channel: Option<&[f32]> = self
+                    .ffn_sparsity_thresholds
+                    .as_ref()
+                    .and_then(|t| t.get(lid));
+                let sparse_active = per_channel.is_some() || threshold > 0.0;
+                if self.ffn_axpy_down && sparse_active {
                     let intermediate = cascadia_int4_gemm::INTERMEDIATE;
                     // Same on-disk-store pattern as the Int4Bin path
                     // above. See that branch for the rationale.
@@ -1029,44 +1148,96 @@ impl Runner {
                         })?;
                     let td_packed = td.packed_t();
                     let td_scale = td.scale_t_bits();
+                    // Capture state is an Arc — clone before borrowing
+                    // `self.ffn_scratch` so we can dispatch into it and
+                    // still record from `scratch.silu_gate` without
+                    // re-borrowing `self`.
+                    let gate_capture = self.gate_capture.clone();
                     let scratch = self
                         .ffn_scratch
                         .get_or_insert_with(|| IntFfnScratch::new(hidden, intermediate));
                     let mut out_f32 = vec![0.0f32; hidden];
-                    let active_frac = ffn_forward_sparse_axpy_f32(
-                        scratch,
-                        attn_row,
-                        hidden,
-                        intermediate,
-                        gate_packed,
-                        gate_scale,
-                        up_packed,
-                        up_scale,
-                        td_packed,
-                        td_scale,
-                        &mut out_f32,
-                        threshold,
-                    );
+                    let mode = match per_channel {
+                        Some(τ) => cascadia_int4_gemm::SparsityMode::PerChannel(τ),
+                        None => cascadia_int4_gemm::SparsityMode::Global(threshold),
+                    };
+                    let active_frac =
+                        cascadia_int4_gemm::ffn_sparsity::ffn_forward_sparse_axpy_f32_mode(
+                            scratch,
+                            attn_row,
+                            hidden,
+                            intermediate,
+                            gate_packed,
+                            gate_scale,
+                            up_packed,
+                            up_scale,
+                            td_packed,
+                            td_scale,
+                            &mut out_f32,
+                            mode,
+                        );
+                    if let Some(cap) = gate_capture {
+                        let silu = &scratch.silu_gate[..intermediate];
+                        let max_abs = silu.iter().fold(0.0f32, |a, &v| a.max(v.abs()));
+                        cap.record(lid, silu, max_abs);
+                    }
+                    // End of scratch borrow — now safe to re-borrow self.
                     self.accumulate_ffn_sparsity_stat(active_frac);
                     Ok(out_f32)
                 } else {
                     let x_bf16: Vec<bf16> = attn_row.iter().map(|v| bf16::from_f32(*v)).collect();
                     let mut out_bf16 = vec![bf16::ZERO; hidden];
-                    let active_frac = int4_expert_forward_sparse(
-                        &x_bf16,
-                        w.gate_packed,
-                        w.gate_scale,
-                        w.up_packed,
-                        w.up_scale,
-                        w.down_packed,
-                        w.down_scale,
-                        &mut out_bf16,
-                        threshold,
-                    );
+                    let active_frac = match per_channel {
+                        Some(τ) => cascadia_int4_gemm::expert_forward_sparse_per_channel(
+                            &x_bf16,
+                            w.gate_packed,
+                            w.gate_scale,
+                            w.up_packed,
+                            w.up_scale,
+                            w.down_packed,
+                            w.down_scale,
+                            &mut out_bf16,
+                            τ,
+                        ),
+                        None => int4_expert_forward_sparse(
+                            &x_bf16,
+                            w.gate_packed,
+                            w.gate_scale,
+                            w.up_packed,
+                            w.up_scale,
+                            w.down_packed,
+                            w.down_scale,
+                            &mut out_bf16,
+                            threshold,
+                        ),
+                    };
                     self.accumulate_ffn_sparsity_stat(active_frac);
                     Ok(out_bf16.iter().map(|b| b.to_f32()).collect())
                 }
             }
+        }
+    }
+
+    /// Drain the per-channel `silu(gate)` capture state to the
+    /// configured directory. Returns `(n_layers_written, total_samples)`
+    /// or `(0, 0)` if capture wasn't enabled. Called from the engine
+    /// `close` path to persist calibration data before shutdown.
+    pub fn dump_gate_capture(&self) -> Result<(usize, u64), RunnerError> {
+        let Some(cap) = self.gate_capture.as_ref() else {
+            return Ok((0, 0));
+        };
+        cap.dump()
+            .map_err(|e| RunnerError::Internal(format!("dump gate capture: {e}")))
+    }
+
+    /// Inspect the gate-capture state. Returns `(n_layers, total_samples)`
+    /// for instrumentation; `(0, 0)` when capture isn't enabled. Useful
+    /// for periodic "how much have we collected" logging during long
+    /// calibration runs.
+    pub fn gate_capture_stats(&self) -> (usize, u64) {
+        match self.gate_capture.as_ref() {
+            Some(c) => (c.n_layers(), c.total_samples()),
+            None => (0, 0),
         }
     }
 
@@ -1111,7 +1282,6 @@ impl Runner {
         if self.transposed_down_store.is_none() {
             return Ok((0, 0));
         }
-        let intermediate = cascadia_int4_gemm::INTERMEDIATE;
         let hidden = self.manifest.hidden_size as usize;
         let moe_layer_ids = self.manifest.moe_layer_ids();
         let n_experts = self.manifest.num_experts;

--- a/crates/cascadia-int4-gemm/Cargo.toml
+++ b/crates/cascadia-int4-gemm/Cargo.toml
@@ -11,6 +11,7 @@ half = "2"
 memmap2 = "0.9"
 parking_lot = { workspace = true }
 rayon = "1"
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/cascadia-int4-gemm/src/bin/bench_ffn_sparsity.rs
+++ b/crates/cascadia-int4-gemm/src/bin/bench_ffn_sparsity.rs
@@ -29,7 +29,7 @@ use std::time::Instant;
 
 use cascadia_int4_gemm::{
     dequant_gemv_int4_auto, dequant_gemv_int4_rows_subset_auto, expert_forward,
-    expert_forward_sparse, GROUP_SIZE, HIDDEN, INTERMEDIATE,
+    expert_forward_sparse, expert_forward_sparse_per_channel, GROUP_SIZE, HIDDEN, INTERMEDIATE,
 };
 use half::bf16;
 
@@ -180,6 +180,83 @@ fn main() {
         );
     }
     println!();
+
+    // --- Per-channel-τ overhead microbench (issue #38) ---
+    //
+    // Compares the global-τ path against the per-channel-τ path with
+    // a UNIFORM threshold vector (every τ[c] = τ0). With uniform
+    // thresholds the two paths must produce bit-identical output (we
+    // assert this in `per_channel_uniform_matches_global`), so any
+    // runtime gap is pure dispatcher + per-element-multiply overhead.
+    println!("---");
+    println!();
+    println!("# Per-channel-τ overhead (uniform vector vs global scalar)");
+    println!();
+    println!("Both runs construct the same mask; per-channel adds one extra");
+    println!("multiply per intermediate lane per token. Expect <1% gap.");
+    println!();
+    println!("| τ0      | global  | per-channel | overhead |");
+    println!("| ------- | ------- | ----------- | -------- |");
+    for &tau in &thresholds {
+        if tau <= 0.0 {
+            continue;
+        }
+        let τ_vec: Vec<f32> = vec![tau; INTERMEDIATE];
+        let mut out_g = vec![bf16::ZERO; HIDDEN];
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            expert_forward_sparse(
+                &x,
+                &gate_packed,
+                &gate_scale,
+                &up_packed,
+                &up_scale,
+                &down_packed,
+                &down_scale,
+                &mut out_g,
+                tau,
+            );
+        }
+        let per_call_g = t0.elapsed().as_secs_f64() / iters as f64;
+
+        let mut out_pc = vec![bf16::ZERO; HIDDEN];
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            expert_forward_sparse_per_channel(
+                &x,
+                &gate_packed,
+                &gate_scale,
+                &up_packed,
+                &up_scale,
+                &down_packed,
+                &down_scale,
+                &mut out_pc,
+                &τ_vec,
+            );
+        }
+        let per_call_pc = t0.elapsed().as_secs_f64() / iters as f64;
+        let overhead = (per_call_pc - per_call_g) / per_call_g * 100.0;
+
+        // Sanity check: outputs must be bit-identical (uniform-τ →
+        // global-τ contract). Cheap assert that catches accidental
+        // divergence between the two code paths.
+        for h in 0..HIDDEN {
+            assert_eq!(
+                out_g[h].to_bits(),
+                out_pc[h].to_bits(),
+                "τ={tau}, h={h}: global/per-channel output divergence (uniform vector should be bit-identical)",
+            );
+        }
+        println!(
+            "| {:<7.3} | {:>7} | {:>11} | {:>+6.2}%  |",
+            tau,
+            fmt_us(per_call_g),
+            fmt_us(per_call_pc),
+            overhead,
+        );
+    }
+    println!();
+
     println!("Notes:");
     println!(" - τ=0.00 path falls through to dense; speedup ≈1.00 confirms no overhead.");
     println!(" - Active-frac is the per-token fraction of intermediate lanes computed by");
@@ -188,6 +265,9 @@ fn main() {
     println!("   no lanes fall below the relative threshold. Real K2.6 activations have a");
     println!("   heavy tail that yields 30–50% sparsity at τ=0.10 (CATS/CHESS), making");
     println!("   the kernel speedup numbers below the practical upper bound.");
+    println!(" - Per-channel overhead measures the cost of the per-lane threshold vector vs");
+    println!("   a single scalar. Real wins from per-channel come from CHESS calibration");
+    println!("   allowing higher sparsity at the same quality — not from this overhead.");
     println!();
     println!("---");
     println!();

--- a/crates/cascadia-int4-gemm/src/bin/calibrate_ffn_thresholds.rs
+++ b/crates/cascadia-int4-gemm/src/bin/calibrate_ffn_thresholds.rs
@@ -1,0 +1,474 @@
+//! Compute per-channel FFN sparsity thresholds (CHESS / issue #38) from
+//! a directory of `layer_<lid>.bin` capture files produced by a
+//! `cascadia worker --ffn-sparsity-capture-dir <PATH>` run.
+//!
+//! ## Inputs
+//!
+//! - `--capture-dir <PATH>`: directory containing `layer_<lid>.bin`
+//!   files in the format documented in `ffn_capture.rs`.
+//! - `--target-active-frac <0.0..1.0>`: target fraction of intermediate
+//!   lanes that should remain active after thresholding. The tool
+//!   picks the `1 - target_active_frac` percentile of each channel's
+//!   `|silu(gate[c])| / max_j |silu(gate[j])|` distribution as that
+//!   channel's threshold.
+//! - `--model-id <STRING>`: free-form identifier baked into the file
+//!   header. Convention: HF repo id or local cache name. Matched
+//!   loosely (printed to logs; not enforced) by the runner at load.
+//! - `--output <PATH>`: where to write the resulting threshold JSON.
+//!   Atomic-rename write.
+//! - `--n-intermediate <N>` (default 2048): expected intermediate dim.
+//!   The tool rejects any capture file with a different `n_intermediate`
+//!   header field.
+//! - `--notes "<TEXT>"`: optional free-form provenance string.
+//!
+//! ## Output
+//!
+//! A `PerChannelThresholds` v1 JSON file (see `ffn_thresholds.rs`):
+//! one entry per covered layer with `[f32; n_intermediate]` per-
+//! channel thresholds. Layers without a capture file are simply
+//! absent — the runtime falls back to the global-τ (or dense) path
+//! for them.
+//!
+//! ## Method
+//!
+//! For each (layer, channel):
+//!   1. Read the histogram bin counts `[u32; N_BINS]`.
+//!   2. Compute the cumulative distribution.
+//!   3. Find the smallest bin index `b` such that the CDF at `b`
+//!      reaches `1 - target_active_frac`.
+//!   4. Set `τ[layer, channel] = (b + 0.5) / N_BINS`
+//!      (midpoint of bin `b`).
+//!
+//! Step 4's midpoint estimator is the standard non-interpolating
+//! quantile read-out from a uniform-bin histogram. At `N_BINS=128`
+//! the bin width is 0.0078, so the quantile estimate is accurate to
+//! ±0.4%. If a channel saw zero samples, its threshold defaults to
+//! 0.0 (always-active fallback — won't ever drop the channel).
+//!
+//! ## Example
+//!
+//! ```text
+//! # Step 1: capture from a representative corpus
+//! CASCADIA_FFN_SPARSITY_CAPTURE_DIR=/tmp/caps \
+//!   cascadia worker --model <K26-DIR> --device CPU
+//! # ... serve a representative prompt set, then stop the worker ...
+//!
+//! # Step 2: calibrate
+//! cargo run --release --bin calibrate_ffn_thresholds -- \
+//!     --capture-dir /tmp/caps \
+//!     --target-active-frac 0.5 \
+//!     --model-id kimi-k2.6-instruct \
+//!     --output /tmp/k26_thresholds_50.json
+//!
+//! # Step 3: serve with per-channel thresholds
+//! cascadia worker --model <K26-DIR> --device CPU \
+//!     --ffn-sparsity-thresholds-file /tmp/k26_thresholds_50.json
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use cascadia_int4_gemm::ffn_capture::{CAPTURE_FILE_MAGIC, N_BINS};
+use cascadia_int4_gemm::PerChannelThresholds;
+
+struct Args {
+    capture_dir: PathBuf,
+    target_active_frac: f32,
+    model_id: String,
+    output: PathBuf,
+    n_intermediate: usize,
+    notes: String,
+}
+
+fn print_usage() {
+    eprintln!(
+        "calibrate_ffn_thresholds — convert capture histograms → per-channel τ\n\n\
+        Required:\n\
+        \t--capture-dir <PATH>           directory of layer_<lid>.bin files\n\
+        \t--target-active-frac <F>       target active fraction in [0, 1]\n\
+        \t--model-id <STR>               free-form model identifier\n\
+        \t--output <PATH>                output threshold JSON path\n\n\
+        Optional:\n\
+        \t--n-intermediate <N>           expected intermediate dim (default 2048)\n\
+        \t--notes <STR>                  free-form provenance string\n"
+    );
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut capture_dir: Option<PathBuf> = None;
+    let mut target_active_frac: Option<f32> = None;
+    let mut model_id: Option<String> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut n_intermediate: usize = 2048;
+    let mut notes = String::new();
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--capture-dir" => capture_dir = it.next().map(PathBuf::from),
+            "--target-active-frac" => {
+                target_active_frac = it.next().and_then(|s| s.parse().ok());
+            }
+            "--model-id" => model_id = it.next(),
+            "--output" => output = it.next().map(PathBuf::from),
+            "--n-intermediate" => {
+                n_intermediate = it
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .ok_or_else(|| "--n-intermediate requires a positive integer".to_string())?;
+            }
+            "--notes" => notes = it.next().unwrap_or_default(),
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown arg: {other}")),
+        }
+    }
+    let capture_dir = capture_dir.ok_or_else(|| "--capture-dir is required".to_string())?;
+    let target_active_frac = target_active_frac
+        .ok_or_else(|| "--target-active-frac is required (e.g. 0.5)".to_string())?;
+    let model_id = model_id.ok_or_else(|| "--model-id is required".to_string())?;
+    let output = output.ok_or_else(|| "--output is required".to_string())?;
+    if !(0.0..=1.0).contains(&target_active_frac) {
+        return Err(format!(
+            "--target-active-frac must be in [0, 1]; got {target_active_frac}"
+        ));
+    }
+    if n_intermediate == 0 {
+        return Err("--n-intermediate must be > 0".into());
+    }
+    Ok(Args {
+        capture_dir,
+        target_active_frac,
+        model_id,
+        output,
+        n_intermediate,
+        notes,
+    })
+}
+
+/// One layer's parsed histogram data, ready for quantile read-out.
+struct LayerHist {
+    layer_id: u32,
+    n_intermediate: usize,
+    total_samples: u32,
+    /// `counts.len() == n_intermediate * N_BINS`, channel-major.
+    counts: Vec<u32>,
+}
+
+/// Parse one `layer_<lid>.bin` file. Rejects mismatched magic /
+/// n_bins / n_intermediate.
+fn read_layer_capture(path: &Path, expected_intermediate: usize) -> Result<LayerHist, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    if bytes.len() < 32 {
+        return Err(format!(
+            "{} too short ({} bytes)",
+            path.display(),
+            bytes.len()
+        ));
+    }
+    if &bytes[..16] != CAPTURE_FILE_MAGIC {
+        return Err(format!(
+            "{} magic mismatch (got {:?}, expected {:?})",
+            path.display(),
+            &bytes[..16],
+            CAPTURE_FILE_MAGIC,
+        ));
+    }
+    let layer_id = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
+    let n_intermediate = u32::from_le_bytes(bytes[20..24].try_into().unwrap()) as usize;
+    let n_bins = u32::from_le_bytes(bytes[24..28].try_into().unwrap()) as usize;
+    let total_samples = u32::from_le_bytes(bytes[28..32].try_into().unwrap());
+    if n_intermediate != expected_intermediate {
+        return Err(format!(
+            "{}: n_intermediate {} != expected {}",
+            path.display(),
+            n_intermediate,
+            expected_intermediate,
+        ));
+    }
+    if n_bins != N_BINS {
+        return Err(format!(
+            "{}: n_bins {} != runtime N_BINS {} (capture from a different cascadia build?)",
+            path.display(),
+            n_bins,
+            N_BINS,
+        ));
+    }
+    let expected_body = n_intermediate * n_bins * 4;
+    if bytes.len() < 32 + expected_body {
+        return Err(format!(
+            "{}: body too short (got {} bytes, expected {})",
+            path.display(),
+            bytes.len() - 32,
+            expected_body,
+        ));
+    }
+    let mut counts = Vec::with_capacity(n_intermediate * n_bins);
+    for chunk in bytes[32..32 + expected_body].chunks_exact(4) {
+        counts.push(u32::from_le_bytes(chunk.try_into().unwrap()));
+    }
+    Ok(LayerHist {
+        layer_id,
+        n_intermediate,
+        total_samples,
+        counts,
+    })
+}
+
+/// Compute the per-channel threshold vector for one layer's
+/// histograms at the given active fraction. Channels with zero
+/// samples → threshold 0.0 (always-active fallback).
+///
+/// `target_active_frac` is the *fraction of lanes we want active*,
+/// which corresponds to the `1 - target_active_frac` quantile of the
+/// magnitude-ratio distribution: a higher τ drops more lanes.
+fn compute_thresholds_for_layer(layer: &LayerHist, target_active_frac: f32) -> Vec<f32> {
+    let n_chan = layer.n_intermediate;
+    let inv_n_bins = 1.0f32 / N_BINS as f32;
+    let target_cdf = 1.0 - target_active_frac;
+    let mut out = Vec::with_capacity(n_chan);
+    for c in 0..n_chan {
+        let base = c * N_BINS;
+        let row = &layer.counts[base..base + N_BINS];
+        let total: u32 = row.iter().sum();
+        if total == 0 {
+            // No samples for this channel — leave threshold at 0
+            // (always-active). The runner's per-channel mask treats
+            // that as "drop nothing for this channel."
+            out.push(0.0);
+            continue;
+        }
+        let target_count = ((total as f32) * target_cdf).ceil() as u32;
+        let mut cum: u32 = 0;
+        let mut chosen_bin: usize = N_BINS - 1;
+        for (b, &c_b) in row.iter().enumerate() {
+            cum = cum.saturating_add(c_b);
+            if cum >= target_count {
+                chosen_bin = b;
+                break;
+            }
+        }
+        // Midpoint of the chosen bin in [0, 1].
+        let τ = (chosen_bin as f32 + 0.5) * inv_n_bins;
+        out.push(τ);
+    }
+    out
+}
+
+fn run(args: Args) -> Result<(), String> {
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&args.capture_dir)
+        .map_err(|e| format!("read_dir {}: {e}", args.capture_dir.display()))?
+        .filter_map(|r| r.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.starts_with("layer_") && s.ends_with(".bin"))
+                .unwrap_or(false)
+        })
+        .collect();
+    entries.sort();
+    if entries.is_empty() {
+        return Err(format!(
+            "no layer_*.bin files in {}",
+            args.capture_dir.display()
+        ));
+    }
+    eprintln!(
+        "calibrate_ffn_thresholds: scanning {} layer files in {}",
+        entries.len(),
+        args.capture_dir.display(),
+    );
+
+    let mut out =
+        PerChannelThresholds::new(args.model_id, args.n_intermediate, args.target_active_frac);
+    out.notes = args.notes;
+    let mut total_samples: u64 = 0;
+    for path in &entries {
+        let layer = read_layer_capture(path, args.n_intermediate)?;
+        let thr = compute_thresholds_for_layer(&layer, args.target_active_frac);
+        total_samples += layer.total_samples as u64;
+        eprintln!(
+            "  layer {:4}: samples={:8}  min_τ={:.4}  max_τ={:.4}  mean_τ={:.4}",
+            layer.layer_id,
+            layer.total_samples,
+            thr.iter().cloned().fold(f32::INFINITY, f32::min),
+            thr.iter().cloned().fold(0.0, f32::max),
+            thr.iter().sum::<f32>() / thr.len() as f32,
+        );
+        out.upsert_layer(layer.layer_id, thr);
+    }
+    out.calibration_n_tokens = total_samples;
+    out.save(&args.output)
+        .map_err(|e| format!("save {}: {e}", args.output.display()))?;
+    eprintln!(
+        "calibrate_ffn_thresholds: wrote {} layers, {} total samples → {}",
+        out.n_layers(),
+        total_samples,
+        args.output.display(),
+    );
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}\n");
+            print_usage();
+            return ExitCode::from(2);
+        }
+    };
+    match run(args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a one-channel layer with the given bin counts.
+    fn one_channel_layer(counts_b: [u32; N_BINS]) -> LayerHist {
+        LayerHist {
+            layer_id: 0,
+            n_intermediate: 1,
+            total_samples: counts_b.iter().sum(),
+            counts: counts_b.to_vec(),
+        }
+    }
+
+    /// Empty histograms get τ = 0.0 (always-active fallback).
+    #[test]
+    fn empty_histogram_yields_zero_threshold() {
+        let layer = one_channel_layer([0u32; N_BINS]);
+        let τ = compute_thresholds_for_layer(&layer, 0.5);
+        assert_eq!(τ[0], 0.0);
+    }
+
+    /// All samples in bin 0 → the median quantile lands in bin 0 →
+    /// τ at the midpoint of bin 0.
+    #[test]
+    fn all_samples_in_bin_zero_yields_low_threshold() {
+        let mut counts = [0u32; N_BINS];
+        counts[0] = 1000;
+        let layer = one_channel_layer(counts);
+        let τ = compute_thresholds_for_layer(&layer, 0.5);
+        assert!((τ[0] - 0.5 / N_BINS as f32).abs() < 1e-6, "got τ={}", τ[0]);
+    }
+
+    /// All samples in the last bin → quantile is the last bin → τ
+    /// at the midpoint of bin N_BINS-1.
+    #[test]
+    fn all_samples_in_last_bin_yields_high_threshold() {
+        let mut counts = [0u32; N_BINS];
+        counts[N_BINS - 1] = 1000;
+        let layer = one_channel_layer(counts);
+        let τ = compute_thresholds_for_layer(&layer, 0.5);
+        let expected = (N_BINS as f32 - 0.5) / N_BINS as f32;
+        assert!((τ[0] - expected).abs() < 1e-6, "got τ={}", τ[0]);
+    }
+
+    /// Uniform distribution across all bins: the median is at bin
+    /// N_BINS/2 (or 1 below due to the ceil() rounding). Confirms
+    /// the quantile is the smallest bin index whose CDF >= target.
+    #[test]
+    fn uniform_distribution_median() {
+        let counts = [10u32; N_BINS];
+        let layer = one_channel_layer(counts);
+        let τ = compute_thresholds_for_layer(&layer, 0.5);
+        // Cumulative reaches `ceil(0.5 * 10 * 128) = 640` at bin 63
+        // (cumulative = 64 * 10 = 640 inclusive at the end of bin
+        // 63). So chosen_bin = 63, τ = 63.5 / 128 ≈ 0.496.
+        let expected = 63.5_f32 / N_BINS as f32;
+        assert!((τ[0] - expected).abs() < 1e-6, "got τ={}", τ[0]);
+    }
+
+    /// Larger target_active_frac → lower threshold (we want MORE
+    /// active lanes, so we accept a lower-magnitude cutoff).
+    #[test]
+    fn higher_active_frac_yields_lower_threshold() {
+        let counts = [10u32; N_BINS];
+        let layer = one_channel_layer(counts);
+        let τ_low = compute_thresholds_for_layer(&layer, 0.2)[0];
+        let τ_mid = compute_thresholds_for_layer(&layer, 0.5)[0];
+        let τ_hi = compute_thresholds_for_layer(&layer, 0.8)[0];
+        assert!(
+            τ_low > τ_mid && τ_mid > τ_hi,
+            "expected τ to decrease as active_frac increases: {τ_low} > {τ_mid} > {τ_hi}",
+        );
+    }
+
+    /// active_frac = 1.0 ⇒ keep every lane ⇒ threshold near 0.
+    /// active_frac = 0.0 ⇒ keep no lanes ⇒ threshold near max.
+    #[test]
+    fn extreme_active_fracs_pin_thresholds() {
+        let counts = [10u32; N_BINS];
+        let layer = one_channel_layer(counts);
+        let τ_all = compute_thresholds_for_layer(&layer, 1.0)[0];
+        let τ_none = compute_thresholds_for_layer(&layer, 0.0)[0];
+        // active_frac=1 → target_cdf=0 → target_count=0 → first
+        // bin (b=0) wins (cum 10 >= 0). τ = 0.5 / 128.
+        assert!(
+            (τ_all - 0.5 / N_BINS as f32).abs() < 1e-6,
+            "got τ_all={}",
+            τ_all
+        );
+        // active_frac=0 → target_cdf=1 → target_count=ceil(1*1280)=1280
+        // → cumulative reaches 1280 only at the last bin. τ at
+        // midpoint of bin N_BINS-1.
+        assert!(
+            (τ_none - (N_BINS as f32 - 0.5) / N_BINS as f32).abs() < 1e-6,
+            "got τ_none={}",
+            τ_none,
+        );
+    }
+
+    /// Smoke test: build a capture in a tempdir, run the full
+    /// pipeline, parse the output JSON, verify the layer count.
+    #[test]
+    fn end_to_end_with_capture_in_tempdir() {
+        use cascadia_int4_gemm::ffn_capture::GateCaptureState;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let st = GateCaptureState::new(dir.path().to_owned(), 4);
+        // Record a few snapshots into two layers.
+        for _ in 0..50 {
+            st.record(0, &[0.1, 0.3, 0.5, 0.7], 0.7);
+            st.record(3, &[0.5, 0.5, 0.5, 0.5], 0.5);
+        }
+        let (n_layers, total) = st.dump().expect("dump");
+        assert_eq!(n_layers, 2);
+        assert_eq!(total, 100);
+
+        let output = dir.path().join("th.json");
+        let args = Args {
+            capture_dir: dir.path().to_owned(),
+            target_active_frac: 0.5,
+            model_id: "test".into(),
+            output: output.clone(),
+            n_intermediate: 4,
+            notes: "smoke".into(),
+        };
+        run(args).expect("run");
+
+        let loaded = PerChannelThresholds::load(&output).expect("load");
+        assert_eq!(loaded.n_layers(), 2);
+        assert_eq!(loaded.n_intermediate, 4);
+        assert_eq!(loaded.target_active_frac, 0.5);
+        // Layer 3 has every channel at ratio 1.0 (all silu values
+        // equal max) → every channel's median quantile is the last
+        // bin → τ ≈ (N_BINS-0.5)/N_BINS for every channel.
+        let l3 = loaded.get(3).expect("layer 3 present");
+        for &t in l3 {
+            assert!(
+                (t - (N_BINS as f32 - 0.5) / N_BINS as f32).abs() < 1e-6,
+                "got τ={t}"
+            );
+        }
+    }
+}

--- a/crates/cascadia-int4-gemm/src/ffn_capture.rs
+++ b/crates/cascadia-int4-gemm/src/ffn_capture.rs
@@ -1,0 +1,352 @@
+//! Per-channel `|silu(gate[c])| / max_j |silu(gate[j])|` histogram
+//! capture for offline CHESS-style threshold calibration.
+//!
+//! The runtime accumulates a fixed-bin histogram per (layer_id,
+//! channel_id) over the lifetime of a worker. After enough tokens
+//! have been processed, the histogram is dumped to disk and the
+//! [`crate::bin::calibrate_ffn_thresholds`] tool converts it into
+//! per-channel quantile thresholds.
+//!
+//! # Why fixed-bin histograms (not reservoir / t-digest)?
+//!
+//! - **Memory**: 60 layers × 2048 channels × `N_BINS=128` × `u32` =
+//!   60 MiB at K2.6 dims. Bounded; allocated once at startup.
+//! - **Update cost**: ~10 ns / sample on warm cache. At 2048 channels
+//!   × 8 routed experts × per-token, that's ~160 µs / token — negligible
+//!   vs the 10+ s/token K2.6 dispatch cost.
+//! - **Quantile precision**: 128 linear bins over `[0, 1]` gives sub-1%
+//!   resolution on the per-channel quantile. CHESS's empirical
+//!   precision target is the 50% quantile ± a few percent; this is
+//!   plenty.
+//!
+//! The ratio's domain is `[0, 1]` by construction (numerator ≤
+//! denominator), so a fixed-range histogram is the right tool. A
+//! reservoir sampler would give us perfect quantiles but at 10 k
+//! samples × 4 B × 60 × 2048 = 4.9 GiB of resident memory; t-digest
+//! would compress better but with a much more complex update path and
+//! a Rust dep we don't currently carry. Histogram bins are the
+//! lowest-friction option that hits the precision target.
+//!
+//! # On-disk format
+//!
+//! One `layer_<lid>.bin` file per covered layer in the capture dir.
+//! Native-endian binary (we never share these files between hosts; the
+//! calibration tool runs on the same machine as the capture).
+//!
+//! ```text
+//! Header (32 bytes):
+//!   magic:           [u8; 16]  // CSCD_FFN_CAP_v1\0
+//!   layer_id:        u32 LE
+//!   n_intermediate:  u32 LE
+//!   n_bins:          u32 LE
+//!   total_samples:   u32 LE    // sum across all channels' bins
+//! Body:
+//!   counts:          [u32 LE; n_intermediate * n_bins]
+//!                    // channel-major: channel c at offset c*n_bins
+//! ```
+//!
+//! See [`LayerCapture::write_to`] for the writer and the matching
+//! reader in `bin/calibrate_ffn_thresholds.rs`.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use parking_lot::Mutex;
+use thiserror::Error;
+
+/// Magic bytes prefixing every layer capture file. Bump if the layout
+/// changes (also bump `MAGIC` in the calibration tool).
+pub const CAPTURE_FILE_MAGIC: &[u8; 16] = b"CSCD_FFN_CAP_v1\0";
+
+/// Bins per channel in the histogram. 128 bins → bin width 1/128 ≈
+/// 0.0078, which gives sub-1% precision on the per-channel quantile.
+pub const N_BINS: usize = 128;
+
+#[derive(Debug, Error)]
+pub enum CaptureError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// One layer's per-channel ratio histograms.
+///
+/// Each channel gets `N_BINS` u32 counts indexed by
+/// `floor(ratio * N_BINS)` (clamped to `N_BINS - 1`). Counts are
+/// **not** Atomic — updates run on the single dispatch thread that
+/// owns the [`GateCaptureState`] mutex.
+pub struct LayerCapture {
+    pub layer_id: u32,
+    pub n_intermediate: usize,
+    /// Flat counts: channel `c`, bin `b` at index `c * N_BINS + b`.
+    pub counts: Vec<u32>,
+    pub total_samples: u64,
+}
+
+impl LayerCapture {
+    pub fn new(layer_id: u32, n_intermediate: usize) -> Self {
+        Self {
+            layer_id,
+            n_intermediate,
+            counts: vec![0u32; n_intermediate * N_BINS],
+            total_samples: 0,
+        }
+    }
+
+    /// Record one (silu_gate, max_abs) snapshot from a single expert
+    /// call. Inactive (max_abs == 0) snapshots are skipped — they
+    /// produce a degenerate ratio of 0/0 and don't say anything
+    /// meaningful about channel-magnitude distribution.
+    pub fn record(&mut self, silu_gate: &[f32], max_abs: f32) {
+        debug_assert_eq!(silu_gate.len(), self.n_intermediate);
+        if max_abs <= 0.0 {
+            return;
+        }
+        let inv = 1.0 / max_abs;
+        let n_bins_f = N_BINS as f32;
+        for (c, &v) in silu_gate.iter().enumerate() {
+            let ratio = (v.abs() * inv).clamp(0.0, 1.0);
+            // The clamp above guarantees ratio ∈ [0, 1]; multiplying
+            // by N_BINS and truncating yields a bin index in [0,
+            // N_BINS]; we additionally clamp to [0, N_BINS-1] so the
+            // exact-1.0 ratio (the max-magnitude channel) maps to
+            // the last bin rather than overflowing.
+            let bin = (ratio * n_bins_f) as usize;
+            let bin = bin.min(N_BINS - 1);
+            self.counts[c * N_BINS + bin] = self.counts[c * N_BINS + bin].saturating_add(1);
+        }
+        self.total_samples += 1;
+    }
+
+    /// Serialise this layer to `dst` in the format documented at the
+    /// module level.
+    pub fn write_to(&self, dst: &mut impl Write) -> Result<(), CaptureError> {
+        let mut header = [0u8; 32];
+        header[..16].copy_from_slice(CAPTURE_FILE_MAGIC);
+        header[16..20].copy_from_slice(&self.layer_id.to_le_bytes());
+        header[20..24].copy_from_slice(&(self.n_intermediate as u32).to_le_bytes());
+        header[24..28].copy_from_slice(&(N_BINS as u32).to_le_bytes());
+        // total_samples is u64 in memory but caps at u32 on disk —
+        // capture runs are bounded by token count, and even at 1k
+        // tokens × 384 experts × 60 layers we're at ~23 M, well
+        // within u32 range. If a capture run somehow exceeds u32::MAX
+        // samples we saturate the disk field; the body counts are
+        // still authoritative.
+        header[28..32]
+            .copy_from_slice(&(self.total_samples.min(u32::MAX as u64) as u32).to_le_bytes());
+        dst.write_all(&header)?;
+        // Body: pack the u32 counts as LE bytes. `bytemuck` would let
+        // us cast the slice in one shot, but we don't have it as a
+        // workspace dep and the per-channel cost is dominated by the
+        // outer file I/O. Loop and write 4 bytes at a time.
+        let mut buf = Vec::with_capacity(self.counts.len() * 4);
+        for &c in &self.counts {
+            buf.extend_from_slice(&c.to_le_bytes());
+        }
+        dst.write_all(&buf)?;
+        Ok(())
+    }
+}
+
+/// Per-worker capture state: one [`LayerCapture`] per covered layer.
+///
+/// The dispatcher calls [`Self::record`] inside its hot loop; the
+/// `Mutex` wraps the per-layer map so multiple dispatcher threads
+/// (rayon, etc.) can update concurrently without races. In practice
+/// the K2.6 dispatch path is serial across experts within a token,
+/// so contention is negligible — this is a future-proofing guard.
+pub struct GateCaptureState {
+    inner: Mutex<GateCaptureInner>,
+    n_intermediate: usize,
+    capture_dir: PathBuf,
+}
+
+struct GateCaptureInner {
+    layers: BTreeMap<u32, LayerCapture>,
+}
+
+impl GateCaptureState {
+    pub fn new(capture_dir: PathBuf, n_intermediate: usize) -> Self {
+        Self {
+            inner: Mutex::new(GateCaptureInner {
+                layers: BTreeMap::new(),
+            }),
+            n_intermediate,
+            capture_dir,
+        }
+    }
+
+    pub fn capture_dir(&self) -> &Path {
+        &self.capture_dir
+    }
+
+    /// Record one expert call's per-channel `silu(gate)` snapshot.
+    /// `max_abs` is the per-token max of `|silu(gate)|` — the same
+    /// number the runtime uses to build the global-τ mask.
+    pub fn record(&self, layer_id: u32, silu_gate: &[f32], max_abs: f32) {
+        let mut g = self.inner.lock();
+        let entry = g
+            .layers
+            .entry(layer_id)
+            .or_insert_with(|| LayerCapture::new(layer_id, self.n_intermediate));
+        entry.record(silu_gate, max_abs);
+    }
+
+    /// Total samples recorded across every covered layer. Useful for
+    /// "is this capture run big enough yet" instrumentation. One
+    /// sample = one expert call observed.
+    pub fn total_samples(&self) -> u64 {
+        let g = self.inner.lock();
+        g.layers.values().map(|l| l.total_samples).sum()
+    }
+
+    /// How many distinct layers have been recorded against.
+    pub fn n_layers(&self) -> usize {
+        self.inner.lock().layers.len()
+    }
+
+    /// Persist every covered layer to `self.capture_dir`. Creates the
+    /// directory if it doesn't exist. Returns `(n_layers_written,
+    /// total_samples)`.
+    pub fn dump(&self) -> Result<(usize, u64), CaptureError> {
+        std::fs::create_dir_all(&self.capture_dir)?;
+        let g = self.inner.lock();
+        let mut total = 0u64;
+        let mut n_layers = 0usize;
+        for layer in g.layers.values() {
+            let path = self
+                .capture_dir
+                .join(format!("layer_{:04}.bin", layer.layer_id));
+            let tmp = self
+                .capture_dir
+                .join(format!("layer_{:04}.bin.tmp", layer.layer_id));
+            // Atomic-rename write so a SIGKILL mid-dump leaves the
+            // previous file (if any) intact.
+            {
+                let mut f = std::fs::File::create(&tmp)?;
+                layer.write_to(&mut f)?;
+                f.sync_all().ok();
+            }
+            std::fs::rename(&tmp, &path)?;
+            total += layer.total_samples;
+            n_layers += 1;
+        }
+        Ok((n_layers, total))
+    }
+
+    /// Test-only: drain the current state into an in-memory snapshot.
+    /// Mostly useful for unit tests that want to inspect counts
+    /// directly without going through the on-disk path.
+    #[cfg(test)]
+    fn snapshot_layers(&self) -> BTreeMap<u32, LayerCapture> {
+        let mut g = self.inner.lock();
+        std::mem::take(&mut g.layers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// `LayerCapture::record` skips snapshots where `max_abs == 0`
+    /// (numerically degenerate). Bin counts stay zero; `total_samples`
+    /// stays zero.
+    #[test]
+    fn record_skips_zero_max_snapshots() {
+        let mut l = LayerCapture::new(0, 4);
+        l.record(&[0.0, 0.0, 0.0, 0.0], 0.0);
+        assert_eq!(l.total_samples, 0);
+        assert!(l.counts.iter().all(|&c| c == 0));
+    }
+
+    /// A snapshot where one channel is max-magnitude and the others
+    /// are zero deposits one count in the last bin of that channel
+    /// (ratio = 1.0) and one count in the first bin of every other
+    /// channel (ratio = 0.0).
+    #[test]
+    fn record_bins_max_and_zero_correctly() {
+        let mut l = LayerCapture::new(0, 3);
+        l.record(&[0.0, 0.0, 5.0], 5.0);
+        assert_eq!(l.total_samples, 1);
+        // Channel 0: bin 0 should hold the only count.
+        assert_eq!(l.counts[0], 1);
+        // Channel 1: same.
+        assert_eq!(l.counts[N_BINS], 1);
+        // Channel 2: last bin (index N_BINS - 1) should hold the
+        // count, since 5.0 / 5.0 = 1.0 maps to bin N_BINS - 1 after
+        // clamp.
+        assert_eq!(l.counts[2 * N_BINS + (N_BINS - 1)], 1);
+        // No other counts.
+        let sum: u32 = l.counts.iter().sum();
+        assert_eq!(sum, 3);
+    }
+
+    /// Many snapshots: empirical CDF of the recorded ratios should
+    /// land approximately where we expect. Channel 0 always emits
+    /// ratio 0.5; the median bin should be at index N_BINS/2.
+    #[test]
+    fn many_snapshots_concentrate_at_known_bin() {
+        let mut l = LayerCapture::new(0, 2);
+        for _ in 0..100 {
+            // silu_gate = [0.5, 1.0]; max = 1.0 → ratios [0.5, 1.0].
+            l.record(&[0.5, 1.0], 1.0);
+        }
+        assert_eq!(l.total_samples, 100);
+        // Channel 0: all 100 samples in bin floor(0.5 * 128) = 64.
+        assert_eq!(l.counts[64], 100);
+        let ch0_total: u32 = l.counts[..N_BINS].iter().sum();
+        assert_eq!(ch0_total, 100);
+        // Channel 1: all 100 samples in bin N_BINS - 1.
+        assert_eq!(l.counts[N_BINS + (N_BINS - 1)], 100);
+    }
+
+    /// `GateCaptureState::dump` writes one file per covered layer
+    /// with the documented magic + dimensions.
+    #[test]
+    fn dump_writes_one_file_per_layer() {
+        let dir = tempdir().expect("tempdir");
+        let st = GateCaptureState::new(dir.path().to_owned(), 4);
+        st.record(0, &[0.1, 0.2, 0.3, 0.4], 0.4);
+        st.record(5, &[0.0, 1.0, 0.5, 0.25], 1.0);
+        let (n_layers, total) = st.dump().expect("dump");
+        assert_eq!(n_layers, 2);
+        assert_eq!(total, 2);
+
+        let p0 = dir.path().join("layer_0000.bin");
+        let p5 = dir.path().join("layer_0005.bin");
+        assert!(p0.exists());
+        assert!(p5.exists());
+
+        // Header sanity-check.
+        let bytes = std::fs::read(&p0).expect("read");
+        assert_eq!(&bytes[..16], &CAPTURE_FILE_MAGIC[..]);
+        let lid = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
+        let ni = u32::from_le_bytes(bytes[20..24].try_into().unwrap());
+        let nb = u32::from_le_bytes(bytes[24..28].try_into().unwrap());
+        let ts = u32::from_le_bytes(bytes[28..32].try_into().unwrap());
+        assert_eq!(lid, 0);
+        assert_eq!(ni, 4);
+        assert_eq!(nb as usize, N_BINS);
+        assert_eq!(ts, 1);
+        // Body length matches dim claim.
+        assert_eq!(bytes.len(), 32 + 4 * 4 * N_BINS);
+    }
+
+    /// Multiple records into the same layer are additive across bins.
+    #[test]
+    fn record_accumulates_within_layer() {
+        let dir = tempdir().expect("tempdir");
+        let st = GateCaptureState::new(dir.path().to_owned(), 2);
+        for _ in 0..3 {
+            st.record(7, &[0.0, 1.0], 1.0);
+        }
+        assert_eq!(st.total_samples(), 3);
+        let snap = st.snapshot_layers();
+        let layer = snap.get(&7).expect("layer 7");
+        assert_eq!(layer.total_samples, 3);
+        // Channel 0: 3 hits in bin 0; channel 1: 3 hits in last bin.
+        assert_eq!(layer.counts[0], 3);
+        assert_eq!(layer.counts[N_BINS + (N_BINS - 1)], 3);
+    }
+}

--- a/crates/cascadia-int4-gemm/src/ffn_sparsity.rs
+++ b/crates/cascadia-int4-gemm/src/ffn_sparsity.rs
@@ -53,6 +53,44 @@ use rayon::prelude::*;
 use crate::format::bf16_bits_to_f32;
 use crate::GROUP_SIZE;
 
+/// How the active-lane cutoff is computed.
+///
+/// - `Global(τ)` — a single scalar threshold, applied as `cutoff[i] = τ ·
+///   max_j|silu(gate[j])|` for every lane `i`. This is the CATS / global-τ
+///   formulation (Lee et al. 2024).
+/// - `PerChannel(τ)` — one threshold per intermediate channel, applied as
+///   `cutoff[i] = τ[i] · max_j|silu(gate[j])|`. This is the CHESS
+///   formulation (Liu et al. 2024). The expected source for the `τ[i]`
+///   vector is offline calibration on a representative corpus:
+///   `τ[i] = quantile_{1-active_frac}(|silu(gate[i])| / max_j|silu(gate[j])|)`.
+///
+/// With a `PerChannel(τ)` slice of length `intermediate` and all entries
+/// equal to a single value `τ0`, the mask must be bit-identical to
+/// `Global(τ0)`. That invariant is locked by the unit test
+/// `per_channel_uniform_matches_global` below.
+#[derive(Debug, Clone, Copy)]
+pub enum SparsityMode<'a> {
+    /// One scalar threshold for every channel.
+    Global(f32),
+    /// Per-channel threshold vector; `len()` must equal the intermediate
+    /// dimension at the call site.
+    PerChannel(&'a [f32]),
+}
+
+impl<'a> SparsityMode<'a> {
+    /// `true` when this mode would short-circuit to "all lanes active"
+    /// (no mask construction needed). For `Global`, that's `τ <= 0`. For
+    /// `PerChannel`, every entry must be `<= 0` for the short-circuit;
+    /// otherwise we still walk the full lane set (an empty per-channel
+    /// vector is treated as dense).
+    fn is_dense(&self) -> bool {
+        match self {
+            SparsityMode::Global(t) => *t <= 0.0,
+            SparsityMode::PerChannel(ts) => ts.is_empty() || ts.iter().all(|&t| t <= 0.0),
+        }
+    }
+}
+
 /// Build the active-lane mask for a sparse FFN forward pass.
 ///
 /// Returns `(silu_gate, active_indices)`:
@@ -67,6 +105,31 @@ use crate::GROUP_SIZE;
 /// `|silu(gate)|`, which makes a single threshold value usable across
 /// model layers and inputs of different scales.
 pub fn build_active_mask(gate_out: &[f32], threshold: f32) -> (Vec<f32>, Vec<u32>) {
+    build_active_mask_mode(gate_out, SparsityMode::Global(threshold))
+}
+
+/// Per-channel variant of [`build_active_mask`].
+///
+/// `thresholds.len()` must equal `gate_out.len()` (the intermediate
+/// dimension); the mask is built with `cutoff[i] = thresholds[i] *
+/// max_j|silu(gate[j])|`. Useful when the threshold vector was
+/// calibrated offline per the CHESS recipe.
+pub fn build_active_mask_per_channel(gate_out: &[f32], thresholds: &[f32]) -> (Vec<f32>, Vec<u32>) {
+    assert_eq!(
+        gate_out.len(),
+        thresholds.len(),
+        "per-channel thresholds length {} != gate_out length {}",
+        thresholds.len(),
+        gate_out.len(),
+    );
+    build_active_mask_mode(gate_out, SparsityMode::PerChannel(thresholds))
+}
+
+/// Mode-aware mask builder shared by [`build_active_mask`] and
+/// [`build_active_mask_per_channel`]. Computes `silu(gate)` once,
+/// tracks the per-token max, then applies the per-mode cutoff in a
+/// second pass.
+pub fn build_active_mask_mode(gate_out: &[f32], mode: SparsityMode<'_>) -> (Vec<f32>, Vec<u32>) {
     let n = gate_out.len();
     // Phase 1: silu element-wise and track max-abs.
     let mut silu_gate = vec![0.0f32; n];
@@ -85,17 +148,34 @@ pub fn build_active_mask(gate_out: &[f32], threshold: f32) -> (Vec<f32>, Vec<u32
             max_abs = m;
         }
     }
-    if threshold <= 0.0 || max_abs == 0.0 {
+    if max_abs == 0.0 || mode.is_dense() {
         // No skip: all lanes active.
         let all = (0..n as u32).collect();
         return (silu_gate, all);
     }
-    let cutoff = threshold * max_abs;
-    let active: Vec<u32> = silu_gate
-        .iter()
-        .enumerate()
-        .filter_map(|(i, v)| (v.abs() >= cutoff).then_some(i as u32))
-        .collect();
+    let active: Vec<u32> = match mode {
+        SparsityMode::Global(threshold) => {
+            let cutoff = threshold * max_abs;
+            silu_gate
+                .iter()
+                .enumerate()
+                .filter_map(|(i, v)| (v.abs() >= cutoff).then_some(i as u32))
+                .collect()
+        }
+        SparsityMode::PerChannel(thresholds) => {
+            // `thresholds.len() == n` is enforced by the public entry
+            // point [`build_active_mask_per_channel`]; debug-assert
+            // here so direct callers of [`build_active_mask_mode`]
+            // also fail loud in dev builds.
+            debug_assert_eq!(thresholds.len(), n);
+            silu_gate
+                .iter()
+                .zip(thresholds.iter())
+                .enumerate()
+                .filter_map(|(i, (v, &t))| (v.abs() >= t * max_abs).then_some(i as u32))
+                .collect()
+        }
+    };
     (silu_gate, active)
 }
 
@@ -304,6 +384,71 @@ pub fn ffn_forward_sparse_f32(
     out_f32: &mut [f32],
     threshold: f32,
 ) -> f32 {
+    ffn_forward_sparse_f32_mode(
+        x_f32,
+        hidden,
+        intermediate,
+        gate_packed,
+        gate_scale,
+        up_packed,
+        up_scale,
+        down_packed,
+        down_scale,
+        out_f32,
+        SparsityMode::Global(threshold),
+    )
+}
+
+/// Per-channel-τ variant of [`ffn_forward_sparse_f32`].
+///
+/// `thresholds.len()` must equal `intermediate`. With every entry equal
+/// to `τ0`, this is bit-identical to `ffn_forward_sparse_f32(..., τ0)`
+/// (verified by `per_channel_uniform_matches_global` below).
+#[allow(clippy::too_many_arguments)]
+pub fn ffn_forward_sparse_f32_per_channel(
+    x_f32: &[f32],
+    hidden: usize,
+    intermediate: usize,
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed: &[u8],
+    down_scale: &[u8],
+    out_f32: &mut [f32],
+    thresholds: &[f32],
+) -> f32 {
+    ffn_forward_sparse_f32_mode(
+        x_f32,
+        hidden,
+        intermediate,
+        gate_packed,
+        gate_scale,
+        up_packed,
+        up_scale,
+        down_packed,
+        down_scale,
+        out_f32,
+        SparsityMode::PerChannel(thresholds),
+    )
+}
+
+/// Mode-aware variant of [`ffn_forward_sparse_f32`] — body shared by
+/// the global-τ and per-channel-τ entry points.
+#[allow(clippy::too_many_arguments)]
+pub fn ffn_forward_sparse_f32_mode(
+    x_f32: &[f32],
+    hidden: usize,
+    intermediate: usize,
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed: &[u8],
+    down_scale: &[u8],
+    out_f32: &mut [f32],
+    mode: SparsityMode<'_>,
+) -> f32 {
     debug_assert_eq!(x_f32.len(), hidden);
     debug_assert_eq!(out_f32.len(), hidden);
 
@@ -318,7 +463,7 @@ pub fn ffn_forward_sparse_f32(
         &mut gate_out,
     );
 
-    if threshold <= 0.0 {
+    if mode.is_dense() {
         // Dense path: SwiGLU as usual. Bit-identical to the pre-port
         // inline gate/up/down sequence in layer0_int4.rs and
         // shell_int4.rs — uses the same kernel calls in the same order
@@ -352,7 +497,7 @@ pub fn ffn_forward_sparse_f32(
     }
 
     // Sparse path: SiLU + threshold → mask → sparse up + elementwise + down.
-    let (silu_gate, active) = build_active_mask(&gate_out, threshold);
+    let (silu_gate, active) = build_active_mask_mode(&gate_out, mode);
     let active_frac = active.len() as f32 / intermediate as f32;
 
     let mut up_out = vec![0.0f32; intermediate];
@@ -436,6 +581,75 @@ pub fn ffn_forward_sparse_axpy_f32(
     out_f32: &mut [f32],
     threshold: f32,
 ) -> f32 {
+    ffn_forward_sparse_axpy_f32_mode(
+        scratch,
+        x_f32,
+        hidden,
+        intermediate,
+        gate_packed,
+        gate_scale,
+        up_packed,
+        up_scale,
+        down_packed_t,
+        down_scale_t_bits,
+        out_f32,
+        SparsityMode::Global(threshold),
+    )
+}
+
+/// Per-channel-τ variant of [`ffn_forward_sparse_axpy_f32`].
+///
+/// `thresholds.len()` must equal `intermediate`. With every entry equal
+/// to `τ0`, this is bit-identical to `ffn_forward_sparse_axpy_f32(...,
+/// τ0)` (verified by `axpy_per_channel_uniform_matches_global` below).
+#[allow(clippy::too_many_arguments)]
+pub fn ffn_forward_sparse_axpy_f32_per_channel(
+    scratch: &mut crate::ffn_axpy::FfnScratch,
+    x_f32: &[f32],
+    hidden: usize,
+    intermediate: usize,
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed_t: &[u8],
+    down_scale_t_bits: &[u8],
+    out_f32: &mut [f32],
+    thresholds: &[f32],
+) -> f32 {
+    ffn_forward_sparse_axpy_f32_mode(
+        scratch,
+        x_f32,
+        hidden,
+        intermediate,
+        gate_packed,
+        gate_scale,
+        up_packed,
+        up_scale,
+        down_packed_t,
+        down_scale_t_bits,
+        out_f32,
+        SparsityMode::PerChannel(thresholds),
+    )
+}
+
+/// Mode-aware AXPY-form sparse SwiGLU FFN — body shared by the global-
+/// τ and per-channel-τ entry points.
+#[allow(clippy::too_many_arguments)]
+pub fn ffn_forward_sparse_axpy_f32_mode(
+    scratch: &mut crate::ffn_axpy::FfnScratch,
+    x_f32: &[f32],
+    hidden: usize,
+    intermediate: usize,
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed_t: &[u8],
+    down_scale_t_bits: &[u8],
+    out_f32: &mut [f32],
+    mode: SparsityMode<'_>,
+) -> f32 {
     debug_assert_eq!(x_f32.len(), hidden);
     debug_assert_eq!(out_f32.len(), hidden);
     scratch.resize_for(hidden, intermediate);
@@ -464,16 +678,26 @@ pub fn ffn_forward_sparse_axpy_f32(
             max_abs = m;
         }
     }
-    if threshold <= 0.0 || max_abs == 0.0 {
+    if max_abs == 0.0 || mode.is_dense() {
         // All lanes active — AXPY-form over the full intermediate.
-        for i in 0..intermediate {
-            scratch.active.push(i as u32);
-        }
+        scratch.active.extend(0..intermediate as u32);
     } else {
-        let cutoff = threshold * max_abs;
-        for i in 0..intermediate {
-            if silu_gate[i].abs() >= cutoff {
-                scratch.active.push(i as u32);
+        match mode {
+            SparsityMode::Global(threshold) => {
+                let cutoff = threshold * max_abs;
+                for (i, &v) in silu_gate.iter().enumerate() {
+                    if v.abs() >= cutoff {
+                        scratch.active.push(i as u32);
+                    }
+                }
+            }
+            SparsityMode::PerChannel(thresholds) => {
+                debug_assert_eq!(thresholds.len(), intermediate);
+                for (i, (&v, &t)) in silu_gate.iter().zip(thresholds.iter()).enumerate() {
+                    if v.abs() >= t * max_abs {
+                        scratch.active.push(i as u32);
+                    }
+                }
             }
         }
     }
@@ -541,7 +765,63 @@ pub fn expert_forward_sparse(
     out_bf16: &mut [bf16],
     threshold: f32,
 ) -> f32 {
-    if threshold <= 0.0 {
+    expert_forward_sparse_mode(
+        x_bf16,
+        gate_packed,
+        gate_scale,
+        up_packed,
+        up_scale,
+        down_packed,
+        down_scale,
+        out_bf16,
+        SparsityMode::Global(threshold),
+    )
+}
+
+/// Per-channel-τ variant of [`expert_forward_sparse`].
+///
+/// `thresholds.len()` must equal the intermediate dim implied by
+/// `gate_scale.len() / 2 / (hidden / GROUP_SIZE)`.
+#[allow(clippy::too_many_arguments)]
+pub fn expert_forward_sparse_per_channel(
+    x_bf16: &[bf16],
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed: &[u8],
+    down_scale: &[u8],
+    out_bf16: &mut [bf16],
+    thresholds: &[f32],
+) -> f32 {
+    expert_forward_sparse_mode(
+        x_bf16,
+        gate_packed,
+        gate_scale,
+        up_packed,
+        up_scale,
+        down_packed,
+        down_scale,
+        out_bf16,
+        SparsityMode::PerChannel(thresholds),
+    )
+}
+
+/// Mode-aware variant of [`expert_forward_sparse`] — body shared by the
+/// global-τ and per-channel-τ entry points.
+#[allow(clippy::too_many_arguments)]
+pub fn expert_forward_sparse_mode(
+    x_bf16: &[bf16],
+    gate_packed: &[u8],
+    gate_scale: &[u8],
+    up_packed: &[u8],
+    up_scale: &[u8],
+    down_packed: &[u8],
+    down_scale: &[u8],
+    out_bf16: &mut [bf16],
+    mode: SparsityMode<'_>,
+) -> f32 {
+    if mode.is_dense() {
         // Dense fallback: delegate to the existing path so output is
         // byte-identical to pre-port. (The f32 dense path in
         // `ffn_forward_sparse_f32` should also be byte-identical, but
@@ -568,7 +848,7 @@ pub fn expert_forward_sparse(
         x_f32[i] = b.to_f32();
     }
     let mut out_f32 = vec![0.0f32; hidden];
-    let active_frac = ffn_forward_sparse_f32(
+    let active_frac = ffn_forward_sparse_f32_mode(
         &x_f32,
         hidden,
         intermediate,
@@ -579,7 +859,7 @@ pub fn expert_forward_sparse(
         down_packed,
         down_scale,
         &mut out_f32,
-        threshold,
+        mode,
     );
     for (i, v) in out_f32.iter().enumerate() {
         out_bf16[i] = bf16::from_f32(*v);
@@ -1066,5 +1346,307 @@ mod tests {
             max_dev <= tol,
             "AXPY-form diverged from dense sparse at τ=0.10: max_dev={max_dev} max_dense={max_dense} tol={tol}",
         );
+    }
+
+    /// `build_active_mask_per_channel` with a uniform threshold vector
+    /// must produce the same mask as `build_active_mask` at the same
+    /// scalar value. Pins the per-channel formulation to the global-τ
+    /// formulation when the calibration says "every channel is equal."
+    #[test]
+    fn per_channel_uniform_matches_global() {
+        // 16-lane gate output with a wide magnitude spread so the
+        // threshold actually filters something.
+        let gate_out: Vec<f32> = (0..16)
+            .map(|i| {
+                let s = if i % 2 == 0 { 1.0 } else { -1.0 };
+                s * ((i + 1) as f32) * 0.5
+            })
+            .collect();
+        for τ in [0.05f32, 0.10, 0.20, 0.50, 0.95] {
+            let (silu_g, active_g) = build_active_mask(&gate_out, τ);
+            let τ_vec = vec![τ; gate_out.len()];
+            let (silu_pc, active_pc) = build_active_mask_per_channel(&gate_out, &τ_vec);
+            for (i, (a, b)) in silu_g.iter().zip(silu_pc.iter()).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "lane {i}: silu mismatch at τ={τ}: {a} vs {b}",
+                );
+            }
+            assert_eq!(
+                active_g, active_pc,
+                "active set mismatch at τ={τ}: global={active_g:?} per-channel={active_pc:?}",
+            );
+        }
+    }
+
+    /// `build_active_mask_per_channel` with a non-uniform threshold
+    /// vector drops the lanes flagged by their per-channel cutoff and
+    /// keeps the others. Locks the per-channel semantics: a high τ[i]
+    /// excludes lane i even when its `|silu(gate[i])|` would clear a
+    /// lower global threshold.
+    #[test]
+    fn per_channel_nonuniform_drops_expected_lanes() {
+        // 4 lanes; silu(10)≈10, silu(5)≈4.97, silu(1)≈0.73, silu(0.1)≈0.052.
+        // max_abs ≈ 10. Ratios ≈ [1.0, 0.497, 0.073, 0.0052].
+        let gate_out = vec![10.0f32, 5.0, 1.0, 0.1];
+        // Per-channel thresholds:
+        //   lane 0: 0.0  → always active.
+        //   lane 1: 0.6  → cutoff 6.0 > 4.97 → dropped.
+        //   lane 2: 0.05 → cutoff 0.5 < 0.73 → kept.
+        //   lane 3: 0.5  → cutoff 5.0 > 0.052 → dropped.
+        let τ = vec![0.0f32, 0.6, 0.05, 0.5];
+        let (_silu, active) = build_active_mask_per_channel(&gate_out, &τ);
+        assert!(active.contains(&0), "lane 0 (τ=0) must always pass");
+        assert!(!active.contains(&1), "lane 1: |silu|≈4.97 < τ·max=6.0");
+        assert!(active.contains(&2), "lane 2: |silu|≈0.73 ≥ τ·max=0.5");
+        assert!(!active.contains(&3), "lane 3: |silu|≈0.052 < τ·max=5.0");
+    }
+
+    /// All-zero per-channel thresholds short-circuit to "all lanes
+    /// active" exactly like `Global(0.0)` — no mask construction and
+    /// the SparsityMode::is_dense() fast path fires.
+    #[test]
+    fn per_channel_all_zero_is_dense() {
+        let gate_out = vec![1.0f32, -2.0, 0.5, -0.1];
+        let τ = vec![0.0f32; 4];
+        let (_silu, active) = build_active_mask_per_channel(&gate_out, &τ);
+        assert_eq!(active, vec![0, 1, 2, 3]);
+    }
+
+    /// `ffn_forward_sparse_f32_per_channel` with a uniform τ vector
+    /// produces output bit-identical to `ffn_forward_sparse_f32` at
+    /// the same scalar τ. This is the contract that lets us collapse
+    /// the dispatcher's per-channel and global-τ paths under a single
+    /// kernel body.
+    #[test]
+    fn ffn_f32_per_channel_uniform_matches_global() {
+        use crate::kernel_avx512::dequant_gemv_int4_auto;
+        let _ = dequant_gemv_int4_auto;
+        let hidden = 32;
+        let intermediate = 32;
+        let n_in_groups = hidden / GROUP_SIZE;
+        let n_mid_groups = intermediate / GROUP_SIZE;
+        let gate_packed = vec![0x9Au8; intermediate * hidden / 2];
+        let gate_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(intermediate * n_in_groups * 2)
+            .collect();
+        let up_packed = vec![0x8Bu8; intermediate * hidden / 2];
+        let up_scale = gate_scale.clone();
+        let down_packed = vec![0x7Cu8; hidden * intermediate / 2];
+        let down_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(hidden * n_mid_groups * 2)
+            .collect();
+        let x_f32: Vec<f32> = (0..hidden).map(|i| (i as f32) * 0.05 - 0.5).collect();
+
+        for τ in [0.0f32, 0.05, 0.10, 0.30] {
+            let mut out_global = vec![0.0f32; hidden];
+            let af_g = ffn_forward_sparse_f32(
+                &x_f32,
+                hidden,
+                intermediate,
+                &gate_packed,
+                &gate_scale,
+                &up_packed,
+                &up_scale,
+                &down_packed,
+                &down_scale,
+                &mut out_global,
+                τ,
+            );
+            let τ_vec = vec![τ; intermediate];
+            let mut out_per_channel = vec![0.0f32; hidden];
+            let af_pc = ffn_forward_sparse_f32_per_channel(
+                &x_f32,
+                hidden,
+                intermediate,
+                &gate_packed,
+                &gate_scale,
+                &up_packed,
+                &up_scale,
+                &down_packed,
+                &down_scale,
+                &mut out_per_channel,
+                &τ_vec,
+            );
+            assert_eq!(
+                af_g.to_bits(),
+                af_pc.to_bits(),
+                "τ={τ}: active_frac mismatch: global={af_g} per_channel={af_pc}",
+            );
+            for h in 0..hidden {
+                assert_eq!(
+                    out_global[h].to_bits(),
+                    out_per_channel[h].to_bits(),
+                    "τ={τ}, h={h}: out mismatch: global={} per_channel={}",
+                    out_global[h],
+                    out_per_channel[h],
+                );
+            }
+        }
+    }
+
+    /// `ffn_forward_sparse_axpy_f32_per_channel` with a uniform τ
+    /// vector produces output bit-identical to the global-τ AXPY
+    /// path at the same scalar τ. Locks the same invariant for the
+    /// AXPY-down kernel.
+    #[test]
+    fn axpy_per_channel_uniform_matches_global() {
+        use crate::ffn_axpy::{transpose_requantize_down, FfnScratch};
+        let hidden = 64;
+        let intermediate = 64;
+        let n_in_groups = hidden / GROUP_SIZE;
+        let n_mid_groups = intermediate / GROUP_SIZE;
+        let gate_packed = vec![0x9Au8; intermediate * hidden / 2];
+        let gate_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(intermediate * n_in_groups * 2)
+            .collect();
+        let up_packed = vec![0x8Bu8; intermediate * hidden / 2];
+        let up_scale = gate_scale.clone();
+        let down_packed = vec![0x7Cu8; hidden * intermediate / 2];
+        let down_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(hidden * n_mid_groups * 2)
+            .collect();
+        let x_f32: Vec<f32> = (0..hidden).map(|i| (i as f32) * 0.05 - 0.5).collect();
+        let (down_packed_t, down_scale_t_bits) =
+            transpose_requantize_down(&down_packed, &down_scale, hidden, intermediate);
+
+        for τ in [0.0f32, 0.05, 0.10, 0.30] {
+            let mut scratch_g = FfnScratch::new(hidden, intermediate);
+            let mut out_global = vec![0.0f32; hidden];
+            let af_g = ffn_forward_sparse_axpy_f32(
+                &mut scratch_g,
+                &x_f32,
+                hidden,
+                intermediate,
+                &gate_packed,
+                &gate_scale,
+                &up_packed,
+                &up_scale,
+                &down_packed_t,
+                &down_scale_t_bits,
+                &mut out_global,
+                τ,
+            );
+            let τ_vec = vec![τ; intermediate];
+            let mut scratch_pc = FfnScratch::new(hidden, intermediate);
+            let mut out_pc = vec![0.0f32; hidden];
+            let af_pc = ffn_forward_sparse_axpy_f32_per_channel(
+                &mut scratch_pc,
+                &x_f32,
+                hidden,
+                intermediate,
+                &gate_packed,
+                &gate_scale,
+                &up_packed,
+                &up_scale,
+                &down_packed_t,
+                &down_scale_t_bits,
+                &mut out_pc,
+                &τ_vec,
+            );
+            assert_eq!(
+                af_g.to_bits(),
+                af_pc.to_bits(),
+                "τ={τ}: active_frac mismatch"
+            );
+            for h in 0..hidden {
+                assert_eq!(
+                    out_global[h].to_bits(),
+                    out_pc[h].to_bits(),
+                    "τ={τ}, h={h}: AXPY out mismatch: global={} per_channel={}",
+                    out_global[h],
+                    out_pc[h],
+                );
+            }
+        }
+    }
+
+    /// `expert_forward_sparse_per_channel` is the bf16-boundary public
+    /// surface; with uniform τ it matches `expert_forward_sparse` at
+    /// the same scalar.
+    #[test]
+    fn expert_forward_per_channel_uniform_matches_global() {
+        let hidden = 32;
+        let intermediate = 32;
+        let gate_packed = vec![0x9Au8; intermediate * hidden / 2];
+        let gate_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(intermediate * (hidden / GROUP_SIZE) * 2)
+            .collect();
+        let up_packed = vec![0x8Bu8; intermediate * hidden / 2];
+        let up_scale = gate_scale.clone();
+        let down_packed = vec![0x7Cu8; hidden * intermediate / 2];
+        let down_scale: Vec<u8> = vec![0x80, 0x3f]
+            .into_iter()
+            .cycle()
+            .take(hidden * (intermediate / GROUP_SIZE) * 2)
+            .collect();
+        let x: Vec<bf16> = (0..hidden)
+            .map(|i| bf16::from_f32((i as f32) * 0.05 - 0.5))
+            .collect();
+        let mut out_global = vec![bf16::ZERO; hidden];
+        let τ = 0.10f32;
+        let af_g = expert_forward_sparse(
+            &x,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed,
+            &down_scale,
+            &mut out_global,
+            τ,
+        );
+        let τ_vec = vec![τ; intermediate];
+        let mut out_pc = vec![bf16::ZERO; hidden];
+        let af_pc = expert_forward_sparse_per_channel(
+            &x,
+            &gate_packed,
+            &gate_scale,
+            &up_packed,
+            &up_scale,
+            &down_packed,
+            &down_scale,
+            &mut out_pc,
+            &τ_vec,
+        );
+        assert_eq!(af_g.to_bits(), af_pc.to_bits(), "active_frac mismatch");
+        for h in 0..hidden {
+            assert_eq!(
+                out_global[h].to_bits(),
+                out_pc[h].to_bits(),
+                "h={h}: bf16 out mismatch",
+            );
+        }
+    }
+
+    /// Per-channel mask drops more aggressively than a global τ when
+    /// the calibrated thresholds for the heavy-magnitude lanes are
+    /// higher than the global value. Sanity-checks that the per-
+    /// channel formulation can do something the global-τ formulation
+    /// cannot.
+    #[test]
+    fn per_channel_can_be_stricter_than_global() {
+        // gate_out → silu_gate magnitudes: [10, 5, 1, 0.1]; max = 10.
+        let gate_out = vec![10.0f32, 5.0, 1.0, 0.1];
+        // Global τ=0.05 → cutoff 0.5 → active = [0,1,2] (lane 3 drops).
+        let (_, active_global) = build_active_mask(&gate_out, 0.05);
+        assert_eq!(active_global, vec![0, 1, 2]);
+        // Per-channel τ that targets a 25%-active rate: keep only the
+        // top lane. lane 0 τ=0.05, lane 1 τ=0.6 (drops 4.97),
+        // lane 2 τ=0.5 (drops 0.73), lane 3 τ=0.5.
+        let τ = vec![0.05f32, 0.6, 0.5, 0.5];
+        let (_, active_pc) = build_active_mask_per_channel(&gate_out, &τ);
+        assert_eq!(active_pc, vec![0]);
     }
 }

--- a/crates/cascadia-int4-gemm/src/ffn_thresholds.rs
+++ b/crates/cascadia-int4-gemm/src/ffn_thresholds.rs
@@ -1,0 +1,375 @@
+//! Per-channel FFN sparsity thresholds — file format + loader.
+//!
+//! Issue #38, the CHESS extension to the global-τ FFN sparsity landed
+//! in PR #34. Each (layer, channel) pair gets its own threshold
+//! `τ[layer, channel]`, calibrated offline:
+//!
+//! ```text
+//! τ[layer, channel] = quantile_{1 - target_active_frac}(
+//!     |silu(gate[layer, channel])| / max_j |silu(gate[layer, j])|
+//! )
+//! ```
+//!
+//! ## File format
+//!
+//! JSON, schema `version: 1`. One file per model (not per layer) —
+//! at K2.6 dims this is 60 layers × 2048 channels × 4 B ≈ 480 KiB on
+//! disk after JSON encoding (~1.5 MB pretty-printed).
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "model_id": "kimi-k2.6-instruct",
+//!   "n_intermediate": 2048,
+//!   "calibration_n_tokens": 12345,
+//!   "target_active_frac": 0.5,
+//!   "notes": "optional free-form provenance",
+//!   "layers": [
+//!     { "layer_id": 0, "thresholds": [0.123, 0.456, ...] },
+//!     ...
+//!   ]
+//! }
+//! ```
+//!
+//! The runtime treats the file as advisory: if a layer is missing
+//! from `layers`, [`PerChannelThresholds::get`] returns `None` and
+//! the dispatcher falls back to the global-τ (or dense) path for
+//! that layer. This is the right behaviour for partial-coverage
+//! calibration runs (e.g. only the first N layers were covered).
+//!
+//! Schema bumps: increment `version` and add a v2-aware path here.
+//! Today the loader rejects anything that isn't `version: 1`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Current threshold-file schema version. Bump on any layout change.
+pub const THRESHOLDS_FILE_VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum ThresholdsError {
+    #[error("io error reading thresholds file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json parse error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported thresholds schema version: got {got}, supported up to {supported}")]
+    UnsupportedVersion { got: u32, supported: u32 },
+    #[error(
+        "intermediate dim mismatch on layer_id {layer_id}: file says {file}, runtime expects {expected}"
+    )]
+    IntermediateMismatch {
+        layer_id: u32,
+        file: usize,
+        expected: usize,
+    },
+    #[error("duplicate layer_id {0} in thresholds file")]
+    DuplicateLayer(u32),
+}
+
+/// One layer's per-channel threshold vector. `thresholds.len()` should
+/// equal the model's intermediate dim; mismatch is checked at
+/// [`PerChannelThresholds::verify_for_intermediate`] time, not at file
+/// load (so calibration tools can build files iteratively).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerThresholds {
+    pub layer_id: u32,
+    pub thresholds: Vec<f32>,
+}
+
+/// Per-channel thresholds for every covered MoE layer.
+///
+/// Files load via [`Self::load`]; runtime lookup via [`Self::get`].
+/// Layers absent from the file return `None` from `get`, letting the
+/// dispatcher fall back to global-τ for them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerChannelThresholds {
+    pub version: u32,
+    pub model_id: String,
+    pub n_intermediate: usize,
+    /// How many tokens the calibration corpus contributed. Useful for
+    /// catching "we calibrated on 200 tokens, the file might be noisy"
+    /// at startup.
+    #[serde(default)]
+    pub calibration_n_tokens: u64,
+    /// The target active fraction the calibration aimed at — i.e. the
+    /// quantile at `1 - target_active_frac` of each channel's
+    /// magnitude ratio distribution. Stored so a deployment can sanity-
+    /// check it matches their expected sparsity budget.
+    pub target_active_frac: f32,
+    #[serde(default)]
+    pub notes: String,
+    pub layers: Vec<LayerThresholds>,
+
+    /// Index built at load time: `layer_id -> position in self.layers`.
+    /// `#[serde(skip)]` so it doesn't bloat the file.
+    #[serde(skip)]
+    by_layer: HashMap<u32, usize>,
+}
+
+impl PerChannelThresholds {
+    /// Build a fresh in-memory thresholds object (used by the
+    /// calibration tool before writing to disk). Caller must invoke
+    /// [`Self::rebuild_index`] (or [`Self::save`], which does it for
+    /// you) before [`Self::get`] is meaningful.
+    pub fn new(
+        model_id: impl Into<String>,
+        n_intermediate: usize,
+        target_active_frac: f32,
+    ) -> Self {
+        Self {
+            version: THRESHOLDS_FILE_VERSION,
+            model_id: model_id.into(),
+            n_intermediate,
+            calibration_n_tokens: 0,
+            target_active_frac,
+            notes: String::new(),
+            layers: Vec::new(),
+            by_layer: HashMap::new(),
+        }
+    }
+
+    /// Add (or replace) a layer's thresholds. `thresholds.len()` must
+    /// equal `self.n_intermediate`.
+    pub fn upsert_layer(&mut self, layer_id: u32, thresholds: Vec<f32>) {
+        assert_eq!(
+            thresholds.len(),
+            self.n_intermediate,
+            "layer {layer_id}: thresholds.len() {} != n_intermediate {}",
+            thresholds.len(),
+            self.n_intermediate,
+        );
+        if let Some(&idx) = self.by_layer.get(&layer_id) {
+            self.layers[idx].thresholds = thresholds;
+        } else {
+            let idx = self.layers.len();
+            self.layers.push(LayerThresholds {
+                layer_id,
+                thresholds,
+            });
+            self.by_layer.insert(layer_id, idx);
+        }
+    }
+
+    /// Number of layers covered by this file.
+    pub fn n_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// Per-channel thresholds for one layer, or `None` if not covered.
+    pub fn get(&self, layer_id: u32) -> Option<&[f32]> {
+        self.by_layer
+            .get(&layer_id)
+            .map(|&idx| self.layers[idx].thresholds.as_slice())
+    }
+
+    /// Verify every loaded layer matches the runtime's intermediate
+    /// dim. Returns the first mismatch (if any) — call once at startup
+    /// after loading from disk and before threading into a runner.
+    pub fn verify_for_intermediate(&self, expected: usize) -> Result<(), ThresholdsError> {
+        if self.n_intermediate != expected {
+            return Err(ThresholdsError::IntermediateMismatch {
+                layer_id: u32::MAX,
+                file: self.n_intermediate,
+                expected,
+            });
+        }
+        for layer in &self.layers {
+            if layer.thresholds.len() != expected {
+                return Err(ThresholdsError::IntermediateMismatch {
+                    layer_id: layer.layer_id,
+                    file: layer.thresholds.len(),
+                    expected,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the `by_layer` index after deserialisation (or after
+    /// bulk-mutating `self.layers`). Rejects duplicate layer ids.
+    pub fn rebuild_index(&mut self) -> Result<(), ThresholdsError> {
+        self.by_layer.clear();
+        self.by_layer.reserve(self.layers.len());
+        for (idx, layer) in self.layers.iter().enumerate() {
+            if self.by_layer.insert(layer.layer_id, idx).is_some() {
+                return Err(ThresholdsError::DuplicateLayer(layer.layer_id));
+            }
+        }
+        Ok(())
+    }
+
+    /// Read + parse + index. Rejects unsupported `version` and
+    /// duplicate layer ids early.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ThresholdsError> {
+        let bytes = std::fs::read(path.as_ref())?;
+        let mut t: Self = serde_json::from_slice(&bytes)?;
+        if t.version > THRESHOLDS_FILE_VERSION {
+            return Err(ThresholdsError::UnsupportedVersion {
+                got: t.version,
+                supported: THRESHOLDS_FILE_VERSION,
+            });
+        }
+        t.rebuild_index()?;
+        Ok(t)
+    }
+
+    /// Atomically write to `path`: serialise → write to a sibling
+    /// `<path>.tmp` → rename. Caller-supplied path becomes the final
+    /// file on success; the .tmp is removed on failure inside this
+    /// function (best-effort).
+    pub fn save(&mut self, path: impl AsRef<Path>) -> Result<(), ThresholdsError> {
+        self.rebuild_index()?;
+        let path = path.as_ref();
+        let tmp = match path.file_name() {
+            Some(name) => {
+                let mut t = name.to_owned();
+                t.push(".tmp");
+                path.with_file_name(t)
+            }
+            None => {
+                return Err(ThresholdsError::Io(std::io::Error::other(
+                    "path has no file name",
+                )))
+            }
+        };
+        let bytes = serde_json::to_vec_pretty(self)?;
+        // Write + fsync the temp, then rename. fsync of the parent
+        // directory isn't strictly required for the rename to be
+        // visible — the rename is the durability barrier — but on
+        // Linux/macOS we sync the file itself so the contents are on
+        // disk before the rename publishes them.
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(&tmp).map_err(|e| {
+                ThresholdsError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("create {}: {e}", tmp.display()),
+                ))
+            })?;
+            f.write_all(&bytes)?;
+            f.sync_all().ok();
+        }
+        if let Err(e) = std::fs::rename(&tmp, path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(ThresholdsError::Io(std::io::Error::new(
+                e.kind(),
+                format!("rename {} -> {}: {e}", tmp.display(), path.display()),
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Round-trip: upsert two layers, save, load — get same data back.
+    #[test]
+    fn save_load_round_trip() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("th.json");
+        let mut t = PerChannelThresholds::new("test-model", 4, 0.5);
+        t.upsert_layer(0, vec![0.1, 0.2, 0.3, 0.4]);
+        t.upsert_layer(5, vec![0.5, 0.6, 0.7, 0.8]);
+        t.notes = "round-trip test".into();
+        t.calibration_n_tokens = 1234;
+        t.save(&path).expect("save");
+
+        let loaded = PerChannelThresholds::load(&path).expect("load");
+        assert_eq!(loaded.version, THRESHOLDS_FILE_VERSION);
+        assert_eq!(loaded.model_id, "test-model");
+        assert_eq!(loaded.n_intermediate, 4);
+        assert_eq!(loaded.target_active_frac, 0.5);
+        assert_eq!(loaded.notes, "round-trip test");
+        assert_eq!(loaded.calibration_n_tokens, 1234);
+        assert_eq!(loaded.n_layers(), 2);
+        assert_eq!(loaded.get(0), Some(&[0.1f32, 0.2, 0.3, 0.4][..]));
+        assert_eq!(loaded.get(5), Some(&[0.5f32, 0.6, 0.7, 0.8][..]));
+        assert_eq!(loaded.get(1), None, "uncovered layer returns None");
+    }
+
+    /// upsert with the same layer_id replaces in-place rather than
+    /// duplicating.
+    #[test]
+    fn upsert_replaces_existing_layer() {
+        let mut t = PerChannelThresholds::new("m", 2, 0.5);
+        t.upsert_layer(7, vec![0.1, 0.2]);
+        t.upsert_layer(7, vec![0.9, 0.8]);
+        assert_eq!(t.n_layers(), 1);
+        assert_eq!(t.get(7), Some(&[0.9f32, 0.8][..]));
+    }
+
+    /// Loading a file with mismatched intermediate dim fails
+    /// `verify_for_intermediate`. The load itself succeeds — the
+    /// caller decides what mismatches mean (could be a debug build
+    /// pointing at a prod calibration file).
+    #[test]
+    fn verify_rejects_intermediate_mismatch() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("th.json");
+        let mut t = PerChannelThresholds::new("m", 4, 0.5);
+        t.upsert_layer(0, vec![0.1, 0.2, 0.3, 0.4]);
+        t.save(&path).expect("save");
+
+        let loaded = PerChannelThresholds::load(&path).expect("load");
+        let err = loaded.verify_for_intermediate(8).expect_err("mismatch");
+        match err {
+            ThresholdsError::IntermediateMismatch { file, expected, .. } => {
+                assert_eq!(file, 4);
+                assert_eq!(expected, 8);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    /// Future schema version is rejected on load.
+    #[test]
+    fn rejects_future_version() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("th.json");
+        let json = serde_json::json!({
+            "version": 999,
+            "model_id": "m",
+            "n_intermediate": 4,
+            "target_active_frac": 0.5,
+            "layers": [],
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+        let err = PerChannelThresholds::load(&path).expect_err("should reject");
+        match err {
+            ThresholdsError::UnsupportedVersion { got, supported } => {
+                assert_eq!(got, 999);
+                assert_eq!(supported, THRESHOLDS_FILE_VERSION);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    /// Duplicate layer ids in the file are caught at index-build time.
+    #[test]
+    fn rejects_duplicate_layer_ids() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("th.json");
+        let json = serde_json::json!({
+            "version": 1,
+            "model_id": "m",
+            "n_intermediate": 2,
+            "target_active_frac": 0.5,
+            "layers": [
+                {"layer_id": 3, "thresholds": [0.1, 0.2]},
+                {"layer_id": 3, "thresholds": [0.3, 0.4]},
+            ],
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+        let err = PerChannelThresholds::load(&path).expect_err("duplicate");
+        match err {
+            ThresholdsError::DuplicateLayer(lid) => assert_eq!(lid, 3),
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+}

--- a/crates/cascadia-int4-gemm/src/lib.rs
+++ b/crates/cascadia-int4-gemm/src/lib.rs
@@ -28,7 +28,9 @@
 
 pub mod c_ffi;
 pub mod ffn_axpy;
+pub mod ffn_capture;
 pub mod ffn_sparsity;
+pub mod ffn_thresholds;
 pub mod format;
 pub mod kernel;
 pub mod kernel_avx512;
@@ -44,9 +46,17 @@ pub mod transposed_down_store;
 pub use ffn_axpy::{
     dequant_axpy_int4_active, dequant_axpy_int4_active_auto, transpose_requantize_down, FfnScratch,
 };
+pub use ffn_capture::{
+    CaptureError, GateCaptureState, LayerCapture, CAPTURE_FILE_MAGIC, N_BINS as CAPTURE_N_BINS,
+};
 pub use ffn_sparsity::{
-    build_active_mask, dequant_gemv_int4_rows_subset, dequant_gemv_int4_rows_subset_auto,
-    expert_forward_sparse, ffn_forward_sparse_f32,
+    build_active_mask, build_active_mask_mode, build_active_mask_per_channel,
+    dequant_gemv_int4_rows_subset, dequant_gemv_int4_rows_subset_auto, expert_forward_sparse,
+    expert_forward_sparse_mode, expert_forward_sparse_per_channel, ffn_forward_sparse_f32,
+    ffn_forward_sparse_f32_mode, ffn_forward_sparse_f32_per_channel, SparsityMode,
+};
+pub use ffn_thresholds::{
+    LayerThresholds, PerChannelThresholds, ThresholdsError, THRESHOLDS_FILE_VERSION,
 };
 pub use format::{bf16_bits_to_f32, f32_to_bf16_bits, ExpertWeights, GemmError};
 pub use kernel::{dequant_gemv_int4, expert_forward};

--- a/docs/perf/CHESS_PER_CHANNEL.md
+++ b/docs/perf/CHESS_PER_CHANNEL.md
@@ -1,0 +1,189 @@
+# Per-channel FFN sparsity thresholds (CHESS) — workflow & file format
+
+**Status:** landed alongside PR for issue [#38](https://github.com/labscommunity/cascadia/issues/38).
+**Builds on:** [#34](https://github.com/labscommunity/cascadia/issues/34) (global-τ infra),
+[#35](https://github.com/labscommunity/cascadia/issues/35) (AXPY-form down kernel).
+
+## What this is
+
+PR #34 landed global-τ FFN sparsity: skip any intermediate lane `i` where
+`|silu(gate[i])| < τ · max_j|silu(gate[j])|` for a single scalar `τ`. The
+quality cost rises steeply past τ ≈ 0.05 on K2.6 because *some* channels are
+reliably small-magnitude contributors (safe to drop) while *others* are
+reliably large-magnitude (must keep). A global τ can't separate them.
+
+This PR adds **per-channel thresholds**: τ becomes a vector `τ[c] ∈ R^{intermediate}`
+calibrated offline from a representative corpus, following the
+[CHESS](https://arxiv.org/abs/2409.01366) approach (Liu et al. 2024, MIT).
+Same dispatch shape, same kernels — just substitute a vector cutoff for the
+scalar one.
+
+## The math (one screen)
+
+Runtime mask construction, per (layer, expert) call:
+
+```text
+silu_gate[c] = silu(gate_out[c])
+max_abs      = max_j |silu_gate[j]|
+active[c]    = ( |silu_gate[c]| >= τ[layer, c] * max_abs )
+```
+
+Calibration target, per (layer, channel):
+
+```text
+τ[layer, c] = quantile_{1 - target_active_frac}(
+    |silu(gate[layer, c])| / max_j |silu(gate[layer, j])|
+)
+```
+
+`target_active_frac = 0.5` is the standard CHESS setting (~50% lanes active,
+<1 pp accuracy drop at iso-sparsity vs. CATS in published results).
+
+The per-token `max_abs` normalisation is identical to PR #34's global-τ path,
+which means a uniform threshold vector (`τ[c] = τ0` for all c) is
+**bit-identical** to the global-τ path at `τ = τ0`. That invariant is locked
+by `crates/cascadia-int4-gemm/src/ffn_sparsity.rs::per_channel_uniform_matches_global`
+and equivalents for the AXPY-form and bf16-boundary entry points.
+
+## File format
+
+JSON, schema `version: 1`. See `crates/cascadia-int4-gemm/src/ffn_thresholds.rs`.
+
+```json
+{
+  "version": 1,
+  "model_id": "kimi-k2.6-instruct",
+  "n_intermediate": 2048,
+  "calibration_n_tokens": 12345,
+  "target_active_frac": 0.5,
+  "notes": "optional free-form provenance",
+  "layers": [
+    { "layer_id": 0, "thresholds": [0.123, 0.456, ...] },
+    ...
+  ]
+}
+```
+
+- **Size at K2.6**: 60 layers × 2048 channels × 4 B ≈ 480 KiB binary,
+  ~1.5 MB pretty-printed JSON.
+- **Layer coverage is optional**: layers absent from `layers` fall back to
+  the scalar `--ffn-sparsity-threshold` value (or dense if that's `0.0`).
+  This is the right semantic for partial calibration runs.
+- **Per-(layer, channel) only**: per-(layer, expert, channel) is a future
+  extension (would be 60 × 384 × 2048 ≈ 189 MiB), gated on whether
+  calibration data is dense enough per-expert to estimate the quantile
+  reliably. For K=8 active experts per token × 1k calibration tokens you
+  see ~21 samples per expert per layer — too few. Per-(layer, channel)
+  aggregates across the K=8 active experts and gets ~21k samples per
+  layer-channel.
+
+## Workflow
+
+### Phase 1 — capture
+
+Start a worker with the capture flag pointing at an empty directory.
+Capture requires `--ffn-axpy-down` (the only path that surfaces `silu(gate)`
+to the runner; the bf16-boundary path doesn't).
+
+```bash
+cascadia worker \
+  --model /path/to/k26 \
+  --device CPU \
+  --ffn-axpy-down \
+  --ffn-axpy-prebuild \
+  --ffn-sparsity-capture-dir /tmp/k26_gate_caps
+```
+
+Then exercise the model with a representative prompt corpus via the
+`/v1/chat/completions` endpoint. 500–1000 prompts × ~50 tokens each is
+the CATS / CHESS reference budget. On K2.6 single-stage that's roughly
+half an hour of wall time on miner.
+
+On clean shutdown (`SIGTERM`), the engine drains the in-memory histograms
+to `/tmp/k26_gate_caps/layer_<lid>.bin` — one file per covered layer,
+~1 MiB each.
+
+### Phase 2 — calibrate
+
+```bash
+cargo run --release --bin calibrate_ffn_thresholds -- \
+  --capture-dir /tmp/k26_gate_caps \
+  --target-active-frac 0.5 \
+  --model-id kimi-k2.6-instruct \
+  --output /tmp/k26_thresholds_50.json
+```
+
+The tool reads the histograms, computes per-channel quantiles, and writes
+the threshold JSON file. Wall time on miner: seconds.
+
+### Phase 3 — serve
+
+```bash
+cascadia worker \
+  --model /path/to/k26 \
+  --device CPU \
+  --ffn-axpy-down \
+  --ffn-axpy-prebuild \
+  --ffn-sparsity-thresholds-file /tmp/k26_thresholds_50.json
+```
+
+Per-channel thresholds take precedence over `--ffn-sparsity-threshold` for
+any layer present in the file. Layers absent from the file fall back to the
+scalar value (so you can mix: per-channel for layers you calibrated against,
+global-τ as a conservative fallback for the rest).
+
+## Quality checks before deploy
+
+1. **Smoke test** on the canonical K2.6 prompts:
+   ```bash
+   K26_MODEL_DIR=/path/to/k26 \
+   CASCADIA_FFN_SPARSITY_THRESHOLDS_FILE=/tmp/k26_thresholds_50.json \
+     cargo test -p cascadia-engine-sparse-moe --test k26_layer0_eval -- --nocapture
+   ```
+   Expect the canonical prompts ("Paris", "Pacific", "four") to still produce
+   sensible first tokens. A regression here means the calibration corpus
+   wasn't representative of the test distribution.
+
+2. **Active-fraction sanity check**: the worker logs the average active
+   fraction every N expert calls (`ffn_active_fraction`). With a 0.5
+   `target_active_frac` calibration, the runtime average should land in
+   the 0.45 – 0.55 range. Wide deviation means the calibration corpus
+   doesn't match the served distribution.
+
+3. **End-to-end tok/s**: PR #34 reported no net wall-time win at quality-
+   preserving τ on K2.6 (the global-τ path's safe τ ≤ 0.05 leaves too many
+   lanes active for the down kernel to recoup the overhead). Per-channel
+   at 0.5 active_frac, paired with `--ffn-axpy-down`, should put us into
+   the regime where the kernel speedup ceiling (1/active_frac = 2×) is
+   actually realisable on the down projection.
+
+## Why per-(layer, channel) and not per-(layer, expert, channel)
+
+K2.6 has 60 MoE layers × 384 experts × 2048 intermediate channels. Per-
+(layer, expert, channel) would be 189 MiB on disk (still fine) but the
+calibration data budget doesn't support it: a 1k-token corpus × top-K=8
+routed experts produces ~21 samples per (layer, expert), nowhere near
+enough for a stable quantile estimate. Per-(layer, channel) pools across
+experts and gets ~21k samples per layer-channel, which is plenty for the
+1/128 quantile precision the histogram-based estimator achieves.
+
+If/when calibration data scales to ~50k+ prompts (per the EAC-MoE /
+PreMoE recipes which find per-expert specialisation matters), the file
+format can be bumped to v2 with an inner per-expert dimension and the
+runtime can route to that. The current `PerChannelThresholds::get(layer_id)`
+API leaves room for this extension.
+
+## Attribution
+
+- **CHESS** — Liu et al. 2024, "CHESS: Optimizing LLM Inference via Channel-
+  wise Thresholding and Selective Sparsification" (arxiv:2409.01366,
+  EMNLP 2024, MIT licence). The per-channel formulation we ported.
+- **CATS** — Lee et al. 2024, "CATS: Contextually-Aware Thresholding for
+  Sparsity in LLMs" (arxiv:2404.08763, Apache-2.0). The global-τ baseline
+  PR #34 implemented.
+- **PowerInfer** — Song et al. 2024, the two-phase Gate-then-Up/Down skip
+  pattern (MIT). See rainier `docs/POWERINFER_PORT.md` for the full
+  technique map.
+
+Cascadia's CHESS port is an independent Rust implementation — referenced,
+not copied — under Apache-2.0.


### PR DESCRIPTION
Closes #38.

Extends the global-τ FFN sparsity landed in PR #34 with a per-channel
threshold vector τ[layer, channel] calibrated offline (Liu et al. 2024,
CHESS, MIT). Same dispatch shape — just substitute a vector cutoff for
the scalar one.

## What ships

1. **Per-channel mask + forward kernels** (cascadia-int4-gemm)
   - `SparsityMode` enum (`Global(τ)` vs `PerChannel(&[f32])`)
   - `build_active_mask_per_channel`, `ffn_forward_sparse_f32_per_channel`,
     `ffn_forward_sparse_axpy_f32_per_channel`,
     `expert_forward_sparse_per_channel` + mode-aware variants
   - Existing global-τ entry points kept as thin wrappers (backward compat)

2. **PerChannelThresholds JSON v1 file format** (cascadia-int4-gemm)
   - `model_id`, `n_intermediate`, `target_active_frac`,
     `calibration_n_tokens`, per-layer threshold vector
   - Atomic-rename save; shape verification on load; rejects future
     schema versions and duplicate layer ids

3. **silu(gate) histogram capture** (cascadia-int4-gemm)
   - `GateCaptureState` with per-(layer, channel) fixed-bin histograms
     (128 bins, ~60 MiB resident at K2.6 single-stage)
   - One binary file per covered layer, atomic write on engine close

4. **`calibrate_ffn_thresholds` CLI** (new bin)
   - Standalone tool: reads capture-dir histograms → per-channel quantiles →
     threshold JSON. No model dependency.

5. **Runner / Builder / CLI integration** (cascadia-engine-sparse-moe + cascadia-cli)
   - \`--ffn-sparsity-thresholds-file <PATH>\` loads + applies per-channel τ
   - \`--ffn-sparsity-capture-dir <PATH>\` enables capture; dumped on
     graceful shutdown
   - Per-channel τ takes precedence over scalar τ for any layer covered
     by the file; uncovered layers fall back to scalar (or dense)

6. **Bench harness** comparing per-channel vs global runtime overhead
   - Asserts bit-identity in-bench (uniform vector == scalar contract)

7. **Docs**: \`docs/perf/CHESS_PER_CHANNEL.md\` — three-phase workflow,
   math, file format, deploy checklist, per-(layer, channel) vs
   per-(layer, expert, channel) data-budget rationale.

## Test coverage

- 22 new unit tests across the four new modules + bin
- Bit-identity invariants between per-channel-uniform and global-τ
  pinned at \`build_active_mask\`, \`ffn_forward_sparse_f32\`,
  \`ffn_forward_sparse_axpy_f32\`, and \`expert_forward_sparse\`
- Round-trip file-format tests, duplicate-layer / version / shape
  rejection tests, end-to-end capture → calibrate → load smoke test
- Full workspace: 213 tests pass, 0 fail

## Bench (Apple Silicon scalar path, 30 iters)

Per-channel-τ overhead vs global-τ at uniform threshold vector:

| τ0    | global   | per-channel | overhead |
| ----- | -------- | ----------- | -------- |
| 0.050 | 3.14 ms  | 3.25 ms     | +3.30%   |
| 0.100 | 3.36 ms  | 3.24 ms     | −3.67%   |

Within measurement noise — per-channel is effectively free. The real win
from per-channel comes from CHESS calibration allowing higher sparsity
at the same quality (the published CHESS result is ~+1 pp accuracy vs
CATS at iso-sparsity, or ~7 pp fewer activated params at iso-quality).

## Deployment

Three-phase workflow (full procedure in \`docs/perf/CHESS_PER_CHANNEL.md\`):

\`\`\`bash
# 1. Capture
cascadia worker --model <K26-DIR> --device CPU \\
  --ffn-axpy-down --ffn-axpy-prebuild \\
  --ffn-sparsity-capture-dir /tmp/k26_caps
# ... exercise model with representative corpus, SIGTERM ...

# 2. Calibrate
cargo run --release --bin calibrate_ffn_thresholds -- \\
  --capture-dir /tmp/k26_caps --target-active-frac 0.5 \\
  --model-id kimi-k2.6-instruct --output /tmp/k26_thresholds_50.json

# 3. Serve
cascadia worker --model <K26-DIR> --device CPU \\
  --ffn-axpy-down --ffn-axpy-prebuild \\
  --ffn-sparsity-thresholds-file /tmp/k26_thresholds_50.json
\`\`\`

K2.6 production calibration run is out of scope for this PR (it's a
deployment-time activity; the runbook covers the procedure). Together with
PR #43's AXPY-form down kernel, per-channel τ should let us hit the
"production-ready FFN sparsity for K2.6" regime that PR #34's global-τ
couldn't reach on its own.

## Follow-ups

- #40 — trained predictor MLP (PowerInfer §5.1) — orthogonal to this PR;
  shares the threshold-file format
- Per-(layer, expert, channel) thresholds — gated on calibration-data
  budget growth; file format can bump to v2 with an inner expert dim