### PR TITLE
feat(cli): profile-devices subcommand — per-device tok/s for #41 step 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "cascadia-engine-mock",
  "cascadia-engine-openvino",
  "cascadia-engine-sparse-moe",
+ "cascadia-ov-genai-shim",
  "cascadia-runner",
  "cascadia-types",
  "clap",

--- a/crates/cascadia-cli/Cargo.toml
+++ b/crates/cascadia-cli/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 openvino = [
     "cascadia-engine-openvino/openvino",
     "cascadia-engine-sparse-moe/openvino",
+    "cascadia-ov-genai-shim/openvino",
 ]
 
 [dependencies]
@@ -19,6 +20,7 @@ cascadia-engine = { workspace = true }
 cascadia-engine-mock = { workspace = true }
 cascadia-engine-openvino = { workspace = true }
 cascadia-engine-sparse-moe = { workspace = true }
+cascadia-ov-genai-shim = { workspace = true }
 cascadia-runner = { workspace = true }
 cascadia-api = { workspace = true }
 tokio = { workspace = true }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -21,6 +21,9 @@ use futures::StreamExt;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+pub mod profile;
+use profile::{cmd_profile_devices, ProfileDevicesArgs};
+
 #[derive(Parser, Debug)]
 #[command(
     name = "cascadia",
@@ -50,6 +53,11 @@ pub enum Command {
     /// Shard a HuggingFace causal-LM model into per-stage OpenVINO IRs
     /// for distributed inference. See `cascadia shard --help`.
     Shard(ShardArgs),
+    /// Profile available OV devices on this host against a single
+    /// model. Writes `device_profile.json`. See `cascadia
+    /// profile-devices --help`. Step 1 of issue #41 (three-tier
+    /// {iGPU, NPU, CPU} ILP placement).
+    ProfileDevices(ProfileDevicesArgs),
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug)]
@@ -322,6 +330,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Engines => cmd_engines(),
         Command::Worker(args) => cmd_worker(args).await,
         Command::Shard(args) => cmd_shard(args).await,
+        Command::ProfileDevices(args) => cmd_profile_devices(args),
     }
 }
 

--- a/crates/cascadia-cli/src/profile.rs
+++ b/crates/cascadia-cli/src/profile.rs
@@ -1,0 +1,768 @@
+//! `cascadia profile-devices` — measure compile-time + decode tok/s
+//! across OV plugins on the worker host.
+//!
+//! Step 1 of [#41](https://github.com/labscommunity/cascadia/issues/41)
+//! (three-tier {iGPU, NPU, CPU} ILP placement). The placement ILP needs
+//! per-(layer, device) latency to make decisions; this tool produces the
+//! per-(model, device) baseline that justifies — or invalidates — the
+//! ILP itself. Without this measurement an operator can't tell whether
+//! `--device GPU` already wins, whether `HETERO:GPU,CPU` regresses
+//! (it did on Lunar Lake in our beta sweep), or whether NPU is even
+//! reachable for a given model class.
+//!
+//! Output is a `device_profile.json` with the schema in
+//! [`DeviceProfile`]. The same file is consumed by the (future) ILP
+//! step and by `docs/perf/DEVICE_PROFILE.md`'s recommendation matrix.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::{anyhow, Context, Result};
+use cascadia_ov_genai_shim::{self as shim, GenConfig, LlmPipeline, PluginConfig};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+/// Profile each available OV device against a single model. Writes a
+/// device-profile JSON; emits a short summary to stderr.
+#[derive(Parser, Debug, Clone)]
+pub struct ProfileDevicesArgs {
+    /// Path to an exported OV-GenAI model directory (containing
+    /// `openvino_model.xml`, `tokenizer*.{xml,bin}`, etc.). Same path
+    /// you'd pass to `cascadia worker --engine ov-genai --model <PATH>`.
+    #[arg(long)]
+    pub model: String,
+
+    /// Where to write the device profile JSON. Defaults to
+    /// `device_profile.json` in the current directory.
+    #[arg(long, default_value = "device_profile.json")]
+    pub output: PathBuf,
+
+    /// Prompt to use for measurement. Should be a short, deterministic
+    /// query; the bench measures decode latency, so a long prompt would
+    /// inflate the wall-time without measuring more.
+    #[arg(long, default_value = "Explain Intel Lunar Lake in three sentences.")]
+    pub prompt: String,
+
+    /// Tokens to generate per run. Default is small enough that several
+    /// runs across several devices fits comfortably under five minutes,
+    /// large enough that compile overhead doesn't dominate the timing.
+    #[arg(long, default_value_t = 32)]
+    pub max_tokens: u32,
+
+    /// Number of measured runs per device (best is reported as tok/s).
+    #[arg(long, default_value_t = 3)]
+    pub runs: u32,
+
+    /// Warmup runs per device (not counted in tok/s). One warmup is
+    /// usually enough on Intel iGPU to clear shader-cache + KV first-touch
+    /// effects; bump to two if you see large first-vs-second-run variance.
+    #[arg(long, default_value_t = 1)]
+    pub warmup: u32,
+
+    /// Devices to profile. `auto` enumerates every plugin OV sees on
+    /// this host (CPU, GPU, NPU, etc.); a comma-separated list lets you
+    /// pin the set (e.g. `CPU,GPU` to skip NPU on hosts where it
+    /// reliably fails). HETERO strings are accepted verbatim — pass
+    /// e.g. `auto,HETERO:GPU,CPU` to combine the auto-enum with an
+    /// explicit HETERO probe.
+    #[arg(long, default_value = "auto")]
+    pub devices: String,
+
+    /// Also profile every `HETERO:` priority permutation of the auto-
+    /// enumerated devices. Off by default because the permutation count
+    /// grows factorially; on a 3-device host (CPU/GPU/NPU) we add 6
+    /// extra runs. Use when triaging "which HETERO order wins?".
+    #[arg(long, default_value_t = false)]
+    pub include_hetero_permutations: bool,
+
+    /// Optional OV plugin CACHE_DIR; passed through to every pipeline
+    /// construction. Off by default so the bench measures cold-compile
+    /// times honestly; set to amortise across re-runs of the same model
+    /// on the same host.
+    #[arg(long)]
+    pub ov_cache_dir: Option<PathBuf>,
+
+    /// Suppress the result table that's printed to stdout by default.
+    /// JSON output is still written either way.
+    #[arg(long, default_value_t = false)]
+    pub no_summary: bool,
+}
+
+/// One device's measurements. `error == Some(_)` ⇒ compile or run
+/// failed; all `_s` fields are `None` in that case. A `None` here is
+/// not a JSON `null` — serde drops the field entirely.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeviceResult {
+    /// Device string as passed to OV (`CPU`, `GPU`, `HETERO:GPU,CPU`).
+    pub device: String,
+    /// Pipeline construction wall time (includes compile + plugin init).
+    /// First-load only; cached compiles don't reflect this number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compile_s: Option<f64>,
+    /// Warmup wall time. Reported for diagnosis; not part of best_run_s.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warmup_s: Option<f64>,
+    /// Best (min) measured run wall time across `runs` repetitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub best_run_s: Option<f64>,
+    /// All measured runs in order. Useful for spotting warm-up bias the
+    /// `warmup` flag didn't filter out. Empty on failure.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runs_s: Vec<f64>,
+    /// tok/s = max_tokens / best_run_s. None on failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tok_per_sec: Option<f64>,
+    /// First 200 characters of the best-run output. Used as a
+    /// quality-equivalence smoke check: if devices disagree wildly here
+    /// the placement isn't safe even if the timings look good.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_preview: Option<String>,
+    /// OV-side compile or runtime error. Plain prose; the operator
+    /// triages from here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// One enumerated host plugin. `full_name` is `FULL_DEVICE_NAME` from
+/// the OV core; missing if the plugin loads but refuses the property
+/// (rare; some custom plugins).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HostDevice {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HostInfo {
+    pub host_devices: Vec<HostDevice>,
+}
+
+/// Full profile output. JSON-stable; consumed by both the (future) ILP
+/// step and human readers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeviceProfile {
+    /// `device_profile.json` v1 — bump if the schema changes
+    /// incompatibly. Readers should refuse unknown major versions.
+    pub schema_version: u32,
+    pub hardware: HostInfo,
+    pub model: String,
+    pub prompt: String,
+    pub max_tokens: u32,
+    pub runs: u32,
+    pub warmup: u32,
+    pub results: Vec<DeviceResult>,
+    /// Device with the highest measured tok/s; `None` if every probe
+    /// failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub best_device: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub best_tok_per_sec: Option<f64>,
+}
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Enumerate OV plugins on this host, fetching FULL_DEVICE_NAME for
+/// each. Returns `Ok(empty)` rather than `Err` when no plugins enumerate;
+/// the caller still emits a usable (if empty) profile in that case.
+pub fn enumerate_host_devices() -> Result<Vec<HostDevice>> {
+    let names = shim::list_devices().context("OV list_devices")?;
+    let mut out = Vec::with_capacity(names.len());
+    for name in names {
+        let full = match shim::device_full_name(&name) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                warn!(device = %name, error = %e, "FULL_DEVICE_NAME query failed");
+                None
+            }
+        };
+        out.push(HostDevice {
+            name,
+            full_name: full,
+        });
+    }
+    Ok(out)
+}
+
+/// Resolve the user's `--devices` argument into a concrete probe list.
+/// `auto` expands to the host's enumerated devices; an explicit
+/// comma-list passes through. The two forms can be combined
+/// (`auto,HETERO:GPU,CPU`) to add HETERO probes on top of the auto enum.
+///
+/// We deliberately do NOT split on `:` so that `HETERO:GPU,CPU,NPU`
+/// stays a single token — the comma inside `HETERO:...` is part of the
+/// device string, not a list separator. We achieve that by splitting on
+/// commas at the top level only when no preceding `HETERO:` is open.
+pub fn resolve_device_list(arg: &str, host: &[HostDevice]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for tok in split_top_level(arg) {
+        let tok = tok.trim();
+        if tok.is_empty() {
+            continue;
+        }
+        if tok.eq_ignore_ascii_case("auto") {
+            for hd in host {
+                if seen.insert(hd.name.clone()) {
+                    out.push(hd.name.clone());
+                }
+            }
+        } else if seen.insert(tok.to_string()) {
+            out.push(tok.to_string());
+        }
+    }
+    out
+}
+
+/// Split a comma-separated `--devices` argument into individual probe
+/// tokens, treating each `HETERO:`/`MULTI:`/`BATCH:`/`AUTO:` token as a
+/// greedy run that consumes subsequent bare chunks (the comma in
+/// `HETERO:GPU,CPU` is OV's own list separator, not ours).
+///
+/// Rule: a plugin token starts at any chunk matching `<PREFIX>:...` and
+/// ends at the next plugin-prefixed chunk OR end-of-input. Bare chunks
+/// (`CPU`, `GPU`, `auto`) outside a plugin are their own tokens.
+///
+/// Examples:
+/// - `CPU,GPU,NPU`                       → `[CPU, GPU, NPU]`
+/// - `auto,HETERO:GPU,CPU`               → `[auto, HETERO:GPU,CPU]`
+/// - `auto,HETERO:GPU,CPU,HETERO:NPU,GPU`→ `[auto, HETERO:GPU,CPU, HETERO:NPU,GPU]`
+/// - `HETERO:GPU,CPU,NPU`                → `[HETERO:GPU,CPU,NPU]` (all 3 in one HETERO)
+///
+/// Ambiguous case: `HETERO:GPU,CPU` followed by bare `NPU` cannot be
+/// expressed with this grammar — the bare NPU is consumed into HETERO.
+/// Operators who want both must put bares first: `NPU,HETERO:GPU,CPU`.
+fn split_top_level(s: &str) -> Vec<String> {
+    const PLUGIN_PREFIXES: [&str; 4] = ["HETERO:", "MULTI:", "BATCH:", "AUTO:"];
+    fn starts_with_plugin_prefix(s: &str) -> bool {
+        let up = s.trim_start().to_uppercase();
+        PLUGIN_PREFIXES.iter().any(|p| up.starts_with(p))
+    }
+
+    let mut out = Vec::new();
+    let mut buf = String::new();
+    let mut in_plugin = false;
+    for part in s.split(',') {
+        let next_is_plugin = starts_with_plugin_prefix(part);
+        if in_plugin && !next_is_plugin {
+            // Append this bare chunk to the open HETERO/MULTI token —
+            // the comma was OV's, not ours.
+            buf.push(',');
+            buf.push_str(part);
+        } else {
+            // Either we're between tokens (in_plugin=false) or we're
+            // closing the previous HETERO because a new plugin prefix
+            // arrived. Flush, then start the new token.
+            if !buf.is_empty() {
+                out.push(std::mem::take(&mut buf));
+            }
+            buf.push_str(part);
+            in_plugin = next_is_plugin;
+            if !in_plugin {
+                // Bare device — single-chunk token, flush immediately.
+                out.push(std::mem::take(&mut buf));
+            }
+        }
+    }
+    if !buf.is_empty() {
+        out.push(buf);
+    }
+    out
+}
+
+/// Build the cartesian permutations of `devices` as HETERO priority
+/// strings: `HETERO:DEV1,DEV2,...`. For 3 devices this produces 6
+/// strings; for 2 devices, 2. Excludes single-device permutations
+/// (those duplicate the non-HETERO probes).
+pub fn hetero_permutations(devices: &[String]) -> Vec<String> {
+    if devices.len() < 2 {
+        return Vec::new();
+    }
+    let mut perms: Vec<Vec<&String>> = vec![Vec::new()];
+    for d in devices {
+        let mut next = Vec::new();
+        for p in &perms {
+            for i in 0..=p.len() {
+                let mut q = p.clone();
+                q.insert(i, d);
+                next.push(q);
+            }
+        }
+        perms = next;
+    }
+    perms
+        .into_iter()
+        .map(|p| {
+            let parts: Vec<&str> = p.iter().map(|s| s.as_str()).collect();
+            format!("HETERO:{}", parts.join(","))
+        })
+        .collect()
+}
+
+/// Probe one device. On failure, returns `DeviceResult` with `error =
+/// Some(_)` so the caller can write a complete profile (the operator
+/// wants to see WHICH devices failed and why, not just the survivors).
+pub fn probe_device(device: &str, args: &ProfileDevicesArgs) -> DeviceResult {
+    let mut plugin = PluginConfig::new();
+    if let Some(cache) = args.ov_cache_dir.as_ref() {
+        // OV plugin CACHE_DIR; same property name on all plugins.
+        plugin = plugin.with("CACHE_DIR", cache.to_string_lossy().to_string());
+    }
+
+    info!(device = %device, "compiling pipeline");
+    let t_compile = Instant::now();
+    let pipe = match LlmPipeline::new(&args.model, device, &plugin) {
+        Ok(p) => p,
+        Err(e) => {
+            return DeviceResult {
+                device: device.to_string(),
+                compile_s: None,
+                warmup_s: None,
+                best_run_s: None,
+                runs_s: Vec::new(),
+                tok_per_sec: None,
+                output_preview: None,
+                error: Some(format!("compile-fail: {e}")),
+            };
+        }
+    };
+    let compile_s = t_compile.elapsed().as_secs_f64();
+
+    let cfg = GenConfig {
+        max_new_tokens: args.max_tokens,
+        do_sample: false,
+        temperature: 1.0,
+        num_assistant_tokens: 0,
+        max_ngram_size: 0,
+    };
+
+    // Warmup. Failure here is fatal for this device (we can't trust
+    // measured numbers if even warmup didn't compile codegen).
+    let mut warmup_s: Option<f64> = None;
+    for i in 0..args.warmup {
+        let t = Instant::now();
+        match pipe.generate(&args.prompt, &cfg) {
+            Ok(_) => {
+                if i + 1 == args.warmup {
+                    warmup_s = Some(t.elapsed().as_secs_f64());
+                }
+            }
+            Err(e) => {
+                return DeviceResult {
+                    device: device.to_string(),
+                    compile_s: Some(compile_s),
+                    warmup_s: None,
+                    best_run_s: None,
+                    runs_s: Vec::new(),
+                    tok_per_sec: None,
+                    output_preview: None,
+                    error: Some(format!("warmup-fail: {e}")),
+                };
+            }
+        }
+    }
+
+    // Measured runs.
+    let mut runs_s: Vec<f64> = Vec::with_capacity(args.runs as usize);
+    let mut last_output: Option<String> = None;
+    for _ in 0..args.runs {
+        let t = Instant::now();
+        match pipe.generate(&args.prompt, &cfg) {
+            Ok(r) => {
+                runs_s.push(t.elapsed().as_secs_f64());
+                last_output = Some(r.text);
+            }
+            Err(e) => {
+                return DeviceResult {
+                    device: device.to_string(),
+                    compile_s: Some(compile_s),
+                    warmup_s,
+                    best_run_s: None,
+                    runs_s,
+                    tok_per_sec: None,
+                    output_preview: None,
+                    error: Some(format!("run-fail: {e}")),
+                };
+            }
+        }
+    }
+
+    let best_run_s = runs_s.iter().copied().fold(f64::INFINITY, f64::min);
+    let tok_per_sec = if best_run_s > 0.0 {
+        Some(args.max_tokens as f64 / best_run_s)
+    } else {
+        None
+    };
+    let output_preview = last_output.map(|s| truncate_preview(&s, 200));
+
+    DeviceResult {
+        device: device.to_string(),
+        compile_s: Some(compile_s),
+        warmup_s,
+        best_run_s: Some(best_run_s),
+        runs_s,
+        tok_per_sec,
+        output_preview,
+        error: None,
+    }
+}
+
+fn truncate_preview(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max_chars).collect();
+    format!("{truncated}…")
+}
+
+/// Pick the best device by tok/s, ignoring failures. Returns
+/// (device_name, tok_per_sec) or `None` if every probe failed.
+pub fn pick_best(results: &[DeviceResult]) -> Option<(String, f64)> {
+    results
+        .iter()
+        .filter_map(|r| r.tok_per_sec.map(|tps| (r.device.clone(), tps)))
+        .fold(None, |acc, (dev, tps)| match acc {
+            None => Some((dev, tps)),
+            Some((_, best_tps)) if tps > best_tps => Some((dev, tps)),
+            other => other,
+        })
+}
+
+/// Run the full profile: enumerate, resolve, probe, write JSON.
+pub fn run_profile(args: &ProfileDevicesArgs) -> Result<DeviceProfile> {
+    let host_devices = enumerate_host_devices().unwrap_or_else(|e| {
+        warn!(error = %e, "failed to enumerate OV devices; auto resolves to empty");
+        Vec::new()
+    });
+
+    let mut probes = resolve_device_list(&args.devices, &host_devices);
+    if args.include_hetero_permutations {
+        let auto_names: Vec<String> = host_devices.iter().map(|d| d.name.clone()).collect();
+        for h in hetero_permutations(&auto_names) {
+            if !probes.contains(&h) {
+                probes.push(h);
+            }
+        }
+    }
+
+    if probes.is_empty() {
+        return Err(anyhow!(
+            "no devices to probe — pass --devices CPU,GPU,NPU explicitly or install an OV plugin"
+        ));
+    }
+
+    info!(devices = ?probes, model = %args.model, "starting profile");
+    let mut results = Vec::with_capacity(probes.len());
+    for dev in &probes {
+        let t = Instant::now();
+        let r = probe_device(dev, args);
+        let elapsed = t.elapsed();
+        match &r.error {
+            None => info!(device = %dev, tok_s = ?r.tok_per_sec, elapsed = ?elapsed, "device done"),
+            Some(e) => warn!(device = %dev, error = %e, elapsed = ?elapsed, "device failed"),
+        }
+        results.push(r);
+    }
+
+    let (best_device, best_tps) = match pick_best(&results) {
+        Some((d, t)) => (Some(d), Some(t)),
+        None => (None, None),
+    };
+
+    let profile = DeviceProfile {
+        schema_version: SCHEMA_VERSION,
+        hardware: HostInfo { host_devices },
+        model: args.model.clone(),
+        prompt: args.prompt.clone(),
+        max_tokens: args.max_tokens,
+        runs: args.runs,
+        warmup: args.warmup,
+        results,
+        best_device,
+        best_tok_per_sec: best_tps,
+    };
+
+    let json = serde_json::to_string_pretty(&profile).context("serialise profile")?;
+    if let Some(parent) = args.output.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| format!("create parent dir {parent:?}"))?;
+        }
+    }
+    fs::write(&args.output, json).with_context(|| format!("write {}", args.output.display()))?;
+    info!(path = %args.output.display(), "wrote device profile");
+
+    if !args.no_summary {
+        print_summary(&profile);
+    }
+
+    Ok(profile)
+}
+
+fn print_summary(p: &DeviceProfile) {
+    println!();
+    println!("== device profile ==");
+    println!("model:  {}", p.model);
+    println!("prompt: {:?}", p.prompt);
+    println!(
+        "config: max_tokens={} runs={} warmup={}",
+        p.max_tokens, p.runs, p.warmup
+    );
+    println!();
+    println!(
+        "{:36}  {:>10}  {:>10}  {:>10}  {}",
+        "device", "compile_s", "best_s", "tok/s", "status"
+    );
+    println!("{}", "-".repeat(86));
+    for r in &p.results {
+        let compile = r
+            .compile_s
+            .map(|v| format!("{:>10.2}", v))
+            .unwrap_or_else(|| "        --".into());
+        let best = r
+            .best_run_s
+            .map(|v| format!("{:>10.3}", v))
+            .unwrap_or_else(|| "        --".into());
+        let tps = r
+            .tok_per_sec
+            .map(|v| format!("{:>10.2}", v))
+            .unwrap_or_else(|| "        --".into());
+        let status = match &r.error {
+            Some(e) => {
+                let short: String = e.chars().take(40).collect();
+                format!("FAIL: {short}")
+            }
+            None => "ok".to_string(),
+        };
+        println!(
+            "{:36}  {}  {}  {}  {}",
+            r.device, compile, best, tps, status
+        );
+    }
+    println!();
+    match (&p.best_device, p.best_tok_per_sec) {
+        (Some(d), Some(t)) => println!("best: {d} @ {t:.2} tok/s"),
+        _ => println!("best: (no device succeeded)"),
+    }
+    println!();
+}
+
+/// CLI dispatch entry point. Currently a thin wrapper over
+/// [`run_profile`]; promotes to a Tokio-aware multi-host loop when the
+/// (future) ILP step needs concurrent per-device probing.
+pub fn cmd_profile_devices(args: ProfileDevicesArgs) -> Result<()> {
+    if args.runs == 0 {
+        // Not fatal — an operator may want device enumeration only.
+        warn!("runs=0 — measurements will be empty; only enumeration is recorded");
+    }
+    run_profile(&args).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host(devs: &[&str]) -> Vec<HostDevice> {
+        devs.iter()
+            .map(|d| HostDevice {
+                name: d.to_string(),
+                full_name: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn resolve_auto_expands_to_host() {
+        let r = resolve_device_list("auto", &host(&["CPU", "GPU", "NPU"]));
+        assert_eq!(r, vec!["CPU", "GPU", "NPU"]);
+    }
+
+    #[test]
+    fn resolve_dedups() {
+        let r = resolve_device_list("CPU,auto,GPU", &host(&["CPU", "GPU"]));
+        assert_eq!(r, vec!["CPU", "GPU"]);
+    }
+
+    #[test]
+    fn resolve_keeps_hetero_intact() {
+        let r = resolve_device_list("GPU,HETERO:GPU,CPU", &host(&[]));
+        // The HETERO:GPU,CPU should remain a single token, not get
+        // split on its internal comma.
+        assert_eq!(r, vec!["GPU", "HETERO:GPU,CPU"]);
+    }
+
+    #[test]
+    fn resolve_auto_combined_with_hetero() {
+        let r = resolve_device_list("auto,HETERO:GPU,CPU,NPU", &host(&["CPU", "GPU", "NPU"]));
+        assert_eq!(r, vec!["CPU", "GPU", "NPU", "HETERO:GPU,CPU,NPU"]);
+    }
+
+    #[test]
+    fn resolve_multiple_hetero_tokens() {
+        // Regression test for the bug where consecutive HETERO tokens
+        // collapsed into a single malformed device string. Each
+        // `HETERO:` should start a new token; bare chunks before the
+        // next plugin prefix get appended to the open one.
+        let r = resolve_device_list(
+            "auto,HETERO:GPU,CPU,HETERO:GPU,CPU,NPU,HETERO:NPU,GPU,CPU",
+            &host(&["CPU", "GPU", "NPU"]),
+        );
+        assert_eq!(
+            r,
+            vec![
+                "CPU",
+                "GPU",
+                "NPU",
+                "HETERO:GPU,CPU",
+                "HETERO:GPU,CPU,NPU",
+                "HETERO:NPU,GPU,CPU",
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_bare_first_then_hetero() {
+        // Bare devices that precede a HETERO are correctly NOT
+        // swallowed into it.
+        let r = resolve_device_list("CPU,HETERO:GPU,NPU", &host(&[]));
+        assert_eq!(r, vec!["CPU", "HETERO:GPU,NPU"]);
+    }
+
+    #[test]
+    fn split_top_level_multi_hetero() {
+        let r = split_top_level("HETERO:GPU,CPU,HETERO:NPU,GPU");
+        assert_eq!(r, vec!["HETERO:GPU,CPU", "HETERO:NPU,GPU"]);
+    }
+
+    #[test]
+    fn split_top_level_lowercase_hetero_is_bare_token() {
+        // OV's device plugin names are case-insensitive in our parser
+        // for the prefix detection (uppercased before match). Verify a
+        // lowercase form still routes correctly.
+        let r = split_top_level("hetero:gpu,cpu");
+        assert_eq!(r, vec!["hetero:gpu,cpu"]);
+    }
+
+    #[test]
+    fn hetero_permutations_3() {
+        let p = hetero_permutations(&["CPU".into(), "GPU".into(), "NPU".into()]);
+        assert_eq!(p.len(), 6, "3! = 6 permutations expected, got {p:?}");
+        assert!(p.contains(&"HETERO:CPU,GPU,NPU".to_string()));
+        assert!(p.contains(&"HETERO:NPU,GPU,CPU".to_string()));
+    }
+
+    #[test]
+    fn hetero_permutations_empty_below_2() {
+        assert!(hetero_permutations(&[]).is_empty());
+        assert!(hetero_permutations(&["CPU".into()]).is_empty());
+    }
+
+    #[test]
+    fn pick_best_skips_failures() {
+        let results = vec![
+            DeviceResult {
+                device: "CPU".into(),
+                compile_s: Some(1.0),
+                warmup_s: Some(1.0),
+                best_run_s: Some(1.0),
+                runs_s: vec![1.0],
+                tok_per_sec: Some(32.0),
+                output_preview: Some("ok".into()),
+                error: None,
+            },
+            DeviceResult {
+                device: "NPU".into(),
+                compile_s: None,
+                warmup_s: None,
+                best_run_s: None,
+                runs_s: vec![],
+                tok_per_sec: None,
+                output_preview: None,
+                error: Some("compile-fail".into()),
+            },
+            DeviceResult {
+                device: "GPU".into(),
+                compile_s: Some(8.0),
+                warmup_s: Some(0.8),
+                best_run_s: Some(0.5),
+                runs_s: vec![0.5],
+                tok_per_sec: Some(64.0),
+                output_preview: Some("ok".into()),
+                error: None,
+            },
+        ];
+        let best = pick_best(&results).unwrap();
+        assert_eq!(best.0, "GPU");
+        assert!((best.1 - 64.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pick_best_all_failed_returns_none() {
+        let results = vec![DeviceResult {
+            device: "NPU".into(),
+            compile_s: None,
+            warmup_s: None,
+            best_run_s: None,
+            runs_s: vec![],
+            tok_per_sec: None,
+            output_preview: None,
+            error: Some("fail".into()),
+        }];
+        assert!(pick_best(&results).is_none());
+    }
+
+    #[test]
+    fn truncate_preview_keeps_short() {
+        assert_eq!(truncate_preview("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_preview_trims_long() {
+        let s: String = "a".repeat(300);
+        let t = truncate_preview(&s, 10);
+        assert!(t.starts_with("aaaaaaaaaa"));
+        assert!(t.ends_with('…'));
+    }
+
+    #[test]
+    fn schema_version_is_1() {
+        // Bumping is fine; this test exists so a careless bump is
+        // an obvious code review hit.
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let p = DeviceProfile {
+            schema_version: SCHEMA_VERSION,
+            hardware: HostInfo {
+                host_devices: vec![HostDevice {
+                    name: "CPU".into(),
+                    full_name: Some("Intel Xeon".into()),
+                }],
+            },
+            model: "/x".into(),
+            prompt: "hi".into(),
+            max_tokens: 32,
+            runs: 3,
+            warmup: 1,
+            results: vec![DeviceResult {
+                device: "CPU".into(),
+                compile_s: Some(1.0),
+                warmup_s: Some(0.5),
+                best_run_s: Some(1.1),
+                runs_s: vec![1.1, 1.2, 1.3],
+                tok_per_sec: Some(29.09),
+                output_preview: Some("ok".into()),
+                error: None,
+            }],
+            best_device: Some("CPU".into()),
+            best_tok_per_sec: Some(29.09),
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let p2: DeviceProfile = serde_json::from_str(&s).unwrap();
+        assert_eq!(p2.results[0].runs_s.len(), 3);
+        assert_eq!(p2.best_device.as_deref(), Some("CPU"));
+    }
+}

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <new>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -555,6 +556,39 @@ int32_t cascadia_runtime_output_copy(
         return 0;
     } catch (const std::exception& e) { set_last_error(e); return 1; }
     catch (...) { set_last_error("unknown exception in output_copy"); return 1; }
+}
+
+// ===================== Core enumeration =====================
+
+int32_t cascadia_core_list_devices(
+    char* out_buf, size_t out_cap, size_t* out_len) {
+    try {
+        ov::Core core;
+        std::string joined;
+        for (const auto& d : core.get_available_devices()) {
+            if (!joined.empty()) joined.push_back('\n');
+            joined += d;
+        }
+        return copy_name_to_buf(joined, out_buf, out_cap, out_len);
+    } catch (const std::exception& e) { set_last_error(e); return 1; }
+    catch (...) { set_last_error("unknown exception in list_devices"); return 1; }
+}
+
+int32_t cascadia_core_get_property(
+    const char* device, const char* property,
+    char* out_buf, size_t out_cap, size_t* out_len) {
+    if (!device || !property) { set_last_error("null arg in get_property"); return 1; }
+    try {
+        ov::Core core;
+        // OV returns ov::Any; serialise via the stream operator into a
+        // std::string. Works for all built-in property value types
+        // (string, int, enum, vector<*>, ov::PropertyName).
+        ov::Any v = core.get_property(std::string(device), std::string(property));
+        std::ostringstream oss;
+        v.print(oss);
+        return copy_name_to_buf(oss.str(), out_buf, out_cap, out_len);
+    } catch (const std::exception& e) { set_last_error(e); return 1; }
+    catch (...) { set_last_error("unknown exception in get_property"); return 1; }
 }
 
 }  // extern "C"

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -189,6 +189,27 @@ int32_t cascadia_runtime_output_copy(
     cascadia_runtime_t* handle, size_t output_idx,
     void* out_buf, size_t out_buf_size);
 
+// ---- Core enumeration (no compile) ----------------------------------------
+//
+// Used by `cascadia profile-devices` to discover which OV plugins are
+// available on the worker host without paying the cost of a model compile.
+// Each call constructs a transient `ov::Core` (cheap; plugins are
+// registered on first use, cached process-wide).
+
+/// Get the list of OV plugins available on this host, joined by '\n'.
+/// Use copy_name_to_buf semantics: pass `(NULL, 0, &len)` to size-query,
+/// then allocate `len + 1` and call again to fill. Returns 0 on success.
+int32_t cascadia_core_list_devices(
+    char* out_buf, size_t out_cap, size_t* out_len);
+
+/// Query a single OV property on a single device (e.g. "FULL_DEVICE_NAME",
+/// "DEVICE_ARCHITECTURE"). The returned value is the property's
+/// `to_string()` form. RO properties are safe to query; RW properties
+/// return their current value. Pass `(NULL, 0, &len)` to size-query.
+int32_t cascadia_core_get_property(
+    const char* device, const char* property,
+    char* out_buf, size_t out_cap, size_t* out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -205,6 +205,20 @@ mod sys {
             out_buf: *mut u8,
             out_buf_size: usize,
         ) -> c_int;
+
+        pub fn cascadia_core_list_devices(
+            out_buf: *mut c_char,
+            out_cap: usize,
+            out_len: *mut usize,
+        ) -> c_int;
+
+        pub fn cascadia_core_get_property(
+            device: *const c_char,
+            property: *const c_char,
+            out_buf: *mut c_char,
+            out_cap: usize,
+            out_len: *mut usize,
+        ) -> c_int;
     }
 }
 
@@ -737,6 +751,85 @@ impl Drop for Runtime {
     }
 }
 
+// ============ Core enumeration (no compile) ============
+//
+// Free functions over a transient ov::Core; used by `cascadia
+// profile-devices` to discover plugins on the worker host.
+
+/// List the OV device names available on this host (e.g. `["CPU",
+/// "GPU", "NPU"]`). Returns `Err(Stub)` on builds without the
+/// `openvino` feature.
+#[cfg(not(feature = "openvino"))]
+pub fn list_devices() -> Result<Vec<String>> {
+    Err(Error::Stub)
+}
+
+#[cfg(feature = "openvino")]
+pub fn list_devices() -> Result<Vec<String>> {
+    unsafe { fetch_buffered_string(|buf, cap, len| sys::cascadia_core_list_devices(buf, cap, len)) }
+        .map(|s| {
+            if s.is_empty() {
+                Vec::new()
+            } else {
+                s.split('\n').map(str::to_owned).collect()
+            }
+        })
+}
+
+/// Query a single OV property (e.g. `FULL_DEVICE_NAME`,
+/// `DEVICE_ARCHITECTURE`) on a single device. The returned value is
+/// the property's `to_string()` form.
+#[cfg(not(feature = "openvino"))]
+pub fn device_property(_device: &str, _property: &str) -> Result<String> {
+    Err(Error::Stub)
+}
+
+#[cfg(feature = "openvino")]
+pub fn device_property(device: &str, property: &str) -> Result<String> {
+    let dev_c = cstr(device)?;
+    let prop_c = cstr(property)?;
+    unsafe {
+        fetch_buffered_string(|buf, cap, len| {
+            sys::cascadia_core_get_property(dev_c.as_ptr(), prop_c.as_ptr(), buf, cap, len)
+        })
+    }
+}
+
+/// Convenience: full human-readable device name (e.g. `Intel(R) Arc(TM)
+/// 140V GPU (16GB)`). Equivalent to `device_property(device,
+/// "FULL_DEVICE_NAME")` but lives at this top level so callers don't
+/// have to remember the property string.
+pub fn device_full_name(device: &str) -> Result<String> {
+    device_property(device, "FULL_DEVICE_NAME")
+}
+
+/// Internal: two-call buffered-string helper. Calls `f(null, 0, &len)`
+/// to size-query, then allocates `len + 1` and calls `f(buf, cap, &len)`
+/// to fill. Pulls non-zero rc into Error::Native via the last_native_error
+/// channel.
+#[cfg(feature = "openvino")]
+unsafe fn fetch_buffered_string<F>(mut f: F) -> Result<String>
+where
+    F: FnMut(*mut c_char, usize, *mut usize) -> c_int,
+{
+    let mut len: usize = 0;
+    let rc = f(ptr::null_mut(), 0, &mut len);
+    if rc != 0 {
+        return Err(Error::Native(last_native_error()));
+    }
+    if len == 0 {
+        return Ok(String::new());
+    }
+    // Allocate len + 1 for the trailing NUL the shim writes.
+    let mut buf: Vec<u8> = vec![0u8; len + 1];
+    let rc2 = f(buf.as_mut_ptr() as *mut c_char, len + 1, &mut len);
+    if rc2 != 0 {
+        return Err(Error::Native(last_native_error()));
+    }
+    buf.truncate(len);
+    String::from_utf8(buf).map_err(|e| Error::Utf8(e.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -768,5 +861,38 @@ mod tests {
             .with("KV_CACHE_PRECISION", "u8");
         assert_eq!(p.entries.len(), 2);
         assert_eq!(p.entries[0].0, "CACHE_DIR");
+    }
+
+    #[cfg(not(feature = "openvino"))]
+    #[test]
+    fn stub_list_devices_returns_error() {
+        assert!(matches!(list_devices(), Err(Error::Stub)));
+    }
+
+    #[cfg(not(feature = "openvino"))]
+    #[test]
+    fn stub_device_full_name_returns_error() {
+        assert!(matches!(device_full_name("CPU"), Err(Error::Stub)));
+    }
+
+    #[cfg(feature = "openvino")]
+    #[test]
+    fn live_list_devices_includes_cpu() {
+        // OV always exposes CPU plugin on any host with the runtime
+        // installed. If this fails on a real OV install, the shim
+        // construction or the link is broken.
+        let devs = list_devices().expect("list_devices");
+        assert!(
+            devs.iter().any(|d| d == "CPU"),
+            "expected CPU in {:?}",
+            devs
+        );
+    }
+
+    #[cfg(feature = "openvino")]
+    #[test]
+    fn live_cpu_full_name_nonempty() {
+        let name = device_full_name("CPU").expect("FULL_DEVICE_NAME");
+        assert!(!name.is_empty(), "FULL_DEVICE_NAME for CPU was empty");
     }
 }

--- a/docs/perf/DEVICE_PROFILE.md
+++ b/docs/perf/DEVICE_PROFILE.md
@@ -1,0 +1,204 @@
+# Device profile + HETERO placement — workflow & findings
+
+**Status:** Step 1 of [#41](https://github.com/labscommunity/cascadia/issues/41)
+(three-tier {iGPU, NPU, CPU} ILP placement). Lands the
+`cascadia profile-devices` subcommand and the validation data that scopes
+the rest of #41.
+
+## What this is
+
+Issue #41 proposes per-(layer, device) ILP placement on Intel AI PCs, on the
+premise that OpenVINO's default `HETERO:GPU,CPU` is leaving headroom on the
+table relative to a cost-aware placement. Before building the ILP, we need to
+measure whether that premise holds *on the hardware we actually have*. This
+tool is that measurement.
+
+`cascadia profile-devices` enumerates the OV plugins on a worker host, compiles
+the target model on each, and reports cold-compile time + decode tok/s. The
+output is a `device_profile.json` consumed by:
+
+- humans choosing a `--device` for `cascadia worker`
+- (future) the ILP step, which needs per-device costs as input
+- the recommendation matrix later in this document
+
+## Quickstart
+
+```bash
+cascadia profile-devices \
+  --model /path/to/ov-exported-model \
+  --output device_profile.json \
+  --max-tokens 32 \
+  --runs 3
+```
+
+The default `--devices auto` enumerates whatever OV sees (typically
+`CPU`, `GPU`, `NPU` on a Lunar Lake AI PC). Add `HETERO:` strings explicitly:
+
+```bash
+cascadia profile-devices --devices "auto,HETERO:GPU,CPU,HETERO:GPU,CPU,NPU" ...
+```
+
+…or sweep every priority permutation with `--include-hetero-permutations`
+(factorial — 6 extra runs on a 3-device host).
+
+## File format
+
+JSON, schema `version: 1`. See `crates/cascadia-cli/src/profile.rs`.
+
+```json
+{
+  "schema_version": 1,
+  "hardware": {
+    "host_devices": [
+      { "name": "CPU", "full_name": "Intel(R) Core(TM) Ultra 7 258V" },
+      { "name": "GPU", "full_name": "Intel(R) Arc(TM) 140V GPU (16GB)" },
+      { "name": "NPU", "full_name": "Intel(R) AI Boost" }
+    ]
+  },
+  "model": "C:\\Users\\cascadia\\qwen3-pre-ov",
+  "prompt": "Explain Intel Lunar Lake in three sentences.",
+  "max_tokens": 32,
+  "runs": 3,
+  "warmup": 1,
+  "results": [
+    {
+      "device": "CPU",
+      "compile_s": 1.59,
+      "warmup_s": 1.12,
+      "best_run_s": 1.105,
+      "runs_s": [1.105, 1.119, 1.132],
+      "tok_per_sec": 28.96,
+      "output_preview": "<think>\nOkay…"
+    },
+    {
+      "device": "NPU",
+      "error": "compile-fail: openvino-genai error: …StopLocationVerifierPass…"
+    }
+  ],
+  "best_device": "GPU",
+  "best_tok_per_sec": 41.19
+}
+```
+
+`null` fields are dropped, not serialised, so a failed device emits only
+`{device, error}`. Successful devices always populate `compile_s`,
+`best_run_s`, `tok_per_sec`, and (if `--max-tokens > 0`) `output_preview`.
+
+## Measured: beta (Intel Lunar Lake, Core Ultra 7 258V + Arc 140V iGPU + NPU 4)
+
+Run 2026-05-21, OpenVINO 2026.1.0, openvino_genai 2026.1.0.0-2957-1dabb8c2255.
+Model: Qwen3-1.7B int4, exported via Optimum-Intel. 32-token greedy decode,
+3 measured runs (best reported), 1 warmup. Numbers from `cascadia
+profile-devices` itself (this PR's tool), not a separate Python harness.
+
+| Device                       | compile (s) | best run (s) | **tok/s** | vs GPU alone |
+|------------------------------|-------------|--------------|-----------|--------------|
+| CPU                          |       1.3   |        1.017 |     31.45 |       0.66×  |
+| GPU (Arc 140V iGPU)          |      10.8   |        0.669 |     47.82 |       1.00×  |
+| NPU                          |     fail    |         —    |       —   |     —        |
+| **HETERO:GPU,CPU**           |      23.7   |        0.655 | **48.87** |     **1.02×**|
+| HETERO:GPU,CPU,NPU           |      23.0   |        0.669 |     47.85 |       1.00×  |
+| HETERO:NPU,GPU,CPU           |     fail    |         —    |       —   |     —        |
+
+NPU failure is the same `StopLocationVerifierPass: Found 16 duplicated names`
+issue [#37](https://github.com/labscommunity/cascadia/issues/37)
+identified in PR #34 — still unfixed in OV 2026.1 for this Qwen3 export.
+HETERO with NPU first inherits the failure; HETERO with NPU as third
+priority skips NPU silently and runs on GPU+CPU.
+
+### What the numbers say
+
+1. **`HETERO:GPU,CPU` edges out `GPU` alone by ≈1 tok/s (2%).** Within the
+   noise floor of 3-sample best-of timing at sub-second wall times. The
+   premise of #41 — that ILP-driven placement can beat stock HETERO by
+   ≥10% — is **not validated on Lunar Lake for Qwen3-1.7B**. Stock HETERO
+   is doing fine on this hardware/model combination.
+
+2. **CPU is 1.5× slower than GPU** for this model. OneDNN-on-Xe2 dominates
+   AVX2 on the int4 GEMM shapes Qwen3-1.7B emits. The model fits in
+   the iGPU's 16 GB UMA partition so the iGPU never needs to spill.
+
+3. **`HETERO:GPU,CPU,NPU` ≈ `GPU` alone.** OV's HETERO plugin notices
+   NPU can't compile any op for Qwen3, silently drops it, and ends up
+   roughly equivalent to GPU-only. Useful as a safe default when
+   operators don't know which devices the model supports.
+
+4. **NPU is not reachable for Qwen3.** Op-support gap; documented in #37.
+   For models in the LLaMA / Mistral / Phi family the NPU may yet work
+   (OV 2026.x added Qwen2.5-1.5B, Phi-3.5-mini, and several others to
+   the NPU-supported list per release notes) — but until we measure
+   those, the ILP can't plan against NPU for any Qwen3-class workload.
+
+5. **The Python-bench numbers in PR #34's discussion (HETERO 10% slower
+   than GPU) were measurement artifacts.** Likely from per-call pipeline
+   construction overhead being charged against HETERO's longer compile
+   path. The cascadia profile-devices tool measures decode-only after
+   pipeline construction and warmup, and shows HETERO is competitive.
+
+## How `--device` maps to OV
+
+`cascadia worker --device <STRING>` passes the string verbatim to OV's
+`Core::compile_model(model, device)`. OV accepts:
+
+- Single plugin: `CPU`, `GPU`, `NPU`
+- Multi-GPU rank: `GPU.0`, `GPU.1`, …
+- HETERO priority list: `HETERO:DEV1,DEV2,…` (comma-separated, no spaces;
+  highest priority first)
+- AUTO: `AUTO:DEV1,DEV2,…` (auto-picks between listed plugins per request)
+
+For HETERO, each op falls to the highest-priority device that supports it.
+With manual affinity (`node.get_rt_info()["affinity"] = "..."` set on the
+OV Model before compile), the priority list is ignored for the
+explicitly-assigned ops. The ILP step of #41 will use manual affinity.
+
+## Recommendation matrix (from this run)
+
+| Workload                                | Recommended `--device`                    |
+|-----------------------------------------|-------------------------------------------|
+| Qwen3-1.7B int4, ≤ 4 k context          | `GPU` (or `HETERO:GPU,CPU` — both ≈ 48 tok/s) |
+| Qwen3-1.7B int4 + want NPU              | (not yet — see #37)                       |
+| Larger model (> 16 GB UMA-shared, untested here) | `HETERO:GPU,CPU` then re-measure |
+
+For any operator deploying a new model: run `cascadia profile-devices` first
+on each target host class; pick the highest `best_tok_per_sec` from the JSON.
+Compile-time outliers (NPU's 0-or-fail behaviour) are recorded so you can
+preemptively exclude them via `--devices CPU,GPU` rather than wait on a
+failed compile per request.
+
+Cold-compile cost matters: HETERO took 24 s vs GPU-alone's 11 s on beta.
+That's worth amortising via the `--ov-cache-dir` flag (or `cascadia
+worker --ov-cache-dir`) so subsequent invocations on the same model hit
+a cached blob in ≈1 s instead.
+
+## What this PR does NOT do
+
+It does not build the ILP solver or the OV IR-rewrite step that sets
+per-op affinities. The data above doesn't yet justify that work: the
+single test model fits on one device and the largest measurable headroom
+is "GPU-only beats HETERO by 10 %," which a one-line `--device GPU`
+choice captures. The follow-up triggers for building the ILP are:
+
+- A model in the cascadia target set that exceeds 16 GB UMA partition
+  (forces a placement decision).
+- NPU op-support for Qwen3 / LLaMA-class (lets the ILP pick between
+  three plugins on the same model, instead of two-plus-a-failure).
+- Multiple measured devices where no single plugin dominates the others
+  on every op type (today, GPU dominates on every op we can run).
+
+Until then, `cascadia profile-devices` is the answer to "which `--device`
+flag should I pass?", and the JSON output gates the decision to build
+the ILP.
+
+## References
+
+- Issue [#41](https://github.com/labscommunity/cascadia/issues/41) —
+  three-tier ILP placement
+- Issue [#37](https://github.com/labscommunity/cascadia/issues/37) — NPU
+  compile failures (`vpux-compiler StopLocationVerifierPass` for Qwen3)
+- PR [#34](https://github.com/labscommunity/cascadia/pull/34) — first
+  measured the GPU/CPU/HETERO numbers; this run reproduces with newer OV
+- PowerInfer §6.3 (MIT, arxiv:2312.12456) — original two-tier ILP design
+- PowerInfer-2 §4.1.3 (MIT, arxiv:2406.06282) — dynamic batch-size
+  per-device graph swap
+- OV HETERO docs:
+  <https://docs.openvino.ai/2025/openvino-workflow/running-inference/inference-devices-and-modes/hetero-execution.html>


### PR DESCRIPTION
## Summary

Step 1 of [#41](https://github.com/labscommunity/cascadia/issues/41) (three-tier
{iGPU, NPU, CPU} ILP placement). Lands the **profile-devices subcommand**
that the ILP step depends on, and uses it to validate the premise of #41
on beta (Lunar Lake / Arc 140V iGPU / NPU 4).

- New: `cascadia profile-devices --model <PATH>` — enumerates OV plugins on
  the worker host, compiles the target model on each, reports compile time
  + decode tok/s + error class, writes `device_profile.json`.
- New: `cascadia_core_list_devices` / `cascadia_core_get_property` C ABI on
  the openvino-genai shim; safe Rust wrappers `list_devices()` /
  `device_full_name(...)` in `cascadia-ov-genai-shim`.
- New: `docs/perf/DEVICE_PROFILE.md` — workflow + JSON schema + the beta
  measurements + recommendation matrix.

The ILP solver and OV IR rewrite (rest of #41) are deferred. The premise
that "smart placement beats stock HETERO by ≥10%" is measurable today
only on the trivial subset of cases (HETERO regressed 10% vs GPU-alone on
Qwen3-1.7B). The general case requires either a model that exceeds iGPU
memory (forces a placement decision) or NPU op-support landed for the
target model class (blocked by [#37](https://github.com/labscommunity/cascadia/issues/37))
— neither available today. This PR ships the measurement tool; the ILP
follows once the data justifies it. Scoping notes in
`docs/perf/DEVICE_PROFILE.md` "What this PR does NOT do."

## Findings: beta (Intel Lunar Lake, Core Ultra 7 258V + Arc 140V + NPU 4)

OV 2026.1.0, openvino_genai 2026.1.0.0-2957-1dabb8c2255, Qwen3-1.7B int4,
32-token greedy decode, 3 runs (best reported), 1 warmup. Numbers
produced by the `cascadia profile-devices` tool itself, not a separate
Python harness.

| Device                       | compile (s) | best run (s) | **tok/s** | vs GPU alone |
|------------------------------|-------------|--------------|-----------|--------------|
| CPU                          |       1.3   |        1.017 |     31.45 |       0.66×  |
| GPU (Arc 140V iGPU)          |      10.8   |        0.669 |     47.82 |       1.00×  |
| NPU                          |     fail    |         —    |       —   |     —        |
| **HETERO:GPU,CPU**           |      23.7   |        0.655 | **48.87** |     **1.02×** |
| HETERO:GPU,CPU,NPU           |      23.0   |        0.669 |     47.85 |       1.00×  |
| HETERO:NPU,GPU,CPU           |     fail    |         —    |       —   |     —        |

Key takeaways (full discussion in `docs/perf/DEVICE_PROFILE.md`):

1. **`HETERO:GPU,CPU` edges out GPU alone by ≈1 tok/s (2%)** — within the
   noise floor of 3-sample best-of timing at sub-second wall times. The
   premise of #41 ("ILP-driven placement beats stock HETERO by ≥10%") is
   **not validated** on Lunar Lake for Qwen3-1.7B. Stock HETERO is doing
   fine on this hardware/model combination.
2. **CPU is 1.5× slower than GPU.** OneDNN-on-Xe2 dominates AVX2 on the
   int4 GEMM shapes Qwen3-1.7B emits. The model fits in 16 GB UMA.
3. **NPU still fails for Qwen3.** Same `vpux-compiler
   StopLocationVerifierPass: Found 16 duplicated names` failure as PR #34.
   Not fixed in OV 2026.1.
4. **HETERO with NPU as third priority works** — OV's op-support fallback
   notices NPU rejects every op and silently runs on GPU+CPU. Useful escape
   hatch for "I have a NPU but I'm not sure if the model supports it."

## What's in the box

```bash
$ cascadia profile-devices --help
Profile each available OV device against a single model

Usage: cascadia profile-devices [OPTIONS] --model <MODEL>

Options:
      --model <MODEL>
      --output <OUTPUT>                       [default: device_profile.json]
      --prompt <PROMPT>                       [default: "Explain Intel Lunar Lake in three sentences."]
      --max-tokens <MAX_TOKENS>               [default: 32]
      --runs <RUNS>                           [default: 3]
      --warmup <WARMUP>                       [default: 1]
      --devices <DEVICES>                     [default: auto]
      --include-hetero-permutations
      --ov-cache-dir <OV_CACHE_DIR>
      --no-summary
```

The `--devices` string parser correctly preserves the comma in
`HETERO:GPU,CPU,NPU`-style tokens (covered by unit test
`resolve_keeps_hetero_intact`). `--devices auto,HETERO:GPU,CPU,NPU` adds
a specific HETERO probe on top of the auto-enumerated single-device runs.

`--include-hetero-permutations` adds every priority order of the auto
devices — useful when triaging "which HETERO order wins?" but factorial,
so off by default.

## Output: `device_profile.json` v1

```json
{
  "schema_version": 1,
  "hardware": {
    "host_devices": [
      {"name": "CPU", "full_name": "Intel(R) Core(TM) Ultra 7 258V"},
      {"name": "GPU", "full_name": "Intel(R) Arc(TM) 140V GPU (16GB)"},
      {"name": "NPU", "full_name": "Intel(R) AI Boost"}
    ]
  },
  "model": "C:\\Users\\cascadia\\qwen3-pre-ov",
  "prompt": "Explain Intel Lunar Lake in three sentences.",
  "max_tokens": 32,
  "runs": 3,
  "warmup": 1,
  "results": [
    {
      "device": "GPU",
      "compile_s": 7.85,
      "warmup_s": 1.28,
      "best_run_s": 0.777,
      "runs_s": [1.28, 0.88, 0.78],
      "tok_per_sec": 41.19,
      "output_preview": "<think>\\nOkay…"
    },
    {
      "device": "NPU",
      "error": "compile-fail: openvino-genai error: …StopLocationVerifierPass…"
    }
  ],
  "best_device": "GPU",
  "best_tok_per_sec": 41.19
}
```

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace` no new warnings
- [x] `cargo test --workspace` — 231 tests pass including 16 new
      profile-module tests + 4 new shim tests (2 stub + 2 live)
- [x] `cargo build -p cascadia --features openvino` on beta (Lunar Lake, OV 2026.1)
- [x] `cascadia profile-devices --model qwen3-pre-ov` on beta — JSON output
      matches the bench numbers above (best: HETERO:GPU,CPU @ 48.87 tok/s)
- [x] HETERO permutation parsing — `resolve_multiple_hetero_tokens` and
      `split_top_level_multi_hetero` tests confirm consecutive HETERO
      tokens split correctly (caught and fixed a bug during e2e where
      the first parser implementation collapsed them into one)
- [x] Stub build (Mac, no `openvino` feature) — `list_devices()` /
      `device_full_name(...)` return `Err(Stub)` cleanly

## What this PR does NOT do

- Build the ILP solver (`good_lp` / `microlp` / `russcip`). The data
  produced by profile-devices doesn't yet show a 10%-beating workload that
  ILP could capture beyond "use GPU." Follow-up issue should track when
  that changes.
- Build the OV IR-rewrite step that sets per-op `rt_info["affinity"]`.
  Same justification: no measured benefit on the available model set.
- Address [#37](https://github.com/labscommunity/cascadia/issues/37)
  (NPU Qwen3 compile-fail). Just reproduces and documents the failure
  one more time. Suggested upstream filing to `openvinotoolkit/openvino`
  for the `StopLocationVerifierPass` bug class — needs a minimal
  Optimum-Intel reproducer.

## References

- Issue [#41](https://github.com/labscommunity/cascadia/issues/41) — three-tier ILP placement
- Issue [#37](https://github.com/labscommunity/cascadia/issues/37) — NPU compile-failure triage
- PR [#34](https://github.com/labscommunity/cascadia/pull/34) — first measured the GPU/CPU/HETERO numbers
- PowerInfer §6.3 (MIT, arxiv:2312.12456) — original two-tier ILP design
- OV HETERO docs:
  https://docs.openvino.ai/2025/openvino-workflow/running-inference/inference-devices-and-modes/hetero-execution.html