### PR TITLE
feat(engine-openvino): implement Engine::cancel for the OpenVINO engines

### DIFF
--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1335,6 +1335,14 @@ impl Engine for OvDistSpecEngine {
             }
         }
     }
+
+    fn cancel(&mut self, task_id: &TaskId) {
+        if crate::clear_task(&mut self.pending, &mut self.active, task_id, |a, id| {
+            a.task.task_id == *id
+        }) {
+            tracing::debug!(task = %task_id, "ov-dist-spec: cancelled active task");
+        }
+    }
 }
 
 struct RoundResult {

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -283,6 +283,13 @@ impl Engine for OvGenaiEngine {
         let chunk = Chunk::final_marker(task.task_id.clone(), text);
         vec![(task.task_id, chunk)]
     }
+
+    fn cancel(&mut self, task_id: &TaskId) {
+        // Drop a queued task so it never starts. An already-running
+        // generate() is a single blocking FFI call and can't be
+        // interrupted mid-flight.
+        self.pending.retain(|t| t.task_id != *task_id);
+    }
 }
 
 impl OvGenaiEngine {

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -109,4 +109,35 @@ mod cancel_tests {
         assert_eq!(pending.len(), 1);
         assert!(!cleared);
     }
+
+    #[test]
+    fn clears_active_and_leaves_unrelated_pending() {
+        // Cancel the in-flight task; an unrelated queued task must survive.
+        let mut pending = vec![gen_task("keep")];
+        let mut active = Some(FakeActive {
+            task: gen_task("x"),
+        });
+        let cleared = clear_task(&mut pending, &mut active, &"x".to_string(), |a, id| {
+            a.task.task_id == *id
+        });
+        assert!(cleared);
+        assert!(active.is_none());
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].task_id, "keep");
+    }
+
+    #[test]
+    fn cancels_pending_while_active_keeps_running() {
+        // Cancel a queued task; a different in-flight task keeps running.
+        let mut pending = vec![gen_task("queued")];
+        let mut active = Some(FakeActive {
+            task: gen_task("inflight"),
+        });
+        let cleared = clear_task(&mut pending, &mut active, &"queued".to_string(), |a, id| {
+            a.task.task_id == *id
+        });
+        assert!(!cleared);
+        assert!(active.is_some());
+        assert!(pending.is_empty());
+    }
 }

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -22,3 +22,91 @@ pub use dist_spec::{
 pub use genai::{OvGenaiBuilder, OvGenaiEngine};
 pub use rotary::{ModelTextConfig, RopeScalingConfig, Rotary};
 pub use runtime::{OvRuntimeBuilder, OvRuntimeEngine};
+
+use cascadia_types::{GenerationTask, TaskId};
+
+/// Remove `task_id` from `pending` and clear it from `active` if in-flight.
+/// Returns `true` if the active task was cleared.
+///
+/// No reset: the next task's activation resets the engine (as on normal
+/// completion). Direct mutation is safe — `cancel` and `step` never overlap
+/// (both `&mut self`, engine held behind a `Mutex`).
+pub(crate) fn clear_task<A>(
+    pending: &mut Vec<GenerationTask>,
+    active: &mut Option<A>,
+    task_id: &TaskId,
+    active_is: impl Fn(&A, &TaskId) -> bool,
+) -> bool {
+    pending.retain(|t| t.task_id != *task_id);
+    if active.as_ref().is_some_and(|a| active_is(a, task_id)) {
+        *active = None;
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod cancel_tests {
+    use super::clear_task;
+    use cascadia_types::GenerationTask;
+
+    /// Minimal stand-in for an engine's `ActiveTask` / `ActiveSpec`:
+    /// both expose `.task.task_id`, which is all the matcher reads.
+    struct FakeActive {
+        task: GenerationTask,
+    }
+
+    fn gen_task(id: &str) -> GenerationTask {
+        GenerationTask::new(id, "prompt")
+    }
+
+    #[test]
+    fn drops_matching_pending_task() {
+        let mut pending = vec![gen_task("a"), gen_task("b")];
+        let mut active: Option<FakeActive> = None;
+        let cleared = clear_task(&mut pending, &mut active, &"a".to_string(), |a, id| {
+            a.task.task_id == *id
+        });
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].task_id, "b");
+        assert!(!cleared);
+    }
+
+    #[test]
+    fn clears_matching_active() {
+        let mut pending: Vec<GenerationTask> = vec![];
+        let mut active = Some(FakeActive {
+            task: gen_task("x"),
+        });
+        let cleared = clear_task(&mut pending, &mut active, &"x".to_string(), |a, id| {
+            a.task.task_id == *id
+        });
+        assert!(active.is_none());
+        assert!(cleared);
+    }
+
+    #[test]
+    fn leaves_nonmatching_active() {
+        let mut pending: Vec<GenerationTask> = vec![];
+        let mut active = Some(FakeActive {
+            task: gen_task("x"),
+        });
+        let cleared = clear_task(&mut pending, &mut active, &"y".to_string(), |a, id| {
+            a.task.task_id == *id
+        });
+        assert!(active.is_some());
+        assert!(!cleared);
+    }
+
+    #[test]
+    fn unknown_id_is_noop() {
+        let mut pending = vec![gen_task("a")];
+        let mut active: Option<FakeActive> = None;
+        let cleared = clear_task(&mut pending, &mut active, &"zzz".to_string(), |a, id| {
+            a.task.task_id == *id
+        });
+        assert_eq!(pending.len(), 1);
+        assert!(!cleared);
+    }
+}

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -834,6 +834,14 @@ impl Engine for OvRuntimeEngine {
             }
         }
     }
+
+    fn cancel(&mut self, task_id: &TaskId) {
+        if crate::clear_task(&mut self.pending, &mut self.active, task_id, |a, id| {
+            a.task.task_id == *id
+        }) {
+            tracing::debug!(task = %task_id, "ov-runtime: cancelled active task");
+        }
+    }
 }
 
 // -------- Builder --------

--- a/docs/engines/ov-dist-spec.md
+++ b/docs/engines/ov-dist-spec.md
@@ -87,3 +87,9 @@ Measured on Llama-3.1-8B INT4 target + Llama-3.2-1B INT4 draft, alpha+charlie vi
 - Mask-based rewind (v5) is ~free vs the ~40 ms-per-call physical rewind that v3 shards forced. The win shows up most on long generations and low-accept prompts.
 - Per-FORWARD network cost dominates on slow links. Thunderbolt 4/5 between hosts on AC power gives a 25% throughput bump over LAN; on battery the link drops under load.
 - `--device GPU` resolves to whatever Intel iGPU/dGPU OpenVINO sees; `cascadia engines` does not currently list devices.
+
+## Cancellation
+
+`cancel(task_id)` on the driver drops the task from pending and clears the `active` spec-decode state; the next task re-initialises via the normal `start_task` path (`target.reset()` + `draft.reset()`), identical to back-to-back requests. Workers hold no per-task queue and need no cancel.
+
+Limitation: a multi-stage step can block on a downstream `recv` (bounded by the transport recv timeout); because `cancel` and `step` are mutually exclusive (both take `&mut self`), the clear lands only after the in-flight step returns. The blocked step is idle on the wire (not consuming compute), so this is a teardown-latency bound, not wasted work.

--- a/docs/engines/ov-genai.md
+++ b/docs/engines/ov-genai.md
@@ -86,3 +86,7 @@ Sweet spot is K=5 for short factual prompts; drop to K=3 for long-creative outpu
 - **Streaming**: yields one chunk per task with `is_final=True`. Per-token streaming is a follow-up.
 - **Draft / target tokeniser must match.** FastDraft companions are trained per target family; mixing across families won't work.
 - **`--draft-model` and `--prompt-lookup` are mutually exclusive.** Both set `GenerationConfig.num_assistant_tokens`; the validator rejects the combination.
+
+## Cancellation
+
+`cancel(task_id)` drops the task from the pending queue if it has not started yet. A task already inside `generate()` runs to completion — it is a single blocking FFI call into `openvino_genai` with no interruption hook — so only queued (not in-flight) tasks are cancellable on this engine.

--- a/docs/engines/ov-runtime.md
+++ b/docs/engines/ov-runtime.md
@@ -65,4 +65,4 @@ cascadia worker --rank 0 --total 2 --engine ov-runtime --device GPU \
 
 ## Cancellation
 
-`cancel(task_id)` drops the task: it is removed from the pending queue and, if it is the in-flight task, the `active` slot is cleared so the next request starts immediately instead of waiting out the abandoned task's `max_tokens`. No explicit engine reset is performed — the next task's activation already calls `reset_state()`, the same as after a normal completion (which clears `active` without resetting). Callers: the `/v1/cancel` endpoint and `ChunkStream::Drop` on client disconnect.
+`cancel(task_id)` drops the task: it is removed from the pending queue and, if it is the in-flight task, the `active` slot is cleared so the next request starts immediately instead of waiting out the abandoned task's `max_tokens`. No explicit engine reset is performed — the next task's activation already calls `reset_state()`, the same as after a normal completion (which clears `active` without resetting). Callers: the `/v1/cancel/:task_id` endpoint and `ChunkStream::Drop` on client disconnect.

--- a/docs/engines/ov-runtime.md
+++ b/docs/engines/ov-runtime.md
@@ -62,3 +62,7 @@ cascadia worker --rank 0 --total 2 --engine ov-runtime --device GPU \
 - Cross-stage activation transfer is hidden_states float16 — small enough that LAN/TB is rarely the bottleneck.
 - Same shards file path on every node simplifies launch (use `--model <same-path>` everywhere).
 - Tokenizer is loaded from the model_id's HF snapshot if the bundled `tokenizer/` dir uses a class the local `transformers` install can't import (common with rainier exports).
+
+## Cancellation
+
+`cancel(task_id)` drops the task: it is removed from the pending queue and, if it is the in-flight task, the `active` slot is cleared so the next request starts immediately instead of waiting out the abandoned task's `max_tokens`. No explicit engine reset is performed — the next task's activation already calls `reset_state()`, the same as after a normal completion (which clears `active` without resetting). Callers: the `/v1/cancel` endpoint and `ChunkStream::Drop` on client disconnect.


### PR DESCRIPTION
## What

Implements `Engine::cancel` on the OpenVINO engines. Today it is an inherited
no-op (`cascadia-engine` trait default), so the OV engines ignore cancellation.

## Why

`Runner::cancel` (via `POST /v1/cancel/:task_id`) and `ChunkStream::Drop` (SSE
client disconnect) already call `engine.cancel(task_id)` — but the OV engines
do nothing with it. As a result a cancelled / abandoned task stays in the
engine's `active` slot, and the **next request stalls**: `step` only promotes a
new task when `active.is_none()`, so the engine decodes the dead task to
`max_tokens` (wasted NPU + head-of-line latency) before serving the next one.

This fills in the cancel hook so an abandoned request frees the engine
immediately. No new callers — the existing ones just start working.

## Changes

- `clear_task` helper (crate root): drops a task from `pending` and clears it
  from `active` if in-flight. **No engine reset** — the next task's activation
  already resets (`reset_state()` / `target.reset()`+`draft.reset()`), the same
  as after a normal completion (which also clears `active` without resetting).
- `OvRuntimeEngine::cancel` + `OvDistSpecEngine::cancel` (driver) — clear
  pending + active via `clear_task`.
- `OvGenaiEngine::cancel` — drops a queued task; an in-flight `generate()` is a
  single blocking FFI call and can't be interrupted, so only queued tasks are
  cancellable there.
- `OvDistSpecWorkerEngine` — unchanged (no per-task queue; keeps the no-op).
- Per-engine `## Cancellation` docs.

Safe to mutate directly: `cancel` and `step` never overlap (both `&mut self`,
engine held behind a `Mutex`), so `cancel` only ever runs between steps.

## Testing

- Unit tests for `clear_task` (pure logic, no hardware): drop pending, clear
  matching active, leave non-matching active, unknown-id no-op, and
  pending/active independence. `cargo test --workspace` green.
- **Manual real-OV gate (not CI):** mid-stream cancel → next request runs clean,
  single-stage and a 2-stage chain. Needs real OpenVINO + hardware.
  - [ ] single-stage ov-runtime
  - [ ] 2-stage ov-dist-spec chain

## Known limitation / follow-up (pre-existing, not introduced here)

In multi-stage `ov-runtime`, downstream stages reset on prefill `seq_len > 1`
(`runtime.rs`), so a next prompt that tokenizes to exactly one token would not
reset workers — they'd inherit stale KV. This predates this branch and affects
normal back-to-back completion equally; cancel sets `active = None` identically
to normal completion, so it neither introduces nor worsens it. A proper fix
(explicit task-boundary reset on the ov-runtime wire path) is separate work.