### PR TITLE
fix(transport): deadline mid-task replies to prevent chain-head wedge

### DIFF
--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -635,7 +635,8 @@ impl Gemma4Engine {
         let (tensor, _) = self
             .block_on(async move {
                 let mut guard = downstream.lock().await;
-                guard.recv().await
+                // MID-TASK reply — deadlined; see `recv_tensor_reply` (Item 5).
+                guard.recv_reply().await
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
         if tensor.data.len() < 4 {
@@ -664,9 +665,12 @@ impl Gemma4Engine {
         let (pos_t, hid_t, header_t) = self
             .block_on(async {
                 let mut guard = upstream.lock().await;
+                // First frame of the step is the IDLE wait; the frames that
+                // must follow it are mid-sequence replies — deadlined so a
+                // half-sent step can't wedge the stage (Item 5).
                 let pos = guard.recv().await?.0;
-                let hid = guard.recv().await?.0;
-                let hdr = guard.recv().await?.0;
+                let hid = guard.recv_reply().await?.0;
+                let hdr = guard.recv_reply().await?.0;
                 Ok::<_, cascadia_transport::TransportError>((pos, hid, hdr))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
@@ -696,7 +700,7 @@ impl Gemma4Engine {
                 let mut guard = up2.lock().await;
                 let mut v = Vec::with_capacity(n);
                 for _ in 0..n {
-                    v.push(guard.recv().await?.0);
+                    v.push(guard.recv_reply().await?.0);
                 }
                 Ok::<_, cascadia_transport::TransportError>(v)
             })

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -627,7 +627,7 @@ impl Gemma4Engine {
         Ok(())
     }
 
-    fn recv_token_from_downstream(&mut self) -> EngineResult<i32> {
+    fn recv_token_from_downstream(&mut self, prefill: bool) -> EngineResult<i32> {
         let downstream = self
             .downstream
             .clone()
@@ -636,7 +636,14 @@ impl Gemma4Engine {
             .block_on(async move {
                 let mut guard = downstream.lock().await;
                 // MID-TASK reply — deadlined; see `recv_tensor_reply` (Item 5).
-                guard.recv_reply().await
+                // A prefill reply waits on every remaining stage's
+                // whole-prompt compute — widened budget (see
+                // `recv_tensor_reply_prefill`).
+                if prefill {
+                    guard.recv_reply_prefill().await
+                } else {
+                    guard.recv_reply().await
+                }
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
         if tensor.data.len() < 4 {
@@ -856,7 +863,8 @@ impl Gemma4Engine {
         let (out, shape) = self.run_first(&tokens, position)?;
         let alpha = ts.elapsed();
         self.position += tokens.len() as i64;
-        let (next_token, wire) = self.resolve_next_token(&out, &shape, single_stage, position)?;
+        let (next_token, wire) =
+            self.resolve_next_token(&out, &shape, single_stage, position, prefill)?;
         if let Some(a) = self.active.as_mut() {
             a.t_alpha_compute += alpha;
             a.t_wire += wire;
@@ -875,6 +883,7 @@ impl Gemma4Engine {
         shape: &[usize],
         single_stage: bool,
         position: i64,
+        prefill: bool,
     ) -> EngineResult<(i32, std::time::Duration)> {
         if single_stage {
             Ok((argmax_logits(out, shape)?, std::time::Duration::ZERO))
@@ -882,7 +891,7 @@ impl Gemma4Engine {
             let s3 = to_shape3(shape);
             let ts = std::time::Instant::now();
             self.send_hidden_downstream(out, s3, position)?;
-            let token = self.recv_token_from_downstream()?;
+            let token = self.recv_token_from_downstream(prefill)?;
             Ok((token, ts.elapsed()))
         }
     }
@@ -976,6 +985,9 @@ impl Gemma4Engine {
 
     fn step_middle(&mut self) -> EngineResult<()> {
         let (hidden, shape, position) = self.recv_hidden_from_upstream()?;
+        // Multi-token hidden = prefill: the token reply waits on every
+        // remaining stage's whole-prompt compute — widened budget.
+        let prefill_reply = shape[1] > 1;
         if position == 0 {
             self.runtime.reset_state().map_err(map_ov_err)?;
         }
@@ -983,7 +995,7 @@ impl Gemma4Engine {
         let s3 = to_shape3(&out_shape);
         // Forward the SAME absolute position downstream so every stage aligns.
         self.send_hidden_downstream(&out, s3, position)?;
-        let token = self.recv_token_from_downstream()?;
+        let token = self.recv_token_from_downstream(prefill_reply)?;
         self.send_token_to_upstream(token)?;
         Ok(())
     }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -863,8 +863,16 @@ impl Gemma4Engine {
         let (out, shape) = self.run_first(&tokens, position)?;
         let alpha = ts.elapsed();
         self.position += tokens.len() as i64;
-        let (next_token, wire) =
-            self.resolve_next_token(&out, &shape, single_stage, position, prefill)?;
+        // 1-token prompt prefill costs the same downstream as a decode step —
+        // keep the strict deadline (mirrors step_middle's shape[1] > 1) so
+        // wedge eviction stays fast.
+        let (next_token, wire) = self.resolve_next_token(
+            &out,
+            &shape,
+            single_stage,
+            position,
+            prefill && tokens.len() > 1,
+        )?;
         if let Some(a) = self.active.as_mut() {
             a.t_alpha_compute += alpha;
             a.t_wire += wire;

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -982,8 +982,16 @@ impl OvRuntimeEngine {
             let (out, shape) = self.run_first(&tokens, position)?;
             let alpha = ts.elapsed();
             self.position += tokens.len() as i64;
-            let (nt, wire) =
-                self.resolve_next_token(&out, &shape, single_stage, position, prefill)?;
+            // 1-token prompt prefill costs the same downstream as a decode
+            // step — keep the strict deadline (mirrors step_middle's
+            // shape[1] > 1) so wedge eviction stays fast.
+            let (nt, wire) = self.resolve_next_token(
+                &out,
+                &shape,
+                single_stage,
+                position,
+                prefill && tokens.len() > 1,
+            )?;
             if let Some(a) = self.active.as_mut() {
                 a.t_alpha_compute += alpha;
                 a.t_wire += wire;

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -732,7 +732,7 @@ impl OvRuntimeEngine {
         Ok(())
     }
 
-    fn recv_token_from_downstream(&mut self) -> EngineResult<i32> {
+    fn recv_token_from_downstream(&mut self, prefill: bool) -> EngineResult<i32> {
         let downstream = self
             .downstream
             .clone()
@@ -744,11 +744,18 @@ impl OvRuntimeEngine {
         // slot held: the live-rig Item-5 wedge ("task active: 1, task done:
         // 0" all day). On timeout the error propagates to `step_first`'s
         // catch, which clears the active task and resets state — the slot
-        // is freed and the next submit starts fresh.
+        // is freed and the next submit starts fresh. A prefill reply waits
+        // on every remaining stage's whole-prompt compute, so it gets the
+        // widened budget (see `recv_tensor_reply_prefill`) — a long prompt
+        // on a slow stage must not read as a wedge.
         let (tensor, _) = self
             .block_on(async move {
                 let mut guard = downstream.lock().await;
-                guard.recv_reply().await
+                if prefill {
+                    guard.recv_reply_prefill().await
+                } else {
+                    guard.recv_reply().await
+                }
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
         if tensor.data.len() < 4 {
@@ -955,8 +962,11 @@ impl OvRuntimeEngine {
                 let (out, shape) = self.run_first(&[t], position)?;
                 let alpha = ts.elapsed();
                 self.position += 1;
+                // Static prefill round-trips per prompt token — each reply
+                // covers one token's relay compute, so it is never a
+                // prefill-budget wait.
                 let (token, wire) =
-                    self.resolve_next_token(&out, &shape, single_stage, position)?;
+                    self.resolve_next_token(&out, &shape, single_stage, position, false)?;
                 nt = token;
                 if let Some(a) = self.active.as_mut() {
                     a.t_alpha_compute += alpha;
@@ -972,7 +982,8 @@ impl OvRuntimeEngine {
             let (out, shape) = self.run_first(&tokens, position)?;
             let alpha = ts.elapsed();
             self.position += tokens.len() as i64;
-            let (nt, wire) = self.resolve_next_token(&out, &shape, single_stage, position)?;
+            let (nt, wire) =
+                self.resolve_next_token(&out, &shape, single_stage, position, prefill)?;
             if let Some(a) = self.active.as_mut() {
                 a.t_alpha_compute += alpha;
                 a.t_wire += wire;
@@ -993,6 +1004,7 @@ impl OvRuntimeEngine {
         shape: &[usize],
         single_stage: bool,
         position: i64,
+        prefill: bool,
     ) -> EngineResult<(i32, std::time::Duration)> {
         if single_stage {
             Ok((argmax_logits(out, shape)?, std::time::Duration::ZERO))
@@ -1000,7 +1012,7 @@ impl OvRuntimeEngine {
             let s3 = to_shape3(shape);
             let ts = std::time::Instant::now();
             self.send_hidden_downstream(out, s3, position)?;
-            let token = self.recv_token_from_downstream()?;
+            let token = self.recv_token_from_downstream(prefill)?;
             Ok((token, ts.elapsed()))
         }
     }
@@ -1210,6 +1222,10 @@ impl OvRuntimeEngine {
 
     fn step_middle(&mut self) -> EngineResult<()> {
         let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
+        // Multi-token hidden = stateful prefill: the token reply waits on
+        // every remaining stage's whole-prompt compute (static is seq=1,
+        // so this is always false there).
+        let prefill_reply = shape[1] > 1;
         let (out, out_shape, fwd_pos) = match pos_opt {
             Some(pos) => {
                 let (o, s) = self.run_relay(&hidden, shape, pos)?;
@@ -1227,7 +1243,7 @@ impl OvRuntimeEngine {
         };
         let s3 = to_shape3(&out_shape);
         self.send_hidden_downstream(&out, s3, fwd_pos)?;
-        let token = self.recv_token_from_downstream()?;
+        let token = self.recv_token_from_downstream(prefill_reply)?;
         self.send_token_to_upstream(token)?;
         Ok(())
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -785,8 +785,9 @@ impl OvRuntimeEngine {
         let (pos_tensor, tensor) = self
             .block_on(async move {
                 let mut guard = upstream.lock().await;
-                // First frame of a task hop is an IDLE wait (no deadline —
-                // "no next request yet" is fine). On the static path the
+                // First frame of a task hop is an IDLE wait (bounded only by
+                // the transport's much larger frame-idle ceiling — "no next
+                // request yet" is fine). On the static path the
                 // hidden tensor that must FOLLOW the position frame is a
                 // mid-pair reply: once the pos frame arrived, the peer owes
                 // the hidden promptly — deadline it so a half-sent pair

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -737,10 +737,18 @@ impl OvRuntimeEngine {
             .downstream
             .clone()
             .ok_or_else(|| EngineError::Backend("no downstream".into()))?;
+        // MID-TASK reply: we just sent a hidden state and the pipeline owes
+        // us the sampled token back. Use the deadlined `recv_reply`, NOT the
+        // idle-tolerant `recv` — a frame lost between stages (pipeline-leg
+        // reset) would otherwise block this step loop forever with the task
+        // slot held: the live-rig Item-5 wedge ("task active: 1, task done:
+        // 0" all day). On timeout the error propagates to `step_first`'s
+        // catch, which clears the active task and resets state — the slot
+        // is freed and the next submit starts fresh.
         let (tensor, _) = self
             .block_on(async move {
                 let mut guard = downstream.lock().await;
-                guard.recv().await
+                guard.recv_reply().await
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
         if tensor.data.len() < 4 {
@@ -770,12 +778,20 @@ impl OvRuntimeEngine {
         let (pos_tensor, tensor) = self
             .block_on(async move {
                 let mut guard = upstream.lock().await;
-                let pos_tensor = if want_pos {
-                    Some(guard.recv().await?.0)
+                // First frame of a task hop is an IDLE wait (no deadline —
+                // "no next request yet" is fine). On the static path the
+                // hidden tensor that must FOLLOW the position frame is a
+                // mid-pair reply: once the pos frame arrived, the peer owes
+                // the hidden promptly — deadline it so a half-sent pair
+                // can't wedge the stage (see `recv_tensor_reply`).
+                let (pos_tensor, t) = if want_pos {
+                    let pos = guard.recv().await?.0;
+                    let (t, _) = guard.recv_reply().await?;
+                    (Some(pos), t)
                 } else {
-                    None
+                    let (t, _) = guard.recv().await?;
+                    (None, t)
                 };
-                let (t, _) = guard.recv().await?;
                 Ok::<_, cascadia_transport::TransportError>((pos_tensor, t))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -355,8 +355,13 @@ impl Stream for ChunkStream {
                 Err(e) => match e.task_id() {
                     Some(failed) if failed != &this.task_id => {
                         // Misattribution guard: fail the named task's stream,
-                        // not ours. Cancelling it makes its own poll_next
-                        // observe termination on its next turn.
+                        // not ours. Route the failure as a final error chunk
+                        // into its buffer — a cancel marker would end its
+                        // stream silently and its client would get a
+                        // truncated 200. Skip the push if its buffer already
+                        // ends in an error chunk (a non-clearing engine
+                        // re-emits the same failure every step; one is
+                        // enough).
                         let failed = failed.clone();
                         warn!(
                             failed_task = %failed,
@@ -365,8 +370,21 @@ impl Stream for ChunkStream {
                             "engine step failed for another task; routing failure to it"
                         );
                         let mut bufs = this.buffers.lock();
-                        bufs.cancelled.insert(failed.clone());
-                        bufs.chunks.remove(&failed);
+                        // Cancelled task = no consumer left; recreating its
+                        // buffer entry would leak until close() (mirror the
+                        // cancelled-check on the distribution path below).
+                        if !bufs.cancelled.contains(&failed) {
+                            let buf = bufs.chunks.entry(failed.clone()).or_default();
+                            // Dedup: one error chunk max. If the buffer
+                            // already ends in a NORMAL final chunk the task
+                            // completed first — the drain delivers that and
+                            // drops the appended error with the entry, which
+                            // is deliberate (a post-completion failure is
+                            // contract noise; the warn above records it).
+                            if !buf.back().is_some_and(|c| c.error.is_some()) {
+                                buf.push_back(Chunk::error(failed.clone(), e.to_string()));
+                            }
+                        }
                         drop(bufs);
                         // Bound only a *non-clearing* engine: one that re-emits
                         // the SAME foreign-task Err every step (never dropping
@@ -380,28 +398,46 @@ impl Stream for ChunkStream {
                         if this.last_errored_task.as_ref() == Some(&failed) {
                             this.consecutive_foreign_err += 1;
                         } else {
-                            this.last_errored_task = Some(failed);
+                            this.last_errored_task = Some(failed.clone());
                             this.consecutive_foreign_err = 1;
                         }
                         if this.consecutive_foreign_err >= MAX_CONSECUTIVE_EMPTY_STEPS {
+                            // Abnormal close of a healthy stream — fail it
+                            // loud (see the own-task arm below).
                             this.done = true;
+                            this.buffers.lock().chunks.remove(&this.task_id);
                             warn!(
                                 task = %this.task_id,
                                 "engine re-failed the same foreign task for {} consecutive steps; closing stream",
                                 MAX_CONSECUTIVE_EMPTY_STEPS
                             );
-                            return Poll::Ready(None);
+                            return Poll::Ready(Some(Chunk::error(
+                                this.task_id.clone(),
+                                format!(
+                                    "engine wedged re-failing task {failed} for {} consecutive steps: {e}",
+                                    MAX_CONSECUTIVE_EMPTY_STEPS
+                                ),
+                            )));
                         }
                         continue;
                     }
                     _ => {
+                        // Surface the failure as a final error chunk: a bare
+                        // end-of-stream builds a 200 with truncated text and
+                        // finish_reason "stop" at the API layer. The error
+                        // chunk routes through the existing 503 / SSE-error
+                        // paths instead.
                         this.done = true;
+                        this.buffers.lock().chunks.remove(&this.task_id);
                         warn!(
                             task = %this.task_id,
                             error = %e,
                             "engine step failed; closing stream"
                         );
-                        return Poll::Ready(None);
+                        return Poll::Ready(Some(Chunk::error(
+                            this.task_id.clone(),
+                            e.to_string(),
+                        )));
                     }
                 },
             };
@@ -409,13 +445,23 @@ impl Stream for ChunkStream {
             if produced.is_empty() {
                 this.consecutive_empty += 1;
                 if this.consecutive_empty >= MAX_CONSECUTIVE_EMPTY_STEPS {
+                    // An engine that wedges by stalling (Ok-empty forever)
+                    // is a failure the client must see — fail loud like the
+                    // step-error arms above.
                     this.done = true;
+                    this.buffers.lock().chunks.remove(&this.task_id);
                     warn!(
                         task = %this.task_id,
                         "engine made no progress for {} consecutive steps; closing stream",
                         MAX_CONSECUTIVE_EMPTY_STEPS
                     );
-                    return Poll::Ready(None);
+                    return Poll::Ready(Some(Chunk::error(
+                        this.task_id.clone(),
+                        format!(
+                            "engine made no progress for {} consecutive steps",
+                            MAX_CONSECUTIVE_EMPTY_STEPS
+                        ),
+                    )));
                 }
                 continue;
             }
@@ -748,7 +794,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn step_error_terminates_stream() {
+    async fn step_error_surfaces_error_chunk_then_terminates() {
         let runner = Runner::new(Box::new(FailingBuilder));
         runner
             .start(
@@ -760,8 +806,24 @@ mod tests {
         let mut stream = runner
             .generate(GenerationTask::new("t1", "hello").with_max_tokens(8))
             .unwrap();
-        // The first poll hits the step error and ends the stream — no
-        // empty-step spinning, no chunks.
+        // The first poll hits the step error. The failure must reach the
+        // consumer as a final error chunk — a bare end-of-stream builds a
+        // 200 with truncated text and finish_reason "stop" at the API layer,
+        // indistinguishable from the model choosing to stop.
+        let chunk = stream
+            .next()
+            .await
+            .expect("failed task must surface a final error chunk, not a silent end");
+        assert!(chunk.is_final);
+        assert!(
+            chunk
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("transport down")),
+            "error chunk must carry the step failure, got: {:?}",
+            chunk.error
+        );
+        // And then the stream terminates — no empty-step spinning.
         assert!(stream.next().await.is_none());
     }
 
@@ -855,11 +917,22 @@ mod tests {
             "healthy task b's stream was killed by task a's failure: {b_chunk:?}"
         );
 
-        // A's stream ends (None) — it was the failed task.
+        // A's stream surfaces the routed failure as a final error chunk —
+        // ending it silently would give A's client a truncated 200.
+        let a_chunk = stream_a
+            .next()
+            .await
+            .expect("failed task a must surface a final error chunk, not a silent end");
+        assert!(a_chunk.is_final);
         assert!(
-            stream_a.next().await.is_none(),
-            "failed task a's stream should have ended"
+            a_chunk
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("transport down")),
+            "task a's error chunk must carry the failure, got: {:?}",
+            a_chunk.error
         );
+        assert!(stream_a.next().await.is_none());
         // B's stream is now complete too.
         assert!(stream_b.next().await.is_none());
     }
@@ -931,17 +1004,120 @@ mod tests {
             .generate(GenerationTask::new("ours", "x").with_max_tokens(64))
             .unwrap();
 
-        // Must terminate (None), not hang. Bounded by the no-progress guard.
+        // Must terminate, not hang — and the abnormal close must surface as
+        // a final error chunk (a bare end-of-stream would build a truncated
+        // 200 at the API layer), bounded by the no-progress guard.
+        let last = stream
+            .next()
+            .await
+            .expect("observing stream must surface an error chunk when the engine wedges");
+        assert!(last.is_final);
         assert!(
-            stream.next().await.is_none(),
-            "stream should terminate on a non-clearing foreign-task Err, not spin"
+            last.error.is_some(),
+            "guard close must carry an error, got: {last:?}"
         );
+        assert!(stream.next().await.is_none());
         // One step per no-progress round; capped by the guard, not unbounded.
         let n = steps.load(Ordering::SeqCst);
         assert!(
             n <= MAX_CONSECUTIVE_EMPTY_STEPS,
             "stream busy-spun on a non-clearing foreign-task Err: {n} steps"
         );
+    }
+
+    /// A foreign-task failure routed to a task whose client already went
+    /// away (cancelled / stream dropped) must NOT recreate that task's
+    /// buffer entry — nothing will ever drain it, so it would leak until
+    /// close(). Mirrors the cancelled-check on the distribution path.
+    #[tokio::test]
+    async fn foreign_err_for_cancelled_task_does_not_recreate_buffer() {
+        let steps = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let runner = Runner::new(Box::new(ForeignErrSpinBuilder {
+            fail: "dead".to_string(),
+            steps,
+        }));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        // "dead" was cancelled before its failure surfaced (the dead
+        // transport is often exactly why the client disconnected).
+        runner.cancel(&"dead".to_string());
+        let mut stream = runner
+            .generate(GenerationTask::new("ours", "x").with_max_tokens(4))
+            .unwrap();
+        // Drive until our stream closes (the engine never serves us).
+        while stream.next().await.is_some() {}
+        assert!(
+            !runner.buffers.lock().chunks.contains_key("dead"),
+            "routing a failure to a cancelled task must not recreate its buffer entry"
+        );
+    }
+
+    /// Engine that never errors and never produces: every step is Ok(empty).
+    /// Models a wedged engine that stalls instead of failing.
+    struct StallingEngine;
+
+    impl Engine for StallingEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct StallingBuilder;
+
+    #[async_trait::async_trait]
+    impl Builder for StallingBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(StallingEngine))
+        }
+    }
+
+    /// The no-progress guard must fail loud: an engine that wedges by
+    /// producing nothing (rather than by erroring) is a failure the client
+    /// must see, not a truncated 200 with finish_reason "stop".
+    #[tokio::test]
+    async fn no_progress_close_surfaces_error_chunk() {
+        let runner = Runner::new(Box::new(StallingBuilder));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        let mut stream = runner
+            .generate(GenerationTask::new("t1", "hello").with_max_tokens(8))
+            .unwrap();
+        let last = stream
+            .next()
+            .await
+            .expect("no-progress close must surface a final error chunk");
+        assert!(last.is_final);
+        assert!(
+            last.error
+                .as_deref()
+                .is_some_and(|e| e.contains("no progress")),
+            "error chunk must name the stall, got: {:?}",
+            last.error
+        );
+        assert!(stream.next().await.is_none());
     }
 
     /// Engine that fails a sequence of DISTINCT foreign tasks, one per step

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -1035,6 +1035,73 @@ mod tests {
         );
     }
 
+    /// Client twin of `reply_wait_longer_than_timeout_fails_fast`: the
+    /// engine's downstream leg is an `ActivationClient` (the production
+    /// path for `recv_token_from_downstream`), and its reply methods are
+    /// separate near-verbatim copies of the server's — pin them
+    /// independently so the twins can't drift apart.
+    #[tokio::test]
+    async fn client_reply_wait_longer_than_timeout_fails_fast() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            // Send nothing: the "reply" never comes. Outlive the 1s deadline
+            // so the client hits the timeout path, not a clean EOF.
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        let started = std::time::Instant::now();
+        let got = client.recv_reply().await;
+        let waited = started.elapsed();
+        h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(
+            got.is_err(),
+            "a missing mid-task reply must time out, got {got:?}"
+        );
+        assert!(
+            waited < Duration::from_secs(5),
+            "must fail within ~the recv timeout, waited {waited:?}"
+        );
+    }
+
+    /// Client twin of `reply_timeout_poisons_connection`: a timed-out reply
+    /// on the downstream leg must poison the client's socket so a late
+    /// reply can't be consumed by the NEXT task as fresh data.
+    #[tokio::test]
+    async fn client_reply_timeout_poisons_connection() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(2500)).await; // miss the 1s deadline
+            let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+            let _ = server.send(&tensor).await; // late reply — client may have hung up
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        let first = client.recv_reply().await;
+        let second = client.recv().await;
+        h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(
+            first.is_err(),
+            "the late reply must time out, got {first:?}"
+        );
+        assert!(
+            matches!(second, Err(TransportError::NotConnected)),
+            "a poisoned connection must fail fast, not serve the stale frame: {second:?}"
+        );
+    }
+
     /// Once a frame has started, a stalled peer must still hit the timeout
     /// (slow-loris / wedged-peer bound is preserved).
     #[tokio::test]

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -175,9 +175,37 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
 /// payload length so a peer can't claim `shape=[u32::MAX, ...]` to
 /// trigger overflow downstream.
 pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
+    recv_tensor_inner(sock, false).await
+}
+
+/// Like [`recv_tensor`] but for a MID-TASK reply: the peer owes us a prompt
+/// response to a frame we just sent (e.g. the pipeline tail returning the
+/// sampled token for a hidden state), so the header's FIRST byte is read
+/// under the strict recv timeout instead of the idle-tolerant indefinite
+/// wait. Call-site rule: a stage waiting for the NEXT task idles on
+/// `recv` (no deadline — "no work yet" is not a failure); a stage waiting
+/// for a reply to in-flight work uses `recv_reply` — otherwise a single
+/// frame lost mid-task (e.g. a pipeline-leg reset between stages) blocks
+/// the engine's step loop forever and the task slot is never freed
+/// (overload-backlog Item 5: forwarded-to head wedges, task never
+/// finalizes).
+pub async fn recv_tensor_reply(
+    sock: &mut TcpStream,
+) -> TransportResult<(Tensor, TransferStats)> {
+    recv_tensor_inner(sock, true).await
+}
+
+async fn recv_tensor_inner(
+    sock: &mut TcpStream,
+    deadline_first_byte: bool,
+) -> TransportResult<(Tensor, TransferStats)> {
     let start = Instant::now();
     let mut header = [0u8; HEADER_SIZE];
-    recv_exact_frame_start(sock, &mut header).await?;
+    if deadline_first_byte {
+        recv_exact(sock, &mut header).await?;
+    } else {
+        recv_exact_frame_start(sock, &mut header).await?;
+    }
 
     let payload_len = u32::from_be_bytes(header[0..4].try_into().unwrap());
     let dtype_code = u32::from_be_bytes(header[4..8].try_into().unwrap());
@@ -496,6 +524,13 @@ impl ActivationServer {
         }
     }
 
+    /// Mid-task reply recv — strict deadline on the first byte. See
+    /// [`recv_tensor_reply`] for the call-site rule.
+    pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
+        recv_tensor_reply(sock).await
+    }
+
     pub async fn send(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
         send_tensor(sock, tensor).await
@@ -634,6 +669,13 @@ impl ActivationClient {
         if err.is_some_and(recv_error_is_connection_fatal) {
             self.sock = None; // drop closes the fd
         }
+    }
+
+    /// Mid-task reply recv — strict deadline on the first byte. See
+    /// [`recv_tensor_reply`] for the call-site rule.
+    pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
+        recv_tensor_reply(sock).await
     }
 
     pub async fn send_raw(&mut self, bytes: &[u8]) -> TransportResult<()> {
@@ -778,6 +820,60 @@ mod tests {
             "idle wait for the next frame must not time out: {:?}",
             got.err()
         );
+    }
+
+    /// A MID-TASK reply (`recv_reply`) is the opposite contract: the peer
+    /// owes us a prompt response, so a silent peer must fail fast instead
+    /// of blocking the engine's step loop forever with the task slot held
+    /// (overload-backlog Item 5).
+    #[tokio::test]
+    async fn reply_wait_longer_than_timeout_fails_fast() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            let started = std::time::Instant::now();
+            let res = server.recv_reply().await;
+            (res, started.elapsed())
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        // Send nothing: the "reply" never comes.
+        let (got, waited) = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(
+            got.is_err(),
+            "a missing mid-task reply must time out, got {got:?}"
+        );
+        assert!(
+            waited < Duration::from_secs(5),
+            "must fail within ~the recv timeout, waited {waited:?}"
+        );
+    }
+
+    /// Happy path: a reply arriving within the deadline is received normally.
+    #[tokio::test]
+    async fn reply_within_timeout_succeeds() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(2);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            server.recv_reply().await
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        client.send(&tensor).await.unwrap();
+        let got = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(got.is_ok(), "in-deadline reply must succeed: {:?}", got.err());
     }
 
     /// Once a frame has started, a stalled peer must still hit the timeout

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -208,7 +208,13 @@ pub const PREFILL_REPLY_TIMEOUT_FACTOR: u32 = 10;
 pub async fn recv_tensor_reply_prefill(
     sock: &mut TcpStream,
 ) -> TransportResult<(Tensor, TransferStats)> {
-    recv_tensor_inner(sock, Some(recv_timeout() * PREFILL_REPLY_TIMEOUT_FACTOR)).await
+    // saturating_mul: an absurdly large configured base must clamp, not
+    // panic the engine thread (Duration's Mul panics on overflow).
+    recv_tensor_inner(
+        sock,
+        Some(recv_timeout().saturating_mul(PREFILL_REPLY_TIMEOUT_FACTOR)),
+    )
+    .await
 }
 
 async fn recv_tensor_inner(

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -181,12 +181,13 @@ pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, Trans
 /// Like [`recv_tensor`] but for a MID-TASK reply: the peer owes us a prompt
 /// response to a frame we just sent (e.g. the pipeline tail returning the
 /// sampled token for a hidden state), so the header's FIRST byte is read
-/// under the strict recv timeout instead of the idle-tolerant indefinite
-/// wait. Call-site rule: a stage waiting for the NEXT task idles on
-/// `recv` (no deadline — "no work yet" is not a failure); a stage waiting
-/// for a reply to in-flight work uses `recv_reply` — otherwise a single
-/// frame lost mid-task (e.g. a pipeline-leg reset between stages) blocks
-/// the engine's step loop forever and the task slot is never freed
+/// under the strict recv timeout instead of the idle-tolerant wait (bounded
+/// only by the much larger `frame_idle_ceiling`). Call-site rule: a stage
+/// waiting for the NEXT task idles on `recv` (idle-ceiling bound only —
+/// "no work yet" is not a failure); a stage waiting for a reply to
+/// in-flight work uses `recv_reply` — otherwise a single frame lost
+/// mid-task (e.g. a pipeline-leg reset between stages) stalls the engine's
+/// step loop for the whole idle ceiling with the task slot held
 /// (overload-backlog Item 5: forwarded-to head wedges, task never
 /// finalizes).
 pub async fn recv_tensor_reply(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
@@ -196,10 +197,11 @@ pub async fn recv_tensor_reply(sock: &mut TcpStream) -> TransportResult<(Tensor,
 /// A PREFILL reply is owed only after every remaining downstream stage has
 /// run whole-prompt inference sequentially — the wait scales with prompt
 /// length × pipeline depth, not with a single frame transfer (which is what
-/// the base recv timeout was sized for). Budget: 10× the base, which at the
-/// 60s default restores the pre-idle-tolerance 600s bound; decode replies
-/// (sub-second when healthy) keep the strict [`recv_tensor_reply`] deadline
-/// so wedge eviction stays fast where it matters.
+/// the base recv timeout was sized for). Budget: this factor × the base
+/// recv timeout, sized to comfortably cover whole-prompt compute across the
+/// deepest pipelines we run; decode replies (sub-second when healthy) keep
+/// the strict [`recv_tensor_reply`] deadline so wedge eviction stays fast
+/// where it matters.
 pub const PREFILL_REPLY_TIMEOUT_FACTOR: u32 = 10;
 
 /// [`recv_tensor_reply`] with the widened prefill budget. Use for the token
@@ -555,7 +557,9 @@ impl ActivationServer {
 
     /// Mid-task reply recv — strict deadline on the first byte. See
     /// [`recv_tensor_reply`] for the call-site rule. A failed reply
-    /// poisons the connection (see [`Self::poison`]).
+    /// poisons the connection (see `poison`: the socket is dropped
+    /// and later calls fail fast with `NotConnected`; recover with a
+    /// fresh connection).
     pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
         let res = recv_tensor_reply(sock).await;
@@ -566,7 +570,9 @@ impl ActivationServer {
     }
 
     /// Prefill-budget reply recv — see [`recv_tensor_reply_prefill`].
-    /// A failed reply poisons the connection (see [`Self::poison`]).
+    /// A failed reply poisons the connection (see `poison`: the socket
+    /// is dropped and later calls fail fast with `NotConnected`;
+    /// recover with a fresh connection).
     pub async fn recv_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
         let res = recv_tensor_reply_prefill(sock).await;
@@ -731,7 +737,9 @@ impl ActivationClient {
 
     /// Mid-task reply recv — strict deadline on the first byte. See
     /// [`recv_tensor_reply`] for the call-site rule. A failed reply
-    /// poisons the connection (see [`Self::poison`]).
+    /// poisons the connection (see `poison`: the socket is dropped
+    /// and later calls fail fast with `NotConnected`; recover with a
+    /// fresh connection).
     pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
         let res = recv_tensor_reply(sock).await;
@@ -742,7 +750,9 @@ impl ActivationClient {
     }
 
     /// Prefill-budget reply recv — see [`recv_tensor_reply_prefill`].
-    /// A failed reply poisons the connection (see [`Self::poison`]).
+    /// A failed reply poisons the connection (see `poison`: the socket
+    /// is dropped and later calls fail fast with `NotConnected`;
+    /// recover with a fresh connection).
     pub async fn recv_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
         let res = recv_tensor_reply_prefill(sock).await;

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -175,7 +175,7 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
 /// payload length so a peer can't claim `shape=[u32::MAX, ...]` to
 /// trigger overflow downstream.
 pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
-    recv_tensor_inner(sock, false).await
+    recv_tensor_inner(sock, None).await
 }
 
 /// Like [`recv_tensor`] but for a MID-TASK reply: the peer owes us a prompt
@@ -189,22 +189,37 @@ pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, Trans
 /// the engine's step loop forever and the task slot is never freed
 /// (overload-backlog Item 5: forwarded-to head wedges, task never
 /// finalizes).
-pub async fn recv_tensor_reply(
+pub async fn recv_tensor_reply(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
+    recv_tensor_inner(sock, Some(recv_timeout())).await
+}
+
+/// A PREFILL reply is owed only after every remaining downstream stage has
+/// run whole-prompt inference sequentially — the wait scales with prompt
+/// length × pipeline depth, not with a single frame transfer (which is what
+/// the base recv timeout was sized for). Budget: 10× the base, which at the
+/// 60s default restores the pre-idle-tolerance 600s bound; decode replies
+/// (sub-second when healthy) keep the strict [`recv_tensor_reply`] deadline
+/// so wedge eviction stays fast where it matters.
+pub const PREFILL_REPLY_TIMEOUT_FACTOR: u32 = 10;
+
+/// [`recv_tensor_reply`] with the widened prefill budget. Use for the token
+/// reply to a multi-token (prefill) hidden state; everything else uses
+/// `recv_tensor_reply`.
+pub async fn recv_tensor_reply_prefill(
     sock: &mut TcpStream,
 ) -> TransportResult<(Tensor, TransferStats)> {
-    recv_tensor_inner(sock, true).await
+    recv_tensor_inner(sock, Some(recv_timeout() * PREFILL_REPLY_TIMEOUT_FACTOR)).await
 }
 
 async fn recv_tensor_inner(
     sock: &mut TcpStream,
-    deadline_first_byte: bool,
+    deadline_first_byte: Option<Duration>,
 ) -> TransportResult<(Tensor, TransferStats)> {
     let start = Instant::now();
     let mut header = [0u8; HEADER_SIZE];
-    if deadline_first_byte {
-        recv_exact(sock, &mut header).await?;
-    } else {
-        recv_exact_frame_start(sock, &mut header).await?;
+    match deadline_first_byte {
+        Some(to) => recv_exact_within(sock, &mut header, to).await?,
+        None => recv_exact_frame_start(sock, &mut header).await?,
     }
 
     let payload_len = u32::from_be_bytes(header[0..4].try_into().unwrap());
@@ -248,6 +263,7 @@ async fn recv_tensor_inner(
 static ACTIVATION_TIMEOUT_SECS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Set the activation recv timeout from node config; takes precedence over the env var.
+/// Process-global, last writer wins — one value per process, not per shard.
 pub fn set_activation_timeout_secs(secs: u64) {
     ACTIVATION_TIMEOUT_SECS.store(secs, std::sync::atomic::Ordering::Relaxed);
 }
@@ -435,6 +451,14 @@ async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()>
     // transfers ever land (e.g. KV-cache blobs), switch to an idle/
     // no-progress timeout (reset the deadline on each read that returns
     // bytes) so progress, not total size, is what's bounded.
+    recv_exact_within(sock, buf, recv_timeout()).await
+}
+
+async fn recv_exact_within(
+    sock: &mut TcpStream,
+    buf: &mut [u8],
+    to: Duration,
+) -> TransportResult<()> {
     let read_fut = async {
         let mut read = 0;
         while read < buf.len() {
@@ -446,7 +470,6 @@ async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()>
         }
         Ok(())
     };
-    let to = recv_timeout();
     match tokio::time::timeout(to, read_fut).await {
         Ok(res) => res,
         Err(_) => Err(TransportError::Io(io::Error::new(
@@ -525,10 +548,39 @@ impl ActivationServer {
     }
 
     /// Mid-task reply recv — strict deadline on the first byte. See
-    /// [`recv_tensor_reply`] for the call-site rule.
+    /// [`recv_tensor_reply`] for the call-site rule. A failed reply
+    /// poisons the connection (see [`Self::poison`]).
     pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        recv_tensor_reply(sock).await
+        let res = recv_tensor_reply(sock).await;
+        if res.is_err() {
+            self.poison().await;
+        }
+        res
+    }
+
+    /// Prefill-budget reply recv — see [`recv_tensor_reply_prefill`].
+    /// A failed reply poisons the connection (see [`Self::poison`]).
+    pub async fn recv_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = recv_tensor_reply_prefill(sock).await;
+        if res.is_err() {
+            self.poison().await;
+        }
+        res
+    }
+
+    /// A failed reply leaves the stream in an unknown framing state: a
+    /// late-but-healthy reply may still arrive and would be consumed by the
+    /// NEXT task as fresh data (silent cross-task token corruption), and a
+    /// partially-read header misaligns every later frame. Drop + shutdown
+    /// the connection so later calls fail fast with `NotConnected` instead
+    /// of corrupting — recovery is a fresh connection, not reuse.
+    async fn poison(&mut self) {
+        if let Some(mut s) = self.client.take() {
+            let _ = s.shutdown().await;
+        }
+        self.accepted_addr = None;
     }
 
     pub async fn send(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
@@ -672,10 +724,34 @@ impl ActivationClient {
     }
 
     /// Mid-task reply recv — strict deadline on the first byte. See
-    /// [`recv_tensor_reply`] for the call-site rule.
+    /// [`recv_tensor_reply`] for the call-site rule. A failed reply
+    /// poisons the connection (see [`Self::poison`]).
     pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        recv_tensor_reply(sock).await
+        let res = recv_tensor_reply(sock).await;
+        if res.is_err() {
+            self.poison().await;
+        }
+        res
+    }
+
+    /// Prefill-budget reply recv — see [`recv_tensor_reply_prefill`].
+    /// A failed reply poisons the connection (see [`Self::poison`]).
+    pub async fn recv_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = recv_tensor_reply_prefill(sock).await;
+        if res.is_err() {
+            self.poison().await;
+        }
+        res
+    }
+
+    /// See [`ActivationServer::poison`]: a failed reply means unknown
+    /// framing state — fail fast on reuse instead of corrupting.
+    async fn poison(&mut self) {
+        if let Some(mut s) = self.sock.take() {
+            let _ = s.shutdown().await;
+        }
     }
 
     pub async fn send_raw(&mut self, bytes: &[u8]) -> TransportResult<()> {
@@ -873,7 +949,74 @@ mod tests {
         client.send(&tensor).await.unwrap();
         let got = h.await.unwrap();
         set_activation_timeout_secs(0);
-        assert!(got.is_ok(), "in-deadline reply must succeed: {:?}", got.err());
+        assert!(
+            got.is_ok(),
+            "in-deadline reply must succeed: {:?}",
+            got.err()
+        );
+    }
+
+    /// A timed-out reply leaves the stream in an unknown framing state — a
+    /// late-but-healthy reply could otherwise be consumed by the NEXT task
+    /// as fresh data (silent cross-task corruption). The connection must be
+    /// poisoned: later recvs fail fast with NotConnected.
+    #[tokio::test]
+    async fn reply_timeout_poisons_connection() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            let first = server.recv_reply().await;
+            let second = server.recv().await;
+            (first, second)
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(2500)).await; // miss the 1s deadline
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        let _ = client.send(&tensor).await; // late reply — server may have hung up
+        let (first, second) = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(
+            first.is_err(),
+            "the late reply must time out, got {first:?}"
+        );
+        assert!(
+            matches!(second, Err(TransportError::NotConnected)),
+            "a poisoned connection must fail fast, not serve the stale frame: {second:?}"
+        );
+    }
+
+    /// A prefill reply legitimately includes the remaining stages'
+    /// whole-prompt compute — it gets the widened budget, not the
+    /// single-frame deadline.
+    #[tokio::test]
+    async fn prefill_reply_outlives_base_timeout() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            server.recv_reply_prefill().await
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        // > 1s base deadline, < the 10x prefill budget.
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        client.send(&tensor).await.unwrap();
+        let got = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(
+            got.is_ok(),
+            "a slow-but-in-budget prefill reply must succeed: {:?}",
+            got.err()
+        );
     }
 
     /// Once a frame has started, a stalled peer must still hit the timeout


### PR DESCRIPTION
## What

Root-causes and fixes the **forwarded-head wedge** — a pipeline head stuck at `task active: 1, task done: 0` indefinitely, later submits queuing silently behind the held slot, clients timing out at 90s. Mid-task activation replies are now **deadlined**, so a single lost inter-stage frame can no longer wedge the step loop forever. (cascadia-enterprise overload-backlog **Item 5**, HIGH.)

## Why

The backlog's original suspects (receipt emission, end-of-generation consumer) are **not** involved. Actual mechanism:

- The pipeline tail is stateless; EOS / max-token detection lives only in the head's `emit_token`.
- The head's per-token loop blocks in `recv_token_from_downstream` awaiting the tail's reply.
- The idle-tolerance fix (`cdb628d`) made **every** frame-start recv wait indefinitely — correct for *"no next task yet"*, but the mid-task token reply travels the same path. So **one lost frame (a pipeline-leg reset / silent peer) blocks the step loop forever, slot held.** Pre-`cdb628d` the 600s recv timeout errored and `step_first` cleared the slot; the idle fix removed that escape hatch.
- *"Forwarded vs local"* was a confound — the mechanism is path-agnostic; the load balancer only ever sent the affected chain forwarded traffic.

## How

**transport** (`cascadia-transport/src/lib.rs`)
- `recv_reply` / `recv_tensor_reply` — the reply's first byte is read under a strict recv timeout (config > `CASCADIA_ACTIVATION_TIMEOUT_SECS` > **60s**). `recv` / `recv_tensor` keep idle-tolerant semantics. Call-site rule: *awaiting the NEXT task → `recv`; awaiting a reply to in-flight work → `recv_reply`.*
- **Poison the connection on a failed reply** (drop + shutdown) — else a late-but-healthy reply sits in the buffer and is consumed by the *next* task as fresh data (silent cross-task corruption), and a half-read header misaligns every later frame. Later calls fail `NotConnected`; recovery is a fresh connection.
- **`recv_reply_prefill`** — a prefill reply waits on every remaining stage's whole-prompt compute (can legitimately exceed 60s), so it gets **10×** the base (`PREFILL_REPLY_TIMEOUT_FACTOR`, `saturating_mul` to clamp not panic); decode replies keep the strict deadline so wedge eviction stays fast.

**engine** (`ov-runtime`, `gemma4`)
- `recv_token_from_downstream(prefill)` threads the prefill flag; `step_middle` detects prefill via `shape[1] > 1`. On timeout the error propagates to `step_first`'s existing catch → the slot is **freed**, next submit starts fresh.
- `step()` returns `EngineResult`, so the runner's `RELAY_ERR_BACKOFF` throttles a dead/poisoned link.

> The `EngineResult` `step()` signature + the 200ms `RELAY_ERR_BACKOFF` already landed on `main` via **#80**; after rebasing, this PR's "back off" commit carries only the `saturating_mul` prefill-budget guard.

## Related

- **Companion:** `labscommunity/cascadia-enterprise#23` shipped the *consumer-side* mitigation (completion-based routing demotes never-completing chains, bounding blast radius to ~2–5 requests). **This PR fixes the root cause.**
- **Commit set:** base landed via **#73**; rebased onto current `main` and reconciled against **#80** (kept its rework — see the note above). #80 does **not** contain this fix.

## Testing

- [x] `cargo test -p cascadia-transport` — `reply_wait_longer_than_timeout_fails_fast`, `reply_within_timeout_succeeds`, `reply_timeout_poisons_connection` (falsified: fails with the poison removed), `prefill_reply_outlives_base_timeout`; idle-gap / mid-frame-stall / soak / concurrent-pairs contracts unchanged
- [x] `cargo test -p cascadia-engine-openvino`, `-p cascadia-runner` — green
- [x] `cargo check --workspace` — clean (post-rebase)
- [x] Adversarial review ×4 (codex + focused): surfaced the stale-reply poisoning gap, prefill false-fire, hot-loop, `Duration` multiply overflow (→ `saturating_mul`), 1-token-prompt prefill asymmetry; final pass clean
- [x] **Rig (AI-PC fleet, 2-node `ov-runtime`, llama31-8b):** silent peer mid-decode (relay holds the socket open, no RST) —
  - **fixed** (`CASCADIA_ACTIVATION_TIMEOUT_SECS=8`): `recv_exact timed out after 8s` → `closing stream` → request returns **bounded ~11s** (3 runs)
  - **`main`:** no deadline → `task active` never finalizes → request **hangs to the 200s client timeout** (2 runs)
  - healthy baseline (no fault) unaffected: `GEN ok 3.69s @ 10.85 tok/s`, coherent output
- [x] **Rig re-run (post review fixes, 2-node `ov-runtime`, matias-03/04):** wedge now returns a **bounded 503** (3 runs, ~12.3s) instead of a truncated 200 — step failures surface as error chunks through the API's existing 503/SSE-error path; healthy baseline unchanged (`ok 4.23s @ 9.45 tok/s`)

## How to reproduce

**No hardware (~15s):**
```bash
cargo test -p cascadia-transport
```
`reply_wait_longer_than_timeout_fails_fast` = the wedge → deadline fires; `reply_timeout_poisons_connection` is **falsifiable** (delete the poison → it fails); `idle_gap_longer_than_timeout_does_not_kill_recv` proves idle waits stay unbounded. Counterfactual: `git checkout main -- crates/cascadia-transport/src/lib.rs` → the old idle path hangs.

**End-to-end A/B (2-node `ov-runtime`)** — scripts in `cascadia-fleet-tests`, run from the fleet controller (has `nodes.conf` + SSH/Tailscale). Args are `<head> <tail>` (any two fleet nodes with the 2-stage model); both `sync-build` and `wedge-repro` touch **only** those two nodes. The relay blackholes the reply mid-decode = silent peer.
```bash
./sync-build.sh pawan/forwarded-task-finalize pawan-01 pawan-02 && ./wedge-repro.sh pawan-01 pawan-02   # fixed   → recv_exact timed out 8s → bounded ~11s
./sync-build.sh main                          pawan-01 pawan-02 && ./wedge-repro.sh pawan-01 pawan-02   # unfixed → no deadline → ~200s hang
```

## Known gaps & follow-ups

- **`dist_spec` + `sparse-moe`** carry the same **latent** wedge class — their mid-task replies use the idle-tolerant `recv_raw` / `recv_tensor` path (~20 sites across the two, code-confirmed: `dist_spec.rs:723/729/1867/2030`), so a silenced peer stalls on the large `frame_idle_ceiling` (a long stall, **not** the permanent freeze fixed here). Both engines *do* run on the fleet, so the fix is validatable. Deferred to its own PR: `recv_raw_reply` + the same call-site rule, with a deterministic unit test (black-box relay is first-byte-timing-flaky here).
- **No reconnect** in the standalone runner after a poison (mesh reattach covers it; standalone needs a worker restart) — loud-and-bounded beats silent corruption.
- **Unbounded sends** — `write_all` into a stalled-but-open peer; pre-existing, send-side, untouched here.
- **After merge:** bump the cascadia-enterprise runtime pin `89b0b44` (`cascadia-inference` / `cascadia-node`) → this PR's merge commit, then `cargo update` the runtime crates.

