### PR TITLE
fix(openvino): rate-limit per-call WARN on failing step()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ models/
 *.gguf
 shards/
 shards_cached/
+
+# Claude Code (local agent state + worktrees)
+.claude/

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -42,7 +42,9 @@ use cascadia_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec,
 use futures::stream;
 use serde::Deserialize;
 use tokenizers::Tokenizer;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
+
+use crate::warn_limit::{StepWarn, StepWarnLimiter};
 
 // -------- pipeline / stage config --------
 
@@ -433,6 +435,7 @@ pub struct Gemma4Engine {
     /// Cross-stage KV received from upstream this step, keyed by wire tag, ready
     /// to feed into the `external_kv.*` inputs. Rebuilt each step.
     pending_external_kv: std::collections::HashMap<i64, (Vec<usize>, Vec<u8>)>,
+    step_warn: StepWarnLimiter,
 }
 
 impl Gemma4Engine {
@@ -793,7 +796,11 @@ impl Gemma4Engine {
         // steps and the API returns `data: [DONE]` with zero chunks.
         let res = self.step_first_body();
         if let Err(ref e) = res {
-            warn!(
+            // DEBUG, not WARN: the outer step() emits the rate-limited WARN
+            // for the same error (StepWarnLimiter); a second unconditional
+            // WARN here would bypass the limiter and double-log every
+            // first-stage failure.
+            debug!(
                 error = %e,
                 "step_first failed; clearing active + reset_state so next \
                  task starts fresh (downstream socket may still be dead)"
@@ -1055,9 +1062,26 @@ impl Engine for Gemma4Engine {
             self.step_middle().map(|_| Vec::new())
         };
         match result {
-            Ok(v) => v,
+            Ok(v) => {
+                // First-stage idle steps return Ok(empty) even mid-failure
+                // (a failed step_first clears `active`; the next poll
+                // no-ops), so only a step that did real work closes a
+                // streak. Relay-stage Ok is always a completed relay round.
+                if !v.is_empty() || !self.spec.is_first_stage {
+                    if let Some(suppressed) = self.step_warn.on_success() {
+                        info!(suppressed, "gemma4 step recovered");
+                    }
+                }
+                v
+            }
             Err(e) => {
-                warn!(error = %e, "gemma4 step failed");
+                match self.step_warn.on_failure(std::time::Instant::now()) {
+                    Some(StepWarn::First) => warn!(error = %e, "gemma4 step failed"),
+                    Some(StepWarn::StillFailing { suppressed }) => {
+                        warn!(error = %e, suppressed, "gemma4 step still failing")
+                    }
+                    None => {}
+                }
                 Vec::new()
             }
         }
@@ -1405,6 +1429,7 @@ impl Builder for Gemma4Builder {
             cross_kv_out,
             external_kv_in,
             pending_external_kv: std::collections::HashMap::new(),
+            step_warn: StepWarnLimiter::default(),
         }))
     }
 }

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -16,6 +16,7 @@ pub mod genai;
 pub mod qwen36;
 pub mod rotary;
 pub mod runtime;
+mod warn_limit;
 
 pub use dist_spec::{
     DistributedMaskedReq, FrameKind, MaskedReq, OvDistSpecBuilder, OvDistSpecEngine,

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1344,8 +1344,14 @@ impl Engine for OvRuntimeEngine {
         };
         match result {
             Ok(v) => {
-                if let Some(suppressed) = self.step_warn.on_success() {
-                    tracing::info!(suppressed, "ov-runtime step recovered");
+                // First-stage idle steps return Ok(empty) even mid-failure
+                // (a failed step clears `active`; the next poll no-ops), so
+                // only a step that did real work closes a failing streak.
+                // Relay-stage Ok is always a completed relay round.
+                if !v.is_empty() || !self.spec.is_first_stage {
+                    if let Some(suppressed) = self.step_warn.on_success() {
+                        info!(suppressed, "ov-runtime step recovered");
+                    }
                 }
                 v
             }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -419,6 +419,54 @@ struct ActiveTask {
     t_wire: std::time::Duration,
 }
 
+/// Rate-limits the "step failed" WARN (cascadia-enterprise issue #30: a
+/// persistently-failing step logged one WARN per call — ~90k/s — and grew
+/// chain.log to 770 GB). First failure of a streak logs in full; later
+/// ones are counted and surfaced as a periodic "still failing" summary.
+/// Success closes the streak so the next failure logs immediately again.
+#[derive(Default)]
+struct StepWarnLimiter {
+    /// `Some(last WARN instant)` while in a failing streak.
+    last_warn: Option<std::time::Instant>,
+    suppressed: u64,
+}
+
+#[derive(Debug)]
+enum StepWarn {
+    First,
+    StillFailing { suppressed: u64 },
+}
+
+impl StepWarnLimiter {
+    const INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// What to log for a failure at `now`, if anything.
+    fn on_failure(&mut self, now: std::time::Instant) -> Option<StepWarn> {
+        match self.last_warn {
+            None => {
+                self.last_warn = Some(now);
+                Some(StepWarn::First)
+            }
+            Some(last) if now.duration_since(last) >= Self::INTERVAL => {
+                self.last_warn = Some(now);
+                let suppressed = std::mem::take(&mut self.suppressed);
+                Some(StepWarn::StillFailing { suppressed })
+            }
+            Some(_) => {
+                self.suppressed += 1;
+                None
+            }
+        }
+    }
+
+    /// Closes a failing streak; returns the suppressed count to report.
+    fn on_success(&mut self) -> Option<u64> {
+        self.last_warn
+            .take()
+            .map(|_| std::mem::take(&mut self.suppressed))
+    }
+}
+
 pub struct OvRuntimeEngine {
     spec: ShardSpec,
     runtime: OvRuntime,
@@ -443,6 +491,7 @@ pub struct OvRuntimeEngine {
     /// Set for stateless static-shape (NPU) shards; drives the host-side
     /// bounded-KV decode path instead of OV internal state.
     static_kv: Option<StaticKv>,
+    step_warn: StepWarnLimiter,
 }
 
 impl OvRuntimeEngine {
@@ -1294,9 +1343,20 @@ impl Engine for OvRuntimeEngine {
             self.step_middle().map(|_| Vec::new())
         };
         match result {
-            Ok(v) => v,
+            Ok(v) => {
+                if let Some(suppressed) = self.step_warn.on_success() {
+                    tracing::info!(suppressed, "ov-runtime step recovered");
+                }
+                v
+            }
             Err(e) => {
-                warn!(error = %e, "ov-runtime step failed");
+                match self.step_warn.on_failure(std::time::Instant::now()) {
+                    Some(StepWarn::First) => warn!(error = %e, "ov-runtime step failed"),
+                    Some(StepWarn::StillFailing { suppressed }) => {
+                        warn!(error = %e, suppressed, "ov-runtime step still failing")
+                    }
+                    None => {}
+                }
                 Vec::new()
             }
         }
@@ -1734,6 +1794,7 @@ impl Builder for OvRuntimeBuilder {
             pending: Vec::new(),
             active: None,
             static_kv,
+            step_warn: StepWarnLimiter::default(),
         }))
     }
 }
@@ -1760,5 +1821,59 @@ mod tests {
     async fn connect_no_peers_is_noop_for_single_stage() {
         let mut b = OvRuntimeBuilder::new("/x", 0, 1, "CPU");
         b.connect(PeerLayout::single_stage()).await.unwrap();
+    }
+
+    // -------- StepWarnLimiter (issue #30: WARN flood on failing step) --------
+
+    fn ms(n: u64) -> std::time::Duration {
+        std::time::Duration::from_millis(n)
+    }
+
+    #[test]
+    fn step_warn_limiter_logs_first_failure_then_suppresses() {
+        let mut l = StepWarnLimiter::default();
+        let t0 = std::time::Instant::now();
+        assert!(matches!(l.on_failure(t0), Some(StepWarn::First)));
+        assert!(l.on_failure(t0 + ms(1)).is_none());
+        assert!(l.on_failure(t0 + ms(2)).is_none());
+    }
+
+    #[test]
+    fn step_warn_limiter_emits_periodic_summary_with_suppressed_count() {
+        let mut l = StepWarnLimiter::default();
+        let t0 = std::time::Instant::now();
+        l.on_failure(t0);
+        for i in 1..=5 {
+            assert!(l.on_failure(t0 + ms(i)).is_none());
+        }
+        let later = t0 + StepWarnLimiter::INTERVAL + ms(10);
+        match l.on_failure(later) {
+            Some(StepWarn::StillFailing { suppressed }) => assert_eq!(suppressed, 5),
+            other => panic!("expected StillFailing summary, got {other:?}"),
+        }
+        // Counter resets after each summary; the next interval reports
+        // only what was suppressed since.
+        assert!(l.on_failure(later + ms(1)).is_none());
+        match l.on_failure(later + StepWarnLimiter::INTERVAL + ms(10)) {
+            Some(StepWarn::StillFailing { suppressed }) => assert_eq!(suppressed, 1),
+            other => panic!("expected second summary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn step_warn_limiter_success_ends_streak_and_relatches() {
+        let mut l = StepWarnLimiter::default();
+        let t0 = std::time::Instant::now();
+        // No streak → nothing to report.
+        assert!(l.on_success().is_none());
+        l.on_failure(t0);
+        l.on_failure(t0 + ms(1));
+        // Streak ends: report the one suppressed failure.
+        assert_eq!(l.on_success(), Some(1));
+        // Latch cleared: a new failure logs immediately again.
+        assert!(matches!(l.on_failure(t0 + ms(2)), Some(StepWarn::First)));
+        // Streak with nothing suppressed still closes (count 0).
+        assert_eq!(l.on_success(), Some(0));
+        assert!(l.on_success().is_none());
     }
 }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -910,7 +910,11 @@ impl OvRuntimeEngine {
         // steps and the API returns `data: [DONE]` with zero chunks.
         let res = self.step_first_body();
         if let Err(ref e) = res {
-            warn!(
+            // DEBUG, not WARN: the outer step() emits the rate-limited
+            // WARN for the same error (StepWarnLimiter); a second
+            // unconditional WARN here would bypass the limiter and
+            // double-log every first-stage failure.
+            tracing::debug!(
                 error = %e,
                 "step_first failed; clearing active + reset_state so next \
                  task starts fresh (downstream socket may still be dead)"

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -46,6 +46,7 @@ use tokenizers::Tokenizer;
 use tracing::{info, warn};
 
 use crate::rotary::{load_model_config, Rotary};
+use crate::warn_limit::{StepWarn, StepWarnLimiter};
 
 // -------- pipeline / stage config --------
 
@@ -418,8 +419,6 @@ struct ActiveTask {
     /// `recv_token_from_downstream` — i.e. wire send + charlie wait + recv.
     t_wire: std::time::Duration,
 }
-
-use crate::warn_limit::{StepWarn, StepWarnLimiter};
 
 pub struct OvRuntimeEngine {
     spec: ShardSpec,

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -419,53 +419,7 @@ struct ActiveTask {
     t_wire: std::time::Duration,
 }
 
-/// Rate-limits the "step failed" WARN (cascadia-enterprise issue #30: a
-/// persistently-failing step logged one WARN per call — ~90k/s — and grew
-/// chain.log to 770 GB). First failure of a streak logs in full; later
-/// ones are counted and surfaced as a periodic "still failing" summary.
-/// Success closes the streak so the next failure logs immediately again.
-#[derive(Default)]
-struct StepWarnLimiter {
-    /// `Some(last WARN instant)` while in a failing streak.
-    last_warn: Option<std::time::Instant>,
-    suppressed: u64,
-}
-
-#[derive(Debug)]
-enum StepWarn {
-    First,
-    StillFailing { suppressed: u64 },
-}
-
-impl StepWarnLimiter {
-    const INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
-
-    /// What to log for a failure at `now`, if anything.
-    fn on_failure(&mut self, now: std::time::Instant) -> Option<StepWarn> {
-        match self.last_warn {
-            None => {
-                self.last_warn = Some(now);
-                Some(StepWarn::First)
-            }
-            Some(last) if now.duration_since(last) >= Self::INTERVAL => {
-                self.last_warn = Some(now);
-                let suppressed = std::mem::take(&mut self.suppressed);
-                Some(StepWarn::StillFailing { suppressed })
-            }
-            Some(_) => {
-                self.suppressed += 1;
-                None
-            }
-        }
-    }
-
-    /// Closes a failing streak; returns the suppressed count to report.
-    fn on_success(&mut self) -> Option<u64> {
-        self.last_warn
-            .take()
-            .map(|_| std::mem::take(&mut self.suppressed))
-    }
-}
+use crate::warn_limit::{StepWarn, StepWarnLimiter};
 
 pub struct OvRuntimeEngine {
     spec: ShardSpec,
@@ -1831,59 +1785,5 @@ mod tests {
     async fn connect_no_peers_is_noop_for_single_stage() {
         let mut b = OvRuntimeBuilder::new("/x", 0, 1, "CPU");
         b.connect(PeerLayout::single_stage()).await.unwrap();
-    }
-
-    // -------- StepWarnLimiter (issue #30: WARN flood on failing step) --------
-
-    fn ms(n: u64) -> std::time::Duration {
-        std::time::Duration::from_millis(n)
-    }
-
-    #[test]
-    fn step_warn_limiter_logs_first_failure_then_suppresses() {
-        let mut l = StepWarnLimiter::default();
-        let t0 = std::time::Instant::now();
-        assert!(matches!(l.on_failure(t0), Some(StepWarn::First)));
-        assert!(l.on_failure(t0 + ms(1)).is_none());
-        assert!(l.on_failure(t0 + ms(2)).is_none());
-    }
-
-    #[test]
-    fn step_warn_limiter_emits_periodic_summary_with_suppressed_count() {
-        let mut l = StepWarnLimiter::default();
-        let t0 = std::time::Instant::now();
-        l.on_failure(t0);
-        for i in 1..=5 {
-            assert!(l.on_failure(t0 + ms(i)).is_none());
-        }
-        let later = t0 + StepWarnLimiter::INTERVAL + ms(10);
-        match l.on_failure(later) {
-            Some(StepWarn::StillFailing { suppressed }) => assert_eq!(suppressed, 5),
-            other => panic!("expected StillFailing summary, got {other:?}"),
-        }
-        // Counter resets after each summary; the next interval reports
-        // only what was suppressed since.
-        assert!(l.on_failure(later + ms(1)).is_none());
-        match l.on_failure(later + StepWarnLimiter::INTERVAL + ms(10)) {
-            Some(StepWarn::StillFailing { suppressed }) => assert_eq!(suppressed, 1),
-            other => panic!("expected second summary, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn step_warn_limiter_success_ends_streak_and_relatches() {
-        let mut l = StepWarnLimiter::default();
-        let t0 = std::time::Instant::now();
-        // No streak → nothing to report.
-        assert!(l.on_success().is_none());
-        l.on_failure(t0);
-        l.on_failure(t0 + ms(1));
-        // Streak ends: report the one suppressed failure.
-        assert_eq!(l.on_success(), Some(1));
-        // Latch cleared: a new failure logs immediately again.
-        assert!(matches!(l.on_failure(t0 + ms(2)), Some(StepWarn::First)));
-        // Streak with nothing suppressed still closes (count 0).
-        assert_eq!(l.on_success(), Some(0));
-        assert!(l.on_success().is_none());
     }
 }

--- a/crates/cascadia-engine-openvino/src/warn_limit.rs
+++ b/crates/cascadia-engine-openvino/src/warn_limit.rs
@@ -2,8 +2,11 @@
 //!
 //! A persistently-failing `Engine::step()` driven by the relay loop logs
 //! one WARN per call (~90k/s when the upstream connection drops and recv
-//! fast-errors), which grew a node's chain.log to 770 GB. Used by every
-//! OpenVINO engine's `step()` so the flood is bounded identically.
+//! fast-errors), which grew a node's chain.log to 770 GB. Used by the
+//! relay-loop engines that fast-error without their own backoff —
+//! `OvRuntimeEngine` and `Gemma4Engine` — so both bound the flood
+//! identically. (`qwen36` already self-throttles with a sleep; `dist_spec`
+//! is the speculative-decode engine.)
 
 /// Rate-limits the per-call "step failed" WARN. First failure of a streak
 /// logs in full; later ones are counted and surfaced as a periodic "still

--- a/crates/cascadia-engine-openvino/src/warn_limit.rs
+++ b/crates/cascadia-engine-openvino/src/warn_limit.rs
@@ -1,0 +1,110 @@
+//! Shared step-failure WARN rate-limiter (cascadia-enterprise issue #30).
+//!
+//! A persistently-failing `Engine::step()` driven by the relay loop logs
+//! one WARN per call (~90k/s when the upstream connection drops and recv
+//! fast-errors), which grew a node's chain.log to 770 GB. Used by every
+//! OpenVINO engine's `step()` so the flood is bounded identically.
+
+/// Rate-limits the per-call "step failed" WARN. First failure of a streak
+/// logs in full; later ones are counted and surfaced as a periodic "still
+/// failing, N suppressed" summary. Success closes the streak so the next
+/// failure logs immediately again.
+#[derive(Default)]
+pub(crate) struct StepWarnLimiter {
+    /// `Some(last WARN instant)` while in a failing streak.
+    last_warn: Option<std::time::Instant>,
+    suppressed: u64,
+}
+
+#[derive(Debug)]
+pub(crate) enum StepWarn {
+    First,
+    StillFailing { suppressed: u64 },
+}
+
+impl StepWarnLimiter {
+    pub(crate) const INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// What to log for a failure at `now`, if anything.
+    pub(crate) fn on_failure(&mut self, now: std::time::Instant) -> Option<StepWarn> {
+        match self.last_warn {
+            None => {
+                self.last_warn = Some(now);
+                Some(StepWarn::First)
+            }
+            Some(last) if now.duration_since(last) >= Self::INTERVAL => {
+                self.last_warn = Some(now);
+                let suppressed = std::mem::take(&mut self.suppressed);
+                Some(StepWarn::StillFailing { suppressed })
+            }
+            Some(_) => {
+                self.suppressed += 1;
+                None
+            }
+        }
+    }
+
+    /// Closes a failing streak; returns the suppressed count to report.
+    pub(crate) fn on_success(&mut self) -> Option<u64> {
+        self.last_warn
+            .take()
+            .map(|_| std::mem::take(&mut self.suppressed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> std::time::Duration {
+        std::time::Duration::from_millis(n)
+    }
+
+    #[test]
+    fn logs_first_failure_then_suppresses() {
+        let mut l = StepWarnLimiter::default();
+        let t0 = std::time::Instant::now();
+        assert!(matches!(l.on_failure(t0), Some(StepWarn::First)));
+        assert!(l.on_failure(t0 + ms(1)).is_none());
+        assert!(l.on_failure(t0 + ms(2)).is_none());
+    }
+
+    #[test]
+    fn emits_periodic_summary_with_suppressed_count() {
+        let mut l = StepWarnLimiter::default();
+        let t0 = std::time::Instant::now();
+        l.on_failure(t0);
+        for i in 1..=5 {
+            assert!(l.on_failure(t0 + ms(i)).is_none());
+        }
+        let later = t0 + StepWarnLimiter::INTERVAL + ms(10);
+        match l.on_failure(later) {
+            Some(StepWarn::StillFailing { suppressed }) => assert_eq!(suppressed, 5),
+            other => panic!("expected StillFailing summary, got {other:?}"),
+        }
+        // Counter resets after each summary; the next interval reports
+        // only what was suppressed since.
+        assert!(l.on_failure(later + ms(1)).is_none());
+        match l.on_failure(later + StepWarnLimiter::INTERVAL + ms(10)) {
+            Some(StepWarn::StillFailing { suppressed }) => assert_eq!(suppressed, 1),
+            other => panic!("expected second summary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn success_ends_streak_and_relatches() {
+        let mut l = StepWarnLimiter::default();
+        let t0 = std::time::Instant::now();
+        // No streak → nothing to report.
+        assert!(l.on_success().is_none());
+        l.on_failure(t0);
+        l.on_failure(t0 + ms(1));
+        // Streak ends: report the one suppressed failure.
+        assert_eq!(l.on_success(), Some(1));
+        // Latch cleared: a new failure logs immediately again.
+        assert!(matches!(l.on_failure(t0 + ms(2)), Some(StepWarn::First)));
+        // Streak with nothing suppressed still closes (count 0).
+        assert_eq!(l.on_success(), Some(0));
+        assert!(l.on_success().is_none());
+    }
+}


### PR DESCRIPTION
## What & why

`OvRuntimeEngine::step()` logged one WARN per failing call (~90k/s when a dropped upstream makes recv fast-error) — the source of cascadia-enterprise#30's 770 GB `chain.log`. Adds a crate-shared `StepWarnLimiter` and wires it into **both** `OvRuntimeEngine` and `Gemma4Engine` (which had the byte-identical flood).

## Related

- **Enterprise half — fixes A + C + consumer:** labscommunity/cascadia-enterprise#31 (relay-loop backoff + log rotation/retention; pins this rev).
- Upstream half (fix B) of labscommunity/cascadia-enterprise#30.

## Changes

- **`warn_limit.rs`** (new, shared): first failure logs in full; later ones counted; 30s `"still failing, N suppressed"` summary; success closes the streak (recovery INFO) and re-latches. ~2 lines/min worst case while wedged.
- **`runtime.rs` + `gemma4.rs`**: `Err` → limiter; `Ok` closes the streak only behind `!v.is_empty() || !self.spec.is_first_stage` (a failed first-stage step clears `active`, so the next idle `Ok(empty)` must not spuriously close it; a relay-stage `Ok` is always a completed round).
- **gemma4 `step_first` inner WARN → debug** (the outer `step()` already rate-limits the same error).
- **`dist_spec` left**: its CPU-speed flood path (socket-closed) is already throttled; the else-branch errors come from a blocking `recv` (frame-rate-bounded, not a spin).

## Test plan

Run from repo root; tick each as it passes.

- [ ] **Limiter + engines** — 28 tests incl. the 3 `warn_limit` state-machine tests (first-failure latch; 30s summary with counter reset; success relatch)
  ```bash
  cargo test -p cascadia-engine-openvino --lib
  ```
- [ ] **No new lint / format**
  ```bash
  cargo clippy -p cascadia-engine-openvino
  cargo fmt -p cascadia-engine-openvino -- --check
  ```

## Review focus

- `StepWarnLimiter` state machine: latch → 30s summary with per-interval counter reset → relatch.
- The idle-first-stage `Ok` gate across first / single (first+last) / middle / last topologies.
- First occurrence still logs the original `"ov-runtime step failed"` / `"gemma4 step failed"` strings, so existing alert matchers keep firing.

## Notes

Logging-cadence change only — `step()` return values are byte-identical, so downstream relay logic is unaffected. The limiter is pure logic with an injected `Instant`, so the state machine is fully unit-tested without an OV runtime. Enterprise consumes this via a pinned git rev (cascadia-enterprise#31).

