### PR TITLE
feat: run cascadia shards on the Intel NPU — single + pipeline-parallel multi-stage (#37)

### DIFF
--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -53,6 +53,10 @@ struct PipelineConfig {
     export_version: Option<String>,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Deserialize, Default)]
 struct StageConfig {
     #[serde(default)]
@@ -65,6 +69,20 @@ struct StageConfig {
     has_head: bool,
     #[serde(default)]
     export_version: Option<String>,
+    /// NPU (`--target npu`) export: KV is stateless (explicit past_kv-in /
+    /// present-out) and all shapes are static. Old/standard shards omit the
+    /// field and are stateful (default true). When false, the engine drives
+    /// the static-KV path (host-side bounded ring) instead of OV state.
+    #[serde(default = "default_true")]
+    stateful: bool,
+    #[serde(default)]
+    static_seq: Option<u32>,
+    #[serde(default)]
+    static_context: Option<u32>,
+    #[serde(default)]
+    num_kv_heads: Option<u32>,
+    #[serde(default)]
+    head_dim: Option<u32>,
 }
 
 fn read_pipeline_config(p: &Path) -> Result<PipelineConfig, EngineError> {
@@ -190,6 +208,91 @@ fn map_ov_err(err: OvError) -> EngineError {
     }
 }
 
+// -------- static-KV (NPU) state --------
+
+/// Per-layer port wiring for a stateless static-shape (NPU) shard.
+struct StaticKvLayer {
+    key_in: String,
+    val_in: String,
+    key_out: usize,
+    val_out: usize,
+}
+
+/// Host-side bounded KV ring for the stateless static-shape (NPU) path.
+/// The exported IR takes explicit `past_key_values.*` (length `past_len`) +
+/// `attention_mask` (length `context = past_len + 1`) + `position_ids`, and
+/// returns `logits` + `present.*` (length `context`). We hold the KV for the
+/// most recent `valid` real tokens left-aligned in `past_len`-slot buffers,
+/// feed them each step, and absorb the new token's KV from `present[past_len]`.
+struct StaticKv {
+    past_len: usize,
+    context: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    elem_bytes: usize,
+    kv_dtype: ShimDType,
+    logits_out: usize,
+    layers: Vec<StaticKvLayer>,
+    key_buf: Vec<Vec<u8>>, // [layer] = kv_heads * past_len * head_dim * elem_bytes
+    val_buf: Vec<Vec<u8>>,
+    valid: usize, // number of real tokens currently in the ring
+}
+
+impl StaticKv {
+    fn reset(&mut self) {
+        for b in self.key_buf.iter_mut().chain(self.val_buf.iter_mut()) {
+            b.iter_mut().for_each(|x| *x = 0);
+        }
+        self.valid = 0;
+    }
+
+    /// attention_mask over `context = past_len + 1`: 1 for the `valid` real
+    /// past slots (left-aligned) + the current token (slot `past_len`), 0 for
+    /// the padding past slots in between.
+    fn attention_mask(&self) -> Vec<i64> {
+        let mut m = vec![0i64; self.context];
+        for v in m.iter_mut().take(self.valid) {
+            *v = 1;
+        }
+        m[self.past_len] = 1;
+        m
+    }
+
+    /// Copy the new token's K/V (slot `past_len` of `present`) into the
+    /// layer's ring buffer, appending at `valid` or sliding the window when
+    /// full. Selects `key_buf[li]` or `val_buf[li]` internally so callers can
+    /// hold `&mut self` without aliasing the buffer field.
+    fn absorb_layer(&mut self, li: usize, is_value: bool, present: &[u8]) {
+        // Read scalar fields into locals before borrowing the buffer field,
+        // so the mutable buffer borrow stays disjoint from these reads.
+        let slot = self.head_dim * self.elem_bytes;
+        let present_row = self.context * slot; // per-head stride in present
+        let buf_row = self.past_len * slot; // per-head stride in the ring
+        let full = self.valid >= self.past_len;
+        let kv_heads = self.kv_heads;
+        let past_len = self.past_len;
+        let valid = self.valid;
+        let buf: &mut [u8] = if is_value {
+            &mut self.val_buf[li]
+        } else {
+            &mut self.key_buf[li]
+        };
+        for h in 0..kv_heads {
+            let src = h * present_row + past_len * slot;
+            let new = &present[src..src + slot];
+            let base = h * buf_row;
+            if full {
+                buf.copy_within(base + slot..base + buf_row, base); // drop oldest
+                let dst = base + (past_len - 1) * slot;
+                buf[dst..dst + slot].copy_from_slice(new);
+            } else {
+                let dst = base + valid * slot;
+                buf[dst..dst + slot].copy_from_slice(new);
+            }
+        }
+    }
+}
+
 // -------- Engine --------
 
 struct ActiveTask {
@@ -230,6 +333,9 @@ pub struct OvRuntimeEngine {
     canonical_inputs: std::collections::HashMap<String, String>,
     pending: Vec<GenerationTask>,
     active: Option<ActiveTask>,
+    /// Set for stateless static-shape (NPU) shards; drives the host-side
+    /// bounded-KV decode path instead of OV internal state.
+    static_kv: Option<StaticKv>,
 }
 
 impl OvRuntimeEngine {
@@ -581,7 +687,9 @@ impl OvRuntimeEngine {
                 .encode(task.prompt.clone(), false)
                 .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
             let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
-            self.runtime.reset_state().map_err(map_ov_err)?;
+            if self.static_kv.is_none() {
+                self.runtime.reset_state().map_err(map_ov_err)?;
+            }
             self.position = 0;
             info!(
                 task = %task.task_id,
@@ -623,6 +731,9 @@ impl OvRuntimeEngine {
     }
 
     fn step_first_body(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        if self.static_kv.is_some() {
+            return self.step_first_static();
+        }
         let active = match self.active.as_mut() {
             Some(a) => a,
             None => return Ok(Vec::new()),
@@ -724,6 +835,159 @@ impl OvRuntimeEngine {
             self.active = None;
         }
 
+        Ok(vec![(task_id, chunk)])
+    }
+
+    /// One static-KV (NPU) inference: feed the current token + the host-side
+    /// KV ring + a mask/position for the absolute position, run, return the
+    /// last-row logits, and absorb the new token's K/V into the ring.
+    fn static_infer_one(&mut self, token: i64) -> EngineResult<Vec<f32>> {
+        let in_ids = self
+            .input_named("input_ids")
+            .ok_or_else(|| EngineError::Backend("static IR missing input_ids".into()))?
+            .to_string();
+        let in_attn = self
+            .input_named("attention_mask")
+            .ok_or_else(|| EngineError::Backend("static IR missing attention_mask".into()))?
+            .to_string();
+        let in_pos = self
+            .input_named("position_ids")
+            .ok_or_else(|| EngineError::Backend("static IR missing position_ids".into()))?
+            .to_string();
+        let pos = self.position;
+        // Snapshot params + per-layer wiring (clone to drop the static_kv
+        // borrow before the runtime calls below).
+        let (ctx, past_len, kvh, hd, kv_dtype, logits_out, mask, wiring) = {
+            let sk = self.static_kv.as_ref().unwrap();
+            (
+                sk.context,
+                sk.past_len,
+                sk.kv_heads,
+                sk.head_dim,
+                sk.kv_dtype,
+                sk.logits_out,
+                sk.attention_mask(),
+                sk.layers
+                    .iter()
+                    .map(|l| (l.key_in.clone(), l.val_in.clone(), l.key_out, l.val_out))
+                    .collect::<Vec<_>>(),
+            )
+        };
+        self.runtime
+            .set_input(&in_ids, ShimDType::I64, &[1, 1], &i64_to_bytes(&[token]))
+            .map_err(map_ov_err)?;
+        self.runtime
+            .set_input(&in_attn, ShimDType::I64, &[1, ctx], &i64_to_bytes(&mask))
+            .map_err(map_ov_err)?;
+        self.runtime
+            .set_input(&in_pos, ShimDType::I64, &[1, 1], &i64_to_bytes(&[pos]))
+            .map_err(map_ov_err)?;
+        for (li, (kin, vin, _ko, _vo)) in wiring.iter().enumerate() {
+            let (kb, vb) = {
+                let sk = self.static_kv.as_ref().unwrap();
+                (sk.key_buf[li].clone(), sk.val_buf[li].clone())
+            };
+            self.runtime
+                .set_input(kin, kv_dtype, &[1, kvh, past_len, hd], &kb)
+                .map_err(map_ov_err)?;
+            self.runtime
+                .set_input(vin, kv_dtype, &[1, kvh, past_len, hd], &vb)
+                .map_err(map_ov_err)?;
+        }
+        self.runtime.infer().map_err(map_ov_err)?;
+        let (ldt, lshape, lbytes) = self.runtime.output(logits_out).map_err(map_ov_err)?;
+        let logits = match ldt {
+            ShimDType::F32 => lbytes
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect::<Vec<_>>(),
+            ShimDType::F16 => f16_bytes_to_f32(&lbytes),
+            other => return Err(EngineError::Backend(format!("logits dtype {other:?}"))),
+        };
+        let vocab = lshape[lshape.len() - 1];
+        let last_row = logits[logits.len() - vocab..].to_vec();
+        for (li, (_kin, _vin, ko, vo)) in wiring.iter().enumerate() {
+            let (_, _, kpres) = self.runtime.output(*ko).map_err(map_ov_err)?;
+            let (_, _, vpres) = self.runtime.output(*vo).map_err(map_ov_err)?;
+            let sk = self.static_kv.as_mut().unwrap();
+            sk.absorb_layer(li, false, &kpres);
+            sk.absorb_layer(li, true, &vpres);
+        }
+        {
+            let sk = self.static_kv.as_mut().unwrap();
+            sk.valid = (sk.valid + 1).min(sk.past_len);
+        }
+        self.position += 1;
+        Ok(last_row)
+    }
+
+    /// First-stage step for stateless static-shape (NPU) shards: prefill the
+    /// prompt one token at a time into the KV ring, then emit one token per
+    /// call. Single-stage only (NPU shards are not pipelined).
+    fn step_first_static(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        if self.active.is_none() {
+            return Ok(Vec::new());
+        }
+        let (prefill, ids) = {
+            let a = self.active.as_mut().unwrap();
+            if !a.prefilled {
+                a.prefilled = true;
+                (true, a.prompt_ids.clone())
+            } else {
+                (false, vec![a.last_token as i64])
+            }
+        };
+        let last_row = if prefill {
+            if let Some(sk) = self.static_kv.as_mut() {
+                sk.reset();
+            }
+            self.position = 0;
+            let mut lr = Vec::new();
+            for &t in &ids {
+                lr = self.static_infer_one(t)?;
+            }
+            lr
+        } else {
+            self.static_infer_one(ids[0])?
+        };
+        let vocab = last_row.len();
+        let next_token = argmax_last_row(&last_row, vocab);
+
+        let active = self.active.as_mut().unwrap();
+        active.last_token = next_token;
+        active.generated.push(next_token);
+        let tok = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| EngineError::Backend("static stage requires tokenizer".into()))?;
+        let all_ids: Vec<u32> = active.generated.iter().map(|&t| t as u32).collect();
+        let full_text = tok
+            .decode(&all_ids, true)
+            .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
+        let delta = full_text
+            .strip_prefix(active.last_text.as_str())
+            .unwrap_or(&full_text)
+            .to_string();
+        active.last_text = full_text;
+        let max_tokens = active.task.max_tokens.max(1) as usize;
+        let is_eos = self.eos_token_ids.contains(&(next_token as u32));
+        let is_final = active.generated.len() >= max_tokens || is_eos;
+        let task_id = active.task.task_id.clone();
+        let chunk = if is_final {
+            Chunk {
+                task_id: task_id.clone(),
+                token_id: next_token as i64,
+                text: delta,
+                is_final: true,
+                logprobs: None,
+                n_tokens: None,
+            }
+        } else {
+            Chunk::token(task_id.clone(), next_token as i64, delta)
+        };
+        if is_final {
+            self.active = None;
+        }
         Ok(vec![(task_id, chunk)])
     }
 
@@ -858,6 +1122,9 @@ pub struct OvRuntimeBuilder {
     downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
     listen_host: String,
     listen_port: Option<u16>,
+    /// (static_seq, context, kv_heads, head_dim) for a stateless static-shape
+    /// (NPU) shard; None for the stateful path.
+    static_params: Option<(u32, u32, u32, u32)>,
 }
 
 impl OvRuntimeBuilder {
@@ -961,6 +1228,26 @@ impl Builder for OvRuntimeBuilder {
         }
         let stage_dir = self.pipeline_dir.join(format!("stage_{}", self.rank));
         let stage_cfg = read_stage_config(&stage_dir)?;
+
+        self.static_params = if !stage_cfg.stateful {
+            let ctx = stage_cfg.static_context.unwrap_or(0);
+            let s = stage_cfg.static_seq.unwrap_or(1);
+            let kvh = stage_cfg.num_kv_heads.unwrap_or(0);
+            let hd = stage_cfg.head_dim.unwrap_or(0);
+            if ctx == 0 || kvh == 0 || hd == 0 || s != 1 {
+                return Err(EngineError::InvalidConfig(format!(
+                    "stateless (NPU) shard needs static_seq=1 + static_context/\
+                     num_kv_heads/head_dim in stage_config; got seq={s} ctx={ctx} \
+                     kvh={kvh} hd={hd}"
+                )));
+            }
+            events.push(LoadProgress::message(format!(
+                "stateless static-KV shard: context={ctx} kv_heads={kvh} head_dim={hd}"
+            )));
+            Some((s, ctx, kvh, hd))
+        } else {
+            None
+        };
 
         let is_first = stage_cfg.has_embed;
         let is_last = stage_cfg.has_head;
@@ -1071,6 +1358,88 @@ impl Builder for OvRuntimeBuilder {
             }
         }
 
+        // Stateless static-shape (NPU) shards: resolve the explicit
+        // past_key_values.* inputs + present.* / logits outputs and allocate
+        // the host-side KV ring.
+        let static_kv = if let Some((_s, ctx, kvh, hd)) = self.static_params {
+            let n_out = runtime.output_count();
+            let mut logits_out = 0usize;
+            for idx in 0..n_out {
+                let al = runtime.output_aliases(idx).map_err(map_ov_err)?;
+                if al.iter().any(|a| a == "logits" || a.contains("logits")) {
+                    logits_out = idx;
+                    break;
+                }
+            }
+            let mut layers: Vec<StaticKvLayer> = Vec::new();
+            loop {
+                let l = layers.len();
+                let kin_s = format!("past_key_values.{l}.key");
+                let vin_s = format!("past_key_values.{l}.value");
+                let kout_s = format!("present.{l}.key");
+                let vout_s = format!("present.{l}.value");
+                let (mut key_in, mut val_in) = (None, None);
+                for idx in 0..n_inputs {
+                    let al = runtime.input_aliases(idx).map_err(map_ov_err)?;
+                    if al.iter().any(|a| a.contains(&kin_s)) {
+                        key_in = Some(runtime.input_name(idx).map_err(map_ov_err)?);
+                    } else if al.iter().any(|a| a.contains(&vin_s)) {
+                        val_in = Some(runtime.input_name(idx).map_err(map_ov_err)?);
+                    }
+                }
+                let (key_in, val_in) = match (key_in, val_in) {
+                    (Some(k), Some(v)) => (k, v),
+                    _ => break,
+                };
+                let (mut key_out, mut val_out) = (None, None);
+                for idx in 0..n_out {
+                    let al = runtime.output_aliases(idx).map_err(map_ov_err)?;
+                    if al.iter().any(|a| a.contains(&kout_s)) {
+                        key_out = Some(idx);
+                    } else if al.iter().any(|a| a.contains(&vout_s)) {
+                        val_out = Some(idx);
+                    }
+                }
+                let key_out = key_out.ok_or_else(|| {
+                    EngineError::Backend(format!("static shard missing {kout_s}"))
+                })?;
+                let val_out = val_out.ok_or_else(|| {
+                    EngineError::Backend(format!("static shard missing {vout_s}"))
+                })?;
+                layers.push(StaticKvLayer {
+                    key_in,
+                    val_in,
+                    key_out,
+                    val_out,
+                });
+            }
+            if layers.is_empty() {
+                return Err(EngineError::Backend(
+                    "static shard: no past_key_values.* inputs found".into(),
+                ));
+            }
+            let (kvh, hd) = (kvh as usize, hd as usize);
+            let past_len = (ctx - 1) as usize;
+            let elem_bytes = 2usize; // KV activations are f16 in the static export
+            let layer_bytes = kvh * past_len * hd * elem_bytes;
+            let n = layers.len();
+            Some(StaticKv {
+                past_len,
+                context: ctx as usize,
+                kv_heads: kvh,
+                head_dim: hd,
+                elem_bytes,
+                kv_dtype: ShimDType::F16,
+                logits_out,
+                layers,
+                key_buf: vec![vec![0u8; layer_bytes]; n],
+                val_buf: vec![vec![0u8; layer_bytes]; n],
+                valid: 0,
+            })
+        } else {
+            None
+        };
+
         Ok(Box::new(OvRuntimeEngine {
             spec,
             runtime,
@@ -1086,6 +1455,7 @@ impl Builder for OvRuntimeBuilder {
             canonical_inputs,
             pending: Vec::new(),
             active: None,
+            static_kv,
         }))
     }
 }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -14,10 +14,18 @@
 //!     stage_N/...
 //! ```
 //!
-//! Wire format between stages: hidden_states f16. Each stage tracks its
-//! own absolute-position counter so it can compute (cos, sin) locally
-//! without sending position metadata. Counter resets when an activation
-//! with seq_len > 1 arrives (signals new prefill on relay/last stages).
+//! Wire format between stages: hidden_states f16. Stateful shards have each
+//! stage track its own absolute-position counter (computing cos/sin locally,
+//! no position metadata on the wire); the counter resets when an activation
+//! with seq_len > 1 arrives (a prefill signal for relay/last stages).
+//!
+//! Stateless static-shape (NPU) shards (`stage_config.stateful == false`)
+//! instead drive a host-side bounded KV ring per stage (see `StaticKv`).
+//! Because static shards are seq=1, the seq>1 prefill signal is unavailable,
+//! so the first stage carries the absolute `position` as an 8-byte prefix on
+//! each activation; downstream stages reset their ring at position 0 and
+//! derive the visible-past count from it, keeping every stage's ring in
+//! lockstep. This path works single- or multi-stage (pipeline-parallel NPU).
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -208,6 +216,51 @@ fn map_ov_err(err: OvError) -> EngineError {
     }
 }
 
+/// Decode a float output port's raw bytes to f32, by its reported dtype.
+/// Shared by every output-reading path (run_first / run_relay / static).
+fn bytes_to_f32(dtype: ShimDType, bytes: &[u8]) -> EngineResult<Vec<f32>> {
+    match dtype {
+        ShimDType::F32 => Ok(bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()),
+        ShimDType::F16 => Ok(f16_bytes_to_f32(bytes)),
+        other => Err(EngineError::Backend(format!(
+            "unexpected float output dtype {other:?}"
+        ))),
+    }
+}
+
+/// Pick the next token from a logits output, guarding the shape so a
+/// rank-0 / zero-width / short logits buffer returns a clear error instead
+/// of panicking with a slice/underflow.
+fn argmax_logits(logits: &[f32], shape: &[usize]) -> EngineResult<i32> {
+    let vocab = match shape.last() {
+        Some(&v) if v > 0 => v,
+        _ => {
+            return Err(EngineError::Backend(format!(
+                "logits output has empty/zero last dim: shape={shape:?}"
+            )))
+        }
+    };
+    if vocab > logits.len() {
+        return Err(EngineError::Backend(format!(
+            "logits len {} < vocab {vocab} (shape={shape:?})",
+            logits.len()
+        )));
+    }
+    Ok(argmax_last_row(logits, vocab))
+}
+
+/// Normalize an output shape to a 3D `[batch, seq, hidden]` for the wire.
+fn to_shape3(shape: &[usize]) -> [usize; 3] {
+    match shape.len() {
+        3 => [shape[0], shape[1], shape[2]],
+        2 => [1, shape[0], shape[1]],
+        _ => [1, 1, shape.last().copied().unwrap_or(0)],
+    }
+}
+
 // -------- static-KV (NPU) state --------
 
 /// Per-layer port wiring for a stateless static-shape (NPU) shard.
@@ -221,9 +274,13 @@ struct StaticKvLayer {
 /// Host-side bounded KV ring for the stateless static-shape (NPU) path.
 /// The exported IR takes explicit `past_key_values.*` (length `past_len`) +
 /// `attention_mask` (length `context = past_len + 1`) + `position_ids`, and
-/// returns `logits` + `present.*` (length `context`). We hold the KV for the
-/// most recent `valid` real tokens left-aligned in `past_len`-slot buffers,
-/// feed them each step, and absorb the new token's KV from `present[past_len]`.
+/// returns its primary output (logits for the head stage, hidden_states
+/// otherwise) at output index 0, plus `present.*` (length `context`). We hold
+/// the KV for the most recent `valid` real tokens left-aligned in
+/// `past_len`-slot buffers, feed them each step, and absorb the new token's KV
+/// from `present[past_len]`. One ring per stage; in a multi-stage pipeline
+/// every stage runs its own ring over its own layers, kept in lockstep by the
+/// absolute `position` the first stage carries with each activation.
 struct StaticKv {
     past_len: usize,
     context: usize,
@@ -231,11 +288,10 @@ struct StaticKv {
     head_dim: usize,
     elem_bytes: usize,
     kv_dtype: ShimDType,
-    logits_out: usize,
     layers: Vec<StaticKvLayer>,
     key_buf: Vec<Vec<u8>>, // [layer] = kv_heads * past_len * head_dim * elem_bytes
     val_buf: Vec<Vec<u8>>,
-    valid: usize, // number of real tokens currently in the ring
+    valid: usize, // number of real past tokens currently in the ring
 }
 
 impl StaticKv {
@@ -244,6 +300,23 @@ impl StaticKv {
             b.iter_mut().for_each(|x| *x = 0);
         }
         self.valid = 0;
+    }
+
+    /// Expected byte length of one layer's `present.*` output:
+    /// `kv_heads * context * head_dim * elem_bytes`. Used to validate the IR's
+    /// output shape/dtype before `absorb_layer` slices it.
+    fn present_layer_bytes(&self) -> usize {
+        self.kv_heads * self.context * self.head_dim * self.elem_bytes
+    }
+
+    /// Set how many real past tokens are visible for a token at absolute
+    /// `position`, resetting the ring at the start of a new sequence
+    /// (`position == 0`). The window is bounded by `past_len`.
+    fn begin_token(&mut self, position: usize) {
+        if position == 0 {
+            self.reset();
+        }
+        self.valid = position.min(self.past_len);
     }
 
     /// attention_mask over `context = past_len + 1`: 1 for the `valid` real
@@ -532,22 +605,28 @@ impl OvRuntimeEngine {
         input_ids: &[i64],
         position: i64,
     ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
+        // Stateless static (NPU): feed one token id + the host-side KV ring.
+        // The caller loops one token at a time (static_seq == 1).
+        if self.static_kv.is_some() {
+            if input_ids.len() != 1 {
+                return Err(EngineError::Backend(format!(
+                    "static shard processes one token per step, got {}",
+                    input_ids.len()
+                )));
+            }
+            let (dtype, shape, bytes) = self.static_infer(
+                "input_ids",
+                ShimDType::I64,
+                &[1, 1],
+                &i64_to_bytes(input_ids),
+                position,
+            )?;
+            return Ok((bytes_to_f32(dtype, &bytes)?, shape));
+        }
         self.build_feed_first(input_ids, position)?;
         self.runtime.infer().map_err(map_ov_err)?;
         let (dtype, shape, bytes) = self.runtime.output(0).map_err(map_ov_err)?;
-        let floats = match dtype {
-            ShimDType::F32 => bytes
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect::<Vec<_>>(),
-            ShimDType::F16 => f16_bytes_to_f32(&bytes),
-            other => {
-                return Err(EngineError::Backend(format!(
-                    "unexpected output dtype {other:?}"
-                )))
-            }
-        };
-        Ok((floats, shape))
+        Ok((bytes_to_f32(dtype, &bytes)?, shape))
     }
 
     fn run_relay(
@@ -556,22 +635,18 @@ impl OvRuntimeEngine {
         shape: [usize; 3],
         position: i64,
     ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
+        // Stateless static (NPU): feed the upstream hidden state + the
+        // host-side KV ring for this stage's layers.
+        if self.static_kv.is_some() {
+            let hs_bytes = f32_to_f16_bytes(hidden);
+            let (dtype, out_shape, bytes) =
+                self.static_infer("hidden_states", ShimDType::F16, &shape, &hs_bytes, position)?;
+            return Ok((bytes_to_f32(dtype, &bytes)?, out_shape));
+        }
         self.build_feed_relay(hidden, shape, position)?;
         self.runtime.infer().map_err(map_ov_err)?;
         let (dtype, out_shape, bytes) = self.runtime.output(0).map_err(map_ov_err)?;
-        let floats = match dtype {
-            ShimDType::F32 => bytes
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect::<Vec<_>>(),
-            ShimDType::F16 => f16_bytes_to_f32(&bytes),
-            other => {
-                return Err(EngineError::Backend(format!(
-                    "unexpected output dtype {other:?}"
-                )))
-            }
-        };
-        Ok((floats, out_shape))
+        Ok((bytes_to_f32(dtype, &bytes)?, out_shape))
     }
 
     fn block_on<F: std::future::Future>(&self, f: F) -> F::Output {
@@ -584,20 +659,42 @@ impl OvRuntimeEngine {
         crate::dist_spec::run_async_pub(&self.runtime_handle, f)
     }
 
-    fn send_hidden_downstream(&mut self, hidden: &[f32], shape: [usize; 3]) -> EngineResult<()> {
+    fn send_hidden_downstream(
+        &mut self,
+        hidden: &[f32],
+        shape: [usize; 3],
+        position: i64,
+    ) -> EngineResult<()> {
         let downstream = self
             .downstream
             .clone()
             .ok_or_else(|| EngineError::Backend("no downstream".into()))?;
-        let bytes = f32_to_f16_bytes(hidden);
         let mut wire_shape = [1u32; MAX_RANK];
         for (i, d) in shape.iter().enumerate().take(MAX_RANK) {
             wire_shape[i] = *d as u32;
         }
-        let tensor = WireTensor::new(WireDType::F16, wire_shape, bytes);
+        let hid = WireTensor::new(WireDType::F16, wire_shape, f32_to_f16_bytes(hidden));
+        // Static (NPU) shards need the absolute position downstream so each
+        // stage can reset its ring at position 0 and align the visible-past
+        // count. The wire shape has only MAX_RANK=3 dims (all used by
+        // [1,1,hidden]) and the transport requires payload_len == shape*dtype,
+        // so we can't pack it into the hidden tensor — send it as its own
+        // framed I64 tensor first. recv_hidden_from_upstream mirrors the order.
+        let pos = if self.static_kv.is_some() {
+            Some(WireTensor::new(
+                WireDType::I64,
+                [1, 1, 1],
+                position.to_le_bytes().to_vec(),
+            ))
+        } else {
+            None
+        };
         self.block_on(async move {
             let mut guard = downstream.lock().await;
-            guard.send(&tensor).await
+            if let Some(p) = pos {
+                guard.send(&p).await?;
+            }
+            guard.send(&hid).await
         })
         .map_err(|e| EngineError::Backend(e.to_string()))?;
         Ok(())
@@ -629,15 +726,29 @@ impl OvRuntimeEngine {
         Ok(token)
     }
 
-    fn recv_hidden_from_upstream(&mut self) -> EngineResult<(Vec<f32>, [usize; 3])> {
+    fn recv_hidden_from_upstream(&mut self) -> EngineResult<(Vec<f32>, [usize; 3], Option<i64>)> {
         let upstream = self
             .upstream
             .clone()
             .ok_or_else(|| EngineError::Backend("no upstream".into()))?;
-        let (tensor, _) = self
+        // Static (NPU) shards send a leading I64 position tensor before the
+        // hidden activation (see send_hidden_downstream). Each frame's payload
+        // must match its shape*dtype, so we recv two separate tensors here.
+        let want_pos = self.static_kv.is_some();
+        let (position, tensor) = self
             .block_on(async move {
                 let mut guard = upstream.lock().await;
-                guard.recv().await
+                let position = if want_pos {
+                    let (p, _) = guard.recv().await?;
+                    let mut b = [0u8; 8];
+                    let n = b.len().min(p.data.len());
+                    b[..n].copy_from_slice(&p.data[..n]);
+                    Some(i64::from_le_bytes(b))
+                } else {
+                    None
+                };
+                let (t, _) = guard.recv().await?;
+                Ok::<_, cascadia_transport::TransportError>((position, t))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
         let shape = [
@@ -658,7 +769,7 @@ impl OvRuntimeEngine {
                 )))
             }
         };
-        Ok((floats, shape))
+        Ok((floats, shape, position))
     }
 
     fn send_token_to_upstream(&mut self, token: i32) -> EngineResult<()> {
@@ -731,57 +842,94 @@ impl OvRuntimeEngine {
     }
 
     fn step_first_body(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
-        if self.static_kv.is_some() {
-            return self.step_first_static();
+        if self.active.is_none() {
+            return Ok(Vec::new());
         }
-        let active = match self.active.as_mut() {
-            Some(a) => a,
-            None => return Ok(Vec::new()),
-        };
-
-        let input_ids: Vec<i64> = if !active.prefilled {
-            active.prefilled = true;
-            active.prompt_ids.clone()
-        } else {
-            vec![active.last_token as i64]
-        };
-
-        let position = self.position;
-        let _ts = std::time::Instant::now();
-        let (out, shape) = self.run_first(&input_ids, position)?;
-        let alpha_dur = _ts.elapsed();
-        self.position += input_ids.len() as i64;
-
-        // Resolve next_token: if 1-stage IR also produced logits; else send hs
-        // downstream and recv next_token back.
-        let mut wire_dur = std::time::Duration::ZERO;
-        let next_token = if self.spec.is_first_stage && self.spec.is_last_stage {
-            // Single-stage: out is logits [1, seq_len, vocab]
-            let vocab = shape[shape.len() - 1];
-            argmax_last_row(&out, vocab)
-        } else {
-            let s3 = if shape.len() == 3 {
-                [shape[0], shape[1], shape[2]]
+        let (prefill, tokens) = {
+            let a = self.active.as_mut().unwrap();
+            if !a.prefilled {
+                a.prefilled = true;
+                (true, a.prompt_ids.clone())
             } else {
-                [1, shape[0], shape[1]]
-            };
-            let _ts = std::time::Instant::now();
-            self.send_hidden_downstream(&out, s3)?;
-            let token = self.recv_token_from_downstream()?;
-            wire_dur = _ts.elapsed();
-            token
+                (false, vec![a.last_token as i64])
+            }
         };
-        if let Some(a) = self.active.as_mut() {
-            a.t_alpha_compute += alpha_dur;
-            a.t_wire += wire_dur;
-        }
+        let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
 
-        // Decode delta + check stop.
-        let active = self.active.as_mut().unwrap();
+        let next_token = if self.static_kv.is_some() {
+            // Static (NPU): one token per inference (static_seq == 1). Prefill
+            // round-trips the whole pipeline once per prompt token so every
+            // stage's KV ring advances in lockstep; the token produced from
+            // the final prompt token is the first generated token.
+            if prefill {
+                self.position = 0;
+            }
+            let mut nt = 0i32;
+            for &t in &tokens {
+                let position = self.position;
+                let ts = std::time::Instant::now();
+                let (out, shape) = self.run_first(&[t], position)?;
+                let alpha = ts.elapsed();
+                self.position += 1;
+                let ts = std::time::Instant::now();
+                nt = if single_stage {
+                    argmax_logits(&out, &shape)?
+                } else {
+                    let s3 = to_shape3(&shape);
+                    self.send_hidden_downstream(&out, s3, position)?;
+                    self.recv_token_from_downstream()?
+                };
+                let wire = ts.elapsed();
+                if let Some(a) = self.active.as_mut() {
+                    a.t_alpha_compute += alpha;
+                    a.t_wire += wire;
+                }
+            }
+            nt
+        } else {
+            // Stateful: the whole prompt (prefill) or one decode token in a
+            // single multi-token inference; the IR keeps KV internally.
+            let position = self.position;
+            let ts = std::time::Instant::now();
+            let (out, shape) = self.run_first(&tokens, position)?;
+            let alpha_dur = ts.elapsed();
+            self.position += tokens.len() as i64;
+            let mut wire_dur = std::time::Duration::ZERO;
+            let nt = if single_stage {
+                argmax_logits(&out, &shape)?
+            } else {
+                let s3 = to_shape3(&shape);
+                let ts = std::time::Instant::now();
+                self.send_hidden_downstream(&out, s3, position)?;
+                let token = self.recv_token_from_downstream()?;
+                wire_dur = ts.elapsed();
+                token
+            };
+            if let Some(a) = self.active.as_mut() {
+                a.t_alpha_compute += alpha_dur;
+                a.t_wire += wire_dur;
+            }
+            nt
+        };
+
+        self.emit_token(next_token)
+    }
+
+    /// Decode the delta text for `next_token`, append it to the active task,
+    /// check stop conditions, and build the streamed chunk. Shared by the
+    /// static and stateful first-stage paths.
+    fn emit_token(&mut self, next_token: i32) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        let active = self
+            .active
+            .as_mut()
+            .ok_or_else(|| EngineError::Backend("emit_token with no active task".into()))?;
         active.last_token = next_token;
         active.generated.push(next_token);
 
-        let tok = self.tokenizer.as_ref().unwrap();
+        let tok = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| EngineError::Backend("first stage requires tokenizer".into()))?;
         let all_ids: Vec<u32> = active.generated.iter().map(|&t| t as u32).collect();
         let full_text = tok
             .decode(&all_ids, true)
@@ -838,13 +986,23 @@ impl OvRuntimeEngine {
         Ok(vec![(task_id, chunk)])
     }
 
-    /// One static-KV (NPU) inference: feed the current token + the host-side
-    /// KV ring + a mask/position for the absolute position, run, return the
-    /// last-row logits, and absorb the new token's K/V into the ring.
-    fn static_infer_one(&mut self, token: i64) -> EngineResult<Vec<f32>> {
-        let in_ids = self
-            .input_named("input_ids")
-            .ok_or_else(|| EngineError::Backend("static IR missing input_ids".into()))?
+    /// One static-KV (NPU) inference for the token at absolute `position`.
+    /// Feeds `primary_in` ("input_ids" on the first stage, "hidden_states" on
+    /// a relay stage) + attention_mask + position_ids + this stage's KV ring,
+    /// runs, absorbs the new token's K/V from `present`, and returns output 0
+    /// (logits on the head stage, hidden_states otherwise). The ring resets at
+    /// `position == 0`, so this is correct for any stage in a pipeline.
+    fn static_infer(
+        &mut self,
+        primary_in: &str,
+        in_dtype: ShimDType,
+        in_shape: &[usize],
+        in_bytes: &[u8],
+        position: i64,
+    ) -> EngineResult<(ShimDType, Vec<usize>, Vec<u8>)> {
+        let in_main = self
+            .input_named(primary_in)
+            .ok_or_else(|| EngineError::Backend(format!("static IR missing {primary_in}")))?
             .to_string();
         let in_attn = self
             .input_named("attention_mask")
@@ -854,167 +1012,132 @@ impl OvRuntimeEngine {
             .input_named("position_ids")
             .ok_or_else(|| EngineError::Backend("static IR missing position_ids".into()))?
             .to_string();
-        let pos = self.position;
-        // Snapshot params + per-layer wiring (clone to drop the static_kv
-        // borrow before the runtime calls below).
-        let (ctx, past_len, kvh, hd, kv_dtype, logits_out, mask, wiring) = {
-            let sk = self.static_kv.as_ref().unwrap();
+
+        // Align the ring to this absolute position (resets at position 0).
+        let (ctx, past_len, kvh, hd, kv_dtype, mask, expect) = {
+            let sk = self.static_kv.as_mut().unwrap();
+            sk.begin_token(position as usize);
             (
                 sk.context,
                 sk.past_len,
                 sk.kv_heads,
                 sk.head_dim,
                 sk.kv_dtype,
-                sk.logits_out,
                 sk.attention_mask(),
-                sk.layers
-                    .iter()
-                    .map(|l| (l.key_in.clone(), l.val_in.clone(), l.key_out, l.val_out))
-                    .collect::<Vec<_>>(),
+                sk.present_layer_bytes(),
             )
         };
+
         self.runtime
-            .set_input(&in_ids, ShimDType::I64, &[1, 1], &i64_to_bytes(&[token]))
+            .set_input(&in_main, in_dtype, in_shape, in_bytes)
             .map_err(map_ov_err)?;
         self.runtime
             .set_input(&in_attn, ShimDType::I64, &[1, ctx], &i64_to_bytes(&mask))
             .map_err(map_ov_err)?;
         self.runtime
-            .set_input(&in_pos, ShimDType::I64, &[1, 1], &i64_to_bytes(&[pos]))
+            .set_input(&in_pos, ShimDType::I64, &[1, 1], &i64_to_bytes(&[position]))
             .map_err(map_ov_err)?;
-        for (li, (kin, vin, _ko, _vo)) in wiring.iter().enumerate() {
-            let (kb, vb) = {
-                let sk = self.static_kv.as_ref().unwrap();
-                (sk.key_buf[li].clone(), sk.val_buf[li].clone())
-            };
-            self.runtime
-                .set_input(kin, kv_dtype, &[1, kvh, past_len, hd], &kb)
-                .map_err(map_ov_err)?;
-            self.runtime
-                .set_input(vin, kv_dtype, &[1, kvh, past_len, hd], &vb)
-                .map_err(map_ov_err)?;
+        // Feed the per-layer past-KV from the ring. self.runtime (mut) and
+        // self.static_kv (shared) are disjoint fields, so we borrow the ring
+        // buffers directly — no per-step clone.
+        {
+            let sk = self.static_kv.as_ref().unwrap();
+            for (li, layer) in sk.layers.iter().enumerate() {
+                self.runtime
+                    .set_input(
+                        &layer.key_in,
+                        kv_dtype,
+                        &[1, kvh, past_len, hd],
+                        &sk.key_buf[li],
+                    )
+                    .map_err(map_ov_err)?;
+                self.runtime
+                    .set_input(
+                        &layer.val_in,
+                        kv_dtype,
+                        &[1, kvh, past_len, hd],
+                        &sk.val_buf[li],
+                    )
+                    .map_err(map_ov_err)?;
+            }
         }
         self.runtime.infer().map_err(map_ov_err)?;
-        let (ldt, lshape, lbytes) = self.runtime.output(logits_out).map_err(map_ov_err)?;
-        let logits = match ldt {
-            ShimDType::F32 => lbytes
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect::<Vec<_>>(),
-            ShimDType::F16 => f16_bytes_to_f32(&lbytes),
-            other => return Err(EngineError::Backend(format!("logits dtype {other:?}"))),
-        };
-        let vocab = lshape[lshape.len() - 1];
-        let last_row = logits[logits.len() - vocab..].to_vec();
-        for (li, (_kin, _vin, ko, vo)) in wiring.iter().enumerate() {
-            let (_, _, kpres) = self.runtime.output(*ko).map_err(map_ov_err)?;
-            let (_, _, vpres) = self.runtime.output(*vo).map_err(map_ov_err)?;
+
+        // Primary output (index 0): logits on the head stage, hidden_states
+        // otherwise — the static export emits it before the present.* outputs.
+        let (odt, oshape, obytes) = self.runtime.output(0).map_err(map_ov_err)?;
+
+        // Absorb the new token's K/V. Snapshot only the per-layer output
+        // indices (cheap) so we don't hold a static_kv borrow across the
+        // runtime.output() + absorb_layer() calls.
+        let outs: Vec<(usize, usize)> = self
+            .static_kv
+            .as_ref()
+            .unwrap()
+            .layers
+            .iter()
+            .map(|l| (l.key_out, l.val_out))
+            .collect();
+        for (li, (ko, vo)) in outs.into_iter().enumerate() {
+            let (_, _, kpres) = self.runtime.output(ko).map_err(map_ov_err)?;
+            let (_, _, vpres) = self.runtime.output(vo).map_err(map_ov_err)?;
+            if kpres.len() != expect || vpres.len() != expect {
+                let elem = self.static_kv.as_ref().unwrap().elem_bytes;
+                return Err(EngineError::Backend(format!(
+                    "static present.{li} byte length key={} val={} != expected {expect} \
+                     (kv_heads*context*head_dim*{elem}); check num_kv_heads/head_dim/KV dtype \
+                     in stage_config",
+                    kpres.len(),
+                    vpres.len(),
+                )));
+            }
             let sk = self.static_kv.as_mut().unwrap();
             sk.absorb_layer(li, false, &kpres);
             sk.absorb_layer(li, true, &vpres);
         }
-        {
-            let sk = self.static_kv.as_mut().unwrap();
-            sk.valid = (sk.valid + 1).min(sk.past_len);
-        }
-        self.position += 1;
-        Ok(last_row)
-    }
-
-    /// First-stage step for stateless static-shape (NPU) shards: prefill the
-    /// prompt one token at a time into the KV ring, then emit one token per
-    /// call. Single-stage only (NPU shards are not pipelined).
-    fn step_first_static(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
-        if self.active.is_none() {
-            return Ok(Vec::new());
-        }
-        let (prefill, ids) = {
-            let a = self.active.as_mut().unwrap();
-            if !a.prefilled {
-                a.prefilled = true;
-                (true, a.prompt_ids.clone())
-            } else {
-                (false, vec![a.last_token as i64])
-            }
-        };
-        let last_row = if prefill {
-            if let Some(sk) = self.static_kv.as_mut() {
-                sk.reset();
-            }
-            self.position = 0;
-            let mut lr = Vec::new();
-            for &t in &ids {
-                lr = self.static_infer_one(t)?;
-            }
-            lr
-        } else {
-            self.static_infer_one(ids[0])?
-        };
-        let vocab = last_row.len();
-        let next_token = argmax_last_row(&last_row, vocab);
-
-        let active = self.active.as_mut().unwrap();
-        active.last_token = next_token;
-        active.generated.push(next_token);
-        let tok = self
-            .tokenizer
-            .as_ref()
-            .ok_or_else(|| EngineError::Backend("static stage requires tokenizer".into()))?;
-        let all_ids: Vec<u32> = active.generated.iter().map(|&t| t as u32).collect();
-        let full_text = tok
-            .decode(&all_ids, true)
-            .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
-        let delta = full_text
-            .strip_prefix(active.last_text.as_str())
-            .unwrap_or(&full_text)
-            .to_string();
-        active.last_text = full_text;
-        let max_tokens = active.task.max_tokens.max(1) as usize;
-        let is_eos = self.eos_token_ids.contains(&(next_token as u32));
-        let is_final = active.generated.len() >= max_tokens || is_eos;
-        let task_id = active.task.task_id.clone();
-        let chunk = if is_final {
-            Chunk {
-                task_id: task_id.clone(),
-                token_id: next_token as i64,
-                text: delta,
-                is_final: true,
-                logprobs: None,
-                n_tokens: None,
-            }
-        } else {
-            Chunk::token(task_id.clone(), next_token as i64, delta)
-        };
-        if is_final {
-            self.active = None;
-        }
-        Ok(vec![(task_id, chunk)])
+        Ok((odt, oshape, obytes))
     }
 
     fn step_last(&mut self) -> EngineResult<()> {
-        let (hidden, shape) = self.recv_hidden_from_upstream()?;
-        if shape[1] > 1 {
-            self.runtime.reset_state().map_err(map_ov_err)?;
-            self.position = 0;
-        }
-        let (out, out_shape) = self.run_relay(&hidden, shape, self.position)?;
-        self.position += shape[1] as i64;
-        let vocab = out_shape[out_shape.len() - 1];
-        let next = argmax_last_row(&out, vocab);
+        let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
+        let (out, out_shape) = match pos_opt {
+            // Static (NPU): the carried absolute position drives the ring
+            // (reset at 0); seq is always 1.
+            Some(pos) => self.run_relay(&hidden, shape, pos)?,
+            None => {
+                if shape[1] > 1 {
+                    self.runtime.reset_state().map_err(map_ov_err)?;
+                    self.position = 0;
+                }
+                let r = self.run_relay(&hidden, shape, self.position)?;
+                self.position += shape[1] as i64;
+                r
+            }
+        };
+        let next = argmax_logits(&out, &out_shape)?;
         self.send_token_to_upstream(next)?;
         Ok(())
     }
 
     fn step_middle(&mut self) -> EngineResult<()> {
-        let (hidden, shape) = self.recv_hidden_from_upstream()?;
-        if shape[1] > 1 {
-            self.runtime.reset_state().map_err(map_ov_err)?;
-            self.position = 0;
-        }
-        let (out, _) = self.run_relay(&hidden, shape, self.position)?;
-        self.position += shape[1] as i64;
-        let s3 = [shape[0], shape[1], shape[2]];
-        self.send_hidden_downstream(&out, s3)?;
+        let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
+        let (out, out_shape, fwd_pos) = match pos_opt {
+            Some(pos) => {
+                let (o, s) = self.run_relay(&hidden, shape, pos)?;
+                (o, s, pos)
+            }
+            None => {
+                if shape[1] > 1 {
+                    self.runtime.reset_state().map_err(map_ov_err)?;
+                    self.position = 0;
+                }
+                let (o, s) = self.run_relay(&hidden, shape, self.position)?;
+                self.position += shape[1] as i64;
+                (o, s, 0)
+            }
+        };
+        let s3 = to_shape3(&out_shape);
+        self.send_hidden_downstream(&out, s3, fwd_pos)?;
         let token = self.recv_token_from_downstream()?;
         self.send_token_to_upstream(token)?;
         Ok(())
@@ -1042,9 +1165,16 @@ impl Engine for OvRuntimeEngine {
             }
         };
         let ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
-        match self.run_first(&ids, 0) {
+        // run_first processes one token per call on the static path, so warm
+        // with a single token (enough to JIT the OV graph) regardless of path.
+        let warm = &ids[..ids.len().min(1)];
+        match self.run_first(warm, 0) {
             Ok(_) => {
-                let _ = self.runtime.reset_state();
+                if let Some(sk) = self.static_kv.as_mut() {
+                    sk.reset();
+                } else {
+                    let _ = self.runtime.reset_state();
+                }
                 self.position = 0;
                 info!("ov-runtime warmup ok");
             }
@@ -1234,10 +1364,12 @@ impl Builder for OvRuntimeBuilder {
             let s = stage_cfg.static_seq.unwrap_or(1);
             let kvh = stage_cfg.num_kv_heads.unwrap_or(0);
             let hd = stage_cfg.head_dim.unwrap_or(0);
-            if ctx == 0 || kvh == 0 || hd == 0 || s != 1 {
+            // static_seq must be 1 (the runtime decodes one token per step) and
+            // static_context must exceed it so past_len = context - 1 >= 1.
+            if kvh == 0 || hd == 0 || s != 1 || ctx <= s {
                 return Err(EngineError::InvalidConfig(format!(
-                    "stateless (NPU) shard needs static_seq=1 + static_context/\
-                     num_kv_heads/head_dim in stage_config; got seq={s} ctx={ctx} \
+                    "stateless (NPU) shard needs static_seq=1, static_context>static_seq, \
+                     and num_kv_heads/head_dim in stage_config; got seq={s} ctx={ctx} \
                      kvh={kvh} hd={hd}"
                 )));
             }
@@ -1359,18 +1491,11 @@ impl Builder for OvRuntimeBuilder {
         }
 
         // Stateless static-shape (NPU) shards: resolve the explicit
-        // past_key_values.* inputs + present.* / logits outputs and allocate
-        // the host-side KV ring.
+        // past_key_values.* inputs + present.* outputs and allocate the
+        // host-side KV ring. The primary output (logits on the head stage,
+        // hidden_states otherwise) is output index 0 — no alias guess needed.
         let static_kv = if let Some((_s, ctx, kvh, hd)) = self.static_params {
             let n_out = runtime.output_count();
-            let mut logits_out = 0usize;
-            for idx in 0..n_out {
-                let al = runtime.output_aliases(idx).map_err(map_ov_err)?;
-                if al.iter().any(|a| a == "logits" || a.contains("logits")) {
-                    logits_out = idx;
-                    break;
-                }
-            }
             let mut layers: Vec<StaticKvLayer> = Vec::new();
             loop {
                 let l = layers.len();
@@ -1418,6 +1543,26 @@ impl Builder for OvRuntimeBuilder {
                     "static shard: no past_key_values.* inputs found".into(),
                 ));
             }
+            // Cross-check: the contiguous-from-0 discovery above stops at the
+            // first missing index. Compare against the total number of
+            // past_key_values.* input ports so a gap / renamed / folded port is
+            // a hard error instead of silently building fewer layers.
+            let mut kv_input_ports = 0usize;
+            for idx in 0..n_inputs {
+                let al = runtime.input_aliases(idx).map_err(map_ov_err)?;
+                if al.iter().any(|a| a.contains("past_key_values.")) {
+                    kv_input_ports += 1;
+                }
+            }
+            if kv_input_ports != layers.len() * 2 {
+                return Err(EngineError::Backend(format!(
+                    "static shard: resolved {} contiguous KV layers ({} ports) but the IR has \
+                     {kv_input_ports} past_key_values.* input ports — a layer port is missing or \
+                     misnamed (gap in the past_key_values.N sequence)",
+                    layers.len(),
+                    layers.len() * 2,
+                )));
+            }
             let (kvh, hd) = (kvh as usize, hd as usize);
             let past_len = (ctx - 1) as usize;
             let elem_bytes = 2usize; // KV activations are f16 in the static export
@@ -1430,7 +1575,6 @@ impl Builder for OvRuntimeBuilder {
                 head_dim: hd,
                 elem_bytes,
                 kv_dtype: ShimDType::F16,
-                logits_out,
                 layers,
                 key_buf: vec![vec![0u8; layer_bytes]; n],
                 val_buf: vec![vec![0u8; layer_bytes]; n],

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -145,14 +145,6 @@ fn lookup_eos(model_dir: &Path) -> Vec<u32> {
 
 // -------- helpers: bytes <-> typed slices --------
 
-fn f32_to_bytes(v: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(v.len() * 4);
-    for x in v {
-        out.extend_from_slice(&x.to_le_bytes());
-    }
-    out
-}
-
 fn i64_to_bytes(v: &[i64]) -> Vec<u8> {
     let mut out = Vec::with_capacity(v.len() * 8);
     for x in v {
@@ -261,6 +253,34 @@ fn to_shape3(shape: &[usize]) -> [usize; 3] {
     }
 }
 
+/// Encode the absolute position as its own framed wire tensor (I64 `[1,1,1]`).
+/// The static (NPU) path sends this immediately before each hidden activation
+/// so relay stages reset/align their KV ring; the transport requires
+/// `payload_len == shape*dtype`, so position cannot be packed into the hidden
+/// tensor (and MAX_RANK=3 leaves no spare shape slot). Paired with
+/// `decode_wire_position` — keep the two in sync.
+fn encode_wire_position(position: i64) -> WireTensor {
+    WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
+}
+
+/// Decode + strictly validate a wire position frame. Must be I64 with exactly
+/// 8 payload bytes; anything else (a desynced stream, or a stateful peer that
+/// sent a hidden tensor where a position was expected) is a hard error rather
+/// than a silently zero-padded wrong position.
+fn decode_wire_position(t: &WireTensor) -> EngineResult<i64> {
+    if t.dtype != WireDType::I64 || t.data.len() != 8 {
+        return Err(EngineError::Backend(format!(
+            "expected an I64 8-byte position frame, got dtype={:?} len={} — likely a \
+             stateful/static pipeline mismatch or a desynced activation stream",
+            t.dtype,
+            t.data.len()
+        )));
+    }
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&t.data);
+    Ok(i64::from_le_bytes(b))
+}
+
 // -------- static-KV (NPU) state --------
 
 /// Per-layer port wiring for a stateless static-shape (NPU) shard.
@@ -288,10 +308,20 @@ struct StaticKv {
     head_dim: usize,
     elem_bytes: usize,
     kv_dtype: ShimDType,
+    /// Resolved primary input port names (cached at build so the per-token
+    /// decode loop does no HashMap lookups / string allocs). `ids_in` is set
+    /// for the embed stage, `hidden_in` for relay/head stages.
+    ids_in: Option<String>,
+    hidden_in: Option<String>,
+    attn_in: String,
+    pos_in: String,
     layers: Vec<StaticKvLayer>,
     key_buf: Vec<Vec<u8>>, // [layer] = kv_heads * past_len * head_dim * elem_bytes
     val_buf: Vec<Vec<u8>>,
     valid: usize, // number of real past tokens currently in the ring
+    /// Reusable attention_mask byte buffer (i64 LE, length context*8), rewritten
+    /// in place each token to avoid a per-token allocation.
+    mask_bytes: Vec<u8>,
 }
 
 impl StaticKv {
@@ -319,16 +349,20 @@ impl StaticKv {
         self.valid = position.min(self.past_len);
     }
 
-    /// attention_mask over `context = past_len + 1`: 1 for the `valid` real
-    /// past slots (left-aligned) + the current token (slot `past_len`), 0 for
-    /// the padding past slots in between.
-    fn attention_mask(&self) -> Vec<i64> {
-        let mut m = vec![0i64; self.context];
-        for v in m.iter_mut().take(self.valid) {
-            *v = 1;
+    /// Rewrite `mask_bytes` (i64 LE) for the current `valid`: 1 for the `valid`
+    /// real past slots (left-aligned) + the current token (slot `past_len`), 0
+    /// for the padding past slots in between. Reuses the buffer's capacity.
+    fn write_mask_bytes(&mut self) {
+        self.mask_bytes.clear();
+        self.mask_bytes.resize(self.context * 8, 0);
+        for i in 0..self.context {
+            let v: i64 = if i < self.valid || i == self.past_len {
+                1
+            } else {
+                0
+            };
+            self.mask_bytes[i * 8..i * 8 + 8].copy_from_slice(&v.to_le_bytes());
         }
-        m[self.past_len] = 1;
-        m
     }
 
     /// Copy the new token's K/V (slot `past_len` of `present`) into the
@@ -615,7 +649,7 @@ impl OvRuntimeEngine {
                 )));
             }
             let (dtype, shape, bytes) = self.static_infer(
-                "input_ids",
+                false,
                 ShimDType::I64,
                 &[1, 1],
                 &i64_to_bytes(input_ids),
@@ -640,7 +674,7 @@ impl OvRuntimeEngine {
         if self.static_kv.is_some() {
             let hs_bytes = f32_to_f16_bytes(hidden);
             let (dtype, out_shape, bytes) =
-                self.static_infer("hidden_states", ShimDType::F16, &shape, &hs_bytes, position)?;
+                self.static_infer(true, ShimDType::F16, &shape, &hs_bytes, position)?;
             return Ok((bytes_to_f32(dtype, &bytes)?, out_shape));
         }
         self.build_feed_relay(hidden, shape, position)?;
@@ -681,11 +715,7 @@ impl OvRuntimeEngine {
         // so we can't pack it into the hidden tensor — send it as its own
         // framed I64 tensor first. recv_hidden_from_upstream mirrors the order.
         let pos = if self.static_kv.is_some() {
-            Some(WireTensor::new(
-                WireDType::I64,
-                [1, 1, 1],
-                position.to_le_bytes().to_vec(),
-            ))
+            Some(encode_wire_position(position))
         } else {
             None
         };
@@ -735,22 +765,24 @@ impl OvRuntimeEngine {
         // hidden activation (see send_hidden_downstream). Each frame's payload
         // must match its shape*dtype, so we recv two separate tensors here.
         let want_pos = self.static_kv.is_some();
-        let (position, tensor) = self
+        let (pos_tensor, tensor) = self
             .block_on(async move {
                 let mut guard = upstream.lock().await;
-                let position = if want_pos {
-                    let (p, _) = guard.recv().await?;
-                    let mut b = [0u8; 8];
-                    let n = b.len().min(p.data.len());
-                    b[..n].copy_from_slice(&p.data[..n]);
-                    Some(i64::from_le_bytes(b))
+                let pos_tensor = if want_pos {
+                    Some(guard.recv().await?.0)
                 } else {
                     None
                 };
                 let (t, _) = guard.recv().await?;
-                Ok::<_, cascadia_transport::TransportError>((position, t))
+                Ok::<_, cascadia_transport::TransportError>((pos_tensor, t))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
+        // Decode + strictly validate the position frame outside the transport
+        // closure (so a bad frame yields a clear EngineError, not a desync).
+        let position = match pos_tensor {
+            Some(p) => Some(decode_wire_position(&p)?),
+            None => None,
+        };
         let shape = [
             tensor.shape[0] as usize,
             tensor.shape[1] as usize,
@@ -836,6 +868,9 @@ impl OvRuntimeEngine {
             );
             self.active = None;
             let _ = self.runtime.reset_state();
+            if let Some(sk) = self.static_kv.as_mut() {
+                sk.reset();
+            }
             self.position = 0;
         }
         res
@@ -856,6 +891,15 @@ impl OvRuntimeEngine {
         };
         let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
 
+        // A generation request must carry at least one prompt token; an empty
+        // prompt would otherwise emit a fabricated token with no inference (and
+        // on the static path skip the position-0 ring reset).
+        if prefill && tokens.is_empty() {
+            return Err(EngineError::Backend(
+                "empty prompt: no tokens to prefill".into(),
+            ));
+        }
+
         let next_token = if self.static_kv.is_some() {
             // Static (NPU): one token per inference (static_seq == 1). Prefill
             // round-trips the whole pipeline once per prompt token so every
@@ -863,6 +907,16 @@ impl OvRuntimeEngine {
             // the final prompt token is the first generated token.
             if prefill {
                 self.position = 0;
+                if let Some(sk) = self.static_kv.as_ref() {
+                    if tokens.len() > sk.past_len {
+                        warn!(
+                            prompt_tokens = tokens.len(),
+                            past_len = sk.past_len,
+                            "prompt exceeds the static KV window (static_context-1); earliest \
+                             tokens will be evicted — attention degrades to a sliding window"
+                        );
+                    }
+                }
             }
             let mut nt = 0i32;
             for &t in &tokens {
@@ -871,15 +925,9 @@ impl OvRuntimeEngine {
                 let (out, shape) = self.run_first(&[t], position)?;
                 let alpha = ts.elapsed();
                 self.position += 1;
-                let ts = std::time::Instant::now();
-                nt = if single_stage {
-                    argmax_logits(&out, &shape)?
-                } else {
-                    let s3 = to_shape3(&shape);
-                    self.send_hidden_downstream(&out, s3, position)?;
-                    self.recv_token_from_downstream()?
-                };
-                let wire = ts.elapsed();
+                let (token, wire) =
+                    self.resolve_next_token(&out, &shape, single_stage, position)?;
+                nt = token;
                 if let Some(a) = self.active.as_mut() {
                     a.t_alpha_compute += alpha;
                     a.t_wire += wire;
@@ -892,27 +940,39 @@ impl OvRuntimeEngine {
             let position = self.position;
             let ts = std::time::Instant::now();
             let (out, shape) = self.run_first(&tokens, position)?;
-            let alpha_dur = ts.elapsed();
+            let alpha = ts.elapsed();
             self.position += tokens.len() as i64;
-            let mut wire_dur = std::time::Duration::ZERO;
-            let nt = if single_stage {
-                argmax_logits(&out, &shape)?
-            } else {
-                let s3 = to_shape3(&shape);
-                let ts = std::time::Instant::now();
-                self.send_hidden_downstream(&out, s3, position)?;
-                let token = self.recv_token_from_downstream()?;
-                wire_dur = ts.elapsed();
-                token
-            };
+            let (nt, wire) = self.resolve_next_token(&out, &shape, single_stage, position)?;
             if let Some(a) = self.active.as_mut() {
-                a.t_alpha_compute += alpha_dur;
-                a.t_wire += wire_dur;
+                a.t_alpha_compute += alpha;
+                a.t_wire += wire;
             }
             nt
         };
 
         self.emit_token(next_token)
+    }
+
+    /// From a first-stage output, produce the next token: argmax locally when
+    /// this is the only stage, otherwise forward the hidden state downstream
+    /// and await the token from the pipeline tail. Returns the token + the
+    /// wire round-trip time (zero for single-stage).
+    fn resolve_next_token(
+        &mut self,
+        out: &[f32],
+        shape: &[usize],
+        single_stage: bool,
+        position: i64,
+    ) -> EngineResult<(i32, std::time::Duration)> {
+        if single_stage {
+            Ok((argmax_logits(out, shape)?, std::time::Duration::ZERO))
+        } else {
+            let s3 = to_shape3(shape);
+            let ts = std::time::Instant::now();
+            self.send_hidden_downstream(out, s3, position)?;
+            let token = self.recv_token_from_downstream()?;
+            Ok((token, ts.elapsed()))
+        }
     }
 
     /// Decode the delta text for `next_token`, append it to the active task,
@@ -994,70 +1054,54 @@ impl OvRuntimeEngine {
     /// `position == 0`, so this is correct for any stage in a pipeline.
     fn static_infer(
         &mut self,
-        primary_in: &str,
+        use_hidden: bool,
         in_dtype: ShimDType,
         in_shape: &[usize],
         in_bytes: &[u8],
         position: i64,
     ) -> EngineResult<(ShimDType, Vec<usize>, Vec<u8>)> {
-        let in_main = self
-            .input_named(primary_in)
-            .ok_or_else(|| EngineError::Backend(format!("static IR missing {primary_in}")))?
-            .to_string();
-        let in_attn = self
-            .input_named("attention_mask")
-            .ok_or_else(|| EngineError::Backend("static IR missing attention_mask".into()))?
-            .to_string();
-        let in_pos = self
-            .input_named("position_ids")
-            .ok_or_else(|| EngineError::Backend("static IR missing position_ids".into()))?
-            .to_string();
-
-        // Align the ring to this absolute position (resets at position 0).
-        let (ctx, past_len, kvh, hd, kv_dtype, mask, expect) = {
+        // Align the ring to this absolute position (resets at position 0) and
+        // refresh the reusable mask buffer.
+        {
             let sk = self.static_kv.as_mut().unwrap();
             sk.begin_token(position as usize);
-            (
-                sk.context,
-                sk.past_len,
-                sk.kv_heads,
-                sk.head_dim,
-                sk.kv_dtype,
-                sk.attention_mask(),
-                sk.present_layer_bytes(),
-            )
-        };
+            sk.write_mask_bytes();
+        }
+        let pos_bytes = position.to_le_bytes();
 
-        self.runtime
-            .set_input(&in_main, in_dtype, in_shape, in_bytes)
-            .map_err(map_ov_err)?;
-        self.runtime
-            .set_input(&in_attn, ShimDType::I64, &[1, ctx], &i64_to_bytes(&mask))
-            .map_err(map_ov_err)?;
-        self.runtime
-            .set_input(&in_pos, ShimDType::I64, &[1, 1], &i64_to_bytes(&[position]))
-            .map_err(map_ov_err)?;
-        // Feed the per-layer past-KV from the ring. self.runtime (mut) and
-        // self.static_kv (shared) are disjoint fields, so we borrow the ring
-        // buffers directly — no per-step clone.
+        // Feed primary input + mask + position + the per-layer past-KV ring.
+        // self.runtime (mut) and self.static_kv (shared) are disjoint fields,
+        // so we borrow cached names + ring buffers directly — no per-token
+        // string or buffer allocation.
         {
             let sk = self.static_kv.as_ref().unwrap();
+            let in_main = if use_hidden {
+                sk.hidden_in.as_deref()
+            } else {
+                sk.ids_in.as_deref()
+            }
+            .ok_or_else(|| EngineError::Backend("static IR missing primary input".into()))?;
+            self.runtime
+                .set_input(in_main, in_dtype, in_shape, in_bytes)
+                .map_err(map_ov_err)?;
+            self.runtime
+                .set_input(
+                    &sk.attn_in,
+                    ShimDType::I64,
+                    &[1, sk.context],
+                    &sk.mask_bytes,
+                )
+                .map_err(map_ov_err)?;
+            self.runtime
+                .set_input(&sk.pos_in, ShimDType::I64, &[1, 1], &pos_bytes)
+                .map_err(map_ov_err)?;
+            let shape = [1, sk.kv_heads, sk.past_len, sk.head_dim];
             for (li, layer) in sk.layers.iter().enumerate() {
                 self.runtime
-                    .set_input(
-                        &layer.key_in,
-                        kv_dtype,
-                        &[1, kvh, past_len, hd],
-                        &sk.key_buf[li],
-                    )
+                    .set_input(&layer.key_in, sk.kv_dtype, &shape, &sk.key_buf[li])
                     .map_err(map_ov_err)?;
                 self.runtime
-                    .set_input(
-                        &layer.val_in,
-                        kv_dtype,
-                        &[1, kvh, past_len, hd],
-                        &sk.val_buf[li],
-                    )
+                    .set_input(&layer.val_in, sk.kv_dtype, &shape, &sk.val_buf[li])
                     .map_err(map_ov_err)?;
             }
         }
@@ -1067,26 +1111,36 @@ impl OvRuntimeEngine {
         // otherwise — the static export emits it before the present.* outputs.
         let (odt, oshape, obytes) = self.runtime.output(0).map_err(map_ov_err)?;
 
-        // Absorb the new token's K/V. Snapshot only the per-layer output
-        // indices (cheap) so we don't hold a static_kv borrow across the
-        // runtime.output() + absorb_layer() calls.
-        let outs: Vec<(usize, usize)> = self
-            .static_kv
-            .as_ref()
-            .unwrap()
-            .layers
-            .iter()
-            .map(|l| (l.key_out, l.val_out))
-            .collect();
-        for (li, (ko, vo)) in outs.into_iter().enumerate() {
-            let (_, _, kpres) = self.runtime.output(ko).map_err(map_ov_err)?;
-            let (_, _, vpres) = self.runtime.output(vo).map_err(map_ov_err)?;
-            if kpres.len() != expect || vpres.len() != expect {
-                let elem = self.static_kv.as_ref().unwrap().elem_bytes;
+        // Absorb the new token's K/V. Validate each present.* output's byte
+        // length AND shape against [1, kv_heads, context, head_dim] so a
+        // dtype/factorization mismatch is a clear error, not silent corruption.
+        let (n, expect, kvh, ctx, hd) = {
+            let sk = self.static_kv.as_ref().unwrap();
+            (
+                sk.layers.len(),
+                sk.present_layer_bytes(),
+                sk.kv_heads,
+                sk.context,
+                sk.head_dim,
+            )
+        };
+        let want_shape = [1usize, kvh, ctx, hd];
+        for li in 0..n {
+            let (ko, vo) = {
+                let l = &self.static_kv.as_ref().unwrap().layers[li];
+                (l.key_out, l.val_out)
+            };
+            let (_, kshape, kpres) = self.runtime.output(ko).map_err(map_ov_err)?;
+            let (_, vshape, vpres) = self.runtime.output(vo).map_err(map_ov_err)?;
+            if kpres.len() != expect
+                || vpres.len() != expect
+                || kshape != want_shape
+                || vshape != want_shape
+            {
                 return Err(EngineError::Backend(format!(
-                    "static present.{li} byte length key={} val={} != expected {expect} \
-                     (kv_heads*context*head_dim*{elem}); check num_kv_heads/head_dim/KV dtype \
-                     in stage_config",
+                    "static present.{li} mismatch: key shape={kshape:?} len={} val shape={vshape:?} \
+                     len={}; expected shape {want_shape:?} ({expect} bytes f16). Check \
+                     num_kv_heads/head_dim/KV dtype in stage_config.",
                     kpres.len(),
                     vpres.len(),
                 )));
@@ -1252,9 +1306,10 @@ pub struct OvRuntimeBuilder {
     downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
     listen_host: String,
     listen_port: Option<u16>,
-    /// (static_seq, context, kv_heads, head_dim) for a stateless static-shape
-    /// (NPU) shard; None for the stateful path.
-    static_params: Option<(u32, u32, u32, u32)>,
+    /// (context, kv_heads, head_dim) for a stateless static-shape (NPU) shard;
+    /// None for the stateful path. static_seq is validated == 1 at load and not
+    /// stored (the ring math assumes one token per step).
+    static_params: Option<(u32, u32, u32)>,
 }
 
 impl OvRuntimeBuilder {
@@ -1376,10 +1431,34 @@ impl Builder for OvRuntimeBuilder {
             events.push(LoadProgress::message(format!(
                 "stateless static-KV shard: context={ctx} kv_heads={kvh} head_dim={hd}"
             )));
-            Some((s, ctx, kvh, hd))
+            // static_seq is validated == 1 above and never stored (the ring math
+            // assumes one token per step); carry only (ctx, kv_heads, head_dim).
+            Some((ctx, kvh, hd))
         } else {
             None
         };
+
+        // A pipeline must be homogeneous: the static path carries a wire
+        // position frame the stateful path does not, so a mixed pipeline would
+        // desync. Fail fast when sibling stage configs are present locally
+        // (single-host multi-process); for distributed deploys each node has
+        // only its own stage dir, so the strict wire-frame validation in
+        // recv_hidden_from_upstream is the backstop at the first activation.
+        for r in 0..pipeline_cfg.num_stages {
+            if r == self.rank {
+                continue;
+            }
+            if let Ok(cfg) = read_stage_config(&self.pipeline_dir.join(format!("stage_{r}"))) {
+                if cfg.stateful != stage_cfg.stateful {
+                    return Err(EngineError::ShardRejected(format!(
+                        "pipeline is not homogeneous: stage_{} stateful={} but stage_{r} \
+                         stateful={} — all stages must share one KV mode (re-export the whole \
+                         pipeline with a single --target)",
+                        self.rank, stage_cfg.stateful, cfg.stateful
+                    )));
+                }
+            }
+        }
 
         let is_first = stage_cfg.has_embed;
         let is_last = stage_cfg.has_head;
@@ -1494,7 +1573,7 @@ impl Builder for OvRuntimeBuilder {
         // past_key_values.* inputs + present.* outputs and allocate the
         // host-side KV ring. The primary output (logits on the head stage,
         // hidden_states otherwise) is output index 0 — no alias guess needed.
-        let static_kv = if let Some((_s, ctx, kvh, hd)) = self.static_params {
+        let static_kv = if let Some((ctx, kvh, hd)) = self.static_params {
             let n_out = runtime.output_count();
             let mut layers: Vec<StaticKvLayer> = Vec::new();
             loop {
@@ -1565,20 +1644,56 @@ impl Builder for OvRuntimeBuilder {
             }
             let (kvh, hd) = (kvh as usize, hd as usize);
             let past_len = (ctx - 1) as usize;
-            let elem_bytes = 2usize; // KV activations are f16 in the static export
+            // KV activations are f16 in the static export; derive elem_bytes
+            // from the dtype so the two can never drift.
+            let kv_dtype = ShimDType::F16;
+            let elem_bytes = match kv_dtype {
+                ShimDType::F16 | ShimDType::Bf16 => 2,
+                ShimDType::F32 | ShimDType::I32 => 4,
+                ShimDType::I64 => 8,
+                ShimDType::I8 => 1,
+            };
             let layer_bytes = kvh * past_len * hd * elem_bytes;
             let n = layers.len();
+            // Cache the resolved primary/aux input port names so the per-token
+            // decode loop does no HashMap lookups or string allocs. A static
+            // shard always has attention_mask + position_ids; embed stages have
+            // input_ids, relay/head stages have hidden_states.
+            let attn_in = canonical_inputs
+                .get("attention_mask")
+                .cloned()
+                .ok_or_else(|| {
+                    EngineError::Backend("static IR missing attention_mask input".into())
+                })?;
+            let pos_in = canonical_inputs
+                .get("position_ids")
+                .cloned()
+                .ok_or_else(|| {
+                    EngineError::Backend("static IR missing position_ids input".into())
+                })?;
+            let ids_in = canonical_inputs.get("input_ids").cloned();
+            let hidden_in = canonical_inputs.get("hidden_states").cloned();
+            if ids_in.is_none() && hidden_in.is_none() {
+                return Err(EngineError::Backend(
+                    "static IR has neither input_ids nor hidden_states input".into(),
+                ));
+            }
             Some(StaticKv {
                 past_len,
                 context: ctx as usize,
                 kv_heads: kvh,
                 head_dim: hd,
                 elem_bytes,
-                kv_dtype: ShimDType::F16,
+                kv_dtype,
+                ids_in,
+                hidden_in,
+                attn_in,
+                pos_in,
                 layers,
                 key_buf: vec![vec![0u8; layer_bytes]; n],
                 val_buf: vec![vec![0u8; layer_bytes]; n],
                 valid: 0,
+                mask_bytes: vec![0u8; ctx as usize * 8],
             })
         } else {
             None

--- a/tools/export_shards.py
+++ b/tools/export_shards.py
@@ -782,6 +782,12 @@ def export_single_stage(
             name = "input_ids" if has_embed else "hidden_states"
             if len(shape) >= 2:
                 shape[1] = static_seq if npu else -1
+            # Relay/last stages take hidden_states [batch, seq, hidden]; the
+            # hidden dim is dynamic out of the tracer, so pin it for NPU too
+            # (the seq pin above is not enough — the NPU compiler rejects the
+            # dynamic last dim).
+            if npu and not has_embed and len(shape) >= 3:
+                shape[2] = config.hidden_size
         elif i == 1:
             name = "attention_mask"
             if len(shape) >= 2:
@@ -821,6 +827,41 @@ def export_single_stage(
             kv_type = "value" if is_value else "key"
             name = f"present.{layer_local}.{kv_type}"
         out.set_names({name})
+
+    # NPU: EVERY dim (inputs AND outputs) must be static or the compiler
+    # rejects the IR (#37). We pinned the inputs above, but the outputs only
+    # got names — re-infer so they pick up static shapes, then verify. A traced
+    # ShapeOf/Reshape can leave a symbolic output dim even when all inputs are
+    # static; catching it here fails the export instead of producing an IR that
+    # only blows up at NPU load (and which CPU/GPU would happily accept).
+    if npu:
+        ov_model.validate_nodes_and_infer_types()
+
+        def _dynamic(ports):
+            out = []
+            for idx, p in enumerate(ports):
+                ps = p.partial_shape
+                if not ps.is_static:
+                    try:
+                        nm = p.get_any_name()
+                    except Exception:
+                        nm = f"#{idx}"
+                    out.append(f"{nm}{ps}")
+            return out
+
+        bad_in = _dynamic(ov_model.inputs)
+        bad_out = _dynamic(ov_model.outputs)
+        if bad_in or bad_out:
+            raise RuntimeError(
+                f"NPU export (stage {stage_idx}): shapes still dynamic after static pinning "
+                f"— the NPU compiler will reject this IR (#37). Pin or fold these dims. "
+                f"dynamic inputs={bad_in} dynamic outputs={bad_out}"
+            )
+        print(
+            f"  NPU static-shape check OK: all {len(ov_model.inputs)} inputs + "
+            f"{len(ov_model.outputs)} outputs static",
+            flush=True,
+        )
 
     # 6+7. Make stateful with init-bearing ReadValues (+ beam_idx cache-reorder).
     # NPU mode skips this entirely: the NPU stack does not support state
@@ -1043,6 +1084,28 @@ def main():
         help="NPU only: fixed total context; past-KV length = context - seq.",
     )
     args = parser.parse_args()
+
+    # The NPU runtime decodes one token per step and derives past-KV length as
+    # static_context - 1, so reject configs it cannot load (fail fast — the
+    # export takes minutes). chunked prefill (static_seq > 1) is not yet wired
+    # into the runtime.
+    if args.target == "npu":
+        if args.static_seq != 1:
+            parser.error(
+                "--static-seq must be 1 for --target npu (the runtime decodes one token "
+                "per step; chunked prefill is not implemented yet)"
+            )
+        if args.static_context <= args.static_seq:
+            parser.error(
+                f"--static-context ({args.static_context}) must be > --static-seq "
+                f"({args.static_seq}) so past-KV length >= 1"
+            )
+    elif args.static_seq != 1 or args.static_context != 1024:
+        print(
+            "WARNING: --static-seq/--static-context are ignored without --target npu "
+            "(the cpu-gpu export is dynamic-shape)",
+            flush=True,
+        )
 
     if args.default_dtype == "fp16":
         torch.set_default_dtype(torch.float16)

--- a/tools/export_shards.py
+++ b/tools/export_shards.py
@@ -828,41 +828,6 @@ def export_single_stage(
             name = f"present.{layer_local}.{kv_type}"
         out.set_names({name})
 
-    # NPU: EVERY dim (inputs AND outputs) must be static or the compiler
-    # rejects the IR (#37). We pinned the inputs above, but the outputs only
-    # got names — re-infer so they pick up static shapes, then verify. A traced
-    # ShapeOf/Reshape can leave a symbolic output dim even when all inputs are
-    # static; catching it here fails the export instead of producing an IR that
-    # only blows up at NPU load (and which CPU/GPU would happily accept).
-    if npu:
-        ov_model.validate_nodes_and_infer_types()
-
-        def _dynamic(ports):
-            out = []
-            for idx, p in enumerate(ports):
-                ps = p.partial_shape
-                if not ps.is_static:
-                    try:
-                        nm = p.get_any_name()
-                    except Exception:
-                        nm = f"#{idx}"
-                    out.append(f"{nm}{ps}")
-            return out
-
-        bad_in = _dynamic(ov_model.inputs)
-        bad_out = _dynamic(ov_model.outputs)
-        if bad_in or bad_out:
-            raise RuntimeError(
-                f"NPU export (stage {stage_idx}): shapes still dynamic after static pinning "
-                f"— the NPU compiler will reject this IR (#37). Pin or fold these dims. "
-                f"dynamic inputs={bad_in} dynamic outputs={bad_out}"
-            )
-        print(
-            f"  NPU static-shape check OK: all {len(ov_model.inputs)} inputs + "
-            f"{len(ov_model.outputs)} outputs static",
-            flush=True,
-        )
-
     # 6+7. Make stateful with init-bearing ReadValues (+ beam_idx cache-reorder).
     # NPU mode skips this entirely: the NPU stack does not support state
     # variables, so the model stays STATELESS (explicit past_kv in / present_kv
@@ -918,6 +883,43 @@ def export_single_stage(
                 f"  WARNING: INT8 compression failed ({e}); falling back to FP16",
                 flush=True,
             )
+
+    # NPU: EVERY dim (inputs AND outputs) must be static or the compiler
+    # rejects the IR (#37). Run this on the FINAL graph — after make_stateful is
+    # skipped AND after nncf weight compression — so a dynamic dim introduced by
+    # a decompression subgraph is also caught, not just the post-trace shape. We
+    # pinned the inputs earlier (incl. the relay hidden dim); re-infer so the
+    # outputs pick up static shapes, then verify. Catching it here fails the
+    # export instead of producing an IR that only blows up at NPU load (and that
+    # CPU/GPU would happily accept).
+    if npu:
+        ov_model.validate_nodes_and_infer_types()
+
+        def _dynamic(ports):
+            out = []
+            for idx, p in enumerate(ports):
+                ps = p.partial_shape
+                if not ps.is_static:
+                    try:
+                        nm = p.get_any_name()
+                    except Exception:
+                        nm = f"#{idx}"
+                    out.append(f"{nm}{ps}")
+            return out
+
+        bad_in = _dynamic(ov_model.inputs)
+        bad_out = _dynamic(ov_model.outputs)
+        if bad_in or bad_out:
+            raise RuntimeError(
+                f"NPU export (stage {stage_idx}): shapes still dynamic after static pinning "
+                f"+ compression — the NPU compiler will reject this IR (#37). Pin or fold these "
+                f"dims. dynamic inputs={bad_in} dynamic outputs={bad_out}"
+            )
+        print(
+            f"  NPU static-shape check OK: all {len(ov_model.inputs)} inputs + "
+            f"{len(ov_model.outputs)} outputs static",
+            flush=True,
+        )
 
     # 9. Save.
     stage_dir = os.path.join(output_dir, f"stage_{stage_idx}")
@@ -1099,6 +1101,12 @@ def main():
             parser.error(
                 f"--static-context ({args.static_context}) must be > --static-seq "
                 f"({args.static_seq}) so past-KV length >= 1"
+            )
+        if args.default_dtype != "fp16":
+            parser.error(
+                f"--default-dtype must be fp16 for --target npu (the runtime feeds KV as "
+                f"f16; --default-dtype {args.default_dtype} would emit f32 KV ports and fail "
+                f"the present-shape check at first inference)"
             )
     elif args.static_seq != 1 or args.static_context != 1024:
         print(

--- a/tools/export_shards.py
+++ b/tools/export_shards.py
@@ -694,6 +694,7 @@ def make_stateful_with_init(ov_model, add_reorder=True):
 def export_single_stage(
     model_dir, output_dir, stage_plan, config, quantization, rope_theta, arch_tag,
     cache_reorder=True,
+    target="cpu-gpu", static_seq=1, static_context=1024,
 ):
     import openvino as ov
 
@@ -771,21 +772,24 @@ def export_single_stage(
     del traced
     gc.collect()
 
-    # 5. Name inputs/outputs and set dynamic shapes.
+    # 5. Name inputs/outputs and set shapes. NPU requires fully STATIC shapes
+    # (it cannot compile dynamic dims — #37); cpu-gpu keeps dynamic seq/KV.
+    npu = target == "npu"
+    past_len = max(static_context - static_seq, 1)
     for i, inp in enumerate(ov_model.inputs):
         shape = inp.partial_shape
         if i == 0:
             name = "input_ids" if has_embed else "hidden_states"
             if len(shape) >= 2:
-                shape[1] = -1
+                shape[1] = static_seq if npu else -1
         elif i == 1:
             name = "attention_mask"
             if len(shape) >= 2:
-                shape[1] = -1
+                shape[1] = static_context if npu else -1
         elif i == 2:
             name = "position_ids"
             if len(shape) >= 2:
-                shape[1] = -1
+                shape[1] = static_seq if npu else -1
         else:
             kv_idx = i - 3
             layer_local = kv_idx // 2
@@ -793,12 +797,17 @@ def export_single_stage(
             kv_type = "value" if is_value else "key"
             name = f"past_key_values.{layer_local}.{kv_type}"
             if len(shape) >= 3:
-                # Static batch=1 so the (init-less) stateful KV variable
+                # Static batch=1 so the cpu-gpu stateful KV variable
                 # initialises to batch 1, not 0 — otherwise the first-step KV
                 # Concat fails on the CPU plugin ({0,h,0,d} vs {1,h,S,d}).
-                # cascadia always runs a single sequence (batch 1).
+                # cascadia always runs a single sequence (batch 1). For NPU the
+                # past length is also pinned static (context - seq).
                 shape[0] = 1
-                shape[2] = -1
+                shape[2] = past_len if npu else -1
+        if npu and len(shape) >= 1:
+            # NPU: batch must be static (=1) on EVERY input, not just KV —
+            # a dynamic batch leaves unbounded upper bounds the compiler rejects.
+            shape[0] = 1
         inp.node.set_partial_shape(shape)
         inp.set_names({name})
 
@@ -814,17 +823,26 @@ def export_single_stage(
         out.set_names({name})
 
     # 6+7. Make stateful with init-bearing ReadValues (+ beam_idx cache-reorder).
-    # Building the stateful nodes directly — instead of
-    # apply_make_stateful_transformation, which emits init-less ReadValues the
-    # OpenVINO CPU plugin rejects (#57) — gives each ReadValue a real init, so
-    # the SAME IR loads on CPU AND keeps the IndirectKVCache (cache_reorder)
-    # that the GPU needs for speed.
-    ov_model = make_stateful_with_init(ov_model, add_reorder=cache_reorder)
-    print(
-        f"  stateful: init-bearing ReadValue/Assign ({num_layers} KV pairs)"
-        + (" + cache_reorder (beam_idx Gather)" if cache_reorder else ""),
-        flush=True,
-    )
+    # NPU mode skips this entirely: the NPU stack does not support state
+    # variables, so the model stays STATELESS (explicit past_kv in / present_kv
+    # out) with static shapes — #37. The cpu-gpu path builds the stateful nodes
+    # directly (init-bearing ReadValues) instead of
+    # apply_make_stateful_transformation, whose init-less ReadValues the
+    # OpenVINO CPU plugin rejects (#57) — the same IR then loads on CPU AND
+    # keeps the IndirectKVCache (cache_reorder) the GPU needs for speed.
+    if not npu:
+        ov_model = make_stateful_with_init(ov_model, add_reorder=cache_reorder)
+        print(
+            f"  stateful: init-bearing ReadValue/Assign ({num_layers} KV pairs)"
+            + (" + cache_reorder (beam_idx Gather)" if cache_reorder else ""),
+            flush=True,
+        )
+    else:
+        print(
+            "  NPU mode: stateless (explicit KV in/out) + static shapes — "
+            "skipping make_stateful + cache_reorder (#37)",
+            flush=True,
+        )
 
     # 8. Compress weights.
     if quantization in ("int4", "int4_asym"):
@@ -882,11 +900,17 @@ def export_single_stage(
         "num_layers_total": config.num_hidden_layers,
         "num_kv_heads": num_kv_heads,
         "head_dim": head_dim,
-        "stateful": True,
+        "stateful": not npu,
         "rope_theta": rope_theta,
         "arch_tag": arch_tag,
+        "target": target,
+        "static_seq": static_seq if npu else None,
+        "static_context": static_context if npu else None,
         "inputs": (
-            "input_ids/hidden_states, attention_mask, position_ids"
+            "input_ids/hidden_states, attention_mask, position_ids, "
+            "past_key_values.* (explicit KV in/out)"
+            if npu
+            else "input_ids/hidden_states, attention_mask, position_ids"
             + (", beam_idx" if cache_reorder else "")
             + " (KV cache is internal state)"
         ),
@@ -999,6 +1023,25 @@ def main():
     parser.add_argument(
         "--stage", type=int, default=None, help="Export only this stage index (debug)"
     )
+    parser.add_argument(
+        "--target",
+        choices=["cpu-gpu", "npu"],
+        default="cpu-gpu",
+        help="Deployment target. 'npu' emits a STATELESS, STATIC-shape IR "
+        "(no make_stateful, fixed seq/KV) that the NPU compiler accepts (#37).",
+    )
+    parser.add_argument(
+        "--static-seq",
+        type=int,
+        default=1,
+        help="NPU only: fixed query-window length (default 1 = decode step).",
+    )
+    parser.add_argument(
+        "--static-context",
+        type=int,
+        default=1024,
+        help="NPU only: fixed total context; past-KV length = context - seq.",
+    )
     args = parser.parse_args()
 
     if args.default_dtype == "fp16":
@@ -1078,6 +1121,9 @@ def main():
             args.quantization,
             rope_theta,
             arch_tag,
+            target=args.target,
+            static_seq=args.static_seq,
+            static_context=args.static_context,
         )
         total_mb += size
         gc.collect()


### PR DESCRIPTION
Fixes #37.

Runs `cascadia shard` models on the Intel NPU — **single-stage and pipeline-parallel multi-stage** — end to end, export through runtime, validated on real Lunar Lake NPU hardware. This revision also folds in the fixes from the PR review (incl. one that turned out to be load-bearing for multi-stage).

## Problem

The NPU plugin rejects cascadia's shards for two independent reasons:
1. **Dynamic shapes** — the NPU compiler rejects dynamic dims (`to_shape was called on a dynamic shape`).
2. **State variables** — the NPU stack doesn't support stateful models; KV must be explicit in/out.

cascadia's default export is *both* dynamic and stateful → doubly NPU-incompatible.

## Fix

### Export — `cascadia shard --target npu`
- **Stateless** (explicit `past_key_values.*` in / `present.*` out; no `make_stateful`/cache-reorder) + **fully static shapes** (`--static-seq` 1, `--static-context`; batch=1; per-stage hidden dim pinned).
- `stage_config.json` records `stateful:false` + the static dims so the runtime auto-selects the path.
- **Asserts every input AND output shape is static after `convert_model`** and fails the export otherwise — a surviving dynamic dim *is* the #37 NPU-compile failure, and CPU/GPU would silently accept it. (This assertion immediately caught a real bug: relay/last stages left the `hidden_states` hidden dim dynamic — now pinned.)

### Runtime — host-side static-KV decode, per stage
`ov-runtime` drives the KV cache itself when `stage_config.stateful == false`: a bounded ring (left-aligned, `valid = min(position, past_len)`) feeds `past_key_values.*` each step, prefills the prompt token-by-token, and absorbs each new token's K/V from `present`.

**Multi-stage (pipeline-parallel NPU):** the ring is a per-stage concern in `run_first`/`run_relay`, so it runs on every stage. Because static shards are seq=1, the usual seq>1 prefill signal is unavailable — so the first stage carries the absolute `position` as its own framed tensor alongside each activation; downstream stages reset their ring at position 0 and stay in lockstep. Single-stage is just the 1-stage case of the same path.

## Validation — real hardware, full 12-prompt suite, via the `cascadia worker` binary

| Config | Device | Verdict | Corrupt? | Latency |
|---|---|---|---|---|
| Single-stage | CPU plugin | **12/12** | no | ~6–9 s/prompt |
| Single-stage | **Lunar Lake NPU** | **12/12** | no | ~1.9–2.6 s/prompt |
| **2-stage pipeline** | CPU + CPU | **12/12** | no | ~6–9 s/prompt |
| **2-stage pipeline** | **NPU + NPU** | **12/12** | no | ~2–4 s/prompt (5.9–8.6 tok/s) |

`qwen2.5-1.5B`, `--static-context 256`, greedy. Two stages = embed+layers[0,14) → layers[14,28)+head, connected over the TCP activation transport. Every answer correct on all four configs — facts, math, instruction-following (`echo → Banana`), multi-sentence coherence.

## Review fixes addressed
- **#1 multi-stage** — implemented properly (not just guarded): relay stages now bind `past_key_values.*` and run the ring; the first stage forwards hidden instead of arg-maxing locally.
- **#2 static outputs** — export asserts output shapes static (caught the hidden-dim bug).
- **#3 static-seq>1** — exporter fails fast (runtime supports seq=1).
- **#5 warmup** — routes through the static path (was always failing for static shards).
- **#6 present dtype/len** — validated against `kv_heads·context·head_dim·elem` before absorb.
- **#7 static_context** — must exceed static_seq (no `past_len=0`).
- **#8 logits guards** — rank-0 / short-logits return a clear error, no panic.
- **#9 layer count** — cross-checked against the IR's `past_key_values.*` port count.
- **#10/#11/#12 cleanup** — no per-token KV clone (disjoint borrow); shared `emit_token` + `bytes_to_f32`/`argmax_logits` helpers; dropped the `logits_out` guess (primary is output 0).

## Changes
- `tools/export_shards.py`: `--target npu`/`--static-seq`/`--static-context`; static-shape pinning (incl. relay hidden dim) + post-`convert_model` static assertion; stage_config dims; fail-fast guards.
- `crates/cascadia-engine-openvino/src/runtime.rs`: per-stage `StaticKv` ring; `static_infer` (no clone, present validation); `run_first`/`run_relay` static branches; wire position carry + relay reset; `emit_token`/`bytes_to_f32`/`argmax_logits` helpers; static-config validation + layer cross-check.

## Environment
cascadia `main` @ `fe392c9`; OpenVINO 2026.1.0; NPU validated on Lunar Lake (Arc 140V + AI Boost) via the release `cascadia.exe`.
