### PR TITLE
feat(engine): Gemma 4 runtime (--engine gemma4) — single + multi-stage pipeline-parallel

### DIFF
--- a/crates/cascadia-api/Cargo.toml
+++ b/crates/cascadia-api/Cargo.toml
@@ -23,7 +23,11 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
 bytes = { workspace = true }
-minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
+# `macros` is required by modern instruct chat templates (Gemma 3/4 define
+# `{% macro %}` helpers for tool/role formatting); without it the template
+# fails to parse and rendering silently falls back to the legacy formatter,
+# which degenerates instruct models. `multi_template` covers `{% include %}`.
+minijinja = { version = "2", default-features = false, features = ["builtins", "serde", "macros", "multi_template"] }
 minijinja-contrib = { version = "2", default-features = false, features = ["pycompat"] }
 
 [dev-dependencies]

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -693,6 +693,7 @@ mod tests {
         // chat_template.jinja file with no inline `chat_template` field in
         // tokenizer_config.json. The loader must pick up the .jinja file.
         let dir = std::env::temp_dir().join(format!("cascadia_g4_tmpl_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir); // robust to leftover dirt (PID reuse)
         let tok = dir.join("tokenizer");
         std::fs::create_dir_all(&tok).unwrap();
         std::fs::write(
@@ -745,6 +746,7 @@ mod tests {
         // worse than the legacy formatter. The loader must return None so the
         // request falls back. Guards #115.
         let dir = std::env::temp_dir().join(format!("cascadia_g4_empty_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir); // robust to leftover dirt (PID reuse)
         let tok = dir.join("tokenizer");
         std::fs::create_dir_all(&tok).unwrap();
         std::fs::write(

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -92,8 +92,16 @@ impl Default for Config {
 /// "role: content" formatting in that case. Some HF tokenizer configs
 /// store special tokens as objects ({"content": "...", ...}) rather than
 /// strings; both shapes are handled.
+///
+/// Newer HF exports (Gemma 3/4, recent Llama) drop the inline
+/// `chat_template` JSON field and ship the template as a sibling
+/// `chat_template.jinja` file instead — too large/complex to embed in
+/// JSON. When the inline field is absent we fall back to that file, so
+/// instruct models render through their real template rather than the
+/// legacy formatter (which degenerates instruct models).
 pub fn load_chat_template_config(model_dir: &std::path::Path) -> ChatTemplateConfig {
-    let p = model_dir.join("tokenizer").join("tokenizer_config.json");
+    let tok_dir = model_dir.join("tokenizer");
+    let p = tok_dir.join("tokenizer_config.json");
     let Ok(bytes) = std::fs::read(&p) else {
         return ChatTemplateConfig::default();
     };
@@ -103,7 +111,8 @@ pub fn load_chat_template_config(model_dir: &std::path::Path) -> ChatTemplateCon
     let template = v
         .get("chat_template")
         .and_then(|t| t.as_str())
-        .map(|s| s.to_owned());
+        .map(|s| s.to_owned())
+        .or_else(|| std::fs::read_to_string(tok_dir.join("chat_template.jinja")).ok());
     let extract_token = |key: &str| -> Option<String> {
         let val = v.get(key)?;
         if let Some(s) = val.as_str() {
@@ -643,5 +652,55 @@ mod tests {
         // Mock yields words from the prompt; check non-empty content.
         let content = v["choices"][0]["message"]["content"].as_str().unwrap();
         assert!(!content.is_empty(), "completion content was empty");
+    }
+
+    #[test]
+    fn load_chat_template_falls_back_to_jinja_sibling() {
+        // Gemma 3/4 (and recent Llama) ship the template as a sibling
+        // chat_template.jinja file with no inline `chat_template` field in
+        // tokenizer_config.json. The loader must pick up the .jinja file.
+        let dir = std::env::temp_dir().join(format!("cascadia_g4_tmpl_{}", std::process::id()));
+        let tok = dir.join("tokenizer");
+        std::fs::create_dir_all(&tok).unwrap();
+        std::fs::write(
+            tok.join("tokenizer_config.json"),
+            r#"{"bos_token": "<bos>", "eos_token": {"content": "<eos>"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            tok.join("chat_template.jinja"),
+            "{%- macro greet() -%}hello{%- endmacro -%}{{ greet() }}",
+        )
+        .unwrap();
+        let cfg = load_chat_template_config(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(
+            cfg.template.as_deref().unwrap_or("").contains("macro"),
+            "expected template loaded from chat_template.jinja"
+        );
+        assert_eq!(cfg.bos_token.as_deref(), Some("<bos>"));
+        assert_eq!(cfg.eos_token.as_deref(), Some("<eos>"));
+    }
+
+    #[test]
+    fn render_prompt_with_template_supports_macros() {
+        // Guards the minijinja `macros` feature: Gemma-style instruct templates
+        // define `{% macro %}` helpers for role formatting. Without the feature
+        // the template fails to parse and chat silently degrades to the legacy
+        // formatter (which produces incoherent output on instruct models).
+        let tmpl = "{%- macro turn(role, text) -%}<start_of_turn>{{ role }}\n\
+                    {{ text }}<end_of_turn>\n{% endmacro -%}\
+                    {{ bos_token }}{% for m in messages %}{{ turn(m.role, m.content) }}{% endfor %}\
+                    {% if add_generation_prompt %}<start_of_turn>model\n{% endif %}";
+        let msgs = [ChatMessage {
+            role: "user".into(),
+            content: "hi".into(),
+        }];
+        let out = render_prompt_with_template(tmpl, &msgs, "<bos>", "<eos>")
+            .expect("macro-based template must render");
+        assert!(out.contains("<bos>"), "out={out}");
+        assert!(out.contains("<start_of_turn>user"), "out={out}");
+        assert!(out.contains("hi"), "out={out}");
+        assert!(out.contains("<start_of_turn>model"), "out={out}");
     }
 }

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -51,11 +51,12 @@ pub struct AppState {
     pub model_id: String,
     pub permits: Arc<Semaphore>,
     pub max_prompt_bytes: usize,
-    /// Optional Jinja2 chat template (from tokenizer_config.json's
-    /// `chat_template` field). When set, /v1/chat/completions renders
-    /// messages through it; when None, falls back to the legacy
-    /// "role: content\n…" join.
-    pub chat_template: Option<Arc<str>>,
+    /// Pre-built minijinja environment for the model's HF chat template (from
+    /// tokenizer_config.json's `chat_template` field or a sibling
+    /// `chat_template.jinja`), parsed ONCE at router construction. When set,
+    /// /v1/chat/completions renders messages through it; when None (no template
+    /// or a parse error), falls back to the legacy "role: content\n…" join.
+    pub chat_env: Option<Arc<minijinja::Environment<'static>>>,
     pub bos_token: Arc<str>,
     pub eos_token: Arc<str>,
 }
@@ -112,7 +113,12 @@ pub fn load_chat_template_config(model_dir: &std::path::Path) -> ChatTemplateCon
         .get("chat_template")
         .and_then(|t| t.as_str())
         .map(|s| s.to_owned())
-        .or_else(|| std::fs::read_to_string(tok_dir.join("chat_template.jinja")).ok());
+        .or_else(|| std::fs::read_to_string(tok_dir.join("chat_template.jinja")).ok())
+        // An empty / whitespace-only template (a zero-byte placeholder, or a
+        // download truncated to empty) must NOT be treated as usable: rendering
+        // through it produces an empty prompt, which is worse than the legacy
+        // "role: content" formatter. Drop to None so the caller falls back.
+        .filter(|s| !s.trim().is_empty());
     let extract_token = |key: &str| -> Option<String> {
         let val = v.get(key)?;
         if let Some(s) = val.as_str() {
@@ -145,7 +151,19 @@ pub fn make_router_with_config(
         model_id: model_id.into(),
         permits: Arc::new(Semaphore::new(cfg.max_concurrent_requests)),
         max_prompt_bytes: cfg.max_prompt_bytes,
-        chat_template: cfg.chat_template.template.map(Arc::from),
+        // Parse the chat template once here (not per request). A parse error
+        // downgrades to the legacy formatter rather than failing every request.
+        chat_env: cfg
+            .chat_template
+            .template
+            .as_deref()
+            .and_then(|src| match build_chat_env(src) {
+                Ok(env) => Some(Arc::new(env)),
+                Err(e) => {
+                    warn!(error = %e, "chat_template failed to parse at startup; using legacy formatter");
+                    None
+                }
+            }),
         bos_token: Arc::from(cfg.chat_template.bos_token.unwrap_or_default()),
         eos_token: Arc::from(cfg.chat_template.eos_token.unwrap_or_default()),
     };
@@ -270,17 +288,15 @@ fn render_prompt_legacy(messages: &[ChatMessage]) -> String {
     buf
 }
 
-/// Render messages through the model's HF Jinja2 chat_template. Returns
-/// Err on any template parse/render error so the caller can fall back to
-/// [`render_prompt_legacy`] rather than fail the request entirely.
-fn render_prompt_with_template(
-    template_src: &str,
-    messages: &[ChatMessage],
-    bos_token: &str,
-    eos_token: &str,
-) -> Result<String, String> {
+/// Build the minijinja environment for a model's HF chat template ONCE, with
+/// the template pre-parsed and the HF-compat shims installed. The template is
+/// fixed at model load, so this is built at router construction and reused
+/// across every request — the ~17 KB Gemma 3/4 macro template is parsed once,
+/// not on each `/v1/chat/completions` call. Returns Err on parse failure so the
+/// caller can fall back to the legacy formatter.
+fn build_chat_env(template_src: &str) -> Result<minijinja::Environment<'static>, String> {
     use minijinja::value::Value;
-    use minijinja::{context, Environment, Error, ErrorKind};
+    use minijinja::{Environment, Error, ErrorKind};
 
     let mut env = Environment::new();
     // HF chat templates were authored against transformers' Jinja2 env,
@@ -302,8 +318,25 @@ fn render_prompt_with_template(
     // inference correctness — a fixed empty string is a safe stand-in.
     env.add_function("strftime_now", |_fmt: String| -> String { String::new() });
 
-    env.add_template("chat", template_src)
+    // add_template_owned (not add_template) so the Environment owns the source
+    // and is 'static — it can then live in AppState behind an Arc.
+    env.add_template_owned("chat", template_src.to_owned())
         .map_err(|e| format!("template parse: {e}"))?;
+    Ok(env)
+}
+
+/// Render messages through a pre-built chat environment (see [`build_chat_env`]).
+/// Returns Err on any render error so the caller can fall back to
+/// [`render_prompt_legacy`] rather than fail the request entirely.
+fn render_with_chat_env(
+    env: &minijinja::Environment<'static>,
+    messages: &[ChatMessage],
+    bos_token: &str,
+    eos_token: &str,
+) -> Result<String, String> {
+    use minijinja::context;
+    use minijinja::value::Value;
+
     let tmpl = env
         .get_template("chat")
         .map_err(|e| format!("template lookup: {e}"))?;
@@ -311,7 +344,7 @@ fn render_prompt_with_template(
     let messages_value: Vec<Value> = messages
         .iter()
         .map(|m| {
-            Value::from_serialize(&serde_json::json!({
+            Value::from_serialize(serde_json::json!({
                 "role": m.role,
                 "content": m.content,
             }))
@@ -330,8 +363,8 @@ fn render_prompt_with_template(
 }
 
 fn render_prompt(state: &AppState, messages: &[ChatMessage]) -> String {
-    if let Some(tmpl) = &state.chat_template {
-        match render_prompt_with_template(tmpl, messages, &state.bos_token, &state.eos_token) {
+    if let Some(env) = &state.chat_env {
+        match render_with_chat_env(env, messages, &state.bos_token, &state.eos_token) {
             Ok(s) => return s,
             Err(e) => {
                 warn!(error = %e, "chat_template render failed; falling back to legacy formatter");
@@ -696,11 +729,37 @@ mod tests {
             role: "user".into(),
             content: "hi".into(),
         }];
-        let out = render_prompt_with_template(tmpl, &msgs, "<bos>", "<eos>")
+        let env = build_chat_env(tmpl).expect("macro-based template must parse");
+        let out = render_with_chat_env(&env, &msgs, "<bos>", "<eos>")
             .expect("macro-based template must render");
         assert!(out.contains("<bos>"), "out={out}");
         assert!(out.contains("<start_of_turn>user"), "out={out}");
         assert!(out.contains("hi"), "out={out}");
         assert!(out.contains("<start_of_turn>model"), "out={out}");
+    }
+
+    #[test]
+    fn empty_jinja_template_falls_back_to_none() {
+        // A present-but-empty chat_template.jinja must not be treated as a
+        // usable template — rendering through it would yield an empty prompt,
+        // worse than the legacy formatter. The loader must return None so the
+        // request falls back. Guards #115.
+        let dir = std::env::temp_dir().join(format!("cascadia_g4_empty_{}", std::process::id()));
+        let tok = dir.join("tokenizer");
+        std::fs::create_dir_all(&tok).unwrap();
+        std::fs::write(
+            tok.join("tokenizer_config.json"),
+            r#"{"bos_token": "<bos>"}"#,
+        )
+        .unwrap();
+        // whitespace-only — the worst case (passes a naive is_empty check)
+        std::fs::write(tok.join("chat_template.jinja"), "   \n\t  ").unwrap();
+        let cfg = load_chat_template_config(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(
+            cfg.template.is_none(),
+            "empty/whitespace chat_template.jinja must yield template=None, got {:?}",
+            cfg.template
+        );
     }
 }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Result};
 use cascadia_engine::Builder;
 use cascadia_engine_mock::MockBuilder;
 use cascadia_engine_openvino::{
-    OvDistSpecBuilder, OvDistSpecWorkerBuilder, OvGenaiBuilder, OvRuntimeBuilder,
+    Gemma4Builder, OvDistSpecBuilder, OvDistSpecWorkerBuilder, OvGenaiBuilder, OvRuntimeBuilder,
 };
 use cascadia_engine_sparse_moe::{SparseMoEBuilder, SparseMoEBuilderConfig};
 use cascadia_runner::Runner;
@@ -102,6 +102,10 @@ pub enum EngineKind {
     OvGenai,
     OvRuntime,
     OvDistSpec,
+    /// Gemma 4 multi-stage engine. Drives `gemma4_cached_v1` shards
+    /// (per-layer-type asymmetric attention, KV-sharing, per-layer
+    /// embeddings, baked softcap) produced by `tools/export_gemma4.py`.
+    Gemma4,
     /// Kimi K2.6-style sparse-MoE engine. Routes only the top-k experts
     /// per token (not all 384) and runs the expert matmuls through the
     /// hand-rolled AVX-512 int4 GEMM kernel. Single-stage, CPU-targeted.
@@ -474,6 +478,7 @@ fn cmd_engines() -> Result<()> {
     println!("  ov-genai       single-stage openvino_genai.LLMPipeline; FastDraft + Prompt Lookup");
     println!("  ov-runtime     multi-stage stateful KV cache; pre-exported per-stage v3+ shards");
     println!("  ov-dist-spec   multi-stage spec decode (mask-based KV rewind); v5 shards");
+    println!("  gemma4         Gemma 4 multi-stage (per-layer-type attn, KV-sharing, PLI); gemma4_cached_v1 shards");
     println!("  sparse-moe     Kimi K2.6 sparse top-8 dispatch; AVX-512 int4 GEMM + Rust shells");
     Ok(())
 }
@@ -553,6 +558,19 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
         }
         EngineKind::OvRuntime => {
             let mut b = OvRuntimeBuilder::new(&args.model, args.rank, args.total, &args.device);
+            if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
+                b = b.with_cache_dir(&dir);
+            }
+            if let Some(prec) = &args.ov_kv_precision {
+                b = b.with_kv_cache_precision(prec);
+            }
+            if let Some(group) = &args.ov_dyn_quant_group {
+                b = b.with_dyn_quant_group(group);
+            }
+            Ok(Box::new(b))
+        }
+        EngineKind::Gemma4 => {
+            let mut b = Gemma4Builder::new(&args.model, args.rank, args.total, &args.device);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 b = b.with_cache_dir(&dir);
             }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -253,6 +253,22 @@ fn to_shape3(shape: &[usize]) -> [usize; 3] {
     }
 }
 
+/// Pack a Gemma 4 `cross_kv.*` output (rank-4 `[1,kvh,ctx,hd]`) into a rank-3
+/// wire frame `[kvh,ctx,hd]`. The batch dim is always 1 (single sequence) and
+/// the transport caps tensor rank at MAX_RANK=3, so we drop it; the receiver
+/// restores it. Payload is unchanged (dropping a unit dim leaves the element
+/// count identical), so the transport's strict `payload == shape*dtype` check
+/// still holds. Errors if the output is not the expected rank-4 batch-1 shape.
+fn pack_cross_kv_frame(shape4: &[usize], bytes: Vec<u8>) -> EngineResult<WireTensor> {
+    if shape4.len() != 4 || shape4[0] != 1 {
+        return Err(EngineError::Backend(format!(
+            "cross_kv output shape {shape4:?} is not [1,kvh,ctx,hd]"
+        )));
+    }
+    let ws = [shape4[1] as u32, shape4[2] as u32, shape4[3] as u32];
+    Ok(WireTensor::new(WireDType::F32, ws, bytes))
+}
+
 /// Encode the absolute position as its own framed wire tensor (I64 `[1,1,1]`).
 /// The static (NPU) path sends this immediately before each hidden activation
 /// so relay stages reset/align their KV ring; the transport requires
@@ -443,6 +459,22 @@ pub struct Gemma4Engine {
     /// Set for stateless static-shape (NPU) shards; drives the host-side
     /// bounded-KV decode path instead of OV internal state.
     static_kv: Option<StaticKv>,
+    /// Output indices of this stage's `cross_kv.*` ports (sorted by name) —
+    /// the cross-stage shared KV this stage's source layers produce for a
+    /// downstream stage (Gemma 4 E2B/E4B KV-sharing). Read after each infer
+    /// and sent downstream alongside the hidden state. Empty for single-stage
+    /// shards and models without cross-stage KV-sharing (e.g. dense 31B).
+    cross_kv_out_idx: Vec<usize>,
+    /// Input names of this stage's `external_kv.*` ports (sorted by name) —
+    /// the cross-stage shared KV this stage's shared layers consume from an
+    /// upstream stage. Fed from `pending_external_kv` each step. Empty unless
+    /// this stage depends on a source layer in an earlier stage.
+    external_kv_in_names: Vec<String>,
+    /// Cross-stage KV received from upstream this step, ready to feed into the
+    /// `external_kv.*` inputs — one (shape, bytes) per name, rank-4
+    /// `[1,kvh,ctx,hd]` f32, in the same name-sorted order as
+    /// `external_kv_in_names`.
+    pending_external_kv: Vec<(Vec<usize>, Vec<u8>)>,
 }
 
 impl Gemma4Engine {
@@ -521,11 +553,33 @@ impl Gemma4Engine {
     }
 
     /// Feed cross-stage shared KV (`external_kv.{i}.{key,value}` inputs) from
-    /// the host-accumulated buffers. No-op for single-stage shards and any
-    /// stage with no external sources (e.g. 31B, which has no KV-sharing).
+    /// the frames received from the upstream stage this step. No-op for
+    /// single-stage shards and any stage with no external sources (e.g. dense
+    /// 31B, which has no KV-sharing).
     fn feed_external_kv(&mut self) -> EngineResult<()> {
-        // tier 3 (E2B/E4B multi-stage): set each external_kv.* input from the
-        // cross_kv tensors forwarded down the pipeline from the owning stage.
+        if self.external_kv_in_names.is_empty() {
+            return Ok(());
+        }
+        if self.pending_external_kv.len() != self.external_kv_in_names.len() {
+            return Err(EngineError::Backend(format!(
+                "external_kv count mismatch: {} frames received from upstream, IR \
+                 expects {} (upstream stage's cross_kv.* count must equal this \
+                 stage's external_kv.* count)",
+                self.pending_external_kv.len(),
+                self.external_kv_in_names.len()
+            )));
+        }
+        // names + pending are both sorted by name, so index i aligns the
+        // sender's cross_kv.i with this stage's external_kv.i. Clone the names
+        // and take the buffers into locals to release the &self borrows before
+        // the &mut self.runtime call.
+        let names = self.external_kv_in_names.clone();
+        let pend = std::mem::take(&mut self.pending_external_kv);
+        for (name, (shape, bytes)) in names.iter().zip(pend.iter()) {
+            self.runtime
+                .set_input(name, ShimDType::F32, shape, bytes)
+                .map_err(map_ov_err)?;
+        }
         Ok(())
     }
 
@@ -614,12 +668,30 @@ impl Gemma4Engine {
         } else {
             None
         };
+        // Gemma 4 E2B/E4B: this stage's source layers produced cross-stage
+        // shared KV (`cross_kv.*` outputs) the downstream stage needs as its
+        // `external_kv.*` inputs. Read each from the just-completed inference
+        // and pack the rank-4 [1,kvh,ctx,hd] tensor into a rank-3 wire frame
+        // [kvh,ctx,hd] (batch is always 1; transport caps rank at MAX_RANK=3).
+        // The cache is the full accumulated source-layer KV (grows each step),
+        // sent as f32 to match the IR output dtype and the Core reference.
+        // Empty for single-stage / dense shards (no cross_kv ports).
+        let cross_idxs = self.cross_kv_out_idx.clone();
+        let mut cross_frames = Vec::with_capacity(cross_idxs.len());
+        for idx in cross_idxs {
+            let (_dt, oshape, bytes) = self.runtime.output(idx).map_err(map_ov_err)?;
+            cross_frames.push(pack_cross_kv_frame(&oshape, bytes)?);
+        }
         self.block_on(async move {
             let mut guard = downstream.lock().await;
             if let Some(p) = pos {
                 guard.send(&p).await?;
             }
-            guard.send(&hid).await
+            guard.send(&hid).await?;
+            for f in &cross_frames {
+                guard.send(f).await?;
+            }
+            Ok::<(), cascadia_transport::TransportError>(())
         })
         .map_err(|e| EngineError::Backend(e.to_string()))?;
         Ok(())
@@ -660,7 +732,12 @@ impl Gemma4Engine {
         // hidden activation (see send_hidden_downstream). Each frame's payload
         // must match its shape*dtype, so we recv two separate tensors here.
         let want_pos = self.static_kv.is_some();
-        let (pos_tensor, tensor) = self
+        // Gemma 4 E2B/E4B: after the hidden frame, the upstream stage sends one
+        // frame per `external_kv.*` input this stage consumes (its shared
+        // layers' cross-stage KV). recv exactly that many, in the same
+        // name-sorted order send_hidden_downstream used for cross_kv.*.
+        let n_ext = self.external_kv_in_names.len();
+        let (pos_tensor, tensor, ext_tensors) = self
             .block_on(async move {
                 let mut guard = upstream.lock().await;
                 let pos_tensor = if want_pos {
@@ -669,7 +746,11 @@ impl Gemma4Engine {
                     None
                 };
                 let (t, _) = guard.recv().await?;
-                Ok::<_, cascadia_transport::TransportError>((pos_tensor, t))
+                let mut exts = Vec::with_capacity(n_ext);
+                for _ in 0..n_ext {
+                    exts.push(guard.recv().await?.0);
+                }
+                Ok::<_, cascadia_transport::TransportError>((pos_tensor, t, exts))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
         // Decode + strictly validate the position frame outside the transport
@@ -678,6 +759,18 @@ impl Gemma4Engine {
             Some(p) => Some(decode_wire_position(&p)?),
             None => None,
         };
+        // Unpack each rank-3 wire frame [kvh,ctx,hd] back to the IR's rank-4
+        // [1,kvh,ctx,hd] f32 for feed_external_kv (called from build_feed_*).
+        self.pending_external_kv = ext_tensors
+            .iter()
+            .map(|wt| {
+                let s = &wt.shape;
+                (
+                    vec![1usize, s[0] as usize, s[1] as usize, s[2] as usize],
+                    wt.data.clone(),
+                )
+            })
+            .collect();
         let shape = [
             tensor.shape[0] as usize,
             tensor.shape[1] as usize,
@@ -1594,6 +1687,36 @@ impl Builder for Gemma4Builder {
             None
         };
 
+        // Enumerate cross-stage shared-KV ports (Gemma 4 E2B/E4B KV-sharing).
+        // `cross_kv.*` are OUTPUTS this stage produces for a downstream stage;
+        // `external_kv.*` are INPUTS it consumes from an upstream stage. Both
+        // sorted by name so cross_kv.i on the sender aligns with external_kv.i
+        // on the receiver. Empty for single-stage shards and dense models
+        // without KV-sharing (e.g. 31B → zero-cost pure hidden relay).
+        let output_names = runtime.output_names().map_err(map_ov_err)?;
+        let mut cross: Vec<(String, usize)> = output_names
+            .iter()
+            .enumerate()
+            .filter(|(_, n)| n.starts_with("cross_kv"))
+            .map(|(i, n)| (n.clone(), i))
+            .collect();
+        cross.sort_by(|a, b| a.0.cmp(&b.0));
+        let cross_kv_out_idx: Vec<usize> = cross.into_iter().map(|(_, i)| i).collect();
+        let mut external_kv_in_names: Vec<String> = runtime
+            .input_names()
+            .map_err(map_ov_err)?
+            .into_iter()
+            .filter(|n| n.starts_with("external_kv"))
+            .collect();
+        external_kv_in_names.sort();
+        if !cross_kv_out_idx.is_empty() || !external_kv_in_names.is_empty() {
+            info!(
+                cross_kv_out = cross_kv_out_idx.len(),
+                external_kv_in = external_kv_in_names.len(),
+                "gemma4 cross-stage shared KV wired"
+            );
+        }
+
         Ok(Box::new(Gemma4Engine {
             spec,
             runtime,
@@ -1610,6 +1733,9 @@ impl Builder for Gemma4Builder {
             pending: Vec::new(),
             active: None,
             static_kv,
+            cross_kv_out_idx,
+            external_kv_in_names,
+            pending_external_kv: Vec::new(),
         }))
     }
 }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -210,7 +210,7 @@ fn map_ov_err(err: OvError) -> EngineError {
 }
 
 /// Decode a float output port's raw bytes to f32, by its reported dtype.
-/// Shared by every output-reading path (run_first / run_relay / static).
+/// Shared by both output-reading paths (run_first / run_relay).
 fn bytes_to_f32(dtype: ShimDType, bytes: &[u8]) -> EngineResult<Vec<f32>> {
     match dtype {
         ShimDType::F32 => Ok(bytes
@@ -672,6 +672,21 @@ impl Gemma4Engine {
         let position = decode_wire_position(&pos_t)?;
         let tags = decode_cross_kv_header(&header_t)?;
         let n = tags.len();
+        // Strict frame-count guard (restores the old count-based check) AND the
+        // distributed-deploy runtime backstop for the load-time adjacency guard
+        // (which is skipped when the sibling stage_config isn't on local disk):
+        // the immediate upstream must send EXACTLY this stage's external_kv
+        // sources — no more (over-production / non-adjacent >1-hop sharing) and
+        // no fewer. A mismatch is a clear error, not a silently-ignored frame.
+        if n != self.external_kv_in.len() {
+            return Err(EngineError::Backend(format!(
+                "upstream sent {n} cross-KV frame(s) but this stage consumes {} external_kv \
+                 input(s) — a cross-stage KV source/consumer mismatch (non-adjacent KV sharing \
+                 across more than one pipeline hop, or a mis-exported pipeline). The immediate \
+                 upstream must produce exactly this stage's external_kv sources.",
+                self.external_kv_in.len()
+            )));
+        }
         let up2 = self.upstream.clone().unwrap();
         let ext_tensors = self
             .block_on(async move {
@@ -854,8 +869,7 @@ impl Gemma4Engine {
     }
 
     /// Decode the delta text for `next_token`, append it to the active task,
-    /// check stop conditions, and build the streamed chunk. Shared by the
-    /// static and stateful first-stage paths.
+    /// check stop conditions, and build the streamed chunk (first stage only).
     fn emit_token(&mut self, next_token: i32) -> EngineResult<Vec<(TaskId, Chunk)>> {
         let active = self
             .active

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -300,7 +300,7 @@ fn encode_cross_kv_header(tags: &[i64]) -> WireTensor {
 /// Decode + validate the cross-KV header (see [`encode_cross_kv_header`]).
 /// Returns the per-frame tags for the frames that follow.
 fn decode_cross_kv_header(t: &WireTensor) -> EngineResult<Vec<i64>> {
-    if t.dtype != WireDType::I64 || t.data.is_empty() || t.data.len() % 8 != 0 {
+    if t.dtype != WireDType::I64 || t.data.is_empty() || !t.data.len().is_multiple_of(8) {
         return Err(EngineError::Backend(format!(
             "expected an I64 cross-KV header frame, got dtype={:?} len={} — likely a \
              desynced activation stream",
@@ -1401,5 +1401,51 @@ mod tests {
     async fn connect_no_peers_is_noop_for_single_stage() {
         let mut b = Gemma4Builder::new("/x", 0, 1, "CPU");
         b.connect(PeerLayout::single_stage()).await.unwrap();
+    }
+
+    /// The load-time adjacency guard must reject a 3-stage pipeline where a
+    /// stage consumes cross-stage KV from a source the immediate upstream does
+    /// NOT produce (non-adjacent / multi-hop sharing) — with a clear error,
+    /// before compiling the IR. Hermetic: only stage_config.json files are
+    /// needed (the guard runs ahead of OV compile), so no IR / transport.
+    #[tokio::test]
+    async fn rejects_non_adjacent_cross_stage_kv() {
+        let dir = std::env::temp_dir().join(format!("cascadia_g4_guard_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("stage_1")).unwrap();
+        std::fs::create_dir_all(dir.join("stage_2")).unwrap();
+        std::fs::write(
+            dir.join("pipeline_config.json"),
+            r#"{"model_id":"m","num_stages":3,"num_layers":30}"#,
+        )
+        .unwrap();
+        // stage_1 (the immediate upstream of stage_2) produces NO cross-stage KV.
+        std::fs::write(
+            dir.join("stage_1/stage_config.json"),
+            r#"{"layer_start":10,"layer_end":20,"stateful":true,"cross_stage_sources_local":[]}"#,
+        )
+        .unwrap();
+        // stage_2 consumes source layer 5 — which lives in stage_0, two hops up.
+        std::fs::write(
+            dir.join("stage_2/stage_config.json"),
+            r#"{"layer_start":20,"layer_end":30,"has_head":true,"stateful":true,
+                "external_shared_sources":[{"src_global_layer":5}]}"#,
+        )
+        .unwrap();
+        let mut b = Gemma4Builder::new(&dir, 2, 3, "CPU");
+        let res = b.load(ShardSpec::single_stage("m", "CPU")).await;
+        std::fs::remove_dir_all(&dir).ok();
+        match res {
+            Err(EngineError::ShardRejected(msg)) => {
+                assert!(
+                    msg.contains("non-adjacent") || msg.contains("does not produce"),
+                    "expected a non-adjacency rejection, got: {msg}"
+                );
+            }
+            Err(e) => panic!("expected ShardRejected, got a different error: {e:?}"),
+            Ok(_) => {
+                panic!("expected ShardRejected for non-adjacent KV sharing, but load() succeeded")
+            }
+        }
     }
 }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1,0 +1,1640 @@
+//! Multi-stage OpenVINO Runtime engine.
+//!
+//! Rust port of `cascadia/worker/engines/openvino/ov_runtime.py`. Loads
+//! pre-exported per-stage stateful OV IRs (rainier v3+ format), runs them
+//! across the existing TCP transport, with stateful KV cache internal to
+//! the IR and `reset_state()` between independent generation tasks.
+//!
+//! Pipeline-dir layout (matches rainier's exporter):
+//! ```text
+//! <pipeline-dir>/
+//!     pipeline_config.json
+//!     tokenizer/                 # HF tokenizer.json + special tokens
+//!     stage_0/openvino_model.{xml,bin}, stage_config.json
+//!     stage_N/...
+//! ```
+//!
+//! Wire format between stages: hidden_states f16. Stateful shards have each
+//! stage track its own absolute-position counter (computing cos/sin locally,
+//! no position metadata on the wire); the counter resets when an activation
+//! with seq_len > 1 arrives (a prefill signal for relay/last stages).
+//!
+//! Stateless static-shape (NPU) shards (`stage_config.stateful == false`)
+//! instead drive a host-side bounded KV ring per stage (see `StaticKv`).
+//! Because static shards are seq=1, the seq>1 prefill signal is unavailable,
+//! so the first stage carries the absolute `position` as an 8-byte prefix on
+//! each activation; downstream stages reset their ring at position 0 and
+//! derive the visible-past count from it, keeping every stage's ring in
+//! lockstep. This path works single- or multi-stage (pipeline-parallel NPU).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
+use cascadia_ov_genai_shim::{
+    DType as ShimDType, Error as OvError, PluginConfig, Runtime as OvRuntime,
+};
+use cascadia_transport::{
+    ActivationClient, ActivationServer, DType as WireDType, Tensor as WireTensor, MAX_RANK,
+};
+use cascadia_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec, TaskId};
+use futures::stream;
+use serde::Deserialize;
+use tokenizers::Tokenizer;
+use tracing::{info, warn};
+
+use crate::rotary::{load_model_config, Rotary};
+
+// -------- pipeline / stage config --------
+
+#[derive(Debug, Deserialize)]
+struct PipelineConfig {
+    model_id: String,
+    num_stages: u32,
+    #[serde(default)]
+    num_layers: u32,
+    #[serde(default)]
+    hidden_size: u32,
+    #[serde(default)]
+    export_version: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct StageConfig {
+    #[serde(default)]
+    layer_start: u32,
+    #[serde(default)]
+    layer_end: u32,
+    #[serde(default)]
+    has_embed: bool,
+    #[serde(default)]
+    has_head: bool,
+    #[serde(default)]
+    export_version: Option<String>,
+    /// NPU (`--target npu`) export: KV is stateless (explicit past_kv-in /
+    /// present-out) and all shapes are static. Old/standard shards omit the
+    /// field and are stateful (default true). When false, the engine drives
+    /// the static-KV path (host-side bounded ring) instead of OV state.
+    #[serde(default = "default_true")]
+    stateful: bool,
+    #[serde(default)]
+    static_seq: Option<u32>,
+    #[serde(default)]
+    static_context: Option<u32>,
+    #[serde(default)]
+    num_kv_heads: Option<u32>,
+    #[serde(default)]
+    head_dim: Option<u32>,
+}
+
+fn read_pipeline_config(p: &Path) -> Result<PipelineConfig, EngineError> {
+    let bytes = std::fs::read(p.join("pipeline_config.json"))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| EngineError::InvalidConfig(format!("pipeline_config.json: {e}")))
+}
+
+fn read_stage_config(p: &Path) -> Result<StageConfig, EngineError> {
+    let bytes = std::fs::read(p.join("stage_config.json"))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| EngineError::InvalidConfig(format!("stage_config.json: {e}")))
+}
+
+// -------- generation_config.json (eos_token_id lookup) --------
+
+#[derive(Debug, Deserialize, Default)]
+struct GenerationCfg {
+    #[serde(default)]
+    eos_token_id: Option<EosId>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum EosId {
+    One(u32),
+    Many(Vec<u32>),
+}
+
+/// Return ALL EOS token ids configured for the model. Many recent
+/// instruct models (Llama 3.x, Qwen3, Gemma 2) list multiple EOS:
+/// `[<|end_of_text|>, <|eom_id|>, <|eot_id|>]` for Llama 3.3, for
+/// example. The chat-end token is usually the LAST entry, not the
+/// first — keeping only `ids.first()` made the model run past
+/// `<|eot_id|>` and start hallucinating fake "assistant\n\n…" turns.
+/// Caller stops generation if the next token matches any of these.
+fn lookup_eos(model_dir: &Path) -> Vec<u32> {
+    for fname in ["generation_config.json", "config.json"] {
+        let p = model_dir.join(fname);
+        if let Ok(bytes) = std::fs::read(&p) {
+            if let Ok(g) = serde_json::from_slice::<GenerationCfg>(&bytes) {
+                return match g.eos_token_id {
+                    Some(EosId::One(id)) => vec![id],
+                    Some(EosId::Many(ids)) => ids,
+                    None => Vec::new(),
+                };
+            }
+        }
+    }
+    Vec::new()
+}
+
+// -------- helpers: bytes <-> typed slices --------
+
+fn i64_to_bytes(v: &[i64]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 8);
+    for x in v {
+        out.extend_from_slice(&x.to_le_bytes());
+    }
+    out
+}
+
+fn f16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+    use half::f16;
+    bytes
+        .chunks_exact(2)
+        .map(|c| {
+            let bits = u16::from_le_bytes([c[0], c[1]]);
+            f16::from_bits(bits).to_f32()
+        })
+        .collect()
+}
+
+fn f32_to_f16_bytes(v: &[f32]) -> Vec<u8> {
+    use half::f16;
+    let mut out = Vec::with_capacity(v.len() * 2);
+    for x in v {
+        let h = f16::from_f32(*x);
+        out.extend_from_slice(&h.to_bits().to_le_bytes());
+    }
+    out
+}
+
+fn argmax_last_row(logits: &[f32], vocab: usize) -> i32 {
+    let row = &logits[logits.len() - vocab..];
+    // NaN-aware (see crate::dist_spec::argmax for rationale).
+    let mut best_i = 0usize;
+    let mut best_v = f32::NEG_INFINITY;
+    let mut saw_finite = false;
+    for (i, v) in row.iter().enumerate() {
+        if v.is_finite() {
+            saw_finite = true;
+            if *v > best_v {
+                best_v = *v;
+                best_i = i;
+            }
+        }
+    }
+    if !saw_finite {
+        warn!(
+            "argmax_last_row: all logits non-finite; returning token 0 — \
+             likely indicates a numerically broken forward pass"
+        );
+    }
+    best_i as i32
+}
+
+fn map_ov_err(err: OvError) -> EngineError {
+    match err {
+        OvError::Stub => {
+            EngineError::Backend("openvino shim built without --features openvino".into())
+        }
+        OvError::Utf8(s) => EngineError::InvalidConfig(s),
+        OvError::Native(s) => EngineError::Backend(s),
+    }
+}
+
+/// Decode a float output port's raw bytes to f32, by its reported dtype.
+/// Shared by every output-reading path (run_first / run_relay / static).
+fn bytes_to_f32(dtype: ShimDType, bytes: &[u8]) -> EngineResult<Vec<f32>> {
+    match dtype {
+        ShimDType::F32 => Ok(bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()),
+        ShimDType::F16 => Ok(f16_bytes_to_f32(bytes)),
+        other => Err(EngineError::Backend(format!(
+            "unexpected float output dtype {other:?}"
+        ))),
+    }
+}
+
+/// Pick the next token from a logits output, guarding the shape so a
+/// rank-0 / zero-width / short logits buffer returns a clear error instead
+/// of panicking with a slice/underflow.
+fn argmax_logits(logits: &[f32], shape: &[usize]) -> EngineResult<i32> {
+    let vocab = match shape.last() {
+        Some(&v) if v > 0 => v,
+        _ => {
+            return Err(EngineError::Backend(format!(
+                "logits output has empty/zero last dim: shape={shape:?}"
+            )))
+        }
+    };
+    if vocab > logits.len() {
+        return Err(EngineError::Backend(format!(
+            "logits len {} < vocab {vocab} (shape={shape:?})",
+            logits.len()
+        )));
+    }
+    Ok(argmax_last_row(logits, vocab))
+}
+
+/// Normalize an output shape to a 3D `[batch, seq, hidden]` for the wire.
+fn to_shape3(shape: &[usize]) -> [usize; 3] {
+    match shape.len() {
+        3 => [shape[0], shape[1], shape[2]],
+        2 => [1, shape[0], shape[1]],
+        _ => [1, 1, shape.last().copied().unwrap_or(0)],
+    }
+}
+
+/// Encode the absolute position as its own framed wire tensor (I64 `[1,1,1]`).
+/// The static (NPU) path sends this immediately before each hidden activation
+/// so relay stages reset/align their KV ring; the transport requires
+/// `payload_len == shape*dtype`, so position cannot be packed into the hidden
+/// tensor (and MAX_RANK=3 leaves no spare shape slot). Paired with
+/// `decode_wire_position` — keep the two in sync.
+fn encode_wire_position(position: i64) -> WireTensor {
+    WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
+}
+
+/// Decode + strictly validate a wire position frame. Must be I64 with exactly
+/// 8 payload bytes; anything else (a desynced stream, or a stateful peer that
+/// sent a hidden tensor where a position was expected) is a hard error rather
+/// than a silently zero-padded wrong position.
+fn decode_wire_position(t: &WireTensor) -> EngineResult<i64> {
+    if t.dtype != WireDType::I64 || t.data.len() != 8 {
+        return Err(EngineError::Backend(format!(
+            "expected an I64 8-byte position frame, got dtype={:?} len={} — likely a \
+             stateful/static pipeline mismatch or a desynced activation stream",
+            t.dtype,
+            t.data.len()
+        )));
+    }
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&t.data);
+    Ok(i64::from_le_bytes(b))
+}
+
+// -------- static-KV (NPU) state --------
+
+/// Per-layer port wiring for a stateless static-shape (NPU) shard.
+struct StaticKvLayer {
+    key_in: String,
+    val_in: String,
+    key_out: usize,
+    val_out: usize,
+}
+
+/// Host-side bounded KV ring for the stateless static-shape (NPU) path.
+/// The exported IR takes explicit `past_key_values.*` (length `past_len`) +
+/// `attention_mask` (length `context = past_len + 1`) + `position_ids`, and
+/// returns its primary output (logits for the head stage, hidden_states
+/// otherwise) at output index 0, plus `present.*` (length `context`). We hold
+/// the KV for the most recent `valid` real tokens left-aligned in
+/// `past_len`-slot buffers, feed them each step, and absorb the new token's KV
+/// from `present[past_len]`. One ring per stage; in a multi-stage pipeline
+/// every stage runs its own ring over its own layers, kept in lockstep by the
+/// absolute `position` the first stage carries with each activation.
+struct StaticKv {
+    past_len: usize,
+    context: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    elem_bytes: usize,
+    kv_dtype: ShimDType,
+    /// Resolved primary input port names (cached at build so the per-token
+    /// decode loop does no HashMap lookups / string allocs). `ids_in` is set
+    /// for the embed stage, `hidden_in` for relay/head stages.
+    ids_in: Option<String>,
+    hidden_in: Option<String>,
+    attn_in: String,
+    pos_in: String,
+    layers: Vec<StaticKvLayer>,
+    key_buf: Vec<Vec<u8>>, // [layer] = kv_heads * past_len * head_dim * elem_bytes
+    val_buf: Vec<Vec<u8>>,
+    valid: usize, // number of real past tokens currently in the ring
+    /// Reusable attention_mask byte buffer (i64 LE, length context*8), rewritten
+    /// in place each token to avoid a per-token allocation.
+    mask_bytes: Vec<u8>,
+}
+
+impl StaticKv {
+    fn reset(&mut self) {
+        for b in self.key_buf.iter_mut().chain(self.val_buf.iter_mut()) {
+            b.iter_mut().for_each(|x| *x = 0);
+        }
+        self.valid = 0;
+    }
+
+    /// Expected byte length of one layer's `present.*` output:
+    /// `kv_heads * context * head_dim * elem_bytes`. Used to validate the IR's
+    /// output shape/dtype before `absorb_layer` slices it.
+    fn present_layer_bytes(&self) -> usize {
+        self.kv_heads * self.context * self.head_dim * self.elem_bytes
+    }
+
+    /// Set how many real past tokens are visible for a token at absolute
+    /// `position`, resetting the ring at the start of a new sequence
+    /// (`position == 0`). The window is bounded by `past_len`.
+    fn begin_token(&mut self, position: usize) {
+        if position == 0 {
+            self.reset();
+        }
+        self.valid = position.min(self.past_len);
+    }
+
+    /// Rewrite `mask_bytes` (i64 LE) for the current `valid`: 1 for the `valid`
+    /// real past slots (left-aligned) + the current token (slot `past_len`), 0
+    /// for the padding past slots in between. Reuses the buffer's capacity.
+    fn write_mask_bytes(&mut self) {
+        self.mask_bytes.clear();
+        self.mask_bytes.resize(self.context * 8, 0);
+        for i in 0..self.context {
+            let v: i64 = if i < self.valid || i == self.past_len {
+                1
+            } else {
+                0
+            };
+            self.mask_bytes[i * 8..i * 8 + 8].copy_from_slice(&v.to_le_bytes());
+        }
+    }
+
+    /// Copy the new token's K/V (slot `past_len` of `present`) into the
+    /// layer's ring buffer, appending at `valid` or sliding the window when
+    /// full. Selects `key_buf[li]` or `val_buf[li]` internally so callers can
+    /// hold `&mut self` without aliasing the buffer field.
+    fn absorb_layer(&mut self, li: usize, is_value: bool, present: &[u8]) {
+        // Read scalar fields into locals before borrowing the buffer field,
+        // so the mutable buffer borrow stays disjoint from these reads.
+        let slot = self.head_dim * self.elem_bytes;
+        let present_row = self.context * slot; // per-head stride in present
+        let buf_row = self.past_len * slot; // per-head stride in the ring
+        let full = self.valid >= self.past_len;
+        let kv_heads = self.kv_heads;
+        let past_len = self.past_len;
+        let valid = self.valid;
+        let buf: &mut [u8] = if is_value {
+            &mut self.val_buf[li]
+        } else {
+            &mut self.key_buf[li]
+        };
+        for h in 0..kv_heads {
+            let src = h * present_row + past_len * slot;
+            let new = &present[src..src + slot];
+            let base = h * buf_row;
+            if full {
+                buf.copy_within(base + slot..base + buf_row, base); // drop oldest
+                let dst = base + (past_len - 1) * slot;
+                buf[dst..dst + slot].copy_from_slice(new);
+            } else {
+                let dst = base + valid * slot;
+                buf[dst..dst + slot].copy_from_slice(new);
+            }
+        }
+    }
+}
+
+// -------- Engine --------
+
+struct ActiveTask {
+    task: GenerationTask,
+    prompt_ids: Vec<i64>,
+    generated: Vec<i32>,
+    last_text: String,
+    prefilled: bool,
+    last_token: i32,
+    /// Wall-clock when the task became active. Used to compute the
+    /// final tok/s the engine prints in its `task done` log line.
+    started: std::time::Instant,
+    /// Cumulative time inside `run_first` (stage_0 compute + read).
+    t_alpha_compute: std::time::Duration,
+    /// Cumulative time inside `send_hidden_downstream` +
+    /// `recv_token_from_downstream` — i.e. wire send + charlie wait + recv.
+    t_wire: std::time::Duration,
+}
+
+pub struct Gemma4Engine {
+    spec: ShardSpec,
+    runtime: OvRuntime,
+    rotary: Rotary,
+    hidden_size: usize,
+    tokenizer: Option<Arc<Tokenizer>>,
+    /// All EOS token ids configured for the model. Generation stops on
+    /// the first token that matches ANY of these. See `lookup_eos`.
+    eos_token_ids: Vec<u32>,
+    upstream: Option<Arc<tokio::sync::Mutex<ActivationServer>>>,
+    downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
+    runtime_handle: tokio::runtime::Handle,
+    position: i64,
+    input_names: Vec<String>,
+    /// Map of canonical name (e.g. "input_ids", "attention_mask") to the
+    /// IR's primary port name. Resolved at engine build time via the
+    /// alias lookup (the IR's primary name is sometimes an internal
+    /// node id, not the canonical name). Empty for v3 IRs.
+    canonical_inputs: std::collections::HashMap<String, String>,
+    pending: Vec<GenerationTask>,
+    active: Option<ActiveTask>,
+    /// Set for stateless static-shape (NPU) shards; drives the host-side
+    /// bounded-KV decode path instead of OV internal state.
+    static_kv: Option<StaticKv>,
+}
+
+impl Gemma4Engine {
+    /// True if the loaded IR uses v5+ canonical inputs (attention_mask +
+    /// position_ids) instead of legacy v3 (cos + sin). Determined from
+    /// the alias-resolved canonical_inputs map populated at build time.
+    fn is_v5_layout(&self) -> bool {
+        self.canonical_inputs.contains_key("attention_mask")
+            && self.canonical_inputs.contains_key("position_ids")
+    }
+
+    /// Resolve a canonical input name to the IR's primary port name.
+    fn input_named(&self, canonical: &str) -> Option<&str> {
+        self.canonical_inputs.get(canonical).map(|s| s.as_str())
+    }
+
+    fn build_feed_first(&mut self, input_ids: &[i64], position: i64) -> EngineResult<()> {
+        // Gemma4: input_ids + position_ids only. The causal mask is baked into
+        // the IR (no attention_mask input) and RoPE is computed internally from
+        // position_ids (no cos/sin). Own KV is OV-stateful; cross-stage shared
+        // KV (external_kv.*) is fed by feed_external_kv().
+        let seq_len = input_ids.len();
+        let pos: Vec<i64> = (position..position + seq_len as i64).collect();
+        let in_ids = self
+            .input_named("input_ids")
+            .ok_or_else(|| EngineError::Backend("gemma4 IR missing input_ids".into()))?
+            .to_string();
+        let in_pos = self
+            .input_named("position_ids")
+            .ok_or_else(|| EngineError::Backend("gemma4 IR missing position_ids".into()))?
+            .to_string();
+        self.runtime
+            .set_input(
+                &in_ids,
+                ShimDType::I64,
+                &[1, seq_len],
+                &i64_to_bytes(input_ids),
+            )
+            .map_err(map_ov_err)?;
+        self.runtime
+            .set_input(&in_pos, ShimDType::I64, &[1, seq_len], &i64_to_bytes(&pos))
+            .map_err(map_ov_err)?;
+        self.feed_external_kv()?;
+        Ok(())
+    }
+
+    fn build_feed_relay(
+        &mut self,
+        hidden: &[f32],
+        shape: [usize; 3],
+        position: i64,
+    ) -> EngineResult<()> {
+        // hidden_states (f16) + position_ids. `shape[2]` is the full width
+        // (hidden_size + the per-layer-embedding tail when pli_dim>0); the IR
+        // input accepts that width, so PLI rides inside hidden_states with no
+        // special handling here.
+        let seq_len = shape[1];
+        let pos: Vec<i64> = (position..position + seq_len as i64).collect();
+        let in_hs = self
+            .input_named("hidden_states")
+            .ok_or_else(|| EngineError::Backend("gemma4 IR missing hidden_states".into()))?
+            .to_string();
+        let in_pos = self
+            .input_named("position_ids")
+            .ok_or_else(|| EngineError::Backend("gemma4 IR missing position_ids".into()))?
+            .to_string();
+        let hs_bytes = f32_to_f16_bytes(hidden);
+        self.runtime
+            .set_input(&in_hs, ShimDType::F16, &shape, &hs_bytes)
+            .map_err(map_ov_err)?;
+        self.runtime
+            .set_input(&in_pos, ShimDType::I64, &[1, seq_len], &i64_to_bytes(&pos))
+            .map_err(map_ov_err)?;
+        self.feed_external_kv()?;
+        Ok(())
+    }
+
+    /// Feed cross-stage shared KV (`external_kv.{i}.{key,value}` inputs) from
+    /// the host-accumulated buffers. No-op for single-stage shards and any
+    /// stage with no external sources (e.g. 31B, which has no KV-sharing).
+    fn feed_external_kv(&mut self) -> EngineResult<()> {
+        // tier 3 (E2B/E4B multi-stage): set each external_kv.* input from the
+        // cross_kv tensors forwarded down the pipeline from the owning stage.
+        Ok(())
+    }
+
+    fn run_first(
+        &mut self,
+        input_ids: &[i64],
+        position: i64,
+    ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
+        // Stateless static (NPU): feed one token id + the host-side KV ring.
+        // The caller loops one token at a time (static_seq == 1).
+        if self.static_kv.is_some() {
+            if input_ids.len() != 1 {
+                return Err(EngineError::Backend(format!(
+                    "static shard processes one token per step, got {}",
+                    input_ids.len()
+                )));
+            }
+            let (dtype, shape, bytes) = self.static_infer(
+                false,
+                ShimDType::I64,
+                &[1, 1],
+                &i64_to_bytes(input_ids),
+                position,
+            )?;
+            return Ok((bytes_to_f32(dtype, &bytes)?, shape));
+        }
+        self.build_feed_first(input_ids, position)?;
+        self.runtime.infer().map_err(map_ov_err)?;
+        let (dtype, shape, bytes) = self.runtime.output(0).map_err(map_ov_err)?;
+        Ok((bytes_to_f32(dtype, &bytes)?, shape))
+    }
+
+    fn run_relay(
+        &mut self,
+        hidden: &[f32],
+        shape: [usize; 3],
+        position: i64,
+    ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
+        // Stateless static (NPU): feed the upstream hidden state + the
+        // host-side KV ring for this stage's layers.
+        if self.static_kv.is_some() {
+            let hs_bytes = f32_to_f16_bytes(hidden);
+            let (dtype, out_shape, bytes) =
+                self.static_infer(true, ShimDType::F16, &shape, &hs_bytes, position)?;
+            return Ok((bytes_to_f32(dtype, &bytes)?, out_shape));
+        }
+        self.build_feed_relay(hidden, shape, position)?;
+        self.runtime.infer().map_err(map_ov_err)?;
+        let (dtype, out_shape, bytes) = self.runtime.output(0).map_err(map_ov_err)?;
+        Ok((bytes_to_f32(dtype, &bytes)?, out_shape))
+    }
+
+    fn block_on<F: std::future::Future>(&self, f: F) -> F::Output {
+        // The runner's ChunkStream::poll_next is itself an async fn —
+        // calling block_on inside an async context panics with "Cannot
+        // start a runtime from within a runtime". Use the same
+        // dispatch the dist_spec engine uses (block_in_place when on
+        // the async worker thread, naked block_on when on a
+        // spawn_blocking thread or off-runtime).
+        crate::dist_spec::run_async_pub(&self.runtime_handle, f)
+    }
+
+    fn send_hidden_downstream(
+        &mut self,
+        hidden: &[f32],
+        shape: [usize; 3],
+        position: i64,
+    ) -> EngineResult<()> {
+        let downstream = self
+            .downstream
+            .clone()
+            .ok_or_else(|| EngineError::Backend("no downstream".into()))?;
+        let mut wire_shape = [1u32; MAX_RANK];
+        for (i, d) in shape.iter().enumerate().take(MAX_RANK) {
+            wire_shape[i] = *d as u32;
+        }
+        let hid = WireTensor::new(WireDType::F16, wire_shape, f32_to_f16_bytes(hidden));
+        // Static (NPU) shards need the absolute position downstream so each
+        // stage can reset its ring at position 0 and align the visible-past
+        // count. The wire shape has only MAX_RANK=3 dims (all used by
+        // [1,1,hidden]) and the transport requires payload_len == shape*dtype,
+        // so we can't pack it into the hidden tensor — send it as its own
+        // framed I64 tensor first. recv_hidden_from_upstream mirrors the order.
+        let pos = if self.static_kv.is_some() {
+            Some(encode_wire_position(position))
+        } else {
+            None
+        };
+        self.block_on(async move {
+            let mut guard = downstream.lock().await;
+            if let Some(p) = pos {
+                guard.send(&p).await?;
+            }
+            guard.send(&hid).await
+        })
+        .map_err(|e| EngineError::Backend(e.to_string()))?;
+        Ok(())
+    }
+
+    fn recv_token_from_downstream(&mut self) -> EngineResult<i32> {
+        let downstream = self
+            .downstream
+            .clone()
+            .ok_or_else(|| EngineError::Backend("no downstream".into()))?;
+        let (tensor, _) = self
+            .block_on(async move {
+                let mut guard = downstream.lock().await;
+                guard.recv().await
+            })
+            .map_err(|e| EngineError::Backend(e.to_string()))?;
+        if tensor.data.len() < 4 {
+            return Err(EngineError::Backend(format!(
+                "downstream sent {}-byte token tensor; need at least 4",
+                tensor.data.len()
+            )));
+        }
+        let token = i32::from_le_bytes([
+            tensor.data[0],
+            tensor.data[1],
+            tensor.data[2],
+            tensor.data[3],
+        ]);
+        Ok(token)
+    }
+
+    fn recv_hidden_from_upstream(&mut self) -> EngineResult<(Vec<f32>, [usize; 3], Option<i64>)> {
+        let upstream = self
+            .upstream
+            .clone()
+            .ok_or_else(|| EngineError::Backend("no upstream".into()))?;
+        // Static (NPU) shards send a leading I64 position tensor before the
+        // hidden activation (see send_hidden_downstream). Each frame's payload
+        // must match its shape*dtype, so we recv two separate tensors here.
+        let want_pos = self.static_kv.is_some();
+        let (pos_tensor, tensor) = self
+            .block_on(async move {
+                let mut guard = upstream.lock().await;
+                let pos_tensor = if want_pos {
+                    Some(guard.recv().await?.0)
+                } else {
+                    None
+                };
+                let (t, _) = guard.recv().await?;
+                Ok::<_, cascadia_transport::TransportError>((pos_tensor, t))
+            })
+            .map_err(|e| EngineError::Backend(e.to_string()))?;
+        // Decode + strictly validate the position frame outside the transport
+        // closure (so a bad frame yields a clear EngineError, not a desync).
+        let position = match pos_tensor {
+            Some(p) => Some(decode_wire_position(&p)?),
+            None => None,
+        };
+        let shape = [
+            tensor.shape[0] as usize,
+            tensor.shape[1] as usize,
+            tensor.shape[2] as usize,
+        ];
+        let floats = match tensor.dtype {
+            WireDType::F32 => tensor
+                .data
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect(),
+            WireDType::F16 => f16_bytes_to_f32(&tensor.data),
+            other => {
+                return Err(EngineError::Backend(format!(
+                    "unexpected upstream dtype {other:?}"
+                )))
+            }
+        };
+        Ok((floats, shape, position))
+    }
+
+    fn send_token_to_upstream(&mut self, token: i32) -> EngineResult<()> {
+        let upstream = self
+            .upstream
+            .clone()
+            .ok_or_else(|| EngineError::Backend("no upstream".into()))?;
+        let bytes = token.to_le_bytes().to_vec();
+        let tensor = WireTensor::new(WireDType::I32, [1, 1, 1], bytes);
+        self.block_on(async move {
+            let mut guard = upstream.lock().await;
+            guard.send(&tensor).await
+        })
+        .map_err(|e| EngineError::Backend(e.to_string()))?;
+        Ok(())
+    }
+
+    fn step_first(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        if self.active.is_none() && !self.pending.is_empty() {
+            let task = self.pending.remove(0);
+            let tok = self
+                .tokenizer
+                .clone()
+                .ok_or_else(|| EngineError::Backend("first stage requires tokenizer".into()))?;
+            let enc = tok
+                .encode(task.prompt.clone(), false)
+                .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
+            let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            if self.static_kv.is_none() {
+                self.runtime.reset_state().map_err(map_ov_err)?;
+            }
+            self.position = 0;
+            info!(
+                task = %task.task_id,
+                prompt_tokens = prompt_ids.len(),
+                "task active (ov-runtime)"
+            );
+            self.active = Some(ActiveTask {
+                task,
+                prompt_ids,
+                generated: Vec::new(),
+                last_text: String::new(),
+                prefilled: false,
+                last_token: 0,
+                started: std::time::Instant::now(),
+                t_alpha_compute: std::time::Duration::ZERO,
+                t_wire: std::time::Duration::ZERO,
+            });
+        }
+
+        // Run the actual step in an inner method so we can catch any
+        // error and clear engine state. Without this, a single
+        // transport / OV-runtime failure leaves `self.active = Some(...)`
+        // and `self.position` stale; the next submit() pushes to pending
+        // but step_first's "if active.is_none()" gate is false, so the
+        // new task is never picked up — runner.poll_next sees empty
+        // steps and the API returns `data: [DONE]` with zero chunks.
+        let res = self.step_first_body();
+        if let Err(ref e) = res {
+            warn!(
+                error = %e,
+                "step_first failed; clearing active + reset_state so next \
+                 task starts fresh (downstream socket may still be dead)"
+            );
+            self.active = None;
+            let _ = self.runtime.reset_state();
+            if let Some(sk) = self.static_kv.as_mut() {
+                sk.reset();
+            }
+            self.position = 0;
+        }
+        res
+    }
+
+    fn step_first_body(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        if self.active.is_none() {
+            return Ok(Vec::new());
+        }
+        let (prefill, tokens) = {
+            let a = self.active.as_mut().unwrap();
+            if !a.prefilled {
+                a.prefilled = true;
+                (true, a.prompt_ids.clone())
+            } else {
+                (false, vec![a.last_token as i64])
+            }
+        };
+        let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
+
+        // A generation request must carry at least one prompt token; an empty
+        // prompt would otherwise emit a fabricated token with no inference (and
+        // on the static path skip the position-0 ring reset).
+        if prefill && tokens.is_empty() {
+            return Err(EngineError::Backend(
+                "empty prompt: no tokens to prefill".into(),
+            ));
+        }
+
+        let next_token = if self.static_kv.is_some() {
+            // Static (NPU): one token per inference (static_seq == 1). Prefill
+            // round-trips the whole pipeline once per prompt token so every
+            // stage's KV ring advances in lockstep; the token produced from
+            // the final prompt token is the first generated token.
+            if prefill {
+                self.position = 0;
+                if let Some(sk) = self.static_kv.as_ref() {
+                    if tokens.len() > sk.past_len {
+                        warn!(
+                            prompt_tokens = tokens.len(),
+                            past_len = sk.past_len,
+                            "prompt exceeds the static KV window (static_context-1); earliest \
+                             tokens will be evicted — attention degrades to a sliding window"
+                        );
+                    }
+                }
+            }
+            let mut nt = 0i32;
+            for &t in &tokens {
+                let position = self.position;
+                let ts = std::time::Instant::now();
+                let (out, shape) = self.run_first(&[t], position)?;
+                let alpha = ts.elapsed();
+                self.position += 1;
+                let (token, wire) =
+                    self.resolve_next_token(&out, &shape, single_stage, position)?;
+                nt = token;
+                if let Some(a) = self.active.as_mut() {
+                    a.t_alpha_compute += alpha;
+                    a.t_wire += wire;
+                }
+            }
+            nt
+        } else {
+            // Stateful: the whole prompt (prefill) or one decode token in a
+            // single multi-token inference; the IR keeps KV internally.
+            let position = self.position;
+            let ts = std::time::Instant::now();
+            let (out, shape) = self.run_first(&tokens, position)?;
+            let alpha = ts.elapsed();
+            self.position += tokens.len() as i64;
+            let (nt, wire) = self.resolve_next_token(&out, &shape, single_stage, position)?;
+            if let Some(a) = self.active.as_mut() {
+                a.t_alpha_compute += alpha;
+                a.t_wire += wire;
+            }
+            nt
+        };
+
+        self.emit_token(next_token)
+    }
+
+    /// From a first-stage output, produce the next token: argmax locally when
+    /// this is the only stage, otherwise forward the hidden state downstream
+    /// and await the token from the pipeline tail. Returns the token + the
+    /// wire round-trip time (zero for single-stage).
+    fn resolve_next_token(
+        &mut self,
+        out: &[f32],
+        shape: &[usize],
+        single_stage: bool,
+        position: i64,
+    ) -> EngineResult<(i32, std::time::Duration)> {
+        if single_stage {
+            Ok((argmax_logits(out, shape)?, std::time::Duration::ZERO))
+        } else {
+            let s3 = to_shape3(shape);
+            let ts = std::time::Instant::now();
+            self.send_hidden_downstream(out, s3, position)?;
+            let token = self.recv_token_from_downstream()?;
+            Ok((token, ts.elapsed()))
+        }
+    }
+
+    /// Decode the delta text for `next_token`, append it to the active task,
+    /// check stop conditions, and build the streamed chunk. Shared by the
+    /// static and stateful first-stage paths.
+    fn emit_token(&mut self, next_token: i32) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        let active = self
+            .active
+            .as_mut()
+            .ok_or_else(|| EngineError::Backend("emit_token with no active task".into()))?;
+        active.last_token = next_token;
+        active.generated.push(next_token);
+
+        let tok = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| EngineError::Backend("first stage requires tokenizer".into()))?;
+        let all_ids: Vec<u32> = active.generated.iter().map(|&t| t as u32).collect();
+        let full_text = tok
+            .decode(&all_ids, true)
+            .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
+        // Use strip_prefix instead of byte-slice indexing — `last_text`
+        // is not always a clean byte-prefix of `full_text` (BPE can
+        // emit a partial UTF-8 sequence on token N and complete the
+        // glyph on token N+1, in which case the prefix bytes change).
+        // Slicing past a UTF-8 boundary panics.
+        let delta = full_text
+            .strip_prefix(active.last_text.as_str())
+            .unwrap_or(&full_text)
+            .to_string();
+        active.last_text = full_text;
+
+        let max_tokens = active.task.max_tokens.max(1) as usize;
+        let is_eos = self.eos_token_ids.contains(&(next_token as u32));
+        let is_final = active.generated.len() >= max_tokens || is_eos;
+
+        let task_id = active.task.task_id.clone();
+        let chunk = if is_final {
+            Chunk {
+                task_id: task_id.clone(),
+                token_id: next_token as i64,
+                text: delta,
+                is_final: true,
+                logprobs: None,
+                n_tokens: None,
+            }
+        } else {
+            Chunk::token(task_id.clone(), next_token as i64, delta)
+        };
+
+        if is_final {
+            let elapsed = active.started.elapsed();
+            let tok_s = active.generated.len() as f64 / elapsed.as_secs_f64();
+            let alpha_ms = active.t_alpha_compute.as_millis() as u64;
+            let wire_ms = active.t_wire.as_millis() as u64;
+            let total_ms = elapsed.as_millis() as u64;
+            let other_ms = total_ms.saturating_sub(alpha_ms).saturating_sub(wire_ms);
+            info!(
+                task = %task_id,
+                tokens = active.generated.len(),
+                elapsed_s = elapsed.as_secs_f64(),
+                tok_s,
+                alpha_ms,
+                wire_ms,
+                other_ms,
+                "ov-runtime task done"
+            );
+            self.active = None;
+        }
+
+        Ok(vec![(task_id, chunk)])
+    }
+
+    /// One static-KV (NPU) inference for the token at absolute `position`.
+    /// Feeds `primary_in` ("input_ids" on the first stage, "hidden_states" on
+    /// a relay stage) + attention_mask + position_ids + this stage's KV ring,
+    /// runs, absorbs the new token's K/V from `present`, and returns output 0
+    /// (logits on the head stage, hidden_states otherwise). The ring resets at
+    /// `position == 0`, so this is correct for any stage in a pipeline.
+    fn static_infer(
+        &mut self,
+        use_hidden: bool,
+        in_dtype: ShimDType,
+        in_shape: &[usize],
+        in_bytes: &[u8],
+        position: i64,
+    ) -> EngineResult<(ShimDType, Vec<usize>, Vec<u8>)> {
+        // Align the ring to this absolute position (resets at position 0) and
+        // refresh the reusable mask buffer.
+        {
+            let sk = self.static_kv.as_mut().unwrap();
+            sk.begin_token(position as usize);
+            sk.write_mask_bytes();
+        }
+        let pos_bytes = position.to_le_bytes();
+
+        // Feed primary input + mask + position + the per-layer past-KV ring.
+        // self.runtime (mut) and self.static_kv (shared) are disjoint fields,
+        // so we borrow cached names + ring buffers directly — no per-token
+        // string or buffer allocation.
+        {
+            let sk = self.static_kv.as_ref().unwrap();
+            let in_main = if use_hidden {
+                sk.hidden_in.as_deref()
+            } else {
+                sk.ids_in.as_deref()
+            }
+            .ok_or_else(|| EngineError::Backend("static IR missing primary input".into()))?;
+            self.runtime
+                .set_input(in_main, in_dtype, in_shape, in_bytes)
+                .map_err(map_ov_err)?;
+            self.runtime
+                .set_input(
+                    &sk.attn_in,
+                    ShimDType::I64,
+                    &[1, sk.context],
+                    &sk.mask_bytes,
+                )
+                .map_err(map_ov_err)?;
+            self.runtime
+                .set_input(&sk.pos_in, ShimDType::I64, &[1, 1], &pos_bytes)
+                .map_err(map_ov_err)?;
+            let shape = [1, sk.kv_heads, sk.past_len, sk.head_dim];
+            for (li, layer) in sk.layers.iter().enumerate() {
+                self.runtime
+                    .set_input(&layer.key_in, sk.kv_dtype, &shape, &sk.key_buf[li])
+                    .map_err(map_ov_err)?;
+                self.runtime
+                    .set_input(&layer.val_in, sk.kv_dtype, &shape, &sk.val_buf[li])
+                    .map_err(map_ov_err)?;
+            }
+        }
+        self.runtime.infer().map_err(map_ov_err)?;
+
+        // Primary output (index 0): logits on the head stage, hidden_states
+        // otherwise — the static export emits it before the present.* outputs.
+        let (odt, oshape, obytes) = self.runtime.output(0).map_err(map_ov_err)?;
+
+        // Absorb the new token's K/V. Validate each present.* output's byte
+        // length AND shape against [1, kv_heads, context, head_dim] so a
+        // dtype/factorization mismatch is a clear error, not silent corruption.
+        let (n, expect, kvh, ctx, hd) = {
+            let sk = self.static_kv.as_ref().unwrap();
+            (
+                sk.layers.len(),
+                sk.present_layer_bytes(),
+                sk.kv_heads,
+                sk.context,
+                sk.head_dim,
+            )
+        };
+        let want_shape = [1usize, kvh, ctx, hd];
+        for li in 0..n {
+            let (ko, vo) = {
+                let l = &self.static_kv.as_ref().unwrap().layers[li];
+                (l.key_out, l.val_out)
+            };
+            let (_, kshape, kpres) = self.runtime.output(ko).map_err(map_ov_err)?;
+            let (_, vshape, vpres) = self.runtime.output(vo).map_err(map_ov_err)?;
+            if kpres.len() != expect
+                || vpres.len() != expect
+                || kshape != want_shape
+                || vshape != want_shape
+            {
+                return Err(EngineError::Backend(format!(
+                    "static present.{li} mismatch: key shape={kshape:?} len={} val shape={vshape:?} \
+                     len={}; expected shape {want_shape:?} ({expect} bytes f16). Check \
+                     num_kv_heads/head_dim/KV dtype in stage_config.",
+                    kpres.len(),
+                    vpres.len(),
+                )));
+            }
+            let sk = self.static_kv.as_mut().unwrap();
+            sk.absorb_layer(li, false, &kpres);
+            sk.absorb_layer(li, true, &vpres);
+        }
+        Ok((odt, oshape, obytes))
+    }
+
+    fn step_last(&mut self) -> EngineResult<()> {
+        let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
+        let (out, out_shape) = match pos_opt {
+            // Static (NPU): the carried absolute position drives the ring
+            // (reset at 0); seq is always 1.
+            Some(pos) => self.run_relay(&hidden, shape, pos)?,
+            None => {
+                if shape[1] > 1 {
+                    self.runtime.reset_state().map_err(map_ov_err)?;
+                    self.position = 0;
+                }
+                let r = self.run_relay(&hidden, shape, self.position)?;
+                self.position += shape[1] as i64;
+                r
+            }
+        };
+        let next = argmax_logits(&out, &out_shape)?;
+        self.send_token_to_upstream(next)?;
+        Ok(())
+    }
+
+    fn step_middle(&mut self) -> EngineResult<()> {
+        let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
+        let (out, out_shape, fwd_pos) = match pos_opt {
+            Some(pos) => {
+                let (o, s) = self.run_relay(&hidden, shape, pos)?;
+                (o, s, pos)
+            }
+            None => {
+                if shape[1] > 1 {
+                    self.runtime.reset_state().map_err(map_ov_err)?;
+                    self.position = 0;
+                }
+                let (o, s) = self.run_relay(&hidden, shape, self.position)?;
+                self.position += shape[1] as i64;
+                (o, s, 0)
+            }
+        };
+        let s3 = to_shape3(&out_shape);
+        self.send_hidden_downstream(&out, s3, fwd_pos)?;
+        let token = self.recv_token_from_downstream()?;
+        self.send_token_to_upstream(token)?;
+        Ok(())
+    }
+}
+
+impl Engine for Gemma4Engine {
+    fn warmup(&mut self) {
+        if !(self.spec.is_first_stage) {
+            info!("ov-runtime warmup skipped on non-first stage");
+            return;
+        }
+        let tok = match self.tokenizer.clone() {
+            Some(t) => t,
+            None => {
+                warn!("ov-runtime warmup skipped: no tokenizer");
+                return;
+            }
+        };
+        let enc = match tok.encode("Hi", false) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(error = %e, "ov-runtime warmup tokenize failed");
+                return;
+            }
+        };
+        let ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+        // run_first processes one token per call on the static path, so warm
+        // with a single token (enough to JIT the OV graph) regardless of path.
+        let warm = &ids[..ids.len().min(1)];
+        match self.run_first(warm, 0) {
+            Ok(_) => {
+                if let Some(sk) = self.static_kv.as_mut() {
+                    sk.reset();
+                } else {
+                    let _ = self.runtime.reset_state();
+                }
+                self.position = 0;
+                info!("ov-runtime warmup ok");
+            }
+            Err(e) => warn!(error = %e, "ov-runtime warmup failed"),
+        }
+    }
+
+    fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
+        if !self.spec.is_first_stage {
+            warn!("ov-runtime submit() ignored on non-first stage");
+            return Err(EngineError::Backend(
+                "non-first stage does not accept tasks directly".into(),
+            ));
+        }
+        if self.pending.iter().any(|t| t.task_id == task.task_id)
+            || self
+                .active
+                .as_ref()
+                .is_some_and(|a| a.task.task_id == task.task_id)
+        {
+            return Ok(());
+        }
+        if self.pending.len() >= crate::dist_spec::MAX_PENDING_TASKS {
+            warn!(
+                queued = self.pending.len(),
+                cap = crate::dist_spec::MAX_PENDING_TASKS,
+                "ov-runtime: pending queue at cap; rejecting task"
+            );
+            return Err(EngineError::QueueFull {
+                queued: self.pending.len(),
+                cap: crate::dist_spec::MAX_PENDING_TASKS,
+            });
+        }
+        self.pending.push(task);
+        Ok(())
+    }
+
+    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+        let result: EngineResult<Vec<(TaskId, Chunk)>> = if self.spec.is_first_stage {
+            self.step_first()
+        } else if self.spec.is_last_stage {
+            self.step_last().map(|_| Vec::new())
+        } else {
+            self.step_middle().map(|_| Vec::new())
+        };
+        match result {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "ov-runtime step failed");
+                Vec::new()
+            }
+        }
+    }
+}
+
+// -------- Builder --------
+
+#[derive(Default)]
+pub struct Gemma4Builder {
+    pub pipeline_dir: PathBuf,
+    pub rank: u32,
+    pub total: u32,
+    pub device: String,
+    pub cache_dir: Option<String>,
+    pub kv_cache_precision: Option<String>,
+    pub dyn_quant_group: Option<String>,
+    runtime: Option<OvRuntime>,
+    spec: Option<ShardSpec>,
+    rotary: Option<Rotary>,
+    hidden_size: usize,
+    tokenizer: Option<Arc<Tokenizer>>,
+    eos_token_ids: Vec<u32>,
+    input_names: Vec<String>,
+    upstream: Option<Arc<tokio::sync::Mutex<ActivationServer>>>,
+    downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
+    listen_host: String,
+    listen_port: Option<u16>,
+    /// (context, kv_heads, head_dim) for a stateless static-shape (NPU) shard;
+    /// None for the stateful path. static_seq is validated == 1 at load and not
+    /// stored (the ring math assumes one token per step).
+    static_params: Option<(u32, u32, u32)>,
+}
+
+impl Gemma4Builder {
+    pub fn new(
+        pipeline_dir: impl Into<PathBuf>,
+        rank: u32,
+        total: u32,
+        device: impl Into<String>,
+    ) -> Self {
+        Self {
+            pipeline_dir: pipeline_dir.into(),
+            rank,
+            total,
+            device: device.into(),
+            listen_host: "0.0.0.0".into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_cache_dir(mut self, dir: impl Into<String>) -> Self {
+        self.cache_dir = Some(dir.into());
+        self
+    }
+    pub fn with_kv_cache_precision(mut self, prec: impl Into<String>) -> Self {
+        self.kv_cache_precision = Some(prec.into());
+        self
+    }
+    pub fn with_dyn_quant_group(mut self, group: impl Into<String>) -> Self {
+        self.dyn_quant_group = Some(group.into());
+        self
+    }
+
+    fn plugin(&self) -> PluginConfig {
+        let mut p = PluginConfig::new();
+        if let Some(d) = &self.cache_dir {
+            p = p.with("CACHE_DIR", d);
+        }
+        if let Some(p2) = &self.kv_cache_precision {
+            p = p.with("KV_CACHE_PRECISION", p2);
+        }
+        if let Some(g) = &self.dyn_quant_group {
+            p = p.with("DYNAMIC_QUANTIZATION_GROUP_SIZE", g);
+        }
+        p
+    }
+}
+
+#[async_trait]
+impl Builder for Gemma4Builder {
+    fn configure_listen(&mut self, host: &str, port: u16) {
+        self.listen_host = host.to_string();
+        self.listen_port = Some(port);
+    }
+
+    async fn connect(&mut self, peers: PeerLayout) -> EngineResult<()> {
+        // First, bind upstream listener (so downstream can connect to us
+        // before we connect downstream). Mirrors the Python order.
+        if peers.upstream.is_some() {
+            let port = self
+                .listen_port
+                .ok_or_else(|| EngineError::PeerRejected("configure_listen() required".into()))?;
+            let mut server = ActivationServer::new(self.listen_host.clone(), port);
+            server
+                .start()
+                .await
+                .map_err(|e| EngineError::Backend(e.to_string()))?;
+            self.upstream = Some(Arc::new(tokio::sync::Mutex::new(server)));
+        }
+        if let Some(downstream) = peers.downstream {
+            let mut client = ActivationClient::new(downstream.host, downstream.port);
+            client
+                .connect_with_timeout(Duration::from_secs(60))
+                .await
+                .map_err(|e| EngineError::Backend(e.to_string()))?;
+            self.downstream = Some(Arc::new(tokio::sync::Mutex::new(client)));
+        }
+        if let Some(srv) = &self.upstream {
+            let srv = srv.clone();
+            srv.lock()
+                .await
+                .accept()
+                .await
+                .map_err(|e| EngineError::Backend(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn load(&mut self, _shard: ShardSpec) -> EngineResult<LoadStream> {
+        let mut events = Vec::new();
+        events.push(LoadProgress::message(format!(
+            "reading {}",
+            self.pipeline_dir.display()
+        )));
+
+        let pipeline_cfg = read_pipeline_config(&self.pipeline_dir)?;
+        if pipeline_cfg.num_stages != self.total {
+            return Err(EngineError::ShardRejected(format!(
+                "--total ({}) does not match pipeline_config num_stages ({})",
+                self.total, pipeline_cfg.num_stages
+            )));
+        }
+        let stage_dir = self.pipeline_dir.join(format!("stage_{}", self.rank));
+        let stage_cfg = read_stage_config(&stage_dir)?;
+
+        self.static_params = if !stage_cfg.stateful {
+            let ctx = stage_cfg.static_context.unwrap_or(0);
+            let s = stage_cfg.static_seq.unwrap_or(1);
+            let kvh = stage_cfg.num_kv_heads.unwrap_or(0);
+            let hd = stage_cfg.head_dim.unwrap_or(0);
+            // static_seq must be 1 (the runtime decodes one token per step) and
+            // static_context must exceed it so past_len = context - 1 >= 1.
+            if kvh == 0 || hd == 0 || s != 1 || ctx <= s {
+                return Err(EngineError::InvalidConfig(format!(
+                    "stateless (NPU) shard needs static_seq=1, static_context>static_seq, \
+                     and num_kv_heads/head_dim in stage_config; got seq={s} ctx={ctx} \
+                     kvh={kvh} hd={hd}"
+                )));
+            }
+            events.push(LoadProgress::message(format!(
+                "stateless static-KV shard: context={ctx} kv_heads={kvh} head_dim={hd}"
+            )));
+            // static_seq is validated == 1 above and never stored (the ring math
+            // assumes one token per step); carry only (ctx, kv_heads, head_dim).
+            Some((ctx, kvh, hd))
+        } else {
+            None
+        };
+
+        // A pipeline must be homogeneous: the static path carries a wire
+        // position frame the stateful path does not, so a mixed pipeline would
+        // desync. Fail fast when sibling stage configs are present locally
+        // (single-host multi-process); for distributed deploys each node has
+        // only its own stage dir, so the strict wire-frame validation in
+        // recv_hidden_from_upstream is the backstop at the first activation.
+        for r in 0..pipeline_cfg.num_stages {
+            if r == self.rank {
+                continue;
+            }
+            if let Ok(cfg) = read_stage_config(&self.pipeline_dir.join(format!("stage_{r}"))) {
+                if cfg.stateful != stage_cfg.stateful {
+                    return Err(EngineError::ShardRejected(format!(
+                        "pipeline is not homogeneous: stage_{} stateful={} but stage_{r} \
+                         stateful={} — all stages must share one KV mode (re-export the whole \
+                         pipeline with a single --target)",
+                        self.rank, stage_cfg.stateful, cfg.stateful
+                    )));
+                }
+            }
+        }
+
+        let is_first = stage_cfg.has_embed;
+        let is_last = stage_cfg.has_head;
+        let spec = ShardSpec {
+            model_id: pipeline_cfg.model_id.clone(),
+            layer_start: stage_cfg.layer_start,
+            layer_end: stage_cfg.layer_end,
+            total_layers: pipeline_cfg.num_layers,
+            device: self.device.clone(),
+            is_first_stage: is_first,
+            is_last_stage: is_last,
+            tp_size: 1,
+            tp_rank: 0,
+        };
+        self.hidden_size = pipeline_cfg.hidden_size as usize;
+        self.spec = Some(spec);
+
+        events.push(LoadProgress::message(format!(
+            "compiling stage {} on {}",
+            self.rank, self.device
+        )));
+        let plugin = self.plugin();
+        let xml_path = stage_dir.join("openvino_model.xml");
+        let runtime =
+            OvRuntime::compile(xml_path.to_str().unwrap_or_default(), &self.device, &plugin)
+                .map_err(map_ov_err)?;
+        self.input_names = runtime.input_names().map_err(map_ov_err)?;
+        self.runtime = Some(runtime);
+
+        events.push(LoadProgress::message(
+            "loading rotary + tokenizer".to_string(),
+        ));
+
+        // Rotary from the model's HF config.json. Look in the pipeline
+        // tokenizer dir first (rainier exports include config.json there);
+        // fall back to the HF cache via env, else error.
+        let tokenizer_dir = self.pipeline_dir.join("tokenizer");
+        let cfg = match load_model_config(&tokenizer_dir) {
+            Ok(c) => c,
+            Err(e1) => {
+                let alt = self.pipeline_dir.clone();
+                load_model_config(&alt).map_err(|e2| {
+                    EngineError::InvalidConfig(format!(
+                        "config.json not in {tokenizer_dir:?} ({e1}) or {alt:?} ({e2})"
+                    ))
+                })?
+            }
+        };
+        let rotary = Rotary::from_config(&cfg)
+            .map_err(|e| EngineError::InvalidConfig(format!("rotary: {e}")))?;
+        self.rotary = Some(rotary);
+
+        if is_first {
+            let tok_path = tokenizer_dir.join("tokenizer.json");
+            if tok_path.exists() {
+                let tok = Tokenizer::from_file(&tok_path)
+                    .map_err(|e| EngineError::Backend(format!("tokenizer load: {e}")))?;
+                self.tokenizer = Some(Arc::new(tok));
+                let eos_in_tok = lookup_eos(&tokenizer_dir);
+                self.eos_token_ids = if eos_in_tok.is_empty() {
+                    lookup_eos(&self.pipeline_dir)
+                } else {
+                    eos_in_tok
+                };
+                events.push(LoadProgress::message(format!(
+                    "tokenizer loaded; eos_token_ids={:?}",
+                    self.eos_token_ids
+                )));
+            } else {
+                events.push(LoadProgress::message(format!(
+                    "warning: no tokenizer.json at {tok_path:?}; first-stage tokenization will fail"
+                )));
+            }
+        }
+
+        events.push(LoadProgress::ready());
+        Ok(Box::pin(stream::iter(events)))
+    }
+
+    fn build(self: Box<Self>) -> EngineResult<Box<dyn Engine>> {
+        let runtime = self.runtime.ok_or(EngineError::NotLoaded)?;
+        let spec = self.spec.ok_or(EngineError::NotLoaded)?;
+        let rotary = self.rotary.ok_or(EngineError::NotLoaded)?;
+
+        // Resolve canonical port names via the alias list. v5 IRs export
+        // input ports under conventional names ("input_ids", "attention_mask",
+        // ...) but the IR's "primary" name is sometimes an internal node id;
+        // the alias list is what carries the canonical name.
+        let mut canonical_inputs = std::collections::HashMap::new();
+        let n_inputs = runtime.input_count();
+        for canonical in [
+            "input_ids",
+            "hidden_states",
+            "attention_mask",
+            "position_ids",
+            "beam_idx",
+        ] {
+            for idx in 0..n_inputs {
+                let aliases = runtime.input_aliases(idx).map_err(map_ov_err)?;
+                let primary = runtime.input_name(idx).map_err(map_ov_err)?;
+                if aliases
+                    .iter()
+                    .any(|a| a == canonical || a.contains(canonical))
+                {
+                    canonical_inputs.insert(canonical.to_string(), primary);
+                    break;
+                }
+            }
+        }
+
+        // Stateless static-shape (NPU) shards: resolve the explicit
+        // past_key_values.* inputs + present.* outputs and allocate the
+        // host-side KV ring. The primary output (logits on the head stage,
+        // hidden_states otherwise) is output index 0 — no alias guess needed.
+        let static_kv = if let Some((ctx, kvh, hd)) = self.static_params {
+            let n_out = runtime.output_count();
+            let mut layers: Vec<StaticKvLayer> = Vec::new();
+            loop {
+                let l = layers.len();
+                let kin_s = format!("past_key_values.{l}.key");
+                let vin_s = format!("past_key_values.{l}.value");
+                let kout_s = format!("present.{l}.key");
+                let vout_s = format!("present.{l}.value");
+                let (mut key_in, mut val_in) = (None, None);
+                for idx in 0..n_inputs {
+                    let al = runtime.input_aliases(idx).map_err(map_ov_err)?;
+                    if al.iter().any(|a| a.contains(&kin_s)) {
+                        key_in = Some(runtime.input_name(idx).map_err(map_ov_err)?);
+                    } else if al.iter().any(|a| a.contains(&vin_s)) {
+                        val_in = Some(runtime.input_name(idx).map_err(map_ov_err)?);
+                    }
+                }
+                let (key_in, val_in) = match (key_in, val_in) {
+                    (Some(k), Some(v)) => (k, v),
+                    _ => break,
+                };
+                let (mut key_out, mut val_out) = (None, None);
+                for idx in 0..n_out {
+                    let al = runtime.output_aliases(idx).map_err(map_ov_err)?;
+                    if al.iter().any(|a| a.contains(&kout_s)) {
+                        key_out = Some(idx);
+                    } else if al.iter().any(|a| a.contains(&vout_s)) {
+                        val_out = Some(idx);
+                    }
+                }
+                let key_out = key_out.ok_or_else(|| {
+                    EngineError::Backend(format!("static shard missing {kout_s}"))
+                })?;
+                let val_out = val_out.ok_or_else(|| {
+                    EngineError::Backend(format!("static shard missing {vout_s}"))
+                })?;
+                layers.push(StaticKvLayer {
+                    key_in,
+                    val_in,
+                    key_out,
+                    val_out,
+                });
+            }
+            if layers.is_empty() {
+                return Err(EngineError::Backend(
+                    "static shard: no past_key_values.* inputs found".into(),
+                ));
+            }
+            // Cross-check: the contiguous-from-0 discovery above stops at the
+            // first missing index. Compare against the total number of
+            // past_key_values.* input ports so a gap / renamed / folded port is
+            // a hard error instead of silently building fewer layers.
+            let mut kv_input_ports = 0usize;
+            for idx in 0..n_inputs {
+                let al = runtime.input_aliases(idx).map_err(map_ov_err)?;
+                if al.iter().any(|a| a.contains("past_key_values.")) {
+                    kv_input_ports += 1;
+                }
+            }
+            if kv_input_ports != layers.len() * 2 {
+                return Err(EngineError::Backend(format!(
+                    "static shard: resolved {} contiguous KV layers ({} ports) but the IR has \
+                     {kv_input_ports} past_key_values.* input ports — a layer port is missing or \
+                     misnamed (gap in the past_key_values.N sequence)",
+                    layers.len(),
+                    layers.len() * 2,
+                )));
+            }
+            let (kvh, hd) = (kvh as usize, hd as usize);
+            let past_len = (ctx - 1) as usize;
+            // KV activations are f16 in the static export; derive elem_bytes
+            // from the dtype so the two can never drift.
+            let kv_dtype = ShimDType::F16;
+            let elem_bytes = match kv_dtype {
+                ShimDType::F16 | ShimDType::Bf16 => 2,
+                ShimDType::F32 | ShimDType::I32 => 4,
+                ShimDType::I64 => 8,
+                ShimDType::I8 => 1,
+            };
+            let layer_bytes = kvh * past_len * hd * elem_bytes;
+            let n = layers.len();
+            // Cache the resolved primary/aux input port names so the per-token
+            // decode loop does no HashMap lookups or string allocs. A static
+            // shard always has attention_mask + position_ids; embed stages have
+            // input_ids, relay/head stages have hidden_states.
+            let attn_in = canonical_inputs
+                .get("attention_mask")
+                .cloned()
+                .ok_or_else(|| {
+                    EngineError::Backend("static IR missing attention_mask input".into())
+                })?;
+            let pos_in = canonical_inputs
+                .get("position_ids")
+                .cloned()
+                .ok_or_else(|| {
+                    EngineError::Backend("static IR missing position_ids input".into())
+                })?;
+            let ids_in = canonical_inputs.get("input_ids").cloned();
+            let hidden_in = canonical_inputs.get("hidden_states").cloned();
+            if ids_in.is_none() && hidden_in.is_none() {
+                return Err(EngineError::Backend(
+                    "static IR has neither input_ids nor hidden_states input".into(),
+                ));
+            }
+            Some(StaticKv {
+                past_len,
+                context: ctx as usize,
+                kv_heads: kvh,
+                head_dim: hd,
+                elem_bytes,
+                kv_dtype,
+                ids_in,
+                hidden_in,
+                attn_in,
+                pos_in,
+                layers,
+                key_buf: vec![vec![0u8; layer_bytes]; n],
+                val_buf: vec![vec![0u8; layer_bytes]; n],
+                valid: 0,
+                mask_bytes: vec![0u8; ctx as usize * 8],
+            })
+        } else {
+            None
+        };
+
+        Ok(Box::new(Gemma4Engine {
+            spec,
+            runtime,
+            rotary,
+            hidden_size: self.hidden_size,
+            tokenizer: self.tokenizer,
+            eos_token_ids: self.eos_token_ids.clone(),
+            upstream: self.upstream,
+            downstream: self.downstream,
+            runtime_handle: tokio::runtime::Handle::current(),
+            position: 0,
+            input_names: self.input_names,
+            canonical_inputs,
+            pending: Vec::new(),
+            active: None,
+            static_kv,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cascadia_types::PeerLayout;
+
+    #[tokio::test]
+    async fn rejects_missing_pipeline_config() {
+        let mut b = Gemma4Builder::new("/non/existent", 0, 1, "CPU");
+        let res = b.load(ShardSpec::single_stage("m", "CPU")).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn build_before_load_errors() {
+        let b = Box::new(Gemma4Builder::new("/x", 0, 1, "CPU"));
+        assert!(matches!(b.build(), Err(EngineError::NotLoaded)));
+    }
+
+    #[tokio::test]
+    async fn connect_no_peers_is_noop_for_single_stage() {
+        let mut b = Gemma4Builder::new("/x", 0, 1, "CPU");
+        b.connect(PeerLayout::single_stage()).await.unwrap();
+    }
+}

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -174,6 +174,14 @@ fn f32_to_f16_bytes(v: &[f32]) -> Vec<u8> {
     out
 }
 
+fn f32_to_bytes(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for x in v {
+        out.extend_from_slice(&x.to_le_bytes());
+    }
+    out
+}
+
 fn argmax_last_row(logits: &[f32], vocab: usize) -> i32 {
     let row = &logits[logits.len() - vocab..];
     // NaN-aware (see crate::dist_spec::argmax for rationale).
@@ -541,9 +549,12 @@ impl Gemma4Engine {
             .input_named("position_ids")
             .ok_or_else(|| EngineError::Backend("gemma4 IR missing position_ids".into()))?
             .to_string();
-        let hs_bytes = f32_to_f16_bytes(hidden);
+        // Gemma 4 keeps activations in f32 — the IR's hidden_states input is
+        // f32 (unlike v5, whose hidden is f16). Feed raw f32; the upstream
+        // stage sends it as f32 over the wire (see send_hidden_downstream).
+        let hs_bytes = f32_to_bytes(hidden);
         self.runtime
-            .set_input(&in_hs, ShimDType::F16, &shape, &hs_bytes)
+            .set_input(&in_hs, ShimDType::F32, &shape, &hs_bytes)
             .map_err(map_ov_err)?;
         self.runtime
             .set_input(&in_pos, ShimDType::I64, &[1, seq_len], &i64_to_bytes(&pos))
@@ -656,7 +667,10 @@ impl Gemma4Engine {
         for (i, d) in shape.iter().enumerate().take(MAX_RANK) {
             wire_shape[i] = *d as u32;
         }
-        let hid = WireTensor::new(WireDType::F16, wire_shape, f32_to_f16_bytes(hidden));
+        // Gemma 4 activations are f32 (the IR's hidden_states input/output are
+        // f32). Send raw f32 so the downstream stage feeds it without a lossy
+        // f16 round-trip — matches the f32 Core reference.
+        let hid = WireTensor::new(WireDType::F32, wire_shape, f32_to_bytes(hidden));
         // Static (NPU) shards need the absolute position downstream so each
         // stage can reset its ring at position 0 and align the visible-past
         // count. The wire shape has only MAX_RANK=3 dims (all used by

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -45,8 +45,6 @@ use serde::Deserialize;
 use tokenizers::Tokenizer;
 use tracing::{info, warn};
 
-use crate::rotary::{load_model_config, Rotary};
-
 // -------- pipeline / stage config --------
 
 #[derive(Debug, Deserialize)]
@@ -55,10 +53,6 @@ struct PipelineConfig {
     num_stages: u32,
     #[serde(default)]
     num_layers: u32,
-    #[serde(default)]
-    hidden_size: u32,
-    #[serde(default)]
-    export_version: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -75,8 +69,6 @@ struct StageConfig {
     has_embed: bool,
     #[serde(default)]
     has_head: bool,
-    #[serde(default)]
-    export_version: Option<String>,
     /// NPU (`--target npu`) export: KV is stateless (explicit past_kv-in /
     /// present-out) and all shapes are static. Old/standard shards omit the
     /// field and are stateful (default true). When false, the engine drives
@@ -446,8 +438,6 @@ struct ActiveTask {
 pub struct Gemma4Engine {
     spec: ShardSpec,
     runtime: OvRuntime,
-    rotary: Rotary,
-    hidden_size: usize,
     tokenizer: Option<Arc<Tokenizer>>,
     /// All EOS token ids configured for the model. Generation stops on
     /// the first token that matches ANY of these. See `lookup_eos`.
@@ -456,7 +446,6 @@ pub struct Gemma4Engine {
     downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
     runtime_handle: tokio::runtime::Handle,
     position: i64,
-    input_names: Vec<String>,
     /// Map of canonical name (e.g. "input_ids", "attention_mask") to the
     /// IR's primary port name. Resolved at engine build time via the
     /// alias lookup (the IR's primary name is sometimes an internal
@@ -486,14 +475,6 @@ pub struct Gemma4Engine {
 }
 
 impl Gemma4Engine {
-    /// True if the loaded IR uses v5+ canonical inputs (attention_mask +
-    /// position_ids) instead of legacy v3 (cos + sin). Determined from
-    /// the alias-resolved canonical_inputs map populated at build time.
-    fn is_v5_layout(&self) -> bool {
-        self.canonical_inputs.contains_key("attention_mask")
-            && self.canonical_inputs.contains_key("position_ids")
-    }
-
     /// Resolve a canonical input name to the IR's primary port name.
     fn input_named(&self, canonical: &str) -> Option<&str> {
         self.canonical_inputs.get(canonical).map(|s| s.as_str())
@@ -1299,11 +1280,8 @@ pub struct Gemma4Builder {
     pub dyn_quant_group: Option<String>,
     runtime: Option<OvRuntime>,
     spec: Option<ShardSpec>,
-    rotary: Option<Rotary>,
-    hidden_size: usize,
     tokenizer: Option<Arc<Tokenizer>>,
     eos_token_ids: Vec<u32>,
-    input_names: Vec<String>,
     upstream: Option<Arc<tokio::sync::Mutex<ActivationServer>>>,
     downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
     listen_host: String,
@@ -1475,7 +1453,6 @@ impl Builder for Gemma4Builder {
             tp_size: 1,
             tp_rank: 0,
         };
-        self.hidden_size = pipeline_cfg.hidden_size as usize;
         self.spec = Some(spec);
 
         events.push(LoadProgress::message(format!(
@@ -1487,31 +1464,14 @@ impl Builder for Gemma4Builder {
         let runtime =
             OvRuntime::compile(xml_path.to_str().unwrap_or_default(), &self.device, &plugin)
                 .map_err(map_ov_err)?;
-        self.input_names = runtime.input_names().map_err(map_ov_err)?;
         self.runtime = Some(runtime);
 
-        events.push(LoadProgress::message(
-            "loading rotary + tokenizer".to_string(),
-        ));
+        events.push(LoadProgress::message("loading tokenizer".to_string()));
 
-        // Rotary from the model's HF config.json. Look in the pipeline
-        // tokenizer dir first (rainier exports include config.json there);
-        // fall back to the HF cache via env, else error.
+        // Gemma 4 bakes RoPE into the IR (computed internally from
+        // position_ids), so unlike the v3 path there is no host-side rotary to
+        // load here — only the tokenizer dir, used for the tokenizer + EOS ids.
         let tokenizer_dir = self.pipeline_dir.join("tokenizer");
-        let cfg = match load_model_config(&tokenizer_dir) {
-            Ok(c) => c,
-            Err(e1) => {
-                let alt = self.pipeline_dir.clone();
-                load_model_config(&alt).map_err(|e2| {
-                    EngineError::InvalidConfig(format!(
-                        "config.json not in {tokenizer_dir:?} ({e1}) or {alt:?} ({e2})"
-                    ))
-                })?
-            }
-        };
-        let rotary = Rotary::from_config(&cfg)
-            .map_err(|e| EngineError::InvalidConfig(format!("rotary: {e}")))?;
-        self.rotary = Some(rotary);
 
         if is_first {
             let tok_path = tokenizer_dir.join("tokenizer.json");
@@ -1543,7 +1503,6 @@ impl Builder for Gemma4Builder {
     fn build(self: Box<Self>) -> EngineResult<Box<dyn Engine>> {
         let runtime = self.runtime.ok_or(EngineError::NotLoaded)?;
         let spec = self.spec.ok_or(EngineError::NotLoaded)?;
-        let rotary = self.rotary.ok_or(EngineError::NotLoaded)?;
 
         // Resolve canonical port names via the alias list. v5 IRs export
         // input ports under conventional names ("input_ids", "attention_mask",
@@ -1734,15 +1693,12 @@ impl Builder for Gemma4Builder {
         Ok(Box::new(Gemma4Engine {
             spec,
             runtime,
-            rotary,
-            hidden_size: self.hidden_size,
             tokenizer: self.tokenizer,
             eos_token_ids: self.eos_token_ids.clone(),
             upstream: self.upstream,
             downstream: self.downstream,
             runtime_handle: tokio::runtime::Handle::current(),
             position: 0,
-            input_names: self.input_names,
             canonical_inputs,
             pending: Vec::new(),
             active: None,

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1,11 +1,10 @@
-//! Multi-stage OpenVINO Runtime engine.
+//! Gemma 4 multi-stage OpenVINO engine (`--engine gemma4`).
 //!
-//! Rust port of `cascadia/worker/engines/openvino/ov_runtime.py`. Loads
-//! pre-exported per-stage stateful OV IRs (rainier v3+ format), runs them
-//! across the existing TCP transport, with stateful KV cache internal to
-//! the IR and `reset_state()` between independent generation tasks.
+//! Serves per-stage `gemma4_cached_v1` OV IR shards (exported by
+//! `tools/export_gemma4.py`) across the TCP activation transport, single-stage
+//! or pipeline-parallel. Own KV is OV internal state, reset between tasks.
 //!
-//! Pipeline-dir layout (matches rainier's exporter):
+//! Pipeline-dir layout:
 //! ```text
 //! <pipeline-dir>/
 //!     pipeline_config.json
@@ -14,18 +13,18 @@
 //!     stage_N/...
 //! ```
 //!
-//! Wire format between stages: hidden_states f16. Stateful shards have each
-//! stage track its own absolute-position counter (computing cos/sin locally,
-//! no position metadata on the wire); the counter resets when an activation
-//! with seq_len > 1 arrives (a prefill signal for relay/last stages).
+//! Wire format (downstream, per step): an absolute-position frame (relay stages
+//! use it as their `position_ids` base and reset own KV when it is 0 — correct
+//! for any prompt length), then the hidden activation (f32, matching the IR's
+//! f32 ports; PLI rides inside it), then a self-describing cross-KV header
+//! (count + per-frame tags) and that many cross-stage shared-KV frames.
 //!
-//! Stateless static-shape (NPU) shards (`stage_config.stateful == false`)
-//! instead drive a host-side bounded KV ring per stage (see `StaticKv`).
-//! Because static shards are seq=1, the seq>1 prefill signal is unavailable,
-//! so the first stage carries the absolute `position` as an 8-byte prefix on
-//! each activation; downstream stages reset their ring at position 0 and
-//! derive the visible-past count from it, keeping every stage's ring in
-//! lockstep. This path works single- or multi-stage (pipeline-parallel NPU).
+//! Gemma 4 E2B/E4B reuse a few source layers' KV across later layers; when a
+//! shared layer's source sits in an earlier stage, that KV crosses the wire as
+//! `cross_kv.*` outputs → `external_kv.*` inputs, matched by source-identity tag
+//! (`src_layer*2 + is_value`) so pairing is robust to port ordering and stage
+//! count. Dense shards (no KV-sharing) have no such ports and take a zero-cost
+//! hidden-only relay. Non-adjacent (multi-hop) KV sharing is rejected at load.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -69,20 +68,32 @@ struct StageConfig {
     has_embed: bool,
     #[serde(default)]
     has_head: bool,
-    /// NPU (`--target npu`) export: KV is stateless (explicit past_kv-in /
-    /// present-out) and all shapes are static. Old/standard shards omit the
-    /// field and are stateful (default true). When false, the engine drives
-    /// the static-KV path (host-side bounded ring) instead of OV state.
+    /// All gemma4 shards are stateful (own KV is OV internal state). The field
+    /// is kept so the engine can reject a non-stateful (stateless/NPU) shard
+    /// with a clear message — the gemma4 engine has no static-KV path.
     #[serde(default = "default_true")]
     stateful: bool,
+    /// Local indices (within this stage) of layers whose own KV a LATER stage
+    /// reuses — i.e. the source layers behind this stage's `cross_kv.*` outputs,
+    /// in `cross_kv.0,1,…` order. Global source-layer id = `layer_start + this`.
+    /// Used to tag each cross_kv frame on the wire by source id so the consumer
+    /// pairs explicitly (not positionally). Empty unless this stage produces
+    /// cross-stage shared KV.
     #[serde(default)]
-    static_seq: Option<u32>,
+    cross_stage_sources_local: Vec<u32>,
+    /// The cross-stage shared-KV sources this stage CONSUMES, in
+    /// `external_kv.0,1,…` order. Each carries the GLOBAL source-layer id used
+    /// to match an incoming wire frame to the right `external_kv.*` input.
     #[serde(default)]
-    static_context: Option<u32>,
+    external_shared_sources: Vec<ExternalSrc>,
+}
+
+/// One entry of `external_shared_sources` in stage_config.json. Only the global
+/// source-layer id is needed at runtime (to match cross-stage KV by source).
+#[derive(Debug, Deserialize, Default, Clone)]
+struct ExternalSrc {
     #[serde(default)]
-    num_kv_heads: Option<u32>,
-    #[serde(default)]
-    head_dim: Option<u32>,
+    src_global_layer: u32,
 }
 
 fn read_pipeline_config(p: &Path) -> Result<PipelineConfig, EngineError> {
@@ -154,16 +165,6 @@ fn f16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
             f16::from_bits(bits).to_f32()
         })
         .collect()
-}
-
-fn f32_to_f16_bytes(v: &[f32]) -> Vec<u8> {
-    use half::f16;
-    let mut out = Vec::with_capacity(v.len() * 2);
-    for x in v {
-        let h = f16::from_f32(*x);
-        out.extend_from_slice(&h.to_bits().to_le_bytes());
-    }
-    out
 }
 
 fn f32_to_bytes(v: &[f32]) -> Vec<u8> {
@@ -258,8 +259,20 @@ fn to_shape3(shape: &[usize]) -> [usize; 3] {
 /// the transport caps tensor rank at MAX_RANK=3, so we drop it; the receiver
 /// restores it. Payload is unchanged (dropping a unit dim leaves the element
 /// count identical), so the transport's strict `payload == shape*dtype` check
-/// still holds. Errors if the output is not the expected rank-4 batch-1 shape.
-fn pack_cross_kv_frame(shape4: &[usize], bytes: Vec<u8>) -> EngineResult<WireTensor> {
+/// still holds. Errors if the output dtype is not F32 (the gemma4 IR emits f32
+/// KV; mislabeling it would corrupt the consumer) or the shape is not rank-4
+/// batch-1.
+fn pack_cross_kv_frame(
+    dt: ShimDType,
+    shape4: &[usize],
+    bytes: Vec<u8>,
+) -> EngineResult<WireTensor> {
+    if dt != ShimDType::F32 {
+        return Err(EngineError::Backend(format!(
+            "cross_kv output dtype is {dt:?}, expected F32 (the gemma4 IR emits f32 KV); \
+             the wire frame would mislabel it"
+        )));
+    }
     if shape4.len() != 4 || shape4[0] != 1 {
         return Err(EngineError::Backend(format!(
             "cross_kv output shape {shape4:?} is not [1,kvh,ctx,hd]"
@@ -269,12 +282,85 @@ fn pack_cross_kv_frame(shape4: &[usize], bytes: Vec<u8>) -> EngineResult<WireTen
     Ok(WireTensor::new(WireDType::F32, ws, bytes))
 }
 
-/// Encode the absolute position as its own framed wire tensor (I64 `[1,1,1]`).
-/// The static (NPU) path sends this immediately before each hidden activation
-/// so relay stages reset/align their KV ring; the transport requires
-/// `payload_len == shape*dtype`, so position cannot be packed into the hidden
-/// tensor (and MAX_RANK=3 leaves no spare shape slot). Paired with
-/// `decode_wire_position` — keep the two in sync.
+/// Encode the cross-KV header: an I64 frame whose first element is the number
+/// of cross_kv frames that follow, then that many per-frame TAGS (in send
+/// order). Each tag identifies the source layer + key/value role of the frame
+/// (`src_global_layer * 2 + is_value`), so the consumer reads exactly the right
+/// number of frames (desync-proof) and matches each to its `external_kv.*`
+/// input by tag (order- and stage-count-independent). Always sent — a header of
+/// `[0]` means no cross-stage KV (single-stage / dense shards).
+fn encode_cross_kv_header(tags: &[i64]) -> WireTensor {
+    let mut vals = Vec::with_capacity(1 + tags.len());
+    vals.push(tags.len() as i64);
+    vals.extend_from_slice(tags);
+    let n = vals.len() as u32;
+    WireTensor::new(WireDType::I64, [1, 1, n], i64_to_bytes(&vals))
+}
+
+/// Decode + validate the cross-KV header (see [`encode_cross_kv_header`]).
+/// Returns the per-frame tags for the frames that follow.
+fn decode_cross_kv_header(t: &WireTensor) -> EngineResult<Vec<i64>> {
+    if t.dtype != WireDType::I64 || t.data.is_empty() || t.data.len() % 8 != 0 {
+        return Err(EngineError::Backend(format!(
+            "expected an I64 cross-KV header frame, got dtype={:?} len={} — likely a \
+             desynced activation stream",
+            t.dtype,
+            t.data.len()
+        )));
+    }
+    let vals: Vec<i64> = t
+        .data
+        .chunks_exact(8)
+        .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    let count = vals[0];
+    if count < 0 || count as usize != vals.len() - 1 {
+        return Err(EngineError::Backend(format!(
+            "cross-KV header declares {count} frames but carries {} tags",
+            vals.len() - 1
+        )));
+    }
+    Ok(vals[1..].to_vec())
+}
+
+/// Parse a `cross_kv.{i}.key|value` / `external_kv.{i}.key|value` port name into
+/// its `(index, is_value)`. Returns None for any other port.
+fn parse_kv_port(name: &str, prefix: &str) -> Option<(usize, bool)> {
+    let rest = name.strip_prefix(prefix)?;
+    let mut it = rest.split('.');
+    let idx: usize = it.next()?.parse().ok()?;
+    let is_value = match it.next()? {
+        "value" => true,
+        "key" => false,
+        _ => return None,
+    };
+    Some((idx, is_value))
+}
+
+/// A `cross_kv.*` output this stage produces: the OV output port index + the
+/// wire tag (`src_global_layer * 2 + is_value`) identifying the source layer
+/// and key/value role.
+#[derive(Clone)]
+struct CrossKvOut {
+    out_idx: usize,
+    tag: i64,
+}
+
+/// An `external_kv.*` input this stage consumes: the IR port name + the wire tag
+/// (`src_global_layer * 2 + is_value`) it must be fed from.
+#[derive(Clone)]
+struct ExternalKvIn {
+    name: String,
+    tag: i64,
+}
+
+/// Encode the absolute start-position as its own framed wire tensor (I64
+/// `[1,1,1]`), sent before each hidden activation. Relay stages use it directly
+/// as their `position_ids` base and reset their stateful KV when it is 0 (start
+/// of a new sequence) — so a 1-token prompt is handled correctly, unlike a
+/// `seq_len > 1` heuristic. The transport requires `payload_len == shape*dtype`
+/// and MAX_RANK=3 leaves no spare slot in the hidden tensor, so position rides
+/// as its own frame. Paired with `decode_wire_position` — keep the two in sync.
 fn encode_wire_position(position: i64) -> WireTensor {
     WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
 }
@@ -287,7 +373,7 @@ fn decode_wire_position(t: &WireTensor) -> EngineResult<i64> {
     if t.dtype != WireDType::I64 || t.data.len() != 8 {
         return Err(EngineError::Backend(format!(
             "expected an I64 8-byte position frame, got dtype={:?} len={} — likely a \
-             stateful/static pipeline mismatch or a desynced activation stream",
+             desynced activation stream",
             t.dtype,
             t.data.len()
         )));
@@ -295,125 +381,6 @@ fn decode_wire_position(t: &WireTensor) -> EngineResult<i64> {
     let mut b = [0u8; 8];
     b.copy_from_slice(&t.data);
     Ok(i64::from_le_bytes(b))
-}
-
-// -------- static-KV (NPU) state --------
-
-/// Per-layer port wiring for a stateless static-shape (NPU) shard.
-struct StaticKvLayer {
-    key_in: String,
-    val_in: String,
-    key_out: usize,
-    val_out: usize,
-}
-
-/// Host-side bounded KV ring for the stateless static-shape (NPU) path.
-/// The exported IR takes explicit `past_key_values.*` (length `past_len`) +
-/// `attention_mask` (length `context = past_len + 1`) + `position_ids`, and
-/// returns its primary output (logits for the head stage, hidden_states
-/// otherwise) at output index 0, plus `present.*` (length `context`). We hold
-/// the KV for the most recent `valid` real tokens left-aligned in
-/// `past_len`-slot buffers, feed them each step, and absorb the new token's KV
-/// from `present[past_len]`. One ring per stage; in a multi-stage pipeline
-/// every stage runs its own ring over its own layers, kept in lockstep by the
-/// absolute `position` the first stage carries with each activation.
-struct StaticKv {
-    past_len: usize,
-    context: usize,
-    kv_heads: usize,
-    head_dim: usize,
-    elem_bytes: usize,
-    kv_dtype: ShimDType,
-    /// Resolved primary input port names (cached at build so the per-token
-    /// decode loop does no HashMap lookups / string allocs). `ids_in` is set
-    /// for the embed stage, `hidden_in` for relay/head stages.
-    ids_in: Option<String>,
-    hidden_in: Option<String>,
-    attn_in: String,
-    pos_in: String,
-    layers: Vec<StaticKvLayer>,
-    key_buf: Vec<Vec<u8>>, // [layer] = kv_heads * past_len * head_dim * elem_bytes
-    val_buf: Vec<Vec<u8>>,
-    valid: usize, // number of real past tokens currently in the ring
-    /// Reusable attention_mask byte buffer (i64 LE, length context*8), rewritten
-    /// in place each token to avoid a per-token allocation.
-    mask_bytes: Vec<u8>,
-}
-
-impl StaticKv {
-    fn reset(&mut self) {
-        for b in self.key_buf.iter_mut().chain(self.val_buf.iter_mut()) {
-            b.iter_mut().for_each(|x| *x = 0);
-        }
-        self.valid = 0;
-    }
-
-    /// Expected byte length of one layer's `present.*` output:
-    /// `kv_heads * context * head_dim * elem_bytes`. Used to validate the IR's
-    /// output shape/dtype before `absorb_layer` slices it.
-    fn present_layer_bytes(&self) -> usize {
-        self.kv_heads * self.context * self.head_dim * self.elem_bytes
-    }
-
-    /// Set how many real past tokens are visible for a token at absolute
-    /// `position`, resetting the ring at the start of a new sequence
-    /// (`position == 0`). The window is bounded by `past_len`.
-    fn begin_token(&mut self, position: usize) {
-        if position == 0 {
-            self.reset();
-        }
-        self.valid = position.min(self.past_len);
-    }
-
-    /// Rewrite `mask_bytes` (i64 LE) for the current `valid`: 1 for the `valid`
-    /// real past slots (left-aligned) + the current token (slot `past_len`), 0
-    /// for the padding past slots in between. Reuses the buffer's capacity.
-    fn write_mask_bytes(&mut self) {
-        self.mask_bytes.clear();
-        self.mask_bytes.resize(self.context * 8, 0);
-        for i in 0..self.context {
-            let v: i64 = if i < self.valid || i == self.past_len {
-                1
-            } else {
-                0
-            };
-            self.mask_bytes[i * 8..i * 8 + 8].copy_from_slice(&v.to_le_bytes());
-        }
-    }
-
-    /// Copy the new token's K/V (slot `past_len` of `present`) into the
-    /// layer's ring buffer, appending at `valid` or sliding the window when
-    /// full. Selects `key_buf[li]` or `val_buf[li]` internally so callers can
-    /// hold `&mut self` without aliasing the buffer field.
-    fn absorb_layer(&mut self, li: usize, is_value: bool, present: &[u8]) {
-        // Read scalar fields into locals before borrowing the buffer field,
-        // so the mutable buffer borrow stays disjoint from these reads.
-        let slot = self.head_dim * self.elem_bytes;
-        let present_row = self.context * slot; // per-head stride in present
-        let buf_row = self.past_len * slot; // per-head stride in the ring
-        let full = self.valid >= self.past_len;
-        let kv_heads = self.kv_heads;
-        let past_len = self.past_len;
-        let valid = self.valid;
-        let buf: &mut [u8] = if is_value {
-            &mut self.val_buf[li]
-        } else {
-            &mut self.key_buf[li]
-        };
-        for h in 0..kv_heads {
-            let src = h * present_row + past_len * slot;
-            let new = &present[src..src + slot];
-            let base = h * buf_row;
-            if full {
-                buf.copy_within(base + slot..base + buf_row, base); // drop oldest
-                let dst = base + (past_len - 1) * slot;
-                buf[dst..dst + slot].copy_from_slice(new);
-            } else {
-                let dst = base + valid * slot;
-                buf[dst..dst + slot].copy_from_slice(new);
-            }
-        }
-    }
 }
 
 // -------- Engine --------
@@ -453,25 +420,19 @@ pub struct Gemma4Engine {
     canonical_inputs: std::collections::HashMap<String, String>,
     pending: Vec<GenerationTask>,
     active: Option<ActiveTask>,
-    /// Set for stateless static-shape (NPU) shards; drives the host-side
-    /// bounded-KV decode path instead of OV internal state.
-    static_kv: Option<StaticKv>,
-    /// Output indices of this stage's `cross_kv.*` ports (sorted by name) —
-    /// the cross-stage shared KV this stage's source layers produce for a
-    /// downstream stage (Gemma 4 E2B/E4B KV-sharing). Read after each infer
-    /// and sent downstream alongside the hidden state. Empty for single-stage
-    /// shards and models without cross-stage KV-sharing (e.g. dense 31B).
-    cross_kv_out_idx: Vec<usize>,
-    /// Input names of this stage's `external_kv.*` ports (sorted by name) —
-    /// the cross-stage shared KV this stage's shared layers consume from an
-    /// upstream stage. Fed from `pending_external_kv` each step. Empty unless
-    /// this stage depends on a source layer in an earlier stage.
-    external_kv_in_names: Vec<String>,
-    /// Cross-stage KV received from upstream this step, ready to feed into the
-    /// `external_kv.*` inputs — one (shape, bytes) per name, rank-4
-    /// `[1,kvh,ctx,hd]` f32, in the same name-sorted order as
-    /// `external_kv_in_names`.
-    pending_external_kv: Vec<(Vec<usize>, Vec<u8>)>,
+    /// Cross-stage shared KV this stage PRODUCES (Gemma 4 E2B/E4B KV-sharing):
+    /// each `cross_kv.*` output port + its wire tag (source layer + key/value).
+    /// Read after each infer and sent downstream tagged so the consumer pairs
+    /// by source identity, not port position. Empty for single-stage / dense
+    /// shards (e.g. 31B → zero-cost pure hidden relay).
+    cross_kv_out: Vec<CrossKvOut>,
+    /// Cross-stage shared KV this stage CONSUMES: each `external_kv.*` input
+    /// port + the wire tag it must be fed from. Matched against the tagged
+    /// frames received from upstream each step.
+    external_kv_in: Vec<ExternalKvIn>,
+    /// Cross-stage KV received from upstream this step, keyed by wire tag, ready
+    /// to feed into the `external_kv.*` inputs. Rebuilt each step.
+    pending_external_kv: std::collections::HashMap<i64, (Vec<usize>, Vec<u8>)>,
 }
 
 impl Gemma4Engine {
@@ -516,7 +477,7 @@ impl Gemma4Engine {
         shape: [usize; 3],
         position: i64,
     ) -> EngineResult<()> {
-        // hidden_states (f16) + position_ids. `shape[2]` is the full width
+        // hidden_states (f32) + position_ids. `shape[2]` is the full width
         // (hidden_size + the per-layer-embedding tail when pli_dim>0); the IR
         // input accepts that width, so PLI rides inside hidden_states with no
         // special handling here.
@@ -545,31 +506,31 @@ impl Gemma4Engine {
     }
 
     /// Feed cross-stage shared KV (`external_kv.{i}.{key,value}` inputs) from
-    /// the frames received from the upstream stage this step. No-op for
-    /// single-stage shards and any stage with no external sources (e.g. dense
-    /// 31B, which has no KV-sharing).
+    /// the frames received from upstream this step, matched by wire TAG (source
+    /// layer + key/value role) rather than by position — so pairing is correct
+    /// regardless of port ordering, and a missing source is a clear error, not
+    /// silent wrong-KV. No-op for stages with no external sources (single-stage
+    /// / dense shards).
     fn feed_external_kv(&mut self) -> EngineResult<()> {
-        if self.external_kv_in_names.is_empty() {
+        if self.external_kv_in.is_empty() {
             return Ok(());
         }
-        if self.pending_external_kv.len() != self.external_kv_in_names.len() {
-            return Err(EngineError::Backend(format!(
-                "external_kv count mismatch: {} frames received from upstream, IR \
-                 expects {} (upstream stage's cross_kv.* count must equal this \
-                 stage's external_kv.* count)",
-                self.pending_external_kv.len(),
-                self.external_kv_in_names.len()
-            )));
-        }
-        // names + pending are both sorted by name, so index i aligns the
-        // sender's cross_kv.i with this stage's external_kv.i. Clone the names
-        // and take the buffers into locals to release the &self borrows before
-        // the &mut self.runtime call.
-        let names = self.external_kv_in_names.clone();
-        let pend = std::mem::take(&mut self.pending_external_kv);
-        for (name, (shape, bytes)) in names.iter().zip(pend.iter()) {
+        // Move pending + clone the (small) input list to release the &self
+        // borrows before the &mut self.runtime calls.
+        let pending = std::mem::take(&mut self.pending_external_kv);
+        let inputs = self.external_kv_in.clone();
+        for ext in &inputs {
+            let (shape, bytes) = pending.get(&ext.tag).ok_or_else(|| {
+                EngineError::Backend(format!(
+                    "external_kv input {} needs cross-stage KV (tag {}) but no matching frame \
+                     arrived from upstream — the immediate upstream stage does not produce it. \
+                     Non-adjacent KV sharing across more than one pipeline hop is not supported; \
+                     export with KV source/consumer on adjacent stages (or fewer stages).",
+                    ext.name, ext.tag
+                ))
+            })?;
             self.runtime
-                .set_input(name, ShimDType::F32, shape, bytes)
+                .set_input(&ext.name, ShimDType::F32, shape, bytes)
                 .map_err(map_ov_err)?;
         }
         Ok(())
@@ -580,24 +541,6 @@ impl Gemma4Engine {
         input_ids: &[i64],
         position: i64,
     ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
-        // Stateless static (NPU): feed one token id + the host-side KV ring.
-        // The caller loops one token at a time (static_seq == 1).
-        if self.static_kv.is_some() {
-            if input_ids.len() != 1 {
-                return Err(EngineError::Backend(format!(
-                    "static shard processes one token per step, got {}",
-                    input_ids.len()
-                )));
-            }
-            let (dtype, shape, bytes) = self.static_infer(
-                false,
-                ShimDType::I64,
-                &[1, 1],
-                &i64_to_bytes(input_ids),
-                position,
-            )?;
-            return Ok((bytes_to_f32(dtype, &bytes)?, shape));
-        }
         self.build_feed_first(input_ids, position)?;
         self.runtime.infer().map_err(map_ov_err)?;
         let (dtype, shape, bytes) = self.runtime.output(0).map_err(map_ov_err)?;
@@ -610,14 +553,6 @@ impl Gemma4Engine {
         shape: [usize; 3],
         position: i64,
     ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
-        // Stateless static (NPU): feed the upstream hidden state + the
-        // host-side KV ring for this stage's layers.
-        if self.static_kv.is_some() {
-            let hs_bytes = f32_to_f16_bytes(hidden);
-            let (dtype, out_shape, bytes) =
-                self.static_infer(true, ShimDType::F16, &shape, &hs_bytes, position)?;
-            return Ok((bytes_to_f32(dtype, &bytes)?, out_shape));
-        }
         self.build_feed_relay(hidden, shape, position)?;
         self.runtime.infer().map_err(map_ov_err)?;
         let (dtype, out_shape, bytes) = self.runtime.output(0).map_err(map_ov_err)?;
@@ -652,37 +587,34 @@ impl Gemma4Engine {
         // f32). Send raw f32 so the downstream stage feeds it without a lossy
         // f16 round-trip — matches the f32 Core reference.
         let hid = WireTensor::new(WireDType::F32, wire_shape, f32_to_bytes(hidden));
-        // Static (NPU) shards need the absolute position downstream so each
-        // stage can reset its ring at position 0 and align the visible-past
-        // count. The wire shape has only MAX_RANK=3 dims (all used by
-        // [1,1,hidden]) and the transport requires payload_len == shape*dtype,
-        // so we can't pack it into the hidden tensor — send it as its own
-        // framed I64 tensor first. recv_hidden_from_upstream mirrors the order.
-        let pos = if self.static_kv.is_some() {
-            Some(encode_wire_position(position))
-        } else {
-            None
-        };
+        // The absolute start-position rides as its own frame (sent first): relay
+        // stages use it directly as their position_ids base and reset their KV
+        // when it is 0. MAX_RANK=3 + the strict payload==shape*dtype check leave
+        // no room to pack it into the hidden tensor.
+        let pos = encode_wire_position(position);
         // Gemma 4 E2B/E4B: this stage's source layers produced cross-stage
-        // shared KV (`cross_kv.*` outputs) the downstream stage needs as its
-        // `external_kv.*` inputs. Read each from the just-completed inference
-        // and pack the rank-4 [1,kvh,ctx,hd] tensor into a rank-3 wire frame
-        // [kvh,ctx,hd] (batch is always 1; transport caps rank at MAX_RANK=3).
-        // The cache is the full accumulated source-layer KV (grows each step),
-        // sent as f32 to match the IR output dtype and the Core reference.
-        // Empty for single-stage / dense shards (no cross_kv ports).
-        let cross_idxs = self.cross_kv_out_idx.clone();
-        let mut cross_frames = Vec::with_capacity(cross_idxs.len());
-        for idx in cross_idxs {
-            let (_dt, oshape, bytes) = self.runtime.output(idx).map_err(map_ov_err)?;
-            cross_frames.push(pack_cross_kv_frame(&oshape, bytes)?);
+        // shared KV (`cross_kv.*` outputs) downstream stages consume as their
+        // `external_kv.*` inputs. Read each from the just-completed inference,
+        // pack the rank-4 [1,kvh,ctx,hd] tensor into a rank-3 wire frame
+        // [kvh,ctx,hd] (batch is always 1; transport caps rank at MAX_RANK=3),
+        // and tag it by source so the consumer pairs explicitly. A self-
+        // describing header (count + tags) precedes the frames so the consumer
+        // reads exactly the right number — desync-proof. Empty header [0] for
+        // single-stage / dense shards.
+        let outs = self.cross_kv_out.clone();
+        let mut tags = Vec::with_capacity(outs.len());
+        let mut cross_frames = Vec::with_capacity(outs.len());
+        for o in &outs {
+            let (dt, oshape, bytes) = self.runtime.output(o.out_idx).map_err(map_ov_err)?;
+            cross_frames.push(pack_cross_kv_frame(dt, &oshape, bytes)?);
+            tags.push(o.tag);
         }
+        let header = encode_cross_kv_header(&tags);
         self.block_on(async move {
             let mut guard = downstream.lock().await;
-            if let Some(p) = pos {
-                guard.send(&p).await?;
-            }
+            guard.send(&pos).await?;
             guard.send(&hid).await?;
+            guard.send(&header).await?;
             for f in &cross_frames {
                 guard.send(f).await?;
             }
@@ -718,69 +650,73 @@ impl Gemma4Engine {
         Ok(token)
     }
 
-    fn recv_hidden_from_upstream(&mut self) -> EngineResult<(Vec<f32>, [usize; 3], Option<i64>)> {
+    fn recv_hidden_from_upstream(&mut self) -> EngineResult<(Vec<f32>, [usize; 3], i64)> {
         let upstream = self
             .upstream
             .clone()
             .ok_or_else(|| EngineError::Backend("no upstream".into()))?;
-        // Static (NPU) shards send a leading I64 position tensor before the
-        // hidden activation (see send_hidden_downstream). Each frame's payload
-        // must match its shape*dtype, so we recv two separate tensors here.
-        let want_pos = self.static_kv.is_some();
-        // Gemma 4 E2B/E4B: after the hidden frame, the upstream stage sends one
-        // frame per `external_kv.*` input this stage consumes (its shared
-        // layers' cross-stage KV). recv exactly that many, in the same
-        // name-sorted order send_hidden_downstream used for cross_kv.*.
-        let n_ext = self.external_kv_in_names.len();
-        let (pos_tensor, tensor, ext_tensors) = self
-            .block_on(async move {
+        // Wire order per step: position frame, hidden frame, cross-KV header,
+        // then `count` cross-KV frames (count from the header). Read the first
+        // three, decode the header to learn `count`, then read that many.
+        let (pos_t, hid_t, header_t) = self
+            .block_on(async {
                 let mut guard = upstream.lock().await;
-                let pos_tensor = if want_pos {
-                    Some(guard.recv().await?.0)
-                } else {
-                    None
-                };
-                let (t, _) = guard.recv().await?;
-                let mut exts = Vec::with_capacity(n_ext);
-                for _ in 0..n_ext {
-                    exts.push(guard.recv().await?.0);
-                }
-                Ok::<_, cascadia_transport::TransportError>((pos_tensor, t, exts))
+                let pos = guard.recv().await?.0;
+                let hid = guard.recv().await?.0;
+                let hdr = guard.recv().await?.0;
+                Ok::<_, cascadia_transport::TransportError>((pos, hid, hdr))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
-        // Decode + strictly validate the position frame outside the transport
-        // closure (so a bad frame yields a clear EngineError, not a desync).
-        let position = match pos_tensor {
-            Some(p) => Some(decode_wire_position(&p)?),
-            None => None,
-        };
-        // Unpack each rank-3 wire frame [kvh,ctx,hd] back to the IR's rank-4
-        // [1,kvh,ctx,hd] f32 for feed_external_kv (called from build_feed_*).
-        self.pending_external_kv = ext_tensors
-            .iter()
-            .map(|wt| {
-                let s = &wt.shape;
+        // Decode + strictly validate the position + header outside the transport
+        // closure (so a bad frame is a clear EngineError, not a silent desync).
+        let position = decode_wire_position(&pos_t)?;
+        let tags = decode_cross_kv_header(&header_t)?;
+        let n = tags.len();
+        let up2 = self.upstream.clone().unwrap();
+        let ext_tensors = self
+            .block_on(async move {
+                let mut guard = up2.lock().await;
+                let mut v = Vec::with_capacity(n);
+                for _ in 0..n {
+                    v.push(guard.recv().await?.0);
+                }
+                Ok::<_, cascadia_transport::TransportError>(v)
+            })
+            .map_err(|e| EngineError::Backend(e.to_string()))?;
+        // Index each cross-KV frame by its tag (validating dtype), so
+        // feed_external_kv can match it to the right `external_kv.*` input.
+        self.pending_external_kv.clear();
+        for (tag, wt) in tags.iter().zip(ext_tensors.iter()) {
+            if wt.dtype != WireDType::F32 {
+                return Err(EngineError::Backend(format!(
+                    "cross-KV frame (tag {tag}) has dtype {:?}, expected F32",
+                    wt.dtype
+                )));
+            }
+            let s = &wt.shape;
+            self.pending_external_kv.insert(
+                *tag,
                 (
                     vec![1usize, s[0] as usize, s[1] as usize, s[2] as usize],
                     wt.data.clone(),
-                )
-            })
-            .collect();
+                ),
+            );
+        }
         let shape = [
-            tensor.shape[0] as usize,
-            tensor.shape[1] as usize,
-            tensor.shape[2] as usize,
+            hid_t.shape[0] as usize,
+            hid_t.shape[1] as usize,
+            hid_t.shape[2] as usize,
         ];
-        let floats = match tensor.dtype {
-            WireDType::F32 => tensor
+        let floats = match hid_t.dtype {
+            WireDType::F32 => hid_t
                 .data
                 .chunks_exact(4)
                 .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                 .collect(),
-            WireDType::F16 => f16_bytes_to_f32(&tensor.data),
+            WireDType::F16 => f16_bytes_to_f32(&hid_t.data),
             other => {
                 return Err(EngineError::Backend(format!(
-                    "unexpected upstream dtype {other:?}"
+                    "unexpected upstream hidden dtype {other:?}"
                 )))
             }
         };
@@ -813,14 +749,12 @@ impl Gemma4Engine {
                 .encode(task.prompt.clone(), false)
                 .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
             let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
-            if self.static_kv.is_none() {
-                self.runtime.reset_state().map_err(map_ov_err)?;
-            }
+            self.runtime.reset_state().map_err(map_ov_err)?;
             self.position = 0;
             info!(
                 task = %task.task_id,
                 prompt_tokens = prompt_ids.len(),
-                "task active (ov-runtime)"
+                "gemma4 task active"
             );
             self.active = Some(ActiveTask {
                 task,
@@ -851,9 +785,6 @@ impl Gemma4Engine {
             );
             self.active = None;
             let _ = self.runtime.reset_state();
-            if let Some(sk) = self.static_kv.as_mut() {
-                sk.reset();
-            }
             self.position = 0;
         }
         res
@@ -875,63 +806,27 @@ impl Gemma4Engine {
         let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
 
         // A generation request must carry at least one prompt token; an empty
-        // prompt would otherwise emit a fabricated token with no inference (and
-        // on the static path skip the position-0 ring reset).
+        // prompt would otherwise emit a fabricated token with no inference.
         if prefill && tokens.is_empty() {
             return Err(EngineError::Backend(
                 "empty prompt: no tokens to prefill".into(),
             ));
         }
 
-        let next_token = if self.static_kv.is_some() {
-            // Static (NPU): one token per inference (static_seq == 1). Prefill
-            // round-trips the whole pipeline once per prompt token so every
-            // stage's KV ring advances in lockstep; the token produced from
-            // the final prompt token is the first generated token.
-            if prefill {
-                self.position = 0;
-                if let Some(sk) = self.static_kv.as_ref() {
-                    if tokens.len() > sk.past_len {
-                        warn!(
-                            prompt_tokens = tokens.len(),
-                            past_len = sk.past_len,
-                            "prompt exceeds the static KV window (static_context-1); earliest \
-                             tokens will be evicted — attention degrades to a sliding window"
-                        );
-                    }
-                }
-            }
-            let mut nt = 0i32;
-            for &t in &tokens {
-                let position = self.position;
-                let ts = std::time::Instant::now();
-                let (out, shape) = self.run_first(&[t], position)?;
-                let alpha = ts.elapsed();
-                self.position += 1;
-                let (token, wire) =
-                    self.resolve_next_token(&out, &shape, single_stage, position)?;
-                nt = token;
-                if let Some(a) = self.active.as_mut() {
-                    a.t_alpha_compute += alpha;
-                    a.t_wire += wire;
-                }
-            }
-            nt
-        } else {
-            // Stateful: the whole prompt (prefill) or one decode token in a
-            // single multi-token inference; the IR keeps KV internally.
-            let position = self.position;
-            let ts = std::time::Instant::now();
-            let (out, shape) = self.run_first(&tokens, position)?;
-            let alpha = ts.elapsed();
-            self.position += tokens.len() as i64;
-            let (nt, wire) = self.resolve_next_token(&out, &shape, single_stage, position)?;
-            if let Some(a) = self.active.as_mut() {
-                a.t_alpha_compute += alpha;
-                a.t_wire += wire;
-            }
-            nt
-        };
+        // The whole prompt (prefill) or one decode token in a single
+        // multi-token inference; the IR keeps own KV internally. The absolute
+        // start-position is sent downstream so relay stages align position_ids
+        // and reset on 0.
+        let position = self.position;
+        let ts = std::time::Instant::now();
+        let (out, shape) = self.run_first(&tokens, position)?;
+        let alpha = ts.elapsed();
+        self.position += tokens.len() as i64;
+        let (next_token, wire) = self.resolve_next_token(&out, &shape, single_stage, position)?;
+        if let Some(a) = self.active.as_mut() {
+            a.t_alpha_compute += alpha;
+            a.t_wire += wire;
+        }
 
         self.emit_token(next_token)
     }
@@ -1021,7 +916,7 @@ impl Gemma4Engine {
                 alpha_ms,
                 wire_ms,
                 other_ms,
-                "ov-runtime task done"
+                "gemma4 task done"
             );
             self.active = None;
         }
@@ -1029,152 +924,29 @@ impl Gemma4Engine {
         Ok(vec![(task_id, chunk)])
     }
 
-    /// One static-KV (NPU) inference for the token at absolute `position`.
-    /// Feeds `primary_in` ("input_ids" on the first stage, "hidden_states" on
-    /// a relay stage) + attention_mask + position_ids + this stage's KV ring,
-    /// runs, absorbs the new token's K/V from `present`, and returns output 0
-    /// (logits on the head stage, hidden_states otherwise). The ring resets at
-    /// `position == 0`, so this is correct for any stage in a pipeline.
-    fn static_infer(
-        &mut self,
-        use_hidden: bool,
-        in_dtype: ShimDType,
-        in_shape: &[usize],
-        in_bytes: &[u8],
-        position: i64,
-    ) -> EngineResult<(ShimDType, Vec<usize>, Vec<u8>)> {
-        // Align the ring to this absolute position (resets at position 0) and
-        // refresh the reusable mask buffer.
-        {
-            let sk = self.static_kv.as_mut().unwrap();
-            sk.begin_token(position as usize);
-            sk.write_mask_bytes();
-        }
-        let pos_bytes = position.to_le_bytes();
-
-        // Feed primary input + mask + position + the per-layer past-KV ring.
-        // self.runtime (mut) and self.static_kv (shared) are disjoint fields,
-        // so we borrow cached names + ring buffers directly — no per-token
-        // string or buffer allocation.
-        {
-            let sk = self.static_kv.as_ref().unwrap();
-            let in_main = if use_hidden {
-                sk.hidden_in.as_deref()
-            } else {
-                sk.ids_in.as_deref()
-            }
-            .ok_or_else(|| EngineError::Backend("static IR missing primary input".into()))?;
-            self.runtime
-                .set_input(in_main, in_dtype, in_shape, in_bytes)
-                .map_err(map_ov_err)?;
-            self.runtime
-                .set_input(
-                    &sk.attn_in,
-                    ShimDType::I64,
-                    &[1, sk.context],
-                    &sk.mask_bytes,
-                )
-                .map_err(map_ov_err)?;
-            self.runtime
-                .set_input(&sk.pos_in, ShimDType::I64, &[1, 1], &pos_bytes)
-                .map_err(map_ov_err)?;
-            let shape = [1, sk.kv_heads, sk.past_len, sk.head_dim];
-            for (li, layer) in sk.layers.iter().enumerate() {
-                self.runtime
-                    .set_input(&layer.key_in, sk.kv_dtype, &shape, &sk.key_buf[li])
-                    .map_err(map_ov_err)?;
-                self.runtime
-                    .set_input(&layer.val_in, sk.kv_dtype, &shape, &sk.val_buf[li])
-                    .map_err(map_ov_err)?;
-            }
-        }
-        self.runtime.infer().map_err(map_ov_err)?;
-
-        // Primary output (index 0): logits on the head stage, hidden_states
-        // otherwise — the static export emits it before the present.* outputs.
-        let (odt, oshape, obytes) = self.runtime.output(0).map_err(map_ov_err)?;
-
-        // Absorb the new token's K/V. Validate each present.* output's byte
-        // length AND shape against [1, kv_heads, context, head_dim] so a
-        // dtype/factorization mismatch is a clear error, not silent corruption.
-        let (n, expect, kvh, ctx, hd) = {
-            let sk = self.static_kv.as_ref().unwrap();
-            (
-                sk.layers.len(),
-                sk.present_layer_bytes(),
-                sk.kv_heads,
-                sk.context,
-                sk.head_dim,
-            )
-        };
-        let want_shape = [1usize, kvh, ctx, hd];
-        for li in 0..n {
-            let (ko, vo) = {
-                let l = &self.static_kv.as_ref().unwrap().layers[li];
-                (l.key_out, l.val_out)
-            };
-            let (_, kshape, kpres) = self.runtime.output(ko).map_err(map_ov_err)?;
-            let (_, vshape, vpres) = self.runtime.output(vo).map_err(map_ov_err)?;
-            if kpres.len() != expect
-                || vpres.len() != expect
-                || kshape != want_shape
-                || vshape != want_shape
-            {
-                return Err(EngineError::Backend(format!(
-                    "static present.{li} mismatch: key shape={kshape:?} len={} val shape={vshape:?} \
-                     len={}; expected shape {want_shape:?} ({expect} bytes f16). Check \
-                     num_kv_heads/head_dim/KV dtype in stage_config.",
-                    kpres.len(),
-                    vpres.len(),
-                )));
-            }
-            let sk = self.static_kv.as_mut().unwrap();
-            sk.absorb_layer(li, false, &kpres);
-            sk.absorb_layer(li, true, &vpres);
-        }
-        Ok((odt, oshape, obytes))
-    }
-
     fn step_last(&mut self) -> EngineResult<()> {
-        let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
-        let (out, out_shape) = match pos_opt {
-            // Static (NPU): the carried absolute position drives the ring
-            // (reset at 0); seq is always 1.
-            Some(pos) => self.run_relay(&hidden, shape, pos)?,
-            None => {
-                if shape[1] > 1 {
-                    self.runtime.reset_state().map_err(map_ov_err)?;
-                    self.position = 0;
-                }
-                let r = self.run_relay(&hidden, shape, self.position)?;
-                self.position += shape[1] as i64;
-                r
-            }
-        };
+        // The upstream stage carries the absolute start-position; use it
+        // directly as the position_ids base and reset own KV when it is 0 (a
+        // new sequence). Correct for any prompt length, including 1 token.
+        let (hidden, shape, position) = self.recv_hidden_from_upstream()?;
+        if position == 0 {
+            self.runtime.reset_state().map_err(map_ov_err)?;
+        }
+        let (out, out_shape) = self.run_relay(&hidden, shape, position)?;
         let next = argmax_logits(&out, &out_shape)?;
         self.send_token_to_upstream(next)?;
         Ok(())
     }
 
     fn step_middle(&mut self) -> EngineResult<()> {
-        let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
-        let (out, out_shape, fwd_pos) = match pos_opt {
-            Some(pos) => {
-                let (o, s) = self.run_relay(&hidden, shape, pos)?;
-                (o, s, pos)
-            }
-            None => {
-                if shape[1] > 1 {
-                    self.runtime.reset_state().map_err(map_ov_err)?;
-                    self.position = 0;
-                }
-                let (o, s) = self.run_relay(&hidden, shape, self.position)?;
-                self.position += shape[1] as i64;
-                (o, s, 0)
-            }
-        };
+        let (hidden, shape, position) = self.recv_hidden_from_upstream()?;
+        if position == 0 {
+            self.runtime.reset_state().map_err(map_ov_err)?;
+        }
+        let (out, out_shape) = self.run_relay(&hidden, shape, position)?;
         let s3 = to_shape3(&out_shape);
-        self.send_hidden_downstream(&out, s3, fwd_pos)?;
+        // Forward the SAME absolute position downstream so every stage aligns.
+        self.send_hidden_downstream(&out, s3, position)?;
         let token = self.recv_token_from_downstream()?;
         self.send_token_to_upstream(token)?;
         Ok(())
@@ -1184,44 +956,39 @@ impl Gemma4Engine {
 impl Engine for Gemma4Engine {
     fn warmup(&mut self) {
         if !(self.spec.is_first_stage) {
-            info!("ov-runtime warmup skipped on non-first stage");
+            info!("gemma4 warmup skipped on non-first stage");
             return;
         }
         let tok = match self.tokenizer.clone() {
             Some(t) => t,
             None => {
-                warn!("ov-runtime warmup skipped: no tokenizer");
+                warn!("gemma4 warmup skipped: no tokenizer");
                 return;
             }
         };
         let enc = match tok.encode("Hi", false) {
             Ok(e) => e,
             Err(e) => {
-                warn!(error = %e, "ov-runtime warmup tokenize failed");
+                warn!(error = %e, "gemma4 warmup tokenize failed");
                 return;
             }
         };
         let ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
-        // run_first processes one token per call on the static path, so warm
-        // with a single token (enough to JIT the OV graph) regardless of path.
+        // A single token is enough to JIT the OV graph.
         let warm = &ids[..ids.len().min(1)];
         match self.run_first(warm, 0) {
             Ok(_) => {
-                if let Some(sk) = self.static_kv.as_mut() {
-                    sk.reset();
-                } else {
-                    let _ = self.runtime.reset_state();
-                }
+                let _ = self.runtime.reset_state();
                 self.position = 0;
-                info!("ov-runtime warmup ok");
+                info!("gemma4 warmup ok");
             }
-            Err(e) => warn!(error = %e, "ov-runtime warmup failed"),
+            Err(e) => warn!(error = %e, "gemma4 warmup failed"),
         }
     }
 
     fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
         if !self.spec.is_first_stage {
-            warn!("ov-runtime submit() ignored on non-first stage");
+            warn!("gemma4 submit() ignored on non-first stage");
             return Err(EngineError::Backend(
                 "non-first stage does not accept tasks directly".into(),
             ));
@@ -1238,7 +1005,7 @@ impl Engine for Gemma4Engine {
             warn!(
                 queued = self.pending.len(),
                 cap = crate::dist_spec::MAX_PENDING_TASKS,
-                "ov-runtime: pending queue at cap; rejecting task"
+                "gemma4: pending queue at cap; rejecting task"
             );
             return Err(EngineError::QueueFull {
                 queued: self.pending.len(),
@@ -1260,7 +1027,7 @@ impl Engine for Gemma4Engine {
         match result {
             Ok(v) => v,
             Err(e) => {
-                warn!(error = %e, "ov-runtime step failed");
+                warn!(error = %e, "gemma4 step failed");
                 Vec::new()
             }
         }
@@ -1286,10 +1053,13 @@ pub struct Gemma4Builder {
     downstream: Option<Arc<tokio::sync::Mutex<ActivationClient>>>,
     listen_host: String,
     listen_port: Option<u16>,
-    /// (context, kv_heads, head_dim) for a stateless static-shape (NPU) shard;
-    /// None for the stateful path. static_seq is validated == 1 at load and not
-    /// stored (the ring math assumes one token per step).
-    static_params: Option<(u32, u32, u32)>,
+    /// Global source-layer id for each `cross_kv.{i}` this stage produces, in
+    /// port-index order (= layer_start + cross_stage_sources_local[i]). Used in
+    /// build() to tag each cross_kv frame by source. Populated in load().
+    cross_src_ids: Vec<i64>,
+    /// Global source-layer id for each `external_kv.{i}` this stage consumes, in
+    /// port-index order (= external_shared_sources[i].src_global_layer).
+    external_src_ids: Vec<i64>,
 }
 
 impl Gemma4Builder {
@@ -1394,47 +1164,58 @@ impl Builder for Gemma4Builder {
         let stage_dir = self.pipeline_dir.join(format!("stage_{}", self.rank));
         let stage_cfg = read_stage_config(&stage_dir)?;
 
-        self.static_params = if !stage_cfg.stateful {
-            let ctx = stage_cfg.static_context.unwrap_or(0);
-            let s = stage_cfg.static_seq.unwrap_or(1);
-            let kvh = stage_cfg.num_kv_heads.unwrap_or(0);
-            let hd = stage_cfg.head_dim.unwrap_or(0);
-            // static_seq must be 1 (the runtime decodes one token per step) and
-            // static_context must exceed it so past_len = context - 1 >= 1.
-            if kvh == 0 || hd == 0 || s != 1 || ctx <= s {
-                return Err(EngineError::InvalidConfig(format!(
-                    "stateless (NPU) shard needs static_seq=1, static_context>static_seq, \
-                     and num_kv_heads/head_dim in stage_config; got seq={s} ctx={ctx} \
-                     kvh={kvh} hd={hd}"
-                )));
-            }
-            events.push(LoadProgress::message(format!(
-                "stateless static-KV shard: context={ctx} kv_heads={kvh} head_dim={hd}"
+        // The gemma4 engine only runs stateful shards (own KV is OV internal
+        // state); there is no stateless/static-KV (NPU) path. Reject clearly.
+        if !stage_cfg.stateful {
+            return Err(EngineError::ShardRejected(format!(
+                "stage_{} is a stateless (static-KV/NPU) shard; the gemma4 engine requires \
+                 stateful shards. Re-export without the static/NPU target.",
+                self.rank
             )));
-            // static_seq is validated == 1 above and never stored (the ring math
-            // assumes one token per step); carry only (ctx, kv_heads, head_dim).
-            Some((ctx, kvh, hd))
-        } else {
-            None
-        };
+        }
 
-        // A pipeline must be homogeneous: the static path carries a wire
-        // position frame the stateful path does not, so a mixed pipeline would
-        // desync. Fail fast when sibling stage configs are present locally
-        // (single-host multi-process); for distributed deploys each node has
-        // only its own stage dir, so the strict wire-frame validation in
-        // recv_hidden_from_upstream is the backstop at the first activation.
-        for r in 0..pipeline_cfg.num_stages {
-            if r == self.rank {
-                continue;
-            }
-            if let Ok(cfg) = read_stage_config(&self.pipeline_dir.join(format!("stage_{r}"))) {
-                if cfg.stateful != stage_cfg.stateful {
+        // Cross-stage shared-KV source ids (Gemma 4 E2B/E4B KV-sharing).
+        // Producer: cross_kv.{i} ← layer_start + cross_stage_sources_local[i].
+        // Consumer: external_kv.{i} ← external_shared_sources[i].src_global_layer.
+        // build() tags each wire frame by these so pairing is by source identity,
+        // never by port position.
+        self.cross_src_ids = stage_cfg
+            .cross_stage_sources_local
+            .iter()
+            .map(|s| (stage_cfg.layer_start + s) as i64)
+            .collect();
+        self.external_src_ids = stage_cfg
+            .external_shared_sources
+            .iter()
+            .map(|e| e.src_global_layer as i64)
+            .collect();
+
+        // Load-time adjacency guard: every cross-stage source this stage
+        // consumes must be PRODUCED by the immediately-upstream stage (the only
+        // peer that sends us cross-KV frames). Non-adjacent sharing (a source >1
+        // hop upstream) is not supported — pass-through forwarding is a separate
+        // follow-up. Validate against the sibling config when present locally
+        // (single-host multi-process); for distributed deploys the per-frame tag
+        // match in feed_external_kv is the immediate, deterministic backstop.
+        if self.rank > 0 && !self.external_src_ids.is_empty() {
+            let up_dir = self.pipeline_dir.join(format!("stage_{}", self.rank - 1));
+            if let Ok(up) = read_stage_config(&up_dir) {
+                let produced: std::collections::HashSet<i64> = up
+                    .cross_stage_sources_local
+                    .iter()
+                    .map(|s| (up.layer_start + s) as i64)
+                    .collect();
+                if let Some(missing) = self.external_src_ids.iter().find(|s| !produced.contains(s))
+                {
                     return Err(EngineError::ShardRejected(format!(
-                        "pipeline is not homogeneous: stage_{} stateful={} but stage_{r} \
-                         stateful={} — all stages must share one KV mode (re-export the whole \
-                         pipeline with a single --target)",
-                        self.rank, stage_cfg.stateful, cfg.stateful
+                        "stage_{} consumes cross-stage KV from source layer {missing}, but the \
+                         immediate upstream stage_{} does not produce it (it produces {:?}). \
+                         Non-adjacent KV sharing across more than one pipeline hop is not \
+                         supported — re-export with KV source/consumer on adjacent stages, or \
+                         use fewer stages.",
+                        self.rank,
+                        self.rank - 1,
+                        produced
                     )));
                 }
             }
@@ -1530,162 +1311,51 @@ impl Builder for Gemma4Builder {
             }
         }
 
-        // Stateless static-shape (NPU) shards: resolve the explicit
-        // past_key_values.* inputs + present.* outputs and allocate the
-        // host-side KV ring. The primary output (logits on the head stage,
-        // hidden_states otherwise) is output index 0 — no alias guess needed.
-        let static_kv = if let Some((ctx, kvh, hd)) = self.static_params {
-            let n_out = runtime.output_count();
-            let mut layers: Vec<StaticKvLayer> = Vec::new();
-            loop {
-                let l = layers.len();
-                let kin_s = format!("past_key_values.{l}.key");
-                let vin_s = format!("past_key_values.{l}.value");
-                let kout_s = format!("present.{l}.key");
-                let vout_s = format!("present.{l}.value");
-                let (mut key_in, mut val_in) = (None, None);
-                for idx in 0..n_inputs {
-                    let al = runtime.input_aliases(idx).map_err(map_ov_err)?;
-                    if al.iter().any(|a| a.contains(&kin_s)) {
-                        key_in = Some(runtime.input_name(idx).map_err(map_ov_err)?);
-                    } else if al.iter().any(|a| a.contains(&vin_s)) {
-                        val_in = Some(runtime.input_name(idx).map_err(map_ov_err)?);
-                    }
-                }
-                let (key_in, val_in) = match (key_in, val_in) {
-                    (Some(k), Some(v)) => (k, v),
-                    _ => break,
-                };
-                let (mut key_out, mut val_out) = (None, None);
-                for idx in 0..n_out {
-                    let al = runtime.output_aliases(idx).map_err(map_ov_err)?;
-                    if al.iter().any(|a| a.contains(&kout_s)) {
-                        key_out = Some(idx);
-                    } else if al.iter().any(|a| a.contains(&vout_s)) {
-                        val_out = Some(idx);
-                    }
-                }
-                let key_out = key_out.ok_or_else(|| {
-                    EngineError::Backend(format!("static shard missing {kout_s}"))
+        // Cross-stage shared-KV ports (Gemma 4 E2B/E4B KV-sharing).
+        // `cross_kv.{i}.{key|value}` are OUTPUTS this stage produces; the global
+        // source-layer id is cross_src_ids[i] (set in load()). `external_kv.{i}`
+        // are INPUTS it consumes, source id external_src_ids[i]. Each gets a
+        // wire TAG = src*2 + is_value so the consumer matches frames to inputs
+        // by source identity, not port position (robust to ordering and >9
+        // ports). Empty for single-stage / dense shards (no such ports).
+        let output_names = runtime.output_names().map_err(map_ov_err)?;
+        let mut cross_kv_out = Vec::new();
+        for (oidx, name) in output_names.iter().enumerate() {
+            if let Some((ci, is_value)) = parse_kv_port(name, "cross_kv.") {
+                let src = *self.cross_src_ids.get(ci).ok_or_else(|| {
+                    EngineError::Backend(format!(
+                        "{name}: no source-id metadata (stage_config \
+                         cross_stage_sources_local has {} entries)",
+                        self.cross_src_ids.len()
+                    ))
                 })?;
-                let val_out = val_out.ok_or_else(|| {
-                    EngineError::Backend(format!("static shard missing {vout_s}"))
-                })?;
-                layers.push(StaticKvLayer {
-                    key_in,
-                    val_in,
-                    key_out,
-                    val_out,
+                cross_kv_out.push(CrossKvOut {
+                    out_idx: oidx,
+                    tag: src * 2 + is_value as i64,
                 });
             }
-            if layers.is_empty() {
-                return Err(EngineError::Backend(
-                    "static shard: no past_key_values.* inputs found".into(),
-                ));
-            }
-            // Cross-check: the contiguous-from-0 discovery above stops at the
-            // first missing index. Compare against the total number of
-            // past_key_values.* input ports so a gap / renamed / folded port is
-            // a hard error instead of silently building fewer layers.
-            let mut kv_input_ports = 0usize;
-            for idx in 0..n_inputs {
-                let al = runtime.input_aliases(idx).map_err(map_ov_err)?;
-                if al.iter().any(|a| a.contains("past_key_values.")) {
-                    kv_input_ports += 1;
-                }
-            }
-            if kv_input_ports != layers.len() * 2 {
-                return Err(EngineError::Backend(format!(
-                    "static shard: resolved {} contiguous KV layers ({} ports) but the IR has \
-                     {kv_input_ports} past_key_values.* input ports — a layer port is missing or \
-                     misnamed (gap in the past_key_values.N sequence)",
-                    layers.len(),
-                    layers.len() * 2,
-                )));
-            }
-            let (kvh, hd) = (kvh as usize, hd as usize);
-            let past_len = (ctx - 1) as usize;
-            // KV activations are f16 in the static export; derive elem_bytes
-            // from the dtype so the two can never drift.
-            let kv_dtype = ShimDType::F16;
-            let elem_bytes = match kv_dtype {
-                ShimDType::F16 | ShimDType::Bf16 => 2,
-                ShimDType::F32 | ShimDType::I32 => 4,
-                ShimDType::I64 => 8,
-                ShimDType::I8 => 1,
-            };
-            let layer_bytes = kvh * past_len * hd * elem_bytes;
-            let n = layers.len();
-            // Cache the resolved primary/aux input port names so the per-token
-            // decode loop does no HashMap lookups or string allocs. A static
-            // shard always has attention_mask + position_ids; embed stages have
-            // input_ids, relay/head stages have hidden_states.
-            let attn_in = canonical_inputs
-                .get("attention_mask")
-                .cloned()
-                .ok_or_else(|| {
-                    EngineError::Backend("static IR missing attention_mask input".into())
+        }
+        let input_names = runtime.input_names().map_err(map_ov_err)?;
+        let mut external_kv_in = Vec::new();
+        for name in &input_names {
+            if let Some((ei, is_value)) = parse_kv_port(name, "external_kv.") {
+                let src = *self.external_src_ids.get(ei).ok_or_else(|| {
+                    EngineError::Backend(format!(
+                        "{name}: no source-id metadata (stage_config \
+                         external_shared_sources has {} entries)",
+                        self.external_src_ids.len()
+                    ))
                 })?;
-            let pos_in = canonical_inputs
-                .get("position_ids")
-                .cloned()
-                .ok_or_else(|| {
-                    EngineError::Backend("static IR missing position_ids input".into())
-                })?;
-            let ids_in = canonical_inputs.get("input_ids").cloned();
-            let hidden_in = canonical_inputs.get("hidden_states").cloned();
-            if ids_in.is_none() && hidden_in.is_none() {
-                return Err(EngineError::Backend(
-                    "static IR has neither input_ids nor hidden_states input".into(),
-                ));
+                external_kv_in.push(ExternalKvIn {
+                    name: name.clone(),
+                    tag: src * 2 + is_value as i64,
+                });
             }
-            Some(StaticKv {
-                past_len,
-                context: ctx as usize,
-                kv_heads: kvh,
-                head_dim: hd,
-                elem_bytes,
-                kv_dtype,
-                ids_in,
-                hidden_in,
-                attn_in,
-                pos_in,
-                layers,
-                key_buf: vec![vec![0u8; layer_bytes]; n],
-                val_buf: vec![vec![0u8; layer_bytes]; n],
-                valid: 0,
-                mask_bytes: vec![0u8; ctx as usize * 8],
-            })
-        } else {
-            None
-        };
-
-        // Enumerate cross-stage shared-KV ports (Gemma 4 E2B/E4B KV-sharing).
-        // `cross_kv.*` are OUTPUTS this stage produces for a downstream stage;
-        // `external_kv.*` are INPUTS it consumes from an upstream stage. Both
-        // sorted by name so cross_kv.i on the sender aligns with external_kv.i
-        // on the receiver. Empty for single-stage shards and dense models
-        // without KV-sharing (e.g. 31B → zero-cost pure hidden relay).
-        let output_names = runtime.output_names().map_err(map_ov_err)?;
-        let mut cross: Vec<(String, usize)> = output_names
-            .iter()
-            .enumerate()
-            .filter(|(_, n)| n.starts_with("cross_kv"))
-            .map(|(i, n)| (n.clone(), i))
-            .collect();
-        cross.sort_by(|a, b| a.0.cmp(&b.0));
-        let cross_kv_out_idx: Vec<usize> = cross.into_iter().map(|(_, i)| i).collect();
-        let mut external_kv_in_names: Vec<String> = runtime
-            .input_names()
-            .map_err(map_ov_err)?
-            .into_iter()
-            .filter(|n| n.starts_with("external_kv"))
-            .collect();
-        external_kv_in_names.sort();
-        if !cross_kv_out_idx.is_empty() || !external_kv_in_names.is_empty() {
+        }
+        if !cross_kv_out.is_empty() || !external_kv_in.is_empty() {
             info!(
-                cross_kv_out = cross_kv_out_idx.len(),
-                external_kv_in = external_kv_in_names.len(),
+                cross_kv_out = cross_kv_out.len(),
+                external_kv_in = external_kv_in.len(),
                 "gemma4 cross-stage shared KV wired"
             );
         }
@@ -1702,10 +1372,9 @@ impl Builder for Gemma4Builder {
             canonical_inputs,
             pending: Vec::new(),
             active: None,
-            static_kv,
-            cross_kv_out_idx,
-            external_kv_in_names,
-            pending_external_kv: Vec::new(),
+            cross_kv_out,
+            external_kv_in,
+            pending_external_kv: std::collections::HashMap::new(),
         }))
     }
 }

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -11,6 +11,7 @@
 //! distributed spec-decode protocol; tracked separately.
 
 pub mod dist_spec;
+pub mod gemma4;
 pub mod genai;
 pub mod rotary;
 pub mod runtime;
@@ -19,6 +20,7 @@ pub use dist_spec::{
     DistributedMaskedReq, FrameKind, MaskedReq, OvDistSpecBuilder, OvDistSpecEngine,
     OvDistSpecWorkerBuilder, OvDistSpecWorkerEngine, SpecDecodeStats,
 };
+pub use gemma4::{Gemma4Builder, Gemma4Engine};
 pub use genai::{OvGenaiBuilder, OvGenaiEngine};
 pub use rotary::{ModelTextConfig, RopeScalingConfig, Rotary};
 pub use runtime::{OvRuntimeBuilder, OvRuntimeEngine};

--- a/tools/export_gemma4.py
+++ b/tools/export_gemma4.py
@@ -800,6 +800,77 @@ def build_cached_wrapper(model, text_config, stage_plan):
 # ---------------------------------------------------------------------------
 
 
+def make_stateful_with_init_gemma4(ov_model):
+    """Fold gemma4 own-KV (``present.N`` -> ``past_key_values.N``) into stateful
+    ReadValue/Assign Variables WITH an explicit zero-length, batch-1 init.
+
+    Unlike export_shards.make_stateful_with_init this maps present<->past by
+    NAME (the gemma4 graph interleaves ``cross_kv.*`` outputs and
+    ``external_kv.*`` inputs, so index-based folding does not apply), keeps
+    every non-``present.*`` result (logits/hidden_states + cross_kv.*) and
+    non-``past_key_values.*`` parameter (input_ids/hidden_states, position_ids,
+    external_kv.*), and adds NO beam_idx/cache-reorder (gemma4 has none).
+
+    The init matters: ``apply_make_stateful_transformation`` emits init-less
+    ReadValues that the OV CPU plugin rejects (#57), and even where they load,
+    ``reset_state()`` yields a {0,h,0,d} (batch-0) state whose KV Concat fails
+    against the {1,h,seq,d} new K/V. A {1,h,0,d} init makes ``reset_state()``
+    work uniformly across stages (same approach as the v5 exporter, #62).
+    """
+    import openvino as ov
+    import openvino.opset13 as ops
+    from openvino import Tensor
+    from openvino.op.util import Variable, VariableInfo
+
+    # present.N.{key,value} source outputs, keyed by their port name.
+    present_src = {}
+    keep_results = []
+    for r in ov_model.get_results():
+        name = next(iter(r.output(0).get_names()), "")
+        if name.startswith("present."):
+            present_src[name] = r.input_value(0)
+        else:
+            keep_results.append(r)  # logits / hidden_states + cross_kv.*
+
+    sinks = []
+    keep_params = []
+    for p in ov_model.get_parameters():
+        nm = p.output(0).get_any_name()
+        if not nm.startswith("past_key_values."):
+            keep_params.append(p)  # input_ids/hidden, position_ids, external_kv.*
+            continue
+        src = present_src[nm.replace("past_key_values.", "present.", 1)]
+        et = p.get_element_type()
+        ps = p.get_partial_shape()
+        # Canonical [batch, kv_heads, seq, head_dim]: only seq (axis 2) is
+        # dynamic; batch defaults to 1, seq to 0 for the zero-length init.
+        if len(ps) != 4 or not ps[1].is_static or not ps[3].is_static:
+            raise RuntimeError(
+                f"{nm}: expected static [batch, kv_heads, seq, head_dim], got {ps}"
+            )
+        dims = [
+            (d.get_length() if d.is_static else (0 if idx >= 2 else 1))
+            for idx, d in enumerate(ps)
+        ]
+        vi = VariableInfo()
+        vi.data_shape = ps
+        vi.data_type = et
+        vi.variable_id = nm
+        var = Variable(vi)
+        rv = ops.read_value(ops.constant(Tensor(et, dims)), var)
+        p.output(0).replace(rv.output(0))
+        if src.get_index() != 0:
+            raise RuntimeError(
+                f"present source for {nm} is output #{src.get_index()}; "
+                "assign needs a single-output node"
+            )
+        sinks.append(ops.assign(src.get_node(), var))
+
+    new_model = ov.Model(keep_results, sinks, keep_params)
+    new_model.validate_nodes_and_infer_types()
+    return new_model
+
+
 def export_single_stage(model, text_config, stage_plan, output_dir, quantization, device_verify="CPU"):
     """Trace the Gemma 4 wrapper for one stage, convert to OV, make
     KV state stateful, optionally compress, save under
@@ -929,19 +1000,14 @@ def export_single_stage(model, text_config, stage_plan, output_dir, quantization
         out.set_names({name})
     ov_model.validate_nodes_and_infer_types()
 
-    # Make stateful for own KV (cross_kv stays as regular output; external_kv
-    # stays as regular input).
-    log(f"  apply_make_stateful_transformation ({n_own_kv} KV pairs)...")
-    from openvino._offline_transformations import (
-        apply_make_stateful_transformation,
-    )
-
-    kv_pairs = {}
-    for oi in range(n_own_kv):
-        for kt in ("key", "value"):
-            kv_pairs[f"past_key_values.{oi}.{kt}"] = f"present.{oi}.{kt}"
-    if kv_pairs:
-        apply_make_stateful_transformation(ov_model, kv_pairs)
+    # Make own KV stateful WITH explicit batch-1 zero-length inits (cross_kv
+    # stays a regular output; external_kv stays a regular input). Init-bearing
+    # ReadValues are required so the OV CPU plugin loads the shard AND so
+    # reset_state() yields a {1,h,0,d} state at the runtime (an init-less
+    # ReadValue gives {0,h,0,d}, whose KV Concat fails against the new K/V).
+    log(f"  make_stateful_with_init ({n_own_kv} own-KV pairs)...")
+    if n_own_kv > 0:
+        ov_model = make_stateful_with_init_gemma4(ov_model)
     ov_model.validate_nodes_and_infer_types()
     log(
         f"  Stateful: {len(ov_model.inputs)} inputs, "


### PR DESCRIPTION
## What

Adds a `--engine gemma4` runtime so cascadia's own engine can **serve
`gemma4_cached_v1` shards** (exported by `tools/export_gemma4.py`), both
**single-stage** and **multi-stage pipeline-parallel**. Before this, those
shards could only be driven by raw OpenVINO `Core` in a Python harness — not
through cascadia's `Runner`/transport/API.

This is Phase B of the Gemma 4 work (after the exporter PRs #48/#64/#69).

## Why Gemma 4 needs its own engine

- **No `attention_mask` input** — causal mask baked in; RoPE computed internally
  from `position_ids` (no host cos/sin).
- **Per-layer asymmetric attention** (head_dim 256 sliding / 512 global), final
  softcap in the head stage, per-head Q/K/V RMSNorm.
- **KV-sharing** — E2B reuses 20 of 35 layers' KV, E4B 18 of 42. When a shared
  layer's *source* sits in an earlier pipeline stage, that KV crosses the wire
  (`cross_kv.*` outputs → `external_kv.*` inputs); own KV stays OV-stateful.
- **Per-layer embeddings (PLI)** ride *inside* `hidden_states`, so the relay
  just sends the actual-width tensor.

## Validation — HF parity *through cascadia's engine*

Token-identical to HuggingFace `transformers` (greedy, `apply_chat_template`),
driven through cascadia's API — not self-consistency.

- **Single-stage E2B (CPU):** 4/4 prompts token-identical to HF.
- **2-stage pipeline-parallel E2B (CPU, 2 procs over TCP):** 4/4 token-identical
  — exercises cross-stage shared KV + PLI end-to-end.
- Raw-`Core` shard checks (both): 20/20 greedy, isolating shard-vs-engine.
- **No regressions:** workspace suite passes (0 failures); `cargo clippy
  --features openvino` clean on the engine + api crates.

## Review hardening (this PR was reviewed before merge)

A max-effort review (9 finder angles) ran on the first cut. Every actionable
finding is addressed:

**Correctness (cross-stage KV — `429d88f`)**
- **Pair cross_kv↔external_kv by SOURCE IDENTITY, not port position.** The
  exporter assigns producer indices by sorted source-layer and consumer indices
  by first-use; those orders can differ → silent wrong-KV. `send_hidden_downstream`
  now emits a self-describing header (frame count + per-frame tag
  `src_layer*2 + is_value`) ahead of the cross_kv frames; the consumer reads
  exactly that many (desync-proof) and feeds each `external_kv` input by matching
  tag. Fixes the silent-mispairing, the lexicographic `cross_kv.10`-before-`.2`
  hazard, and turns a frame-count mismatch into a clear error instead of a
  mid-decode desync.
- **Received cross-KV frame dtype validated (F32) before feeding.**
- **Load-time adjacency guard** rejects non-adjacent (>1-hop) KV sharing with an
  actionable message (hermetic unit test), instead of failing opaquely at the
  first decode step.

**Correctness (relay — `429d88f`)**
- **Absolute position now always rides the wire**; relay stages use it as the
  `position_ids` base and reset own KV when it is 0 — so a 1-token prompt is
  handled correctly (the old `seq_len>1` reset heuristic missed it).

**Dead code / latent bug (`429d88f`, `fea2bb1`)**
- **Removed the static-KV (NPU) path** (~350 lines + 9 branches) — unreachable
  for gemma4 (the exporter always emits stateful shards), and its relay branch
  still fed f16 hidden, contradicting the f32 contract. A non-stateful shard is
  now rejected at load with a clear message. Stale `ov-runtime` log labels +
  module doc renamed to `gemma4`.

**API (general — `2f9d477`, `90b3c79`)**
- Load the sibling `chat_template.jinja` + enable minijinja `macros` (instruct
  models like Gemma 3/4 degenerated through the legacy formatter otherwise).
- Reject an empty/whitespace `chat_template.jinja` (would render an empty
  prompt). Parse the template **once** at startup (was re-parsing the ~17 KB
  template per request). Unit-tested.

**Evaluated, deliberately deferred (documented, not shipped under-tested):**
- **Delta-forward cross_kv (perf #674).** gemma4 `sliding_window=512` and a
  cross-KV source layer is sliding-attention, so its exported cache may
  window/evict past 512 tokens — append-only delta-forward could silently
  corrupt at long context, which ≤64-token parity tests can't catch. The new
  wire format is tag-based + forward-compatible, so this can land later (with
  >512-token eviction validation) **without a wire break**.
- **f16 relay (perf #654).** Measured: f16-relay (hidden + cross_kv) showed no
  divergence vs f32/HF on a 12-prompt probe, but the probe was shallow. Kept f32
  (proven byte-parity) as the default rather than flip a correctness-sensitive
  default on shallow evidence; f16 is a viable 2x-bandwidth follow-up.
- **runtime.rs de-duplication.** gemma4.rs shares structure with the v5 engine;
  a shared-module extraction touches the validated production v5 path and is a
  separate refactor. Log labels (the operator-facing part) are fixed here.

### Usage

```sh
python tools/export_gemma4.py --model google/gemma-4-E2B-it \
  --output-dir ./g4 --num-stages 2 --quantization fp16

cascadia worker --model ./g4 --rank 1 --total 2 --engine gemma4 --device CPU --listen :9100
cascadia worker --model ./g4 --rank 0 --total 2 --engine gemma4 --device CPU \
  --next 127.0.0.1:9100 --api :8137
```

## Follow-ups

- Multi-box + heterogeneous device (iGPU/NPU) deployment validation.
- Multi-hop cross-KV forwarding for 3+ stage non-adjacent KV sharing (wire is
  already forward-compatible).
- Delta-forward + f16 relay perf (above), with long-context validation.
- Dense 31B (same relay code; needs a bigger-disk export host).
