### PR TITLE
fix(placement): warn on memory-exhausting placements (#67 was not corruption)

### DIFF
--- a/crates/cascadia-cli/src/placement.rs
+++ b/crates/cascadia-cli/src/placement.rs
@@ -299,6 +299,32 @@ pub struct PlaceArgs {
     /// Where to write the solved `placement.json`.
     #[arg(long, default_value = "placement.json")]
     pub output: PathBuf,
+
+    /// Estimated resident overhead **per worker process** in GiB — the OV
+    /// runtime + device context + KV/activations each stage's worker holds
+    /// beyond its weights. Used only to warn when a placement's total
+    /// footprint (Σ weights + n_stages × this) would exhaust the shared pool
+    /// and swap. Measured ~1 GiB/worker for a 12-stage fp16 run on Lunar Lake.
+    #[arg(long, default_value_t = 1.0)]
+    pub worker_overhead_gb: f64,
+}
+
+/// Total resident footprint of a placement and whether it risks swapping.
+/// The solver's memory gate counts **weights only**; in practice each stage is
+/// a worker process whose OV runtime + device context + KV/activations add
+/// real resident memory, so a placement that "fits" the weight pool can still
+/// drive the box to ~0 free RAM and thrash. Returns the footprint and pool in
+/// bytes plus whether footprint exceeds the pool. Pure — unit-tested.
+fn swap_risk(
+    stage_mem: &[u64],
+    worker_overhead_bytes: u64,
+    pool_bytes: Option<u64>,
+) -> Option<(u64, u64)> {
+    let pool = pool_bytes?;
+    let weights: u64 = stage_mem.iter().sum();
+    let footprint =
+        weights.saturating_add((stage_mem.len() as u64).saturating_mul(worker_overhead_bytes));
+    (footprint > pool).then_some((footprint, pool))
 }
 
 pub fn cmd_place(args: PlaceArgs) -> Result<()> {
@@ -315,6 +341,29 @@ pub fn cmd_place(args: PlaceArgs) -> Result<()> {
         .with_context(|| format!("writing {}", args.output.display()))?;
 
     println!("{}", placement.summary());
+
+    // Warn if the real footprint (weights + per-worker runtime overhead) would
+    // exhaust the shared UMA pool. The solver's gate counts weights only, but
+    // each stage is a worker process whose OV runtime + device context +
+    // KV/activations add ~1 GiB; a placement that "fits" the weights can still
+    // drive the box to ~0 free RAM and swap (slow + highly variable tok/s).
+    let overhead = (args.worker_overhead_gb * (1024.0 * 1024.0 * 1024.0)) as u64;
+    let stage_mem: Vec<u64> = profile.stages.iter().map(|s| s.mem_bytes).collect();
+    if let Some((footprint, pool)) = swap_risk(&stage_mem, overhead, profile.pool_bytes) {
+        let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+        eprintln!(
+            "WARNING: placement footprint ~{:.1} GiB (weights {:.1} + {} workers x {:.1} GiB \
+             overhead) exceeds the usable pool ~{:.1} GiB. Expect heavy swapping and slow, \
+             unstable tok/s. Reduce --num-stages (fewer, larger stages = less per-worker \
+             overhead), use a smaller model, or raise --pool-gb only if you have the RAM.",
+            gib(footprint),
+            gib(stage_mem.iter().sum::<u64>()),
+            stage_mem.len(),
+            args.worker_overhead_gb,
+            gib(pool),
+        );
+    }
+
     println!("wrote {}", args.output.display());
     Ok(())
 }
@@ -546,5 +595,27 @@ mod tests {
         assert_eq!(p.assignment.len(), 20);
         assert_eq!(p.per_device_mem.get("GPU"), Some(&(16 * GB)));
         assert_eq!(p.per_device_mem.get("NPU"), Some(&(4 * GB)));
+    }
+
+    #[test]
+    fn swap_risk_flags_footprint_over_pool_including_worker_overhead() {
+        // 12 stages x 1.67 GiB weights = ~20 GiB (fits the 28 GiB pool on
+        // weights alone), but + 12 workers x 1 GiB overhead = ~32 GiB > 28 GiB
+        // -> swap risk. This is the SOLAR-on-Lunar-Lake case from #67.
+        let weights: Vec<u64> = (0..12).map(|_| (1.67 * GB as f64) as u64).collect();
+        let pool = Some(28 * GB);
+        let risk = swap_risk(&weights, GB, pool);
+        assert!(risk.is_some(), "weights+overhead should exceed the pool");
+        let (footprint, p) = risk.unwrap();
+        assert_eq!(p, 28 * GB);
+        assert!(footprint > 28 * GB && footprint < 33 * GB);
+
+        // Same weights with NO worker overhead fit (weights ~20 < 28).
+        assert!(swap_risk(&weights, 0, pool).is_none());
+        // No pool gate -> never a swap warning.
+        assert!(swap_risk(&weights, GB, None).is_none());
+        // A comfortable model: 4 small stages + overhead well under pool.
+        let small: Vec<u64> = (0..4).map(|_| 2 * GB).collect();
+        assert!(swap_risk(&small, GB, pool).is_none()); // 8 + 4 = 12 < 28
     }
 }

--- a/docs/perf/THREE_TIER_PLACEMENT.md
+++ b/docs/perf/THREE_TIER_PLACEMENT.md
@@ -201,10 +201,21 @@ the NPU, which is the slowest tier for token-by-token decode.
   times each stage *in isolation*) can't see. The ILP found a good placement
   here, but to *target* regime 2 deliberately it needs an end-to-end
   all-GPU-vs-placed probe (or a pressure-penalty term as GPU occupancy → 100%).
-- **NPU is non-competitive for decode** (~1.5× the CPU, ~3× the iGPU per
-  token) and a multi-stage fp16 NPU overflow produced corrupt output in one
-  config — the ILP correctly avoids it. Profiling the NPU is also slow
-  (~100 min/30B); `--devices GPU,CPU` is the practical default.
+- **NPU is non-competitive for decode** (~1.5× the CPU, ~2× the iGPU per
+  token) — the ILP correctly avoids it. Profiling the NPU is also slow
+  (~100 min/30B); `--devices GPU,CPU` is the practical default. (A multi-NPU
+  config once *appeared* to corrupt — #67 — but that was an eval timeout on a
+  RAM-exhausted box, not corruption; output is correct, just slow. NPU
+  multi-stage is verified correct on every topology tested.)
+- **Per-worker overhead / swap (the #67 finding).** The solver's memory gate
+  counts **weights only**, but each stage is a worker process whose OV runtime
+  + device context + KV/activations add ~1 GiB resident. A placement that
+  "fits" the weight pool can still drive the box to ~0 free RAM and swap
+  (slow + highly variable tok/s — a 20 GiB model across 12 workers exhausted a
+  31.6 GiB box). `cascadia place` now **warns** when `Σ weights + n_stages ×
+  --worker-overhead-gb` exceeds the usable pool, advising fewer stages / a
+  smaller model. A fuller fix would fold per-stage runtime footprint into the
+  profiled `mem_bytes` so the solver's gate is exact.
 - **No cross-request pipelining.** Stages run sequentially per token, so the
   throughput-overlap regime (concurrent requests across tiers, potentially
   ~Nx) is untapped — a separate, larger runtime change.


### PR DESCRIPTION
## #67 was not corruption — it's RAM exhaustion; warn about it

Investigating #67 from first principles (reproduce before fixing) overturned the premise.

### Diagnosis

**No corruption.** A small Qwen2.5-1.5B 3-stage shard runs correctly on **every**
NPU topology — including the exact one #67 blamed:

| config | verdict |
|---|---|
| fp16 `NPU,GPU,GPU` / `NPU,NPU,NPU` / `GPU,NPU,GPU` / `GPU,GPU,NPU` | all 12/12 |
| int4 `GPU,NPU,GPU` / `NPU,NPU,NPU` | 11/12 (tiny-model miss, `corrupt=False`) |

**The "0/12 corrupt" was an eval timeout.** The SOLAR-naive results were all
`out=""` at exactly `secs=60.07` — every request hit the eval's timeout, and its
degeneracy detector scored empty-string as `corrupt=True`. Re-running with a long
client timeout produced coherent text (*"Paris, the captivating capital of
France…"*).

**The slowness is RAM exhaustion, not an NPU-count effect.** A controlled
same-model sweep (Yi-9B, varying only NPU-stage count) showed NPU stages cost
~2× at most (0/1/2/3 NPU → 1.84/1.55/0.86/1.07 tok/s — noisy, *not* 100×). The
SOLAR outlier (0.14 tok/s, a one-off; re-run = 0.68) is because a **20 GiB model
across 12 worker processes drives the 31.6 GiB box to ~0 free RAM** (measured min
avail **0.02 GiB**) → swapping. This hits the ILP's *own* placement too (the
GPU+CPU choice ran at 0.11 GiB free).

### The fix

The solver's memory gate counts **weights only**, so it silently emits footprints
that swap. `cascadia place` now warns when

```
Σ weights + n_stages × --worker-overhead-gb   >   usable pool
```

e.g. *"placement footprint ~32.0 GiB (weights 20.0 + 12 workers × 1.0 GiB
overhead) exceeds the usable pool ~28.0 GiB. Expect heavy swapping and slow,
unstable tok/s. Reduce --num-stages …"* — the honest signal that explains the
slow, variable run #67 hit. (`--worker-overhead-gb` default 1.0, the measured
per-worker resident overhead.)

### Tests / no regressions

Pure `swap_risk` helper + unit test (18 placement tests pass); `cargo fmt`,
`clippy --workspace`, and `cargo test --workspace` clean (45 groups, 0 failed).
The change is **feature-independent** (`cmd_place` logic, no `openvino`-gated
code), so the stub build fully covers it. Also corrects the design-doc line that
had repeated the (now-disproven) "corrupt output" claim.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
