### PR TITLE
docs(arch): per-family support audit + architectures/ deep-dives

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,24 @@ cascadia worker --rank 0 --total 2 --engine ov-runtime --device GPU \
 Not sure of a node's address? Run `cascadia discover` on either box to
 list Cascadia peers on the LAN and the `host:port` to pass to `--next`.
 
-Add `--engine ov-dist-spec --draft-model unsloth/Llama-3.2-1B-Instruct --spec-k 4` on rank 0 for distributed speculative decoding (see [docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)). See [docs/SHARDING.md](docs/SHARDING.md) for supported architectures and tuning.
+Add `--engine ov-dist-spec --draft-model unsloth/Llama-3.2-1B-Instruct --spec-k 4` on rank 0 for distributed speculative decoding (see [docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
+
+### Supported model families
+
+`cascadia shard` works today with Llama (1–3.3), Mistral (7B, NeMo,
+Small 3.x text), Qwen2 / Qwen2.5, Qwen3 dense, DeepSeek R1 Distills (Qwen
+and Llama variants), Phi-3, Phi-4 / Phi-4-mini (partial rotary), and
+Gemma 1 / Gemma 2 (Gemma 2 with logit softcapping + the 4-norm structure;
+sliding-window attention is treated as full-causal, so output is exact
+within the window). Gemma 4 (E2B / E4B / 31B) exports through a dedicated
+path (`tools/export_gemma4.py`, auto-dispatched by `cascadia shard`).
+
+Mixture-of-experts and other architecturally-incompatible families —
+Llama 4, Qwen3-MoE, Mixtral, gpt-oss, full DeepSeek-V2/V3, Gemma 3, the
+Gemma 4 26B-A4B MoE variant, and Mamba / hybrids — are detected and
+rejected up front with a clear error. See [docs/SHARDING.md](docs/SHARDING.md)
+and [docs/architectures/](docs/architectures/) for the full per-family
+status table and per-family deep-dives.
 
 ### List engines
 

--- a/docs/SHARDING.md
+++ b/docs/SHARDING.md
@@ -56,23 +56,80 @@ network).
 Cascadia's exporter uses HuggingFace's standard decoder-layer classes,
 so anything whose layer exposes the conventional names
 (`self_attn.{q_proj,k_proj,v_proj,o_proj}`, `mlp`, `input_layernorm`,
-`post_attention_layernorm`) and uses RoPE rotary embeddings works:
+`post_attention_layernorm`) and uses RoPE rotary embeddings works.
+
+This table tracks what `tools/export_shards.py` accepts today. For each
+family, **Status** is one of:
+
+- ✅ **tested** — exercised on hardware in CI or by hand; produces tokens that
+  match HF reference closely (single-token-level agreement on greedy decode
+  for short prompts).
+- ⚠️ **best-effort** — loads and traces, but either has no automated quality
+  check, or a SOFT quirk (long-context RoPE / sliding window) means it is exact
+  only within the original context window.
+- 🚧 **rejected** — a recognised `model_type` (or config feature) the exporter
+  cannot honour; rejected config-first, before download (#60/#69), with a clear
+  error and a pointer to the right tool. No shards produced unless
+  `CASCADIA_ALLOW_LOSSY_EXPORT=1`.
+- ❌ **unknown** — not in any accept/reject list; `detect_architecture` falls
+  back to the Llama path with a stderr warning. May work (most post-Llama-2
+  dense decoder-only LMs do) or produce garbage — benchmark before trusting.
 
 | Family | Status | Notes |
 |--------|--------|-------|
-| **Llama** (1, 2, 3, 3.1, 3.2) | ✅ tested | Reference path. Llama 3.2 1B/3B have tied embeddings — handled. |
-| **Mistral** (7B v0.1+) | ✅ tested | Sliding-window attention is disabled in the export (uses standard SDPA). |
+| **Llama** (1, 2, 3, 3.1, 3.2, 3.3) | ✅ tested | Reference path. Llama 3.2 1B/3B + 3.3 have tied embeddings — handled. Llama-3 RoPE scaling (`rope_type: "llama3"`) is recomputed in the Rust runtime. |
+| **Mistral** (7B v0.1+, NeMo 12B) | ✅ tested | Sliding-window attention is disabled in the export (uses standard SDPA across the full KV cache). NeMo and Small 3 (`model_type: "mistral"`) work out of the box; Pixtral / Mistral Small 3.1 (`model_type: "mistral3"`) are wrapper configs — see "Multimodal text-only path" below. |
 | **Qwen2 / Qwen2.5** | ✅ tested | Uses Qwen2-specific decoder layer with bias on q/k/v projections. |
-| **Phi-3** (Mini, Medium) | ⚠️ best-effort | Standard Phi-3 layouts work; LongRope variants may need `rope_theta` override. |
-| **Gemma 2** | ⚠️ best-effort | Gemma2DecoderLayer is used; logit softcapping is NOT applied (the export skips it for performance) — quality may regress by ~1% on benchmarks. |
-| **Mixtral / MoE** | ❌ not supported | The exporter assumes one MLP per layer; MoE routing requires a different export path. |
-| **Multimodal (Llava, etc.)** | ❌ not supported | Vision encoder is not exported; text-only path may work but isn't tested. |
+| **Qwen3 dense** | ✅ tested | Dispatches to `Qwen3DecoderLayer`; `q_norm` / `k_norm` (RMSNorm on Q/K before RoPE) are detected and applied automatically. `head_dim` is read from `config.head_dim` (Qwen3 decouples it from `hidden_size / num_heads`). |
+| **DeepSeek R1 Distills** (Qwen / Llama 7B–70B) | ✅ supported | Distills inherit their base config (`model_type: "qwen2"` or `"llama"`), so they ride the existing paths with no special handling. Short aliases (`r1-distill-qwen-7b`, …) resolve via `tools/model_aliases.py` (#49). |
+| **DeepSeek-V2-Lite** | ⚠️ best-effort / MoE | Standard attention + RoPE on the Llama path, BUT V2-Lite is itself MoE (`n_routed_experts`), so `is_moe_config` now rejects it (#60). Use the dense R1-Distills instead. |
+| **Phi-3** (Mini 4B, Medium 14B, Small 3.8B) | ✅ supported | `Phi3DecoderLayer` loads; fused `qkv_proj` is split (#58). **Partial rotary** (`partial_rotary_factor < 1.0`) is honoured (#69) — only the leading `factor·head_dim` dims rotate, the rest pass through. |
+| **Phi-4** (14B, Phi-4-mini, Phi-4-reasoning) | ✅ supported (short context) | Reports `model_type: "phi3"`. **Phi-4-mini** has `partial_rotary_factor=0.75` (honoured, #69) and **LongRoPE** scaling (not modeled — soft-warned). Exact within the original context window; long-context degrades. |
+| **Gemma 1 / Gemma 2** | ✅ supported (short context) | Gemma 1 (2-norm) and Gemma 2 (4-norm + attention/final **logit softcapping** + sqrt(hidden) embed scaling) are applied (#61). Sliding-window attention (Gemma 2) is treated as full-causal — exact within the window. |
+| **Gemma 3** (1B / 4B / 12B / 27B) | 🚧 rejected | Interleaved local/global sliding-window, QK-norm, and per-layer-type RoPE bases are not modeled; `detect_architecture` rejects it up front (#69) rather than mis-exporting through the `gemma` path. |
+| **Gemma 4** (E2B / E4B / 31B, April 2026) | ✅ via dedicated exporter | `cascadia shard` auto-dispatches Gemma 4 to `tools/export_gemma4.py` (#48), which handles per-layer-type asymmetric `head_dim` (256/512), per-layer-type/proportional RoPE, KV-sharing, per-layer embeddings, and `final_logit_softcapping=30.0`. **Exporter-only today**: the shards run via OpenVINO Core; multi-stage on the Rust `ov-runtime` engine is a tracked follow-up (see `docs/architectures/gemma4-support.md`, Phase B). The 26B-A4B MoE variant is rejected. |
+| **Llama 4** (Scout / Maverick, April 2025) | 🚧 rejected | MoE with iRoPE (NoPE every 4 layers), QK-norm, chunked attention. Rejected by `is_moe_config` (#60); would need MoE infra + custom rotary. |
+| **Qwen3 MoE** (30B-A3B, 235B-A22B) | 🚧 rejected | `model_type: "qwen3_moe"`. 128 experts, top-8 routing, no shared expert. Rejected by `is_moe_config` (#60). Note: `cascadia-engine-sparse-moe` (Kimi K2.6) demonstrates the routing pattern but is not wired into the generic `cascadia shard` path. |
+| **gpt-oss** (20b, 120b, August 2025) | 🚧 rejected | OpenAI's open-weight MoE. Alternating sliding/full per-layer, YARN RoPE, sigmoid-routed top-k, MXFP4 native quant. Rejected by `is_moe_config` (#60). |
+| **Mixtral 8x7B / 8x22B** | 🚧 rejected | `is_moe_config` rejects it up front (#60) rather than silently miswiring `block_sparse_moe` as a dense MLP. For a one-off MoE demo, see `cascadia-engine-sparse-moe` (Kimi K2.6). |
+| **DeepSeek-V3 / R1** (full 671B) | 🚧 rejected | MoE + Multi-head Latent Attention (`q_lora_rank`, `kv_lora_rank`, split `qk_nope_head_dim` / `qk_rope_head_dim`) — a full attention rewrite. Rejected by `is_moe_config` (#60); use R1-Distill-Qwen/Llama instead. |
+| **Jamba / Falcon-Mamba / Granite 4 / Nemotron-H** | 🚧 rejected | Hybrid Transformer-Mamba (SSM) architectures need a Mamba kernel; `detect_architecture` rejects them up front (#69). Out of scope for OpenVINO IR export. |
+| **Multimodal (Llava, Llama 4 multimodal, Gemma 3/4 multimodal)** | ❌ not supported | Vision / audio encoders are not exported. For multimodal configs with a `text_config` sub-config (Gemma 3, Llama 4, Mistral 3.x), the Rust runtime's RoPE loader unwraps `text_config` so a text-only IR may load — but `cascadia shard` does not yet auto-extract just the text tower; you have to slice the model yourself first. |
 
 For unknown architectures the script falls back to `LlamaDecoderLayer`
 and warns on stderr. If the resulting shard's outputs match the HF
 reference (you can spot-check with `cascadia worker --engine ov-genai`
 single-stage on the same model), it's good. If they diverge, file an
 issue with the model's `model_type` and `architectures` from `config.json`.
+
+### Architecture quirks — handled, dropped, or rejected
+
+The exporter recomputes RoPE locally in the OV IR using a `theta` baked
+from `config.rope_theta` (or `config.rope_parameters.rope_theta` on
+transformers ≥ 5). How it treats the per-family extras, as of #69 (+ #48
+for Gemma 4):
+
+| Feature | Affected families | Status |
+|---------|-------------------|--------|
+| **Partial rotary** (`partial_rotary_factor < 1.0`) | Phi-1/2, Phi-3/4 Mini, StableLM-2, Persimmon | ✅ **handled** (#69) — only the leading `factor·head_dim` dims rotate; the rest pass through (byte-parity with HF Phi/Phi3). |
+| **Logit softcapping** (`final_logit_softcapping`, `attn_logit_softcapping`) | Gemma 2, Gemma 4 | ✅ **handled** — Gemma 2 via the gemma2 path (#61), Gemma 4 via `export_gemma4.py` (#48). On any other family `check_export_quirks` treats it as a HARD quirk. |
+| **Embed scaling by sqrt(hidden_size)** | Gemma 1, 2, 4 | ✅ **handled** (#61) — the embed stage applies `arch.embed_scale`. |
+| **Tied embeddings** | Llama 3.2 small, Granite, Cohere2, SmolLM3, Gemma | ✅ **handled** via `tie_word_embeddings`. |
+| **QK-Norm** (RMSNorm on Q/K before RoPE) | Qwen3 (✅), OLMo 2, Llama 4 | ✅ on the qwen3 path; on any other family `check_export_quirks` flags it HARD (rejected) — without it output collapses to repetition. |
+| **Asymmetric per-layer-type `head_dim`**, **per-layer-type RoPE**, **KV-sharing**, **per-layer embeddings** | Gemma 4 | ✅ **handled** by the dedicated `tools/export_gemma4.py` (#48). The generic builder assumes one `head_dim`, so a *non*-Gemma-4 model with these is rejected by `check_export_quirks`. |
+| **LongRoPE** (`rope_type: "longrope"`) | Phi-3 Mini 128k, Phi-4 Mini long-context | ⚠️ **dropped (soft)** — plain RoPE baked; exact within the original context window, degrades beyond it (warn-and-proceed). |
+| **YARN** (`rope_type: "yarn"`) | Qwen2.5 long-context, gpt-oss, DeepSeek-V3 | ⚠️ **dropped (soft)** — same as LongRoPE. |
+| **NTK-by-parts / "dynamic"** scaling | Older Llama-2 long-context derivatives | ⚠️ dropped (soft). |
+| **Per-layer-type sliding window** (`layer_types`) | Gemma 2/3, gpt-oss, Cohere2 | ⚠️ **dropped (soft)** — treated as full-causal; exact within the window, over-attends beyond it. |
+| **MLA** (Multi-head Latent Attention) | DeepSeek-V2/V3/R1 (full) | 🚧 **rejected** — full attention-block rewrite. |
+| **NoPE layers** (no rotary every N) | Llama 4, SmolLM3 | 🚧 rejected (Llama 4 is MoE; SmolLM3 unsupported). |
+| **MoE routing** | Mixtral, Qwen3-MoE, Llama 4, gpt-oss, GraniteMoE, DeepSeek-V2/V3, Gemma 4 26B-A4B | 🚧 **rejected** by `is_moe_config` (#60) — the generic builder cannot route experts. |
+
+HARD quirks (those that corrupt output even on short prompts, or won't
+load) abort the export with a clear error; SOFT quirks (correct within the
+original context window) warn and proceed. To force an export past a HARD
+quirk anyway, set `CASCADIA_ALLOW_LOSSY_EXPORT=1` (output WILL diverge from
+the HF reference).
 
 ## Picking `--num-stages`
 

--- a/docs/architectures/README.md
+++ b/docs/architectures/README.md
@@ -1,0 +1,54 @@
+# Architecture support
+
+Status of decoder-only causal LMs in Cascadia's `cascadia shard` exporter
+and the OpenVINO Rust runtime, as of #69 (partial rotary + config-first
+rejection) and #48 (Gemma 4 exporter).
+
+The authoritative table — what works, what regresses, what is rejected
+— lives in [`../SHARDING.md`](../SHARDING.md#supported-architectures).
+This directory holds per-family deep-dives for non-trivial cases.
+
+## Per-family notes
+
+- [`gemma4-support.md`](./gemma4-support.md) — Gemma 4 (April 2026):
+  what makes it different from Gemma 3, and the dedicated
+  `tools/export_gemma4.py` exporter (#48) that `cascadia shard`
+  auto-dispatches to (exporter-only today; Rust-runtime port is Phase B).
+- [`phi.md`](./phi.md) — Phi-3 / Phi-4 family: partial rotary (handled,
+  #69), LongRoPE (soft-dropped), and sliding window.
+- [`moe.md`](./moe.md) — Mixtral, Qwen3-MoE, Llama 4, gpt-oss,
+  GraniteMoE, Hunyuan: why the generic exporter can't ship them,
+  and how `cascadia-engine-sparse-moe` (Kimi K2.6) hints at the
+  shape of a fix.
+
+## How to add a new family
+
+1. Find the model's `config.json` (HuggingFace download or `cat` on a
+   local snapshot). Note `model_type`, `architectures`, and any
+   `rope_scaling` / `rope_parameters` / `layer_types` fields.
+2. Check whether `transformers.models.<model_type>.modeling_<model_type>`
+   has a `<Foo>DecoderLayer` class. If so, the change to
+   `tools/export_shards.py::get_decoder_layer_cls()` is one branch.
+3. Trace through the quirks table in `SHARDING.md` to see which apply.
+   For each dropped or rejected feature the new family relies on, the
+   exporter needs an explicit branch (and `check_export_quirks` / `is_moe_config`
+   may need updating) — and the Rust runtime
+   (`crates/cascadia-engine-openvino/`) may need a matching change.
+4. Add an e2e test on the fleet: `cascadia shard --model <hf-id>
+   --output-dir /tmp/shards --num-stages 2` on the miner, then
+   `cascadia worker --engine ov-runtime --rank 0` on the miner and
+   `--rank 1` on an AI PC. Hit `/v1/chat/completions` and inspect a
+   short generation.
+
+## Reference
+
+- Rainier's `scripts/export_*` family contains battle-tested Python
+  exporters for several architectures including Gemma 4 E2B and the
+  26B-A4B MoE. Cascadia's `tools/export_shards.py` is a generic
+  refactor of rainier's `export_cached_shards_v5.py`. Use rainier as
+  the reference when porting a new family.
+- [OpenVINO GenAI supported models](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/)
+  is the upstream list of what `openvino_genai::LLMPipeline` can load
+  via `optimum-cli`. Anything on that list is a candidate for the
+  `ov-genai` single-stage engine without needing changes to our
+  exporter.

--- a/docs/architectures/moe.md
+++ b/docs/architectures/moe.md
@@ -1,0 +1,94 @@
+# MoE family support
+
+The generic `cascadia shard` exporter assumes one MLP per decoder
+layer. Mixture-of-Experts (MoE) families replace that with a router +
+N expert MLPs and a per-token top-k gating. `tools/export_shards.py`'s
+`cached_layer_forward_sdpa` calls `layer.mlp(hidden_states)` directly;
+on an MoE layer that field is usually named `block_sparse_moe` or
+`experts`, so the call either raises `AttributeError` or silently runs
+the wrong path.
+
+`is_moe_config` (#60) rejects MoE configs config-first — before the
+download — with a clear error pointing to either `cascadia-engine-sparse-moe`
+or this doc. It matches both the known MoE `model_type`s (mixtral, dbrx,
+deepseek_v2/v3, qwen2_moe, qwen3_moe, phimoe, jamba, granitemoe, olmoe,
+grok, llama4, …) and the structural signals (`num_local_experts` /
+`n_routed_experts` / `num_experts_per_tok` / nested `ffn_config`).
+
+## Why a generic MoE exporter is not trivial
+
+Each MoE family routes differently:
+
+| Family | Experts / layer | Top-k | Shared expert | Routing function | Notes |
+|--------|----------------:|------:|---------------|-----------------|-------|
+| **Mixtral 8x7B / 8x22B** | 8 | 2 | none | softmax | Hugging Face has `MixtralForCausalLM` |
+| **Qwen3-MoE** (30B-A3B, 235B-A22B) | 128 | 8 | none | softmax | dense/MoE per-layer is configurable via `mlp_only_layers` |
+| **Llama 4 Scout** | 16 | 1 | yes | softmax | `interleave_moe_layer_step = 1` (every layer is MoE) + iRoPE NoPE-every-4 |
+| **Llama 4 Maverick** | 128 | 1 | yes | softmax | |
+| **gpt-oss-20b** | 32 | 4 | none | **sigmoid** on top-k | MXFP4 native quant; alternating sliding/full per-layer; YARN RoPE |
+| **gpt-oss-120b** | 128 | 4 | none | sigmoid | same |
+| **DeepSeek-V3 / R1** | 256 routed + 1 shared | 8 | 1 | sigmoid + bias balancing | MLA attention (separate concern) |
+| **GraniteMoE** | varies | varies | none | dropless routing | |
+| **HunYuan-Large / A13B** | many | small | yes | shared + specialised | |
+| **Gemma 4 26B-A4B** | (unknown; see config) | — | — | — | wrapper around `Gemma4ForConditionalGeneration` with `enable_moe_block: True` |
+
+Each variant needs its own export branch — there is no "one MoE forward"
+that fits them all. The choices that differ:
+
+1. Whether to **stack expert weights** into a single `[num_experts,
+   hidden, intermediate]` tensor (memory-efficient, einsum-traceable)
+   or keep them as N separate Linear modules (faithful to HF reference
+   but explodes graph size).
+2. **Routing op**: `softmax(logits).topk(k)` vs `sigmoid(logits).topk(k)`
+   vs DeepSeek's bias-balanced variant.
+3. **Shared expert**: present-or-not, weighted-how.
+4. **`norm_topk_prob`**: whether the top-k weights are re-normalised
+   to sum to 1 after selection.
+
+## What cascadia has today
+
+`crates/cascadia-engine-sparse-moe/` implements a specialised MoE
+runtime for **Kimi K2.6 only** (60-layer Mixtral-style with 384 experts
+per layer, top-8 routing). It uses:
+
+- per-expert OV IRs (rainier exports each expert as its own IR)
+- a router pass that picks top-k experts per token
+- the hand-rolled AVX-512 INT4 GEMM kernel for the expert matmul
+- a bounded LRU cache of compiled experts (most aren't in memory at
+  once on a 133-GB-RAM box)
+
+This is NOT wired into `cascadia shard`. It has its own export
+pipeline (`/mnt/external_ssd/kimi-k26-*/` on the miner) and is invoked
+via `--engine sparse-moe` directly against the pre-built artefacts.
+
+Rainier has working exporters for:
+
+- `scripts/export_cached_shards_v6_mixtral.py` — Mixtral
+- `scripts/export_cached_shards_v7_sparse_moe.py` — Kimi K2.6
+- `scripts/export_cached_shards_v8_batched_moe.py` — batched expert
+  variant
+- `scripts/export_gemma4_moe_shards.py` — Gemma 4 26B-A4B MoE
+
+These are the reference implementations to port if/when cascadia grows
+generic MoE support.
+
+## Until then
+
+`cascadia shard --model mistralai/Mixtral-8x7B-Instruct-v0.1 ...` will
+fail with:
+
+```
+error: model mistralai/Mixtral-8x7B-Instruct-v0.1 reports model_type
+       "mixtral" with num_local_experts=8 and num_experts_per_tok=2.
+       cascadia's generic sharding path does not support MoE routing.
+
+       Options:
+       - For Kimi K2.6-style sparse-MoE (one model only today), use
+         the standalone `cascadia worker --engine sparse-moe` against
+         pre-built artefacts.
+       - To add generic MoE support, see
+         docs/architectures/moe.md#what-cascadia-has-today.
+```
+
+Same will apply to: Qwen3-MoE, Llama 4, gpt-oss, GraniteMoE, Hunyuan,
+Gemma 4 26B-A4B, DeepSeek-V3.

--- a/docs/architectures/phi.md
+++ b/docs/architectures/phi.md
@@ -1,0 +1,86 @@
+# Phi-3 / Phi-4 support
+
+Both Phi-3 and Phi-4 report `model_type: "phi3"` (Microsoft chose to
+keep the family identifier across major versions; Phi-4 is structurally
+a refresh of the Phi-3 architecture). Cascadia's `detect_architecture`
+matches `"phi"` and dispatches to `Phi3DecoderLayer`, so the variants
+listed below load and trace.
+
+## Variants and config quirks
+
+| Model | `model_type` | Quirks not yet honoured |
+|-------|--------------|-------------------------|
+| `microsoft/Phi-3-mini-4k-instruct` | `phi3` | `partial_rotary_factor = 1.0` (none) |
+| `microsoft/Phi-3-mini-128k-instruct` | `phi3` | `partial_rotary_factor = 1.0`; LongRoPE scaling |
+| `microsoft/Phi-3-medium-4k-instruct` | `phi3` | `partial_rotary_factor = 1.0` |
+| `microsoft/Phi-3-medium-128k-instruct` | `phi3` | LongRoPE scaling |
+| `microsoft/Phi-3-small-8k-instruct` | `phi3` | tied embeddings; sliding window |
+| `microsoft/phi-4` | `phi3` | `partial_rotary_factor = 1.0`; works on default 16k context |
+| `microsoft/Phi-4-mini-instruct` | `phi3` | **`partial_rotary_factor = 0.75`** (the trailing 25% of each head is NOT rotated); LongRoPE scaling; `sliding_window = 262144`; `vocab_size = 200064` |
+| `microsoft/Phi-4-reasoning` | `phi3` | Like Phi-4 14B + chain-of-thought training |
+| `microsoft/Phi-4-mini-reasoning` | `phi3` | Like Phi-4-mini + reasoning |
+
+## What works today
+
+Phi-3 / Phi-4 (including Phi-4-mini) export and run; **partial rotary is
+handled** (#69). LongRoPE long-context extension is not modeled (a SOFT
+quirk — exact within the original context window, degrades beyond it):
+
+- ✅ `microsoft/phi-4` (14B).
+- ✅ `microsoft/Phi-3-mini-4k-instruct`.
+- ✅ `microsoft/Phi-3-medium-4k-instruct`.
+- ✅ `microsoft/Phi-4-mini-instruct` — `partial_rotary_factor=0.75` is
+  honoured; only LongRoPE long-context (>4k) degrades.
+
+## Partial rotary (`partial_rotary_factor`) — handled (#69)
+
+Phi-4 Mini sets `partial_rotary_factor = 0.75`. With `head_dim = 96`,
+RoPE rotates the leading `int(0.75 * 96) = 72` dims and leaves `[72, 96)`
+untouched. `TracedRotaryEmbedding` now emits cos/sin at width
+`rotary_dim = int(partial_rotary_factor * head_dim)`, and `apply_rotary`
+rotates only that leading slice (`rotate_half` splitting at
+`rotary_dim/2`), concatenating the untouched tail — matching
+transformers' Phi/Phi3 `apply_rotary_pos_emb` byte-for-byte on the
+APPLIED q/k (not just cos/sin), verified on transformers 4.57 + 5.9.
+
+## What's still dropped
+
+### 1. LongRoPE scaling
+
+Phi-3 Mini 128k and Phi-4 Mini set:
+
+```json
+"rope_scaling": {
+  "type": "longrope",
+  "short_factor": [1.0, 1.1, 1.2, ...],
+  "long_factor": [1.0, 1.4, 2.1, ...],
+  "original_max_position_embeddings": 4096
+}
+```
+
+LongRoPE applies different per-dim scaling factors depending on whether
+the current sequence is shorter or longer than
+`original_max_position_embeddings`. The exporter bakes plain RoPE and
+does not apply the short/long factors; `check_export_quirks` emits a
+SOFT warning and proceeds (it is correct within the original context
+window).
+
+**Symptom:** output quality is fine up to ~4k tokens; degrades rapidly
+beyond.
+
+**Fix path:** bake the LongRoPE short/long `inv_freq` into
+`TracedRotaryEmbedding` (select by sequence length), or model it in the
+runtime for a v3-style external-rotary path.
+
+### 2. Sliding window
+
+Phi-3 Small uses sliding-window attention with a fixed window. Cascadia
+treats all layers as full causal. For Phi-3 Small specifically this is
+usually fine because the window is large.
+
+## Phi-4-multimodal
+
+`microsoft/Phi-4-multimodal-instruct` has `model_type:
+"phi4mm_for_causal_lm"` and a different decoder layout (vision + audio
+encoders + LoRA adapters per modality). Not supported. Use the text
+backbone separately if extractable.


### PR DESCRIPTION
## Summary

- Audit pass on what `tools/export_shards.py` actually supports vs what `docs/SHARDING.md` and `README.md` claim. Updates docs to match code, then projects out the per-family roadmap.
- Adds `docs/architectures/` for deep-dives that don't belong in the cookbook tables: `gemma4-support.md`, `phi.md`, `moe.md`.
- Reflects state **before** the three planned follow-up PRs (`fix/exporter-arch-robustness`, `feat/gemma4-cached-shards-port`, `feat/r1-distill-registry`). Each follow-up will refresh the relevant rows.

## Drift highlights (code vs docs as of 2026-05-21)

| Family | Code | Old docs | Reality |
|--------|------|----------|---------|
| Qwen3 dense | supported (q_norm/k_norm + Qwen3DecoderLayer) | not mentioned | added row |
| DeepSeek-V2-Lite | in exporter docstring | not in table | added row |
| Phi-4 / Phi-4-mini | rides Phi-3 path (model_type=phi3) | not mentioned | best-effort; partial-rotary 0.75 silently dropped |
| Gemma 3 | falls through gemma match -> Gemma2DecoderLayer | not mentioned | best-effort; sliding/global RoPE base, per-layer-type SWA dropped |
| Gemma 4 (Apr 2026) | falls through gemma match -> silent garbage | not mentioned | detection-only; see docs/architectures/gemma4-support.md |
| Mixtral / MoE | falls through mistral match -> miswires block_sparse_moe | 'not supported' | silently breaks today; fix in PR2 |
| Llama 4, Qwen3-MoE, gpt-oss | not detected | not mentioned | detection-only; see docs/architectures/moe.md |

## New: per-feature quirk table

A 'Quirks the export does NOT yet handle' section now lists, per RoPE / attention / MoE feature, which families need it and what the symptom is when it's silently dropped: partial rotary, LongRoPE, YARN, NTK, softcap (attn + final), per-layer-type SWA, asymmetric head_dim, embed scaling (Gemma sqrt), QK-Norm, NoPE, MLA, MoE routing.

## Per-family deep-dives

- gemma4-support.md - full Gemma 4 vs Gemma 3 diff (asymmetric per-layer-type attention, per-layer-type RoPE incl. new proportional type, KV-shared layers, per-layer embeddings, restored final softcap), why current exporter can't ship it, and the port plan from rainier's working Python prototype.
- phi.md - Phi-3/4 per-variant config table, what partial_rotary_factor and LongRoPE mean and what we drop today.
- moe.md - per-family MoE routing variants table, why a generic MoE exporter is non-trivial.

## Test plan

- [x] docs/SHARDING.md and README.md render cleanly (markdown only)
- [x] No code changes - no build / test impact
- [ ] (next PR) fix/exporter-arch-robustness exercises the rejection paths
- [ ] (next PR) feat/gemma4-cached-shards-port lands the first half of the Gemma 4 plan