### PR TITLE
fix(gemma4-export): asymmetric global KV heads + k_eq_v for Gemma-4-31B

### DIFF
--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -533,6 +533,15 @@ impl ChatPromptRenderer {
     }
 }
 
+/// One-shot chat-prompt render for standalone / embedded callers that hold a
+/// [`ChatTemplateConfig`] directly (e.g. an embedded shard backend) and render
+/// outside the router's `AppState`. Builds a [`ChatPromptRenderer`] per call;
+/// callers that render repeatedly should construct one [`ChatPromptRenderer`]
+/// and reuse it. Falls back to [`render_prompt_legacy`] on parse/render failure.
+pub fn render_chat_prompt(cfg: &ChatTemplateConfig, messages: &[ChatMessage]) -> String {
+    ChatPromptRenderer::new(cfg).render(messages)
+}
+
 async fn chat_completions(
     State(state): State<AppState>,
     Json(req): Json<ChatCompletionRequest>,

--- a/tools/export_gemma4.py
+++ b/tools/export_gemma4.py
@@ -252,11 +252,17 @@ def cached_gemma4_layer_forward(
 
     k = layer.self_attn.k_proj(hidden_states)
     k = k.view(bsz, seq_len, num_kv_heads, head_dim)
+    # k_eq_v (Gemma 4 31B global/full_attention layers): v_proj is None and V
+    # derives from the RAW k_proj output — HF sets value_states = key_states
+    # BEFORE k_norm/rope are applied. Capture v from the pre-norm k here.
+    if layer.self_attn.v_proj is not None:
+        v = layer.self_attn.v_proj(hidden_states)
+        v = v.view(bsz, seq_len, num_kv_heads, head_dim)
+    else:
+        v = k
     k = layer.self_attn.k_norm(k)
     k = k.transpose(1, 2)
 
-    v = layer.self_attn.v_proj(hidden_states)
-    v = v.view(bsz, seq_len, num_kv_heads, head_dim)
     v = layer.self_attn.v_norm(v)
     v = v.transpose(1, 2)
 
@@ -603,7 +609,18 @@ def build_cached_wrapper(model, text_config, stage_plan):
     ]
 
     num_heads = text_config.num_attention_heads
-    num_kv_heads = text_config.num_key_value_heads
+    num_kv_heads_local = text_config.num_key_value_heads
+    # Gemma 4 31B uses asymmetric KV heads per attention type: full_attention
+    # (global) layers have fewer KV heads (num_global_key_value_heads) than
+    # sliding_attention (local) layers, alongside the asymmetric head_dim. E2B/E4B
+    # lack the global field, so this falls back to num_key_value_heads (unchanged).
+    num_kv_heads_global = getattr(
+        text_config, "num_global_key_value_heads", num_kv_heads_local
+    )
+    num_kv_heads_per_layer = [
+        (num_kv_heads_global if lt == "full_attention" else num_kv_heads_local)
+        for lt in stage_layer_types
+    ]
     downstream_pli_count = num_total - le if not has_head else 0
 
     rope_params = getattr(text_config, "rope_parameters", None)
@@ -661,6 +678,7 @@ def build_cached_wrapper(model, text_config, stage_plan):
                 self.lm_head = lm_head_ref
             # Stored attrs for trace fidelity.
             self._head_dims = head_dims
+            self._num_kv_heads = num_kv_heads_per_layer
             self._layer_types = list(stage_layer_types)
             self._unique_types = list(set(stage_layer_types))
             self._is_shared = is_shared
@@ -728,6 +746,7 @@ def build_cached_wrapper(model, text_config, stage_plan):
             for i, layer in enumerate(self.layers):
                 lt = self._layer_types[i]
                 hd = self._head_dims[i]
+                nkv = self._num_kv_heads[i]
                 cos, sin = rotary_cache[lt]
                 pli_slice = stage_pli[:, :, i, :] if stage_pli is not None else None
 
@@ -747,7 +766,7 @@ def build_cached_wrapper(model, text_config, stage_plan):
                         sk,
                         sv,
                         num_heads,
-                        num_kv_heads,
+                        nkv,
                         hd,
                         per_layer_input=pli_slice,
                     )
@@ -760,7 +779,7 @@ def build_cached_wrapper(model, text_config, stage_plan):
                         past_kv[kv_input_idx * 2],
                         past_kv[kv_input_idx * 2 + 1],
                         num_heads,
-                        num_kv_heads,
+                        nkv,
                         hd,
                         per_layer_input=pli_slice,
                     )
@@ -792,7 +811,7 @@ def build_cached_wrapper(model, text_config, stage_plan):
 
     wrapper = CachedStageWrapper()
     wrapper.eval()
-    return wrapper, head_dims, share
+    return wrapper, head_dims, num_kv_heads_per_layer, share
 
 
 # ---------------------------------------------------------------------------
@@ -886,6 +905,9 @@ def export_single_stage(model, text_config, stage_plan, output_dir, quantization
     hidden_dim = text_config.hidden_size
     pli_dim = text_config.hidden_size_per_layer_input or 0
     num_kv_heads = text_config.num_key_value_heads
+    num_kv_heads_global = getattr(
+        text_config, "num_global_key_value_heads", num_kv_heads
+    )
     downstream_pli_count = num_total - le if not has_head else 0
 
     log(f"\n{'=' * 60}")
@@ -894,7 +916,7 @@ def export_single_stage(model, text_config, stage_plan, output_dir, quantization
     )
     log("=" * 60)
 
-    wrapper, head_dims, share = build_cached_wrapper(
+    wrapper, head_dims, num_kv_heads_per_layer, share = build_cached_wrapper(
         model, text_config, stage_plan
     )
     log("  Wrapper built")
@@ -904,6 +926,9 @@ def export_single_stage(model, text_config, stage_plan, output_dir, quantization
     external_shared_sources = share["external_shared_sources"]
 
     own_kv_head_dims = [hd for hd, sh in zip(head_dims, is_shared) if not sh]
+    own_kv_num_heads = [
+        nkv for nkv, sh in zip(num_kv_heads_per_layer, is_shared) if not sh
+    ]
     non_shared_local_indices = [
         i for i, sh in enumerate(is_shared) if not sh
     ]
@@ -931,14 +956,15 @@ def export_single_stage(model, text_config, stage_plan, output_dir, quantization
     position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
 
     ext_kv = []
-    for _, _, hd in external_shared_sources:
-        ext_kv.append(torch.randn(1, num_kv_heads, past_seq, hd))
-        ext_kv.append(torch.randn(1, num_kv_heads, past_seq, hd))
+    for _, lt, hd in external_shared_sources:
+        nkv = num_kv_heads_global if lt == "full_attention" else num_kv_heads
+        ext_kv.append(torch.randn(1, nkv, past_seq, hd))
+        ext_kv.append(torch.randn(1, nkv, past_seq, hd))
 
     own_past_kv = []
-    for hd in own_kv_head_dims:
-        own_past_kv.append(torch.randn(1, num_kv_heads, past_seq, hd))
-        own_past_kv.append(torch.randn(1, num_kv_heads, past_seq, hd))
+    for nkv, hd in zip(own_kv_num_heads, own_kv_head_dims):
+        own_past_kv.append(torch.randn(1, nkv, past_seq, hd))
+        own_past_kv.append(torch.randn(1, nkv, past_seq, hd))
 
     example_inputs = (main_input, position_ids, *ext_kv, *own_past_kv)
 

--- a/tools/export_gemma4.py
+++ b/tools/export_gemma4.py
@@ -614,9 +614,11 @@ def build_cached_wrapper(model, text_config, stage_plan):
     # (global) layers have fewer KV heads (num_global_key_value_heads) than
     # sliding_attention (local) layers, alongside the asymmetric head_dim. E2B/E4B
     # lack the global field, so this falls back to num_key_value_heads (unchanged).
+    # The trailing `or` also covers configs that carry the field but leave it
+    # None/0, which getattr would otherwise pass through as a bad head count.
     num_kv_heads_global = getattr(
         text_config, "num_global_key_value_heads", num_kv_heads_local
-    )
+    ) or num_kv_heads_local
     num_kv_heads_per_layer = [
         (num_kv_heads_global if lt == "full_attention" else num_kv_heads_local)
         for lt in stage_layer_types
@@ -905,9 +907,11 @@ def export_single_stage(model, text_config, stage_plan, output_dir, quantization
     hidden_dim = text_config.hidden_size
     pli_dim = text_config.hidden_size_per_layer_input or 0
     num_kv_heads = text_config.num_key_value_heads
+    # `or num_kv_heads` guards a present-but-None/0 global field (see
+    # build_cached_wrapper); absent → getattr default already handles E2B/E4B.
     num_kv_heads_global = getattr(
         text_config, "num_global_key_value_heads", num_kv_heads
-    )
+    ) or num_kv_heads
     downstream_pli_count = num_total - le if not has_head else 0
 
     log(f"\n{'=' * 60}")


### PR DESCRIPTION
## Problem
`tools/export_gemma4.py` crashed exporting the current **Gemma-4-31B-it** (the doc's "31B tested" predated config changes). Two distinct bugs, both only hit by 31B (E2B/E4B don't have these features):

1. **Asymmetric global KV heads.** 31B's `full_attention` (global) layers use `num_global_key_value_heads` (4) vs `num_key_value_heads` (16) for sliding layers — alongside the asymmetric `head_dim` (256/512). The exporter threaded only per-layer `head_dim`, not per-layer KV-head count.
   `RuntimeError: shape '[1, 4, 16, 512]' is invalid for input of size 8192`
2. **`attention_k_eq_v`.** 31B global layers set `v_proj = None` and derive V from the raw `k_proj` output (HF `Gemma4TextAttention`: `value_states = key_states` *before* k_norm/rope), then `v_norm`. The exporter unconditionally called `v_proj`.
   `TypeError: 'NoneType' object is not callable`

## Fix
- Thread a per-layer `num_kv_heads` list through the wrapper forward + example KV inputs (mirrors the existing per-layer `head_dims`), so the stateful KV Variables get the correct global-layer shape.
- When `v_proj is None`, derive V from the pre-norm raw `k_proj` output (then `v_norm`), matching HF.
- E2B/E4B unaffected (no global-KV field / `k_eq_v=false` → fallbacks preserve prior behavior).
- **Guard a present-but-`None`/`0` global-KV field** (commit `91ff356`): `getattr(text_config, "num_global_key_value_heads", default)` only falls back when the field is *absent*; a config that carries it but leaves it `None`/`0` would otherwise pass that through as the global KV-head count. Append `or num_kv_heads` at both sites so a falsy value also falls back to the local count. No-op for 31B (field = 4); belt-and-suspenders for other Gemma-4 variants.

## Validation
Gemma-4-31B-it int4 3-stage **exports + self-verifies** (Prefill/Decode OK per stage) and **runs end-to-end** pipeline-parallel across 3 Intel Arc iGPUs (~1 tok/s, coherent output).

**Re-validated on the NUC fleet, 2 × Intel iGPU, 2026-06-24.** A fresh **2-stage** int4 31B export from this branch (both stages self-verify Prefill/Decode OK) deployed `stage_0` → one NUC, `stage_1` → another, run as `cascadia worker --engine gemma4 --device GPU` over the TCP relay (cross-machine). Coherent output across prompts — e.g. *"…Capital city.\nParis."* and *"…17 + 25 = 42."*

Engine-measured decode (rank-0 `gemma4 task done` lines): **~2.0–2.5 tok/s**, single request / batch 1. Per-token cost ≈ `alpha_ms` (stage_0 iGPU compute) + `wire_ms` (relay + stage_1 compute, dominated by the downstream stage rather than the ~21 KB/token hidden-state transfer); representative 32-token request `alpha_ms≈7800 wire_ms≈6500`. Concurrent requests **do not** raise throughput on this engine: it uses a **stateful single-sequence KV cache** and runs one task at a time, so requests serialize (measured 3-concurrent = ×0.93; engine log shows strictly back-to-back `task active`/`task done` intervals). True throughput scaling would need continuous batching / in-flight microbatches (not implemented, and non-trivial with stateful KV). Net: 2-stage PP here buys **fitting 31B across two iGPUs**, not single-request speed or concurrency throughput.
