### PR TITLE
feat(engine,transport,runner): pipeline-link reliability & dead-peer recovery

### DIFF
--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1378,6 +1378,9 @@ fn engine_error_response(err: cascadia_engine::EngineError) -> axum::response::R
         | EngineError::ShardRejected(_) => StatusCode::BAD_REQUEST,
         EngineError::ModelNotFound(_) => StatusCode::NOT_FOUND,
         EngineError::Backend(_) | EngineError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        // A task-attributed step failure: the engine abandoned a task; the
+        // underlying cause is a backend/transport failure.
+        EngineError::Task { .. } => StatusCode::INTERNAL_SERVER_ERROR,
     };
     (status, Json(serde_json::json!({"error": err.to_string()}))).into_response()
 }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1164,10 +1164,19 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     if !is_first {
         info!("entering relay loop");
         let r = runner.clone();
-        tokio::task::spawn_blocking(move || r.run_relay_loop())
-            .await
-            .ok();
-        return Ok(());
+        let exit = tokio::task::spawn_blocking(move || r.run_relay_loop()).await;
+        // A connection-fatal exit means the peer link is dead and can't be
+        // re-accepted without a rebuild. Return Err so the process exits
+        // non-zero and systemd's `Restart=on-failure` rebuilds the stage,
+        // rather than exit 0 (a "success" systemd won't restart) and leave
+        // the pipeline a stage short. A clean SlotEmpty exit returns Ok.
+        match exit {
+            Ok(cascadia_runner::RelayExit::ConnectionFatal) => {
+                return Err(anyhow!("relay loop exited: peer link dead; rebuild needed"));
+            }
+            Ok(cascadia_runner::RelayExit::SlotEmpty) => return Ok(()),
+            Err(join_err) => return Err(anyhow!("relay loop task panicked: {join_err}")),
+        }
     }
 
     if let Some(api_addr) = &args.api {

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -84,6 +84,10 @@ impl Engine for MockEngine {
         self.pending.push((task, emitted + 1));
         Ok(vec![(task_id, chunk)])
     }
+
+    fn cancel(&mut self, task_id: &TaskId) {
+        self.pending.retain(|(t, _)| t.task_id != *task_id);
+    }
 }
 
 #[derive(Default)]
@@ -189,6 +193,35 @@ mod tests {
         // We should still have exactly one task pending.
         let chunks = e.step().unwrap();
         assert!(!chunks.is_empty());
+    }
+
+    #[test]
+    fn cancel_pending_task_removes_it() {
+        let mut e = MockEngine::new();
+        e.submit(GenerationTask::new("t1", "alpha bravo")).unwrap();
+        e.submit(GenerationTask::new("t2", "charlie delta"))
+            .unwrap();
+        e.cancel(&"t1".to_string());
+        // Only t2 ever emits; t1 is gone.
+        for _ in 0..8 {
+            for (tid, _) in e.step().unwrap() {
+                assert_eq!(tid, "t2");
+            }
+        }
+    }
+
+    #[test]
+    fn cancel_active_task_lets_next_task_activate_immediately() {
+        let mut e = MockEngine::new();
+        e.submit(GenerationTask::new("t1", "alpha bravo charlie").with_max_tokens(8))
+            .unwrap();
+        // t1 is mid-generation (one token emitted).
+        assert_eq!(e.step().unwrap()[0].0, "t1");
+        e.cancel(&"t1".to_string());
+        e.submit(GenerationTask::new("t2", "delta echo").with_max_tokens(8))
+            .unwrap();
+        // The very next step serves t2 — no draining of the abandoned t1.
+        assert_eq!(e.step().unwrap()[0].0, "t2");
     }
 
     #[test]

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -56,10 +56,10 @@ impl Engine for MockEngine {
         // task loud (emits an error chunk) so consumers' failure paths —
         // e.g. the API's 5xx mapping — can be exercised deterministically.
         if task.prompt.contains("__engine_error__") {
-            return vec![(
+            return Ok(vec![(
                 task.task_id.clone(),
                 Chunk::error(task.task_id, "mock injected engine failure"),
-            )];
+            )]);
         }
         let max = task.max_tokens.max(1) as usize;
         let words: Vec<&str> = task.prompt.split_whitespace().collect();

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -171,12 +171,12 @@ mod tests {
         e.submit(GenerationTask::new("t1", "the quick brown fox jumps").with_max_tokens(64))
             .unwrap();
         // One token out, then cancel mid-generation.
-        let first = e.step();
+        let first = e.step().unwrap();
         assert_eq!(first.len(), 1);
         assert!(first[0].1.text.starts_with("the"));
         e.cancel(&"t1".to_string());
         // Task is gone — no further compute / emission.
-        assert!(e.step().is_empty());
+        assert!(e.step().unwrap().is_empty());
         // Cancelling an unknown id is a harmless no-op.
         e.cancel(&"nope".to_string());
     }

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -12,11 +12,17 @@ use futures::stream;
 #[derive(Default)]
 pub struct MockEngine {
     pending: Vec<(GenerationTask, usize)>,
+    fail_next_step: Option<String>,
 }
 
 impl MockEngine {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Test hook: make the next `step()` return `EngineError::Backend(msg)`.
+    pub fn fail_next_step(&mut self, msg: impl Into<String>) {
+        self.fail_next_step = Some(msg.into());
     }
 }
 
@@ -38,9 +44,12 @@ impl Engine for MockEngine {
         Ok(())
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        if let Some(msg) = self.fail_next_step.take() {
+            return Err(EngineError::Backend(msg));
+        }
         if self.pending.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let (task, emitted) = self.pending.remove(0);
         // Test sentinel: a prompt containing `__engine_error__` fails the
@@ -64,16 +73,16 @@ impl Engine for MockEngine {
             } else {
                 cascadia_types::FinishReason::Length
             };
-            return vec![(
+            return Ok(vec![(
                 task.task_id.clone(),
                 Chunk::final_marker(task.task_id, "").with_finish_reason(reason),
-            )];
+            )]);
         }
         let token = words[emitted].to_string();
         let chunk = Chunk::token(&task.task_id, emitted as i64, token + " ");
         let task_id = task.task_id.clone();
         self.pending.push((task, emitted + 1));
-        vec![(task_id, chunk)]
+        Ok(vec![(task_id, chunk)])
     }
 }
 
@@ -145,7 +154,7 @@ mod tests {
             .unwrap();
         let mut emitted = Vec::new();
         for _ in 0..6 {
-            for (_, chunk) in e.step() {
+            for (_, chunk) in e.step().unwrap() {
                 emitted.push(chunk);
             }
         }
@@ -178,7 +187,18 @@ mod tests {
         e.submit(GenerationTask::new("t1", "hi")).unwrap();
         e.submit(GenerationTask::new("t1", "hi")).unwrap();
         // We should still have exactly one task pending.
-        let chunks = e.step();
+        let chunks = e.step().unwrap();
         assert!(!chunks.is_empty());
+    }
+
+    #[test]
+    fn injected_step_error_surfaces_as_err() {
+        let mut e = MockEngine::new();
+        e.submit(GenerationTask::new("t1", "hello world")).unwrap();
+        e.fail_next_step("boom");
+        let res = e.step();
+        assert!(matches!(res, Err(EngineError::Backend(ref m)) if m == "boom"));
+        // Error is one-shot; the engine resumes on the next step.
+        assert!(!e.step().unwrap().is_empty());
     }
 }

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -84,10 +84,6 @@ impl Engine for MockEngine {
         self.pending.push((task, emitted + 1));
         Ok(vec![(task_id, chunk)])
     }
-
-    fn cancel(&mut self, task_id: &TaskId) {
-        self.pending.retain(|(t, _)| t.task_id != *task_id);
-    }
 }
 
 #[derive(Default)]

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1256,11 +1256,11 @@ impl Engine for OvDistSpecEngine {
         }
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         // ---- Activate next pending task (one-time prompt feed + first sample).
         if self.active.is_none() {
             if self.pending.is_empty() {
-                return Vec::new();
+                return Ok(Vec::new());
             }
             let task = self.pending.remove(0);
             let enc = match self.tokenizer.encode(task.prompt.clone(), false) {
@@ -1268,7 +1268,7 @@ impl Engine for OvDistSpecEngine {
                 Err(e) => {
                     warn!(error = %e, "tokenize failed");
                     let task_id = task.task_id.clone();
-                    return vec![(task_id, Chunk::final_marker(task.task_id, ""))];
+                    return Ok(vec![(task_id, Chunk::final_marker(task.task_id, ""))]);
                 }
             };
             let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
@@ -1284,7 +1284,7 @@ impl Engine for OvDistSpecEngine {
                 Ok(active) => self.active = Some(active),
                 Err(e) => {
                     warn!(task = %task_id, error = %e, "ov-dist-spec start failed");
-                    return vec![(task_id.clone(), Chunk::final_marker(task_id, ""))];
+                    return Ok(vec![(task_id.clone(), Chunk::final_marker(task_id, ""))]);
                 }
             }
         }
@@ -1295,7 +1295,7 @@ impl Engine for OvDistSpecEngine {
         let max_tokens = active.task.max_tokens.max(1) as usize;
 
         // First step after init: emit a chunk for the first sampled token.
-        if !active.initialized {
+        let chunks = if !active.initialized {
             active.initialized = true;
             let new_text = decode_delta(&self.tokenizer, &active.out, &mut active.last_text_len);
             // If the first token already hits max_tokens or EOS, finalize now.
@@ -1353,7 +1353,8 @@ impl Engine for OvDistSpecEngine {
                     }
                 }
             }
-        }
+        };
+        Ok(chunks)
     }
 }
 
@@ -1758,7 +1759,7 @@ impl Engine for OvDistSpecWorkerEngine {
         ))
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         // RAII guard: marks the current thread as blocking-pool for
         // the duration of this step so run_async takes the cheap
         // bare-block_on path. The guard restores the previous flag
@@ -1766,7 +1767,7 @@ impl Engine for OvDistSpecWorkerEngine {
         // pool ever migrates this thread to non-blocking work.
         let _guard = BlockingContextGuard::enter();
         let result = self.handle_one_frame();
-        if let Err(e) = result {
+        if let Err(ref e) = result {
             // Transport-closed errors signal the driver disconnected;
             // don't spam the log. Drop the upstream/downstream so the
             // next step exits the relay loop cleanly via NotConnected.
@@ -1793,7 +1794,7 @@ impl Engine for OvDistSpecWorkerEngine {
                 warn!(error = %e, "ov-dist-spec worker step error");
             }
         }
-        Vec::new()
+        result.map(|_| Vec::new())
     }
 }
 

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1775,12 +1775,20 @@ impl Engine for OvDistSpecWorkerEngine {
             // it from spinning hot until the runner tears us down.
             // "idle ceiling" = frame-start idle ceiling fired (black-holed
             // peer); the transport layer has already dropped that socket —
-            // close the rest here too. Transport errors reach us flattened
-            // to strings (EngineError::Backend), hence the contains().
-            let msg = e.to_string();
+            // close the rest here too. "connection reset"/"broken pipe"/
+            // "connection aborted" = peer crash (TCP RST, the dominant
+            // dead-peer case); "recv_exact timed out" = mid-frame stall.
+            // Transport errors reach us flattened to strings
+            // (EngineError::Backend), hence the contains(). Kept in sync with
+            // EngineError::is_connection_fatal.
+            let msg = e.to_string().to_ascii_lowercase();
             if msg.contains("socket closed")
                 || msg.contains("not connected")
                 || msg.contains("idle ceiling")
+                || msg.contains("connection reset")
+                || msg.contains("broken pipe")
+                || msg.contains("connection aborted")
+                || msg.contains("recv_exact timed out")
             {
                 warn!(error = %e, "ov-dist-spec worker: connection-fatal transport error, dropping links");
                 // Mark engine as drained by clearing connections.

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1771,9 +1771,16 @@ impl Engine for OvDistSpecWorkerEngine {
             // Transport-closed errors signal the driver disconnected;
             // don't spam the log. Drop the upstream/downstream so the
             // next step exits the relay loop cleanly via NotConnected.
+            // "idle ceiling" = frame-start idle ceiling fired (black-holed
+            // peer); the transport layer has already dropped that socket —
+            // close the rest here too. Transport errors reach us flattened
+            // to strings (EngineError::Backend), hence the contains().
             let msg = e.to_string();
-            if msg.contains("socket closed") || msg.contains("not connected") {
-                warn!("ov-dist-spec worker: upstream closed, exiting");
+            if msg.contains("socket closed")
+                || msg.contains("not connected")
+                || msg.contains("idle ceiling")
+            {
+                warn!(error = %e, "ov-dist-spec worker: connection-fatal transport error, dropping links");
                 // Mark engine as drained by clearing connections.
                 let _ = self.runtime_handle.clone().block_on(async {
                     let mut g = self.upstream.lock().await;

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1770,9 +1770,10 @@ impl Engine for OvDistSpecWorkerEngine {
         if let Err(ref e) = result {
             // Transport-closed errors signal the driver disconnected;
             // don't spam the log. Drop the upstream/downstream so
-            // subsequent steps fail fast with NotConnected — the relay
-            // loop never exits on Err, so the sleep below is what keeps
-            // it from spinning hot until the runner tears us down.
+            // subsequent steps fail fast with NotConnected; the relay loop
+            // exits ConnectionFatal on this Err (clean supervisor rebuild),
+            // and the sleep below only throttles the single round before the
+            // loop observes the drop.
             // "idle ceiling" = frame-start idle ceiling fired (black-holed
             // peer); the transport layer has already dropped that socket —
             // close the rest here too. "connection reset"/"broken pipe"/

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1800,7 +1800,14 @@ impl Engine for OvDistSpecWorkerEngine {
                 // hot-loop until the runner notices.
                 std::thread::sleep(std::time::Duration::from_millis(200));
             } else {
+                // Non-connection-fatal error (bad frame kind, stray
+                // LOGITS_RESPONSE, reset/inference failure). recv_raw keeps
+                // succeeding on a connected-but-misbehaving peer, so without
+                // a cool-off a bad-frame flood hot-spins the worker loop and
+                // floods the log. Same 200 ms cadence as the fatal branch;
+                // the sleep also caps the warn rate to ~5/s.
                 warn!(error = %e, "ov-dist-spec worker step error");
+                std::thread::sleep(std::time::Duration::from_millis(200));
             }
         }
         result.map(|_| Vec::new())

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1769,8 +1769,10 @@ impl Engine for OvDistSpecWorkerEngine {
         let result = self.handle_one_frame();
         if let Err(ref e) = result {
             // Transport-closed errors signal the driver disconnected;
-            // don't spam the log. Drop the upstream/downstream so the
-            // next step exits the relay loop cleanly via NotConnected.
+            // don't spam the log. Drop the upstream/downstream so
+            // subsequent steps fail fast with NotConnected — the relay
+            // loop never exits on Err, so the sleep below is what keeps
+            // it from spinning hot until the runner tears us down.
             // "idle ceiling" = frame-start idle ceiling fired (black-holed
             // peer); the transport layer has already dropped that socket —
             // close the rest here too. Transport errors reach us flattened

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1768,29 +1768,15 @@ impl Engine for OvDistSpecWorkerEngine {
         let _guard = BlockingContextGuard::enter();
         let result = self.handle_one_frame();
         if let Err(ref e) = result {
-            // Transport-closed errors signal the driver disconnected;
-            // don't spam the log. Drop the upstream/downstream so
-            // subsequent steps fail fast with NotConnected; the relay loop
-            // exits ConnectionFatal on this Err (clean supervisor rebuild),
-            // and the sleep below only throttles the single round before the
-            // loop observes the drop.
-            // "idle ceiling" = frame-start idle ceiling fired (black-holed
-            // peer); the transport layer has already dropped that socket —
-            // close the rest here too. "connection reset"/"broken pipe"/
-            // "connection aborted" = peer crash (TCP RST, the dominant
-            // dead-peer case); "recv_exact timed out" = mid-frame stall.
-            // Transport errors reach us flattened to strings
-            // (EngineError::Backend), hence the contains(). Kept in sync with
-            // EngineError::is_connection_fatal.
-            let msg = e.to_string().to_ascii_lowercase();
-            if msg.contains("socket closed")
-                || msg.contains("not connected")
-                || msg.contains("idle ceiling")
-                || msg.contains("connection reset")
-                || msg.contains("broken pipe")
-                || msg.contains("connection aborted")
-                || msg.contains("recv_exact timed out")
-            {
+            // Transport-closed errors signal the driver disconnected; don't
+            // spam the log. Drop the upstream/downstream so subsequent steps
+            // fail fast with NotConnected; the relay loop exits ConnectionFatal
+            // on this Err (clean supervisor rebuild), and the sleep below only
+            // throttles the single round before the loop observes the drop.
+            // Fatal-classification is delegated to EngineError::is_connection_fatal
+            // (single source of truth) — clean teardown, black-holed peer (idle
+            // ceiling), peer crash (RST/broken pipe/aborted), mid-frame stall.
+            if e.is_connection_fatal() {
                 warn!(error = %e, "ov-dist-spec worker: connection-fatal transport error, dropping links");
                 // Mark engine as drained by clearing connections.
                 let _ = self.runtime_handle.clone().block_on(async {

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -794,8 +794,8 @@ impl Gemma4Engine {
         // but step_first's "if active.is_none()" gate is false, so the
         // new task is never picked up — runner.poll_next sees empty
         // steps and the API returns `data: [DONE]` with zero chunks.
-        let res = self.step_first_body();
-        if let Err(ref e) = res {
+        let mut res = self.step_first_body();
+        if let Err(e) = res {
             // DEBUG, not WARN: the outer step() emits the rate-limited WARN
             // for the same error (StepWarnLimiter); a second unconditional
             // WARN here would bypass the limiter and double-log every
@@ -805,9 +805,17 @@ impl Gemma4Engine {
                 "step_first failed; clearing active + reset_state so next \
                  task starts fresh (downstream socket may still be dead)"
             );
+            // Attribute to the failed task (if one was active) before we
+            // null it, so the runner routes the failure to that task's
+            // stream instead of ending whichever stream observes the Err.
+            let failed = self.active.as_ref().map(|a| a.task.task_id.clone());
             self.active = None;
             let _ = self.runtime.reset_state();
             self.position = 0;
+            res = Err(match failed {
+                Some(id) => e.for_task(id),
+                None => e,
+            });
         }
         res
     }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1053,7 +1053,7 @@ impl Engine for Gemma4Engine {
         }
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         let result: EngineResult<Vec<(TaskId, Chunk)>> = if self.spec.is_first_stage {
             self.step_first()
         } else if self.spec.is_last_stage {
@@ -1061,7 +1061,11 @@ impl Engine for Gemma4Engine {
         } else {
             self.step_middle().map(|_| Vec::new())
         };
-        match result {
+        // Keep main's rate-limited WARN (a persistently-failing step() must
+        // not flood logs), but surface the Err to the caller — step_first
+        // already cleared active + reset_state, so callers can now tell
+        // "engine failed" from "still prefilling" (both were empty vecs).
+        match &result {
             Ok(v) => {
                 // First-stage idle steps return Ok(empty) even mid-failure
                 // (a failed step_first clears `active`; the next poll
@@ -1072,7 +1076,6 @@ impl Engine for Gemma4Engine {
                         info!(suppressed, "gemma4 step recovered");
                     }
                 }
-                v
             }
             Err(e) => {
                 match self.step_warn.on_failure(std::time::Instant::now()) {
@@ -1082,9 +1085,9 @@ impl Engine for Gemma4Engine {
                     }
                     None => {}
                 }
-                Vec::new()
             }
         }
+        result
     }
 }
 

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1085,15 +1085,13 @@ impl Engine for Gemma4Engine {
                     }
                 }
             }
-            Err(e) => {
-                match self.step_warn.on_failure(std::time::Instant::now()) {
-                    Some(StepWarn::First) => warn!(error = %e, "gemma4 step failed"),
-                    Some(StepWarn::StillFailing { suppressed }) => {
-                        warn!(error = %e, suppressed, "gemma4 step still failing")
-                    }
-                    None => {}
+            Err(e) => match self.step_warn.on_failure(std::time::Instant::now()) {
+                Some(StepWarn::First) => warn!(error = %e, "gemma4 step failed"),
+                Some(StepWarn::StillFailing { suppressed }) => {
+                    warn!(error = %e, suppressed, "gemma4 step still failing")
                 }
-            }
+                None => {}
+            },
         }
         result
     }

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -289,9 +289,9 @@ impl Engine for OvGenaiEngine {
         self.pending.retain(|t| &t.task_id != task_id);
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         if self.pending.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let task = self.pending.remove(0);
         let max_new = if task.max_tokens > 0 {
@@ -312,7 +312,7 @@ impl Engine for OvGenaiEngine {
             Err(err) => {
                 warn!(task = %task.task_id, error = %err, "generate failed");
                 let final_chunk = Chunk::final_marker(task.task_id.clone(), "");
-                return vec![(task.task_id, final_chunk)];
+                return Ok(vec![(task.task_id, final_chunk)]);
             }
         };
         let elapsed = started.elapsed().as_secs_f64();
@@ -362,7 +362,7 @@ impl Engine for OvGenaiEngine {
         if let Some(prompt_tokens) = self.pipe.count_tokens(&task.prompt) {
             chunk = chunk.with_prompt_tokens(prompt_tokens);
         }
-        vec![(task.task_id, chunk)]
+        Ok(vec![(task.task_id, chunk)])
     }
 }
 

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1299,22 +1299,28 @@ impl Engine for Qwen36Engine {
         Ok(())
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        // EngineResult migration (matches the other engines on this branch).
+        // step_local/step_pipe_first already absorb their own errors into the
+        // emitted Vec, so they Ok-wrap directly. The relay arm keeps qwen36's
+        // existing swallow+backoff policy (peer loss = operator restart, §3.5)
+        // rather than propagating Err — that policy is intentional and out of
+        // scope for the type migration.
         if self.total <= 1 {
-            return self.step_local();
+            return Ok(self.step_local());
         }
         if self.rank == 0 {
-            self.step_pipe_first()
+            Ok(self.step_pipe_first())
         } else {
             match self.step_pipe_relay() {
-                Ok(()) => Vec::new(),
+                Ok(()) => Ok(Vec::new()),
                 Err(e) => {
                     // Backoff: a dead upstream session makes recv fail
                     // instantly; without a pause the relay loop spins and
                     // floods the log (peer loss = operator restart, §3.5).
                     warn!(error = %e, "qwen36 pipeline step failed");
                     std::thread::sleep(Duration::from_millis(500));
-                    Vec::new()
+                    Ok(Vec::new())
                 }
             }
         }

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1300,30 +1300,26 @@ impl Engine for Qwen36Engine {
     }
 
     fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
-        // EngineResult migration (matches the other engines on this branch).
-        // step_local/step_pipe_first already absorb their own errors into the
-        // emitted Vec, so they Ok-wrap directly. The relay arm keeps qwen36's
-        // existing swallow+backoff policy (peer loss = operator restart, §3.5)
-        // rather than propagating Err — that policy is intentional and out of
-        // scope for the type migration.
+        // EngineResult migration. step_local/step_pipe_first already absorb their
+        // own task-level errors into the emitted Vec (final error chunks), so
+        // they Ok-wrap directly.
         if self.total <= 1 {
             return Ok(self.step_local());
         }
         if self.rank == 0 {
-            Ok(self.step_pipe_first())
-        } else {
-            match self.step_pipe_relay() {
-                Ok(()) => Ok(Vec::new()),
-                Err(e) => {
-                    // Backoff: a dead upstream session makes recv fail
-                    // instantly; without a pause the relay loop spins and
-                    // floods the log (peer loss = operator restart, §3.5).
-                    warn!(error = %e, "qwen36 pipeline step failed");
-                    std::thread::sleep(Duration::from_millis(500));
-                    Ok(Vec::new())
-                }
-            }
+            return Ok(self.step_pipe_first());
         }
+        // Relay stage: PROPAGATE the error (like runtime/gemma4/sparse-moe). A
+        // dead upstream is connection-fatal, and `run_relay_loop` only restarts
+        // the stage when step() returns that Err (§3.5: peer loss = operator
+        // restart). Swallowing it into Ok(Vec::new()) would leave a silent
+        // zombie that never rebuilds. The runner throttles non-fatal errors via
+        // RELAY_ERR_BACKOFF, so no in-engine backoff is needed.
+        let result = self.step_pipe_relay().map(|_| Vec::new());
+        if let Err(e) = &result {
+            warn!(error = %e, "qwen36 pipeline step failed");
+        }
+        result
     }
 
     fn cancel(&mut self, task_id: &TaskId) {

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1285,20 +1285,6 @@ impl Engine for OvRuntimeEngine {
         Ok(())
     }
 
-    fn cancel(&mut self, task_id: &TaskId) {
-        // Step-wise engine: cancel() runs between steps (both &mut self behind
-        // the runner mutex). Drop the queued task and clear it if it's the one
-        // currently decoding, so step() stops emitting tokens for it.
-        self.pending.retain(|t| &t.task_id != task_id);
-        if self
-            .active
-            .as_ref()
-            .is_some_and(|a| &a.task.task_id == task_id)
-        {
-            self.active = None;
-        }
-    }
-
     fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         let result: EngineResult<Vec<(TaskId, Chunk)>> = if self.spec.is_first_stage {
             self.step_first()

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1327,6 +1327,27 @@ impl Engine for OvRuntimeEngine {
         }
         result
     }
+
+    fn cancel(&mut self, task_id: &TaskId) {
+        self.pending.retain(|t| t.task_id != *task_id);
+        // Abandoning the active task mirrors the step-failure recovery:
+        // clear it and reset generation state so the next pending task
+        // activates immediately instead of waiting for this one to
+        // drain max_tokens worth of inference on the device.
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|a| a.task.task_id == *task_id)
+        {
+            info!(task = %task_id, "ov-runtime cancel: abandoning active task");
+            self.active = None;
+            let _ = self.runtime.reset_state();
+            if let Some(sk) = self.static_kv.as_mut() {
+                sk.reset();
+            }
+            self.position = 0;
+        }
+    }
 }
 
 // -------- Builder --------

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1309,15 +1309,13 @@ impl Engine for OvRuntimeEngine {
                     }
                 }
             }
-            Err(e) => {
-                match self.step_warn.on_failure(std::time::Instant::now()) {
-                    Some(StepWarn::First) => warn!(error = %e, "ov-runtime step failed"),
-                    Some(StepWarn::StillFailing { suppressed }) => {
-                        warn!(error = %e, suppressed, "ov-runtime step still failing")
-                    }
-                    None => {}
+            Err(e) => match self.step_warn.on_failure(std::time::Instant::now()) {
+                Some(StepWarn::First) => warn!(error = %e, "ov-runtime step failed"),
+                Some(StepWarn::StillFailing { suppressed }) => {
+                    warn!(error = %e, suppressed, "ov-runtime step still failing")
                 }
-            }
+                None => {}
+            },
         }
         result
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1291,7 +1291,7 @@ impl Engine for OvRuntimeEngine {
         }
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         let result: EngineResult<Vec<(TaskId, Chunk)>> = if self.spec.is_first_stage {
             self.step_first()
         } else if self.spec.is_last_stage {
@@ -1299,7 +1299,11 @@ impl Engine for OvRuntimeEngine {
         } else {
             self.step_middle().map(|_| Vec::new())
         };
-        match result {
+        // Keep main's rate-limited WARN (a persistently-failing step() must
+        // not flood logs), but surface the Err to the caller — step_first
+        // already cleared active + reset_state, so callers can now tell
+        // "engine failed" from "still prefilling" (both were empty vecs).
+        match &result {
             Ok(v) => {
                 // First-stage idle steps return Ok(empty) even mid-failure
                 // (a failed step clears `active`; the next poll no-ops), so
@@ -1310,7 +1314,6 @@ impl Engine for OvRuntimeEngine {
                         info!(suppressed, "ov-runtime step recovered");
                     }
                 }
-                v
             }
             Err(e) => {
                 match self.step_warn.on_failure(std::time::Instant::now()) {
@@ -1320,9 +1323,9 @@ impl Engine for OvRuntimeEngine {
                     }
                     None => {}
                 }
-                Vec::new()
             }
         }
+        result
     }
 }
 

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -861,8 +861,8 @@ impl OvRuntimeEngine {
         // but step_first's "if active.is_none()" gate is false, so the
         // new task is never picked up — runner.poll_next sees empty
         // steps and the API returns `data: [DONE]` with zero chunks.
-        let res = self.step_first_body();
-        if let Err(ref e) = res {
+        let mut res = self.step_first_body();
+        if let Err(e) = res {
             // DEBUG, not WARN: the outer step() emits the rate-limited
             // WARN for the same error (StepWarnLimiter); a second
             // unconditional WARN here would bypass the limiter and
@@ -872,12 +872,20 @@ impl OvRuntimeEngine {
                 "step_first failed; clearing active + reset_state so next \
                  task starts fresh (downstream socket may still be dead)"
             );
+            // Attribute to the failed task (if one was active) before we
+            // null it, so the runner routes the failure to that task's
+            // stream instead of ending whichever stream observes the Err.
+            let failed = self.active.as_ref().map(|a| a.task.task_id.clone());
             self.active = None;
             let _ = self.runtime.reset_state();
             if let Some(sk) = self.static_kv.as_mut() {
                 sk.reset();
             }
             self.position = 0;
+            res = Err(match failed {
+                Some(id) => e.for_task(id),
+                None => e,
+            });
         }
         res
     }

--- a/crates/cascadia-engine-openvino/tests/qwen36_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/qwen36_parity.rs
@@ -65,7 +65,7 @@ async fn qwen36_greedy_parity() {
     let mut ids = Vec::new();
     let mut text = String::new();
     loop {
-        let chunks = engine.step();
+        let chunks = engine.step().expect("step");
         let mut done = false;
         for (_, c) in chunks {
             if c.is_final {

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -854,15 +854,18 @@ impl Engine for SparseMoEEngine {
         self.pending.retain(|t| &t.task_id != task_id);
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
         if self.total == 1 {
-            return self.step_single_stage();
+            return Ok(self.step_single_stage());
         }
-        if self.rank == 0 {
+        // step_first / step_worker handle their own errors terminally
+        // (final-marker chunk on the driver, latched backoff on the
+        // worker), so there is nothing to surface as Err here.
+        Ok(if self.rank == 0 {
             self.step_first()
         } else {
             self.step_worker()
-        }
+        })
     }
 
     fn close(&mut self) {

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -2231,15 +2231,19 @@ impl Engine for OvMoeEngine {
         self.pending.retain(|t| &t.task_id != task_id);
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        // Behavior-preserving migration to EngineResult: step_single_stage /
+        // step_first / step_worker handle their own errors terminally (the
+        // driver emits a final-marker chunk; the worker latches), so there is
+        // nothing to surface as Err here.
         if self.total <= 1 {
-            return self.step_single_stage();
+            return Ok(self.step_single_stage());
         }
-        if self.rank == 0 {
+        Ok(if self.rank == 0 {
             self.step_first()
         } else {
             self.step_worker()
-        }
+        })
     }
 }
 

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -630,6 +630,7 @@ impl Builder for SparseMoEBuilder {
             tokenizer: self.tokenizer,
             pending: VecDeque::new(),
             peer_disconnected: false,
+            disconnect_reported: false,
             transport: self.transport,
             runtime_handle,
             rank,
@@ -704,6 +705,15 @@ fn even_moe_split(total_moe: u32, rank: u32, total: u32) -> (u32, u32) {
     (start, end)
 }
 
+/// Whether a worker-rank `step()` should surface its latched upstream
+/// disconnect as a connection-fatal `Err` this call: yes exactly once, on the
+/// first step after the link drops. After that the one-shot is spent so a
+/// re-poll (the relay loop has already exited on the first one) doesn't flood.
+/// Pure, for testing.
+fn worker_should_report_disconnect(peer_disconnected: bool, already_reported: bool) -> bool {
+    peer_disconnected && !already_reported
+}
+
 /// Hard cap on the pending-task queue. step() processes one task end-to-end
 /// per call, so the OS-level backpressure of returning QueueFull is
 /// preferable to silently accreting tasks the engine will not reach for
@@ -730,6 +740,11 @@ pub struct SparseMoEEngine {
     /// step_worker from hot-spinning on `recv_kind_server` returning
     /// `Ok(None)` over and over.
     peer_disconnected: bool,
+    /// Worker rank one-shot: true after `step()` has surfaced the latched
+    /// disconnect as a connection-fatal `Err` to the relay loop. Stops the
+    /// fatal Err from being re-emitted if `step()` is somehow polled again
+    /// before the stage is rebuilt (the relay loop exits on the first one).
+    disconnect_reported: bool,
     /// Last-rank only: tokens this rank has sampled since the last
     /// `Reset`. Used as the `history` argument to `sampling::sample` so
     /// the repetition penalty has the recent local emit-stream to
@@ -858,14 +873,24 @@ impl Engine for SparseMoEEngine {
         if self.total == 1 {
             return Ok(self.step_single_stage());
         }
-        // step_first / step_worker handle their own errors terminally
-        // (final-marker chunk on the driver, latched backoff on the
-        // worker), so there is nothing to surface as Err here.
-        Ok(if self.rank == 0 {
-            self.step_first()
-        } else {
-            self.step_worker()
-        })
+        // step_first handles its own errors terminally (final-marker chunk on
+        // the driver), so rank 0 never surfaces an Err here.
+        if self.rank == 0 {
+            return Ok(self.step_first());
+        }
+        // Worker rank. step_worker returns empty on a latched upstream
+        // disconnect. The worker's upstream socket can only be re-accepted by
+        // a rebuild, so once disconnected, surface a connection-fatal Err to
+        // run_relay_loop (its ONLY driver — rank-0/single-stage go through
+        // generate()) so it exits and systemd rebuilds the stage, instead of
+        // backing off Ok(empty) forever. Emit it exactly once; the loop bails
+        // on the first fatal Err.
+        let produced = self.step_worker();
+        if worker_should_report_disconnect(self.peer_disconnected, self.disconnect_reported) {
+            self.disconnect_reported = true;
+            return Err(EngineError::NotConnected);
+        }
+        Ok(produced)
     }
 
     fn close(&mut self) {
@@ -2249,5 +2274,22 @@ mod tests {
     fn single_stage_yields_full_range() {
         let (s, e) = even_moe_split(60, 0, 1);
         assert_eq!((s, e), (0, u32::MAX));
+    }
+
+    /// A latched worker disconnect must surface a connection-fatal Err to the
+    /// relay loop — exactly once — so run_relay_loop exits and systemd
+    /// rebuilds the stage instead of backing off Ok(empty) forever. The Err
+    /// step() emits (EngineError::NotConnected) must be recognized as fatal.
+    #[test]
+    fn worker_disconnect_reports_fatal_once() {
+        // Connected: nothing to report.
+        assert!(!worker_should_report_disconnect(false, false));
+        // First step after the link drops: report.
+        assert!(worker_should_report_disconnect(true, false));
+        // Already reported: suppressed (don't flood if re-polled).
+        assert!(!worker_should_report_disconnect(true, true));
+        // The Err step() returns on that one report is connection-fatal, so
+        // run_relay_loop exits ConnectionFatal.
+        assert!(EngineError::NotConnected.is_connection_fatal());
     }
 }

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -70,7 +70,12 @@ pub trait Engine: Send {
 
     /// Make progress on at most one pending task and return any chunks
     /// emitted. Returns an empty Vec when no work is in flight.
-    fn step(&mut self) -> Vec<(TaskId, Chunk)>;
+    ///
+    /// `Err` means the engine failed to make progress (backend or
+    /// transport failure) and is terminal for the in-flight task —
+    /// engines recover their own state so the next submitted task
+    /// starts fresh, but callers must not retry the failed one.
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>>;
 
     /// Best-effort cancellation of an in-flight task. Engines that do
     /// not support mid-stream cancellation may treat this as a no-op.

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -75,6 +75,18 @@ pub trait Engine: Send {
     /// transport failure) and is terminal for the in-flight task —
     /// engines recover their own state so the next submitted task
     /// starts fresh, but callers must not retry the failed one.
+    ///
+    /// Task attribution: `Err` affects at most the active task; queued
+    /// tasks survive. The error carries no [`TaskId`] today, so callers
+    /// driving multiple concurrent streams cannot attribute the failure —
+    /// the runner's `ChunkStream` ends whichever stream observes the
+    /// `Err`, which may not be the failed task's stream (known
+    /// limitation).
+    ///
+    /// Failure idiom: implementors should return `Err` for engine-level
+    /// failures (engine unusable / task aborted by the engine); emit a
+    /// final-marker chunk for per-task completion, including task-level
+    /// failure where the engine remains healthy.
     fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>>;
 
     /// Cancel a task. Implementors SHOULD guarantee that after `cancel`

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -80,6 +80,33 @@ impl EngineError {
             },
         }
     }
+
+    /// Whether this error means the engine's peer link is dead and cannot
+    /// recover in-process — a worker stage whose upstream socket is dropped
+    /// can only get a fresh connection by being rebuilt (re-`accept()` only
+    /// happens at startup). The relay loop exits on this so the supervisor
+    /// (systemd `Restart=on-failure`) rebuilds the stage, rather than
+    /// spin-and-flood at the backoff rate forever.
+    ///
+    /// Transport errors reach the engine flattened to strings via
+    /// [`EngineError::Backend`] (the worker calls `e.to_string()`), so this
+    /// matches the same substrings the dist-spec worker uses to classify a
+    /// fatal link drop, plus the structural [`EngineError::NotConnected`].
+    /// A connected-but-misbehaving peer (bad frame kind, stray response) is
+    /// NOT fatal — that link can still deliver a good frame next.
+    pub fn is_connection_fatal(&self) -> bool {
+        match self {
+            EngineError::NotConnected => true,
+            EngineError::Task { source, .. } => source.is_connection_fatal(),
+            EngineError::Backend(msg) => {
+                let msg = msg.to_ascii_lowercase();
+                msg.contains("socket closed")
+                    || msg.contains("not connected")
+                    || msg.contains("idle ceiling")
+            }
+            _ => false,
+        }
+    }
 }
 
 pub type EngineResult<T> = Result<T, EngineError>;
@@ -161,4 +188,35 @@ pub trait Builder: Send {
 
     /// Tear down any partially-initialised resources (sockets, weights).
     fn close(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_fatal_classification() {
+        // Structural variant.
+        assert!(EngineError::NotConnected.is_connection_fatal());
+        // Flattened transport strings the dist-spec worker produces.
+        for msg in [
+            "socket closed during recv",
+            "not connected; call connect()/accept() first",
+            "frame-start idle ceiling hit after 900s; connection dropped",
+        ] {
+            assert!(
+                EngineError::Backend(msg.into()).is_connection_fatal(),
+                "expected fatal: {msg}"
+            );
+        }
+        // Recoverable / unrelated failures are NOT fatal.
+        assert!(!EngineError::Backend("bad kind 7".into()).is_connection_fatal());
+        assert!(
+            !EngineError::Backend("worker received LOGITS_RESPONSE".into()).is_connection_fatal()
+        );
+        assert!(!EngineError::NotLoaded.is_connection_fatal());
+        // A task-attributed fatal error unwraps to its source.
+        let wrapped = EngineError::Backend("socket closed".into()).for_task(TaskId::from("t1"));
+        assert!(wrapped.is_connection_fatal());
+    }
 }

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -46,6 +46,40 @@ pub enum EngineError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// A `step()` failure attributed to a specific task. Engines wrap their
+    /// underlying error in this at the failure site when the active task is
+    /// known, so the runner can route the failure to that task's stream
+    /// instead of ending whichever stream happens to observe it.
+    #[error("task {task_id}: {source}")]
+    Task {
+        task_id: TaskId,
+        #[source]
+        source: Box<EngineError>,
+    },
+}
+
+impl EngineError {
+    /// The task this error is attributed to, if any. Returns `None` for
+    /// engine-level / task-less failures.
+    pub fn task_id(&self) -> Option<&TaskId> {
+        match self {
+            EngineError::Task { task_id, .. } => Some(task_id),
+            _ => None,
+        }
+    }
+
+    /// Attribute an error to `task_id`, wrapping it in [`EngineError::Task`]
+    /// unless it already carries an attribution.
+    pub fn for_task(self, task_id: TaskId) -> Self {
+        match self {
+            EngineError::Task { .. } => self,
+            source => EngineError::Task {
+                task_id,
+                source: Box::new(source),
+            },
+        }
+    }
 }
 
 pub type EngineResult<T> = Result<T, EngineError>;
@@ -77,11 +111,13 @@ pub trait Engine: Send {
     /// starts fresh, but callers must not retry the failed one.
     ///
     /// Task attribution: `Err` affects at most the active task; queued
-    /// tasks survive. The error carries no [`TaskId`] today, so callers
-    /// driving multiple concurrent streams cannot attribute the failure —
-    /// the runner's `ChunkStream` ends whichever stream observes the
-    /// `Err`, which may not be the failed task's stream (known
-    /// limitation).
+    /// tasks survive. Implementors that know the failed task SHOULD wrap
+    /// their error with [`EngineError::for_task`] (or return
+    /// [`EngineError::Task`]) so the runner can route the failure to that
+    /// task's stream. A task-less `Err` (no active task, or a genuinely
+    /// engine-level failure) ends whichever stream observes it — correct
+    /// for engine death, the documented behavior for worker stages that
+    /// own no user task.
     ///
     /// Failure idiom: implementors should return `Err` for engine-level
     /// failures (engine unusable / task aborted by the engine); emit a

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -115,6 +115,21 @@ impl EngineError {
                     // Mid-frame deadline (recv_exact wall-clock bound).
                     || msg.contains("recv_exact timed out")
             }
+            // A structurally-typed io error — should a future `?`-on-io path
+            // ever produce one instead of the flattened `Backend` string —
+            // is fatal for the same kinds the transport layer treats as fatal
+            // (see `recv_error_is_connection_fatal`). Belt-and-suspenders: the
+            // dist-spec worker flattens recv errors to `Backend` today, so this
+            // arm is unreachable now, but it keeps the classifier correct if
+            // that ever changes.
+            EngineError::Io(e) => matches!(
+                e.kind(),
+                std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::UnexpectedEof
+            ),
             _ => false,
         }
     }
@@ -226,6 +241,22 @@ mod tests {
                 "expected fatal: {msg}"
             );
         }
+        // Structurally-typed io errors classify by kind (mirrors the
+        // transport recv-fatal set), independent of the Backend-string path.
+        use std::io::{Error as IoError, ErrorKind};
+        for kind in [
+            ErrorKind::TimedOut,
+            ErrorKind::ConnectionReset,
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::UnexpectedEof,
+        ] {
+            assert!(
+                EngineError::Io(IoError::from(kind)).is_connection_fatal(),
+                "expected fatal io kind: {kind:?}"
+            );
+        }
+        assert!(!EngineError::Io(IoError::from(ErrorKind::NotFound)).is_connection_fatal());
         // Recoverable / unrelated failures are NOT fatal.
         assert!(!EngineError::Backend("bad kind 7".into()).is_connection_fatal());
         assert!(

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -77,8 +77,14 @@ pub trait Engine: Send {
     /// starts fresh, but callers must not retry the failed one.
     fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>>;
 
-    /// Best-effort cancellation of an in-flight task. Engines that do
-    /// not support mid-stream cancellation may treat this as a no-op.
+    /// Cancel a task. After `cancel` returns, `step()` emits no further
+    /// chunks for `task_id`: a queued task is dropped from the pending
+    /// queue; an active task is abandoned and the engine's generation
+    /// state reset so the next task starts fresh instead of waiting for
+    /// the abandoned one to drain to completion. Engines that cannot
+    /// cancel mid-stream may keep the default no-op — the runner still
+    /// suppresses the task's chunks, but the engine slot stays busy
+    /// until the task finishes on its own.
     fn cancel(&mut self, _task_id: &TaskId) {}
 
     /// Tear down the engine. Idempotent.

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -92,7 +92,11 @@ impl EngineError {
     /// [`EngineError::Backend`] (the worker calls `e.to_string()`), so this
     /// matches the same substrings the dist-spec worker uses to classify a
     /// fatal link drop, plus the structural [`EngineError::NotConnected`].
-    /// A connected-but-misbehaving peer (bad frame kind, stray response) is
+    /// Covered: clean teardown ("socket closed"/"not connected"), a
+    /// black-holed peer ("idle ceiling"), a peer crash ("connection
+    /// reset"/"broken pipe"/"connection aborted" — TCP RST is the dominant
+    /// dead-peer case), and a mid-frame stall ("recv_exact timed out"). A
+    /// connected-but-misbehaving peer (bad frame kind, stray response) is
     /// NOT fatal — that link can still deliver a good frame next.
     pub fn is_connection_fatal(&self) -> bool {
         match self {
@@ -100,9 +104,16 @@ impl EngineError {
             EngineError::Task { source, .. } => source.is_connection_fatal(),
             EngineError::Backend(msg) => {
                 let msg = msg.to_ascii_lowercase();
+                // Clean teardown / black-holed peer.
                 msg.contains("socket closed")
                     || msg.contains("not connected")
                     || msg.contains("idle ceiling")
+                    // Peer crash: TCP RST / broken pipe / aborted.
+                    || msg.contains("connection reset")
+                    || msg.contains("broken pipe")
+                    || msg.contains("connection aborted")
+                    // Mid-frame deadline (recv_exact wall-clock bound).
+                    || msg.contains("recv_exact timed out")
             }
             _ => false,
         }
@@ -203,6 +214,12 @@ mod tests {
             "socket closed during recv",
             "not connected; call connect()/accept() first",
             "frame-start idle ceiling hit after 900s; connection dropped",
+            // Peer crash (TCP RST and its send/half-close variants).
+            "io error: connection reset by peer",
+            "io error: broken pipe",
+            "io error: connection aborted",
+            // Mid-frame stall surfaced by recv_exact's wall-clock bound.
+            "io error: recv_exact timed out after 60s",
         ] {
             assert!(
                 EngineError::Backend(msg.into()).is_connection_fatal(),

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -77,8 +77,9 @@ pub trait Engine: Send {
     /// starts fresh, but callers must not retry the failed one.
     fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>>;
 
-    /// Cancel a task. After `cancel` returns, `step()` emits no further
-    /// chunks for `task_id`: a queued task is dropped from the pending
+    /// Cancel a task. Implementors SHOULD guarantee that after `cancel`
+    /// returns, `step()` emits no further chunks for `task_id`: a queued
+    /// task is dropped from the pending
     /// queue; an active task is abandoned and the engine's generation
     /// state reset so the next task starts fresh instead of waiting for
     /// the abandoned one to drain to completion. Engines that cannot

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -27,6 +27,13 @@ use tracing::{info, warn};
 /// misbehaving engine.
 const MAX_CONSECUTIVE_EMPTY_STEPS: usize = 3;
 
+/// Cool-off `run_relay_loop` applies after a `step()` returns `Err`, so a
+/// persistently-failing engine (dead peer, bad-frame flood, black-holed
+/// upstream) is throttled regardless of whether the engine self-throttles.
+/// Matches the cadence the sparse-moe / dist_spec workers use for the same
+/// situation (`WORKER_BACKOFF`).
+const RELAY_ERR_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
+
 // ---------------------------------------------------------------------------
 // Shared block_on dispatch + BlockingContextGuard.
 //
@@ -202,10 +209,13 @@ impl Runner {
     /// Step errors are logged and driving continues (engines own their
     /// recovery). Used by non-first pipeline stages.
     ///
-    /// Engines driven by this loop must self-throttle a persistently
-    /// fast-failing `step()` (e.g. sleep on a dead peer) — the loop never
-    /// exits on `Err` and only yields between rounds, so an instant-`Err`
-    /// engine would otherwise spin this thread hot.
+    /// The loop throttles itself: a `step()` that returns `Err` sleeps
+    /// `RELAY_ERR_BACKOFF` before the next round so a persistently-failing
+    /// engine (dead peer, bad-frame flood, black-holed upstream) can't peg
+    /// a core regardless of whether the engine self-throttles. The backoff
+    /// resets on any non-empty `Ok` step. Engines MAY additionally
+    /// self-throttle (e.g. the workers sleep on a dead peer too); the two
+    /// are belt-and-suspenders.
     ///
     /// Enters a `BlockingContextGuard` once per OS thread (since this
     /// loop runs on a single `spawn_blocking` thread) so that engines'
@@ -220,13 +230,24 @@ impl Runner {
             // loop keeps driving — relay engines recover their own state
             // (and self-throttle on dead peers), and a transient frame
             // error must not take the whole stage down.
-            if let Err(e) = engine.step() {
-                warn!(error = %e, "relay step failed");
-            }
+            let failed = match engine.step() {
+                Ok(_) => false,
+                Err(e) => {
+                    warn!(error = %e, "relay step failed");
+                    true
+                }
+            };
             // Don't hold the lock for long under the loop — yield to
             // other generate() callers between rounds.
             drop(guard);
-            std::thread::yield_now();
+            // Throttle a persistently-failing step() so it can't hot-spin
+            // this thread; a successful round (even an idle empty one)
+            // just yields, keeping relay latency low.
+            if failed {
+                std::thread::sleep(RELAY_ERR_BACKOFF);
+            } else {
+                std::thread::yield_now();
+            }
         }
         info!("relay loop exited");
     }
@@ -502,6 +523,51 @@ mod tests {
         fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
             Ok(Box::new(FailingEngine))
         }
+    }
+
+    /// A failing engine that counts `step()` calls, so a test can assert
+    /// the relay loop throttled instead of hot-spinning.
+    struct CountingFailingEngine(Arc<std::sync::atomic::AtomicUsize>);
+
+    impl Engine for CountingFailingEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(EngineError::Backend("transport down".into()))
+        }
+    }
+
+    #[test]
+    fn relay_loop_throttles_persistently_failing_step() {
+        use std::sync::atomic::Ordering;
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let engine: Box<dyn Engine> = Box::new(CountingFailingEngine(calls.clone()));
+        let runner = Arc::new(Runner {
+            builder: Mutex::new(None),
+            engine: Arc::new(Mutex::new(Some(engine))),
+            buffers: Arc::new(Mutex::new(Buffers::default())),
+        });
+
+        // Drive the relay loop on a worker thread, let it run for a window
+        // several backoffs wide, then empty the engine slot to stop it.
+        let driver = runner.clone();
+        let handle = std::thread::spawn(move || driver.run_relay_loop());
+        std::thread::sleep(RELAY_ERR_BACKOFF * 5);
+        runner.close(); // engine slot -> None: loop breaks next round
+        handle.join().unwrap();
+
+        // With a 200 ms backoff per Err round, ~1 s of wall time admits a
+        // handful of iterations, not the millions a hot-spin would do.
+        // Bound generously to stay non-flaky on a loaded CI box.
+        let n = calls.load(Ordering::SeqCst);
+        assert!(
+            n <= 20,
+            "relay loop hot-spun on persistently-failing step(): {n} calls in ~1s"
+        );
+        assert!(n >= 1, "relay loop never stepped the engine");
     }
 
     #[tokio::test]

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -211,6 +211,8 @@ impl Runner {
             engine: self.engine.clone(),
             buffers: self.buffers.clone(),
             consecutive_empty: 0,
+            last_errored_task: None,
+            consecutive_foreign_err: 0,
             done: false,
         })
     }
@@ -290,6 +292,15 @@ pub struct ChunkStream {
     engine: Arc<Mutex<Option<Box<dyn Engine>>>>,
     buffers: Arc<Mutex<Buffers>>,
     consecutive_empty: usize,
+    /// Foreign-task hot-spin guard: the last foreign task-id an engine `step()`
+    /// failed, and how many times in a row it has failed *that same* id. A
+    /// contract-violating engine that re-emits the same foreign Err forever
+    /// (never clearing it) trips the bound; distinct foreign failures mean the
+    /// engine IS clearing each and progressing, so the run resets. Separate
+    /// from `consecutive_empty` so a healthy task isn't false-closed by a few
+    /// distinct foreign failures it observes while waiting its turn.
+    last_errored_task: Option<TaskId>,
+    consecutive_foreign_err: usize,
     done: bool,
 }
 
@@ -357,19 +368,26 @@ impl Stream for ChunkStream {
                         bufs.cancelled.insert(failed.clone());
                         bufs.chunks.remove(&failed);
                         drop(bufs);
-                        // This round made no progress for *us*. Count it
-                        // toward the no-progress guard so a contract-violating
-                        // engine that re-emits the same foreign-task Err every
-                        // step (never clearing it) can't busy-spin this stream
-                        // forever — it falls through to the MAX-empty close
-                        // below. A well-behaved engine clears the failed task
-                        // and serves us, resetting the counter.
-                        this.consecutive_empty += 1;
-                        if this.consecutive_empty >= MAX_CONSECUTIVE_EMPTY_STEPS {
+                        // Bound only a *non-clearing* engine: one that re-emits
+                        // the SAME foreign-task Err every step (never dropping
+                        // it) would busy-spin our `continue` forever, so count
+                        // repeats of the same id toward the guard. Distinct
+                        // foreign failures mean the engine IS clearing each and
+                        // making progress — don't penalize our healthy stream
+                        // for merely observing them, so reset the run on a new
+                        // id. (Tracked separately from `consecutive_empty` so a
+                        // burst of distinct foreign errors can't false-close us.)
+                        if this.last_errored_task.as_ref() == Some(&failed) {
+                            this.consecutive_foreign_err += 1;
+                        } else {
+                            this.last_errored_task = Some(failed);
+                            this.consecutive_foreign_err = 1;
+                        }
+                        if this.consecutive_foreign_err >= MAX_CONSECUTIVE_EMPTY_STEPS {
                             this.done = true;
                             warn!(
                                 task = %this.task_id,
-                                "engine made no progress for {} consecutive steps; closing stream",
+                                "engine re-failed the same foreign task for {} consecutive steps; closing stream",
                                 MAX_CONSECUTIVE_EMPTY_STEPS
                             );
                             return Poll::Ready(None);
@@ -401,7 +419,10 @@ impl Stream for ChunkStream {
                 }
                 continue;
             }
+            // Real progress this round: clear both hot-spin guards.
             this.consecutive_empty = 0;
+            this.last_errored_task = None;
+            this.consecutive_foreign_err = 0;
 
             // 3) Distribute produced chunks: ours go to caller; others to
             //    their owners' buffers. We may then loop to attempt the
@@ -921,5 +942,84 @@ mod tests {
             n <= MAX_CONSECUTIVE_EMPTY_STEPS,
             "stream busy-spun on a non-clearing foreign-task Err: {n} steps"
         );
+    }
+
+    /// Engine that fails a sequence of DISTINCT foreign tasks, one per step
+    /// (clearing each — a correctly-behaving engine), then serves the polled
+    /// task a final chunk. Models concurrent serving where several other
+    /// requests die in a row while a healthy task waits its turn.
+    struct DistinctForeignFailEngine {
+        fails: std::collections::VecDeque<TaskId>,
+        serve: TaskId,
+    }
+
+    impl Engine for DistinctForeignFailEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            if let Some(f) = self.fails.pop_front() {
+                // Each foreign failure is distinct and cleared (popped) — the
+                // engine is making progress, not hot-spinning one task.
+                return Err(EngineError::Backend("transport down".into()).for_task(f));
+            }
+            Ok(vec![(
+                self.serve.clone(),
+                Chunk::final_marker(self.serve.clone(), "ok"),
+            )])
+        }
+    }
+
+    struct DistinctForeignFailBuilder {
+        fails: Vec<TaskId>,
+        serve: TaskId,
+    }
+
+    #[async_trait::async_trait]
+    impl Builder for DistinctForeignFailBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(DistinctForeignFailEngine {
+                fails: self.fails.into_iter().collect(),
+                serve: self.serve,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn distinct_foreign_task_errs_do_not_kill_healthy_stream() {
+        // Three DISTINCT foreign tasks fail in a row (>= MAX_CONSECUTIVE_EMPTY_
+        // STEPS) before our task is served. The old "any foreign err bumps the
+        // bound" logic false-closed us here; the same-task refinement must let
+        // our healthy stream survive and finish.
+        let runner = Runner::new(Box::new(DistinctForeignFailBuilder {
+            fails: vec!["f1".to_string(), "f2".to_string(), "f3".to_string()],
+            serve: "ours".to_string(),
+        }));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        let mut stream = runner
+            .generate(GenerationTask::new("ours", "x").with_max_tokens(4))
+            .unwrap();
+        let chunk = stream.next().await;
+        assert!(
+            chunk.as_ref().map(|c| c.is_final).unwrap_or(false),
+            "healthy stream was false-closed by distinct foreign-task errors: {chunk:?}"
+        );
+        assert!(stream.next().await.is_none(), "stream should be complete");
     }
 }

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -198,8 +198,9 @@ impl Runner {
         })
     }
 
-    /// Step the engine forever; exits when the engine signals io error
-    /// (transport closed). Used by non-first pipeline stages.
+    /// Step the engine forever; exits only when the engine slot empties.
+    /// Step errors are logged and driving continues (engines own their
+    /// recovery). Used by non-first pipeline stages.
     ///
     /// Enters a `BlockingContextGuard` once per OS thread (since this
     /// loop runs on a single `spawn_blocking` thread) so that engines'

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -34,6 +34,16 @@ const MAX_CONSECUTIVE_EMPTY_STEPS: usize = 3;
 /// situation (`WORKER_BACKOFF`).
 const RELAY_ERR_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
 
+/// Why [`Runner::run_relay_loop`] returned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RelayExit {
+    /// The engine slot emptied (clean teardown via [`Runner::close`]).
+    SlotEmpty,
+    /// A `step()` hit an unrecoverable peer-link failure; the caller should
+    /// exit non-zero so the supervisor rebuilds the stage.
+    ConnectionFatal,
+}
+
 // ---------------------------------------------------------------------------
 // Shared block_on dispatch + BlockingContextGuard.
 //
@@ -205,33 +215,46 @@ impl Runner {
         })
     }
 
-    /// Step the engine forever; exits only when the engine slot empties.
-    /// Step errors are logged and driving continues (engines own their
-    /// recovery). Used by non-first pipeline stages.
+    /// Step the engine forever; exits when the engine slot empties (clean
+    /// teardown) or the engine's peer link dies unrecoverably. Used by
+    /// non-first pipeline stages.
     ///
-    /// The loop throttles itself: a `step()` that returns `Err` sleeps
-    /// `RELAY_ERR_BACKOFF` before the next round so a persistently-failing
-    /// engine (dead peer, bad-frame flood, black-holed upstream) can't peg
-    /// a core regardless of whether the engine self-throttles. The backoff
-    /// resets on any non-empty `Ok` step. Engines MAY additionally
-    /// self-throttle (e.g. the workers sleep on a dead peer too); the two
-    /// are belt-and-suspenders.
+    /// A `step()` that returns a *connection-fatal* `Err` ([dead/dropped
+    /// socket, idle-ceiling fire](EngineError::is_connection_fatal)) ends
+    /// the loop with [`RelayExit::ConnectionFatal`]: the worker's upstream
+    /// socket can only be re-accepted by a rebuild, so the caller exits
+    /// non-zero and lets the supervisor (systemd `Restart=on-failure`)
+    /// rebuild the stage — rather than spin-and-flood at the backoff rate
+    /// forever. A *non-fatal* `Err` (bad frame kind, transient inference
+    /// failure) is logged and driving continues, throttled by
+    /// `RELAY_ERR_BACKOFF` so it can't peg a core; the backoff resets on
+    /// any non-empty `Ok` step. Engines MAY additionally self-throttle.
     ///
     /// Enters a `BlockingContextGuard` once per OS thread (since this
     /// loop runs on a single `spawn_blocking` thread) so that engines'
     /// `run_async` calls hit the naked-`block_on` path instead of
     /// `block_in_place` — ~60 ms/frame savings on Windows.
-    pub fn run_relay_loop(&self) {
+    pub fn run_relay_loop(&self) -> RelayExit {
         let _blocking = BlockingContextGuard::enter();
         loop {
             let mut guard = self.engine.lock();
-            let Some(engine) = guard.as_mut() else { break };
-            // Engine.step is sync; just drain. An Err is logged but the
-            // loop keeps driving — relay engines recover their own state
-            // (and self-throttle on dead peers), and a transient frame
-            // error must not take the whole stage down.
+            let Some(engine) = guard.as_mut() else {
+                drop(guard);
+                info!("relay loop exited: engine slot empty");
+                return RelayExit::SlotEmpty;
+            };
+            // Engine.step is sync; just drain. A non-fatal Err is logged
+            // but the loop keeps driving — relay engines recover their own
+            // state and a transient frame error must not take the stage
+            // down. A connection-fatal Err is unrecoverable in-process, so
+            // bail and let the supervisor rebuild us.
             let failed = match engine.step() {
                 Ok(_) => false,
+                Err(e) if e.is_connection_fatal() => {
+                    drop(guard);
+                    warn!(error = %e, "relay step hit a dead peer link; exiting for supervisor rebuild");
+                    return RelayExit::ConnectionFatal;
+                }
                 Err(e) => {
                     warn!(error = %e, "relay step failed");
                     true
@@ -249,7 +272,6 @@ impl Runner {
                 std::thread::yield_now();
             }
         }
-        info!("relay loop exited");
     }
 
     pub fn close(&self) {
@@ -579,7 +601,7 @@ mod tests {
         let handle = std::thread::spawn(move || driver.run_relay_loop());
         std::thread::sleep(RELAY_ERR_BACKOFF * 5);
         runner.close(); // engine slot -> None: loop breaks next round
-        handle.join().unwrap();
+        assert_eq!(handle.join().unwrap(), RelayExit::SlotEmpty);
 
         // With a 200 ms backoff per Err round, ~1 s of wall time admits a
         // handful of iterations, not the millions a hot-spin would do.
@@ -590,6 +612,57 @@ mod tests {
             "relay loop hot-spun on persistently-failing step(): {n} calls in ~1s"
         );
         assert!(n >= 1, "relay loop never stepped the engine");
+    }
+
+    /// A worker whose every step hits a dead peer link (flattened transport
+    /// error). The relay loop must exit ConnectionFatal so the supervisor
+    /// rebuilds the stage, instead of spinning at the backoff rate forever.
+    struct DeadLinkEngine(Arc<std::sync::atomic::AtomicUsize>);
+
+    impl Engine for DeadLinkEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // Same shape the dist-spec worker produces once its socket is
+            // dropped: TransportError::NotConnected flattened to a string.
+            Err(EngineError::Backend(
+                "not connected; call connect()/accept() first".into(),
+            ))
+        }
+    }
+
+    #[test]
+    fn relay_loop_exits_on_connection_fatal_step() {
+        use std::sync::atomic::Ordering;
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let engine: Box<dyn Engine> = Box::new(DeadLinkEngine(calls.clone()));
+        let runner = Arc::new(Runner {
+            builder: Mutex::new(None),
+            engine: Arc::new(Mutex::new(Some(engine))),
+            buffers: Arc::new(Mutex::new(Buffers::default())),
+        });
+
+        // No external stop: the loop must terminate on its own. A timed join
+        // guards against a regression that lets it spin forever.
+        let driver = runner.clone();
+        let handle = std::thread::spawn(move || driver.run_relay_loop());
+        let start = std::time::Instant::now();
+        while !handle.is_finished() {
+            if start.elapsed() > std::time::Duration::from_secs(5) {
+                panic!("relay loop did not exit on connection-fatal step()");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert_eq!(handle.join().unwrap(), RelayExit::ConnectionFatal);
+        // It bails on the first fatal Err — no spin.
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "relay loop should exit on the first connection-fatal step()"
+        );
     }
 
     #[tokio::test]

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -683,6 +683,49 @@ mod tests {
         );
     }
 
+    /// A worker step whose flattened transport error is a peer crash (TCP
+    /// RST) must also exit ConnectionFatal — the dominant dead-peer case,
+    /// not just a clean FIN. Mirrors the test above with the RST string.
+    struct RstStepEngine(EngineError);
+
+    impl Engine for RstStepEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            Err(EngineError::Backend(self.0.to_string()))
+        }
+    }
+
+    #[test]
+    fn relay_loop_exits_on_peer_rst_and_mid_frame_step() {
+        // Both the peer-crash string and the mid-frame stall string must be
+        // treated as connection-fatal by the relay loop.
+        for msg in ["connection reset by peer", "recv_exact timed out after 60s"] {
+            let engine: Box<dyn Engine> = Box::new(RstStepEngine(EngineError::Backend(msg.into())));
+            let runner = Arc::new(Runner {
+                builder: Mutex::new(None),
+                engine: Arc::new(Mutex::new(Some(engine))),
+                buffers: Arc::new(Mutex::new(Buffers::default())),
+            });
+            let driver = runner.clone();
+            let handle = std::thread::spawn(move || driver.run_relay_loop());
+            let start = std::time::Instant::now();
+            while !handle.is_finished() {
+                if start.elapsed() > std::time::Duration::from_secs(5) {
+                    panic!("relay loop did not exit on connection-fatal step() for {msg:?}");
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            assert_eq!(
+                handle.join().unwrap(),
+                RelayExit::ConnectionFatal,
+                "expected ConnectionFatal exit for {msg:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn step_error_terminates_stream() {
         let runner = Runner::new(Box::new(FailingBuilder));

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -202,6 +202,11 @@ impl Runner {
     /// Step errors are logged and driving continues (engines own their
     /// recovery). Used by non-first pipeline stages.
     ///
+    /// Engines driven by this loop must self-throttle a persistently
+    /// fast-failing `step()` (e.g. sleep on a dead peer) — the loop never
+    /// exits on `Err` and only yields between rounds, so an instant-`Err`
+    /// engine would otherwise spin this thread hot.
+    ///
     /// Enters a `BlockingContextGuard` once per OS thread (since this
     /// loop runs on a single `spawn_blocking` thread) so that engines'
     /// `run_async` calls hit the naked-`block_on` path instead of

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -356,6 +356,24 @@ impl Stream for ChunkStream {
                         let mut bufs = this.buffers.lock();
                         bufs.cancelled.insert(failed.clone());
                         bufs.chunks.remove(&failed);
+                        drop(bufs);
+                        // This round made no progress for *us*. Count it
+                        // toward the no-progress guard so a contract-violating
+                        // engine that re-emits the same foreign-task Err every
+                        // step (never clearing it) can't busy-spin this stream
+                        // forever — it falls through to the MAX-empty close
+                        // below. A well-behaved engine clears the failed task
+                        // and serves us, resetting the counter.
+                        this.consecutive_empty += 1;
+                        if this.consecutive_empty >= MAX_CONSECUTIVE_EMPTY_STEPS {
+                            this.done = true;
+                            warn!(
+                                task = %this.task_id,
+                                "engine made no progress for {} consecutive steps; closing stream",
+                                MAX_CONSECUTIVE_EMPTY_STEPS
+                            );
+                            return Poll::Ready(None);
+                        }
                         continue;
                     }
                     _ => {
@@ -780,5 +798,85 @@ mod tests {
         );
         // B's stream is now complete too.
         assert!(stream_b.next().await.is_none());
+    }
+
+    /// Contract-violating engine: every step re-emits the SAME foreign-task
+    /// Err and never clears it (real engines drop the failed task). Models a
+    /// pathological non-clearing engine that would otherwise busy-spin the
+    /// observing stream's `continue`.
+    struct ForeignErrSpinEngine {
+        fail: TaskId,
+        steps: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl Engine for ForeignErrSpinEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            self.steps.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(EngineError::Backend("transport down".into()).for_task(self.fail.clone()))
+        }
+    }
+
+    struct ForeignErrSpinBuilder {
+        fail: TaskId,
+        steps: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Builder for ForeignErrSpinBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(ForeignErrSpinEngine {
+                fail: self.fail,
+                steps: self.steps,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_foreign_task_err_bounds_observing_stream() {
+        use std::sync::atomic::Ordering;
+        // The engine fails task "other" on every step and never clears it.
+        // Our stream ("ours") never gets served, but the cross-task error arm
+        // must count toward the no-progress guard so we terminate rather than
+        // spin a tokio worker forever.
+        let steps = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let runner = Runner::new(Box::new(ForeignErrSpinBuilder {
+            fail: "other".to_string(),
+            steps: steps.clone(),
+        }));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        let mut stream = runner
+            .generate(GenerationTask::new("ours", "x").with_max_tokens(64))
+            .unwrap();
+
+        // Must terminate (None), not hang. Bounded by the no-progress guard.
+        assert!(
+            stream.next().await.is_none(),
+            "stream should terminate on a non-clearing foreign-task Err, not spin"
+        );
+        // One step per no-progress round; capped by the guard, not unbounded.
+        let n = steps.load(Ordering::SeqCst);
+        assert!(
+            n <= MAX_CONSECUTIVE_EMPTY_STEPS,
+            "stream busy-spun on a non-clearing foreign-task Err: {n} steps"
+        );
     }
 }

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -302,19 +302,41 @@ impl Stream for ChunkStream {
                 }
             }
 
-            // 2) Drive the engine one step. An Err is terminal for this
-            //    task: the engine has already abandoned it and reset its
-            //    own state, so end the stream instead of spinning on
-            //    empty steps until MAX_CONSECUTIVE_EMPTY_STEPS.
-            let produced = {
+            // 2) Drive the engine one step. An Err is terminal for the
+            //    failed task: the engine has already abandoned it and reset
+            //    its own state. If the error names a *different* task than
+            //    ours (concurrent serving), route the failure to that task
+            //    and keep polling — ending our healthy stream would kill the
+            //    wrong request. An error for our task, or a task-less /
+            //    engine-level error, ends this stream.
+            let step_result = {
                 let mut guard = this.engine.lock();
                 let Some(engine) = guard.as_mut() else {
                     this.done = true;
                     return Poll::Ready(None);
                 };
-                match engine.step() {
-                    Ok(v) => v,
-                    Err(e) => {
+                engine.step()
+            };
+            let produced = match step_result {
+                Ok(v) => v,
+                Err(e) => match e.task_id() {
+                    Some(failed) if failed != &this.task_id => {
+                        // Misattribution guard: fail the named task's stream,
+                        // not ours. Cancelling it makes its own poll_next
+                        // observe termination on its next turn.
+                        let failed = failed.clone();
+                        warn!(
+                            failed_task = %failed,
+                            polled_task = %this.task_id,
+                            error = %e,
+                            "engine step failed for another task; routing failure to it"
+                        );
+                        let mut bufs = this.buffers.lock();
+                        bufs.cancelled.insert(failed.clone());
+                        bufs.chunks.remove(&failed);
+                        continue;
+                    }
+                    _ => {
                         this.done = true;
                         warn!(
                             task = %this.task_id,
@@ -323,7 +345,7 @@ impl Stream for ChunkStream {
                         );
                         return Poll::Ready(None);
                     }
-                }
+                },
             };
 
             if produced.is_empty() {
@@ -586,5 +608,104 @@ mod tests {
         // The first poll hits the step error and ends the stream — no
         // empty-step spinning, no chunks.
         assert!(stream.next().await.is_none());
+    }
+
+    /// Engine that fails one named task with a task-attributed error on its
+    /// first step, then serves every other task one token + a final marker.
+    /// Models concurrent serving where task A's transport dies while B is
+    /// healthy.
+    struct SelectiveFailEngine {
+        fail: TaskId,
+        tasks: Vec<TaskId>,
+        served: std::collections::HashSet<TaskId>,
+    }
+
+    impl Engine for SelectiveFailEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, task: GenerationTask) -> Result<(), EngineError> {
+            self.tasks.push(task.task_id);
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            if self.tasks.iter().any(|t| t == &self.fail) {
+                // Abandon the doomed task and report it by id.
+                self.tasks.retain(|t| t != &self.fail);
+                return Err(
+                    EngineError::Backend("transport down".into()).for_task(self.fail.clone())
+                );
+            }
+            // Serve the first not-yet-served task a single final chunk.
+            let next = self
+                .tasks
+                .iter()
+                .find(|t| !self.served.contains(*t))
+                .cloned();
+            match next {
+                Some(tid) => {
+                    self.served.insert(tid.clone());
+                    Ok(vec![(tid.clone(), Chunk::final_marker(tid, "ok"))])
+                }
+                None => Ok(Vec::new()),
+            }
+        }
+    }
+
+    struct SelectiveFailBuilder(TaskId);
+
+    #[async_trait::async_trait]
+    impl Builder for SelectiveFailBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(SelectiveFailEngine {
+                fail: self.0,
+                tasks: Vec::new(),
+                served: std::collections::HashSet::new(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn step_err_for_other_task_does_not_kill_healthy_stream() {
+        // Two concurrent streams share one engine. Task "a" fails with a
+        // task-attributed error; task "b" must survive and finish, and only
+        // "a" ends.
+        let runner = Runner::new(Box::new(SelectiveFailBuilder("a".to_string())));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        let mut stream_a = runner
+            .generate(GenerationTask::new("a", "x").with_max_tokens(4))
+            .unwrap();
+        let mut stream_b = runner
+            .generate(GenerationTask::new("b", "y").with_max_tokens(4))
+            .unwrap();
+
+        // Drive B first: it polls the engine, observes the err attributed to
+        // "a", routes the failure to "a", and keeps going to serve itself.
+        let b_chunk = stream_b.next().await;
+        assert!(
+            b_chunk.as_ref().map(|c| c.is_final).unwrap_or(false),
+            "healthy task b's stream was killed by task a's failure: {b_chunk:?}"
+        );
+
+        // A's stream ends (None) — it was the failed task.
+        assert!(
+            stream_a.next().await.is_none(),
+            "failed task a's stream should have ended"
+        );
+        // B's stream is now complete too.
+        assert!(stream_b.next().await.is_none());
     }
 }

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -184,8 +184,9 @@ impl Runner {
     }
 
     /// Submit a task and return a stream of chunks. Stops on the final
-    /// chunk, on cancellation, or after MAX_CONSECUTIVE_EMPTY_STEPS empty
-    /// engine polls (engine appears stuck).
+    /// chunk, on cancellation, on an engine step error, or after
+    /// MAX_CONSECUTIVE_EMPTY_STEPS empty engine polls (engine appears
+    /// stuck).
     pub fn generate(&self, task: GenerationTask) -> Result<ChunkStream, EngineError> {
         self.submit(task.clone())?;
         Ok(ChunkStream {
@@ -209,8 +210,13 @@ impl Runner {
         loop {
             let mut guard = self.engine.lock();
             let Some(engine) = guard.as_mut() else { break };
-            // Engine.step is sync; just drain.
-            let _produced = engine.step();
+            // Engine.step is sync; just drain. An Err is logged but the
+            // loop keeps driving — relay engines recover their own state
+            // (and self-throttle on dead peers), and a transient frame
+            // error must not take the whole stage down.
+            if let Err(e) = engine.step() {
+                warn!(error = %e, "relay step failed");
+            }
             // Don't hold the lock for long under the loop — yield to
             // other generate() callers between rounds.
             drop(guard);
@@ -269,14 +275,28 @@ impl Stream for ChunkStream {
                 }
             }
 
-            // 2) Drive the engine one step.
+            // 2) Drive the engine one step. An Err is terminal for this
+            //    task: the engine has already abandoned it and reset its
+            //    own state, so end the stream instead of spinning on
+            //    empty steps until MAX_CONSECUTIVE_EMPTY_STEPS.
             let produced = {
                 let mut guard = this.engine.lock();
                 let Some(engine) = guard.as_mut() else {
                     this.done = true;
                     return Poll::Ready(None);
                 };
-                engine.step()
+                match engine.step() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        this.done = true;
+                        warn!(
+                            task = %this.task_id,
+                            error = %e,
+                            "engine step failed; closing stream"
+                        );
+                        return Poll::Ready(None);
+                    }
+                }
             };
 
             if produced.is_empty() {
@@ -445,5 +465,54 @@ mod tests {
     async fn close_without_start_does_not_panic() {
         let runner = Runner::new(Box::new(MockBuilder::new()));
         runner.close();
+    }
+
+    /// An engine whose every step fails (e.g. dead transport).
+    struct FailingEngine;
+
+    impl Engine for FailingEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            Err(EngineError::Backend("transport down".into()))
+        }
+    }
+
+    struct FailingBuilder;
+
+    #[async_trait::async_trait]
+    impl Builder for FailingBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(FailingEngine))
+        }
+    }
+
+    #[tokio::test]
+    async fn step_error_terminates_stream() {
+        let runner = Runner::new(Box::new(FailingBuilder));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        let mut stream = runner
+            .generate(GenerationTask::new("t1", "hello").with_max_tokens(8))
+            .unwrap();
+        // The first poll hits the step error and ends the stream — no
+        // empty-step spinning, no chunks.
+        assert!(stream.next().await.is_none());
     }
 }

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -347,7 +347,8 @@ fn frame_idle_ceiling() -> Option<Duration> {
 }
 
 /// Wait for the first byte of a NEW frame exempt from the per-frame recv
-/// timeout, then read the remainder under the strict recv timeout. A
+/// timeout (but still bounded by the much larger [`frame_idle_ceiling`], not
+/// unbounded), then read the remainder under the strict recv timeout. A
 /// pipeline stage is idle between requests by design — "no next frame yet"
 /// is not a failure, and treating it as one made every idle chain kill its
 /// own sockets on a timer. A dead peer still fails fast here via EOF/reset;

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -69,6 +69,14 @@ pub enum TransportError {
 
     #[error("not connected; call connect()/accept() first")]
     NotConnected,
+
+    /// Frame-start idle ceiling fired: the peer is connected but silent
+    /// (black-holed). Connection-fatal — the server/client wrappers drop
+    /// the socket so a frame the peer sends later can never be read into
+    /// a different request; subsequent calls fail fast with
+    /// [`Self::NotConnected`].
+    #[error("frame-start idle ceiling hit after {0:?}; connection dropped (black-holed peer?)")]
+    FrameIdleCeiling(Duration),
 }
 
 pub type TransportResult<T> = Result<T, TransportError>;
@@ -297,19 +305,16 @@ fn frame_idle_ceiling() -> Option<Duration> {
 /// is not a failure, and treating it as one made every idle chain kill its
 /// own sockets on a timer. A dead peer still fails fast here via EOF/reset;
 /// a silent black-hole peer (connected, no FIN/RST) is bounded only by the
-/// much larger [`frame_idle_ceiling`], which converts it into the same
-/// timed-out error class as the deadline'd recvs.
+/// much larger [`frame_idle_ceiling`], surfaced as the dedicated
+/// [`TransportError::FrameIdleCeiling`] — distinguishable from the
+/// per-frame deadline's `Io(TimedOut)` so the wrappers can treat it as
+/// connection-fatal.
 async fn recv_exact_frame_start(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()> {
     let first_read = sock.read(buf);
     let n = match frame_idle_ceiling() {
         Some(ceiling) => match tokio::time::timeout(ceiling, first_read).await {
             Ok(res) => res?,
-            Err(_) => {
-                return Err(TransportError::Io(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    format!("frame-start idle ceiling hit after {ceiling:?} (black-holed peer?)"),
-                )))
-            }
+            Err(_) => return Err(TransportError::FrameIdleCeiling(ceiling)),
         },
         None => first_read.await?,
     };
@@ -401,7 +406,21 @@ impl ActivationServer {
 
     pub async fn recv(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        recv_tensor(sock).await
+        let res = recv_tensor(sock).await;
+        self.drop_connection_on_ceiling(res.as_ref().err());
+        res
+    }
+
+    /// Ceiling fire is connection-fatal: drop the socket here, at the
+    /// transport layer, so the abandoned frame the black-holed peer may
+    /// send later can never be read into a different request (token
+    /// frames carry no task id). Subsequent calls fail fast with
+    /// [`TransportError::NotConnected`].
+    fn drop_connection_on_ceiling(&mut self, err: Option<&TransportError>) {
+        if matches!(err, Some(TransportError::FrameIdleCeiling(_))) {
+            self.client = None; // drop closes the fd
+            self.accepted_addr = None;
+        }
     }
 
     pub async fn send(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
@@ -428,7 +447,9 @@ impl ActivationServer {
         }
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
         let mut buf = vec![0u8; n];
-        recv_exact_frame_start(sock, &mut buf).await?;
+        let res = recv_exact_frame_start(sock, &mut buf).await;
+        self.drop_connection_on_ceiling(res.as_ref().err());
+        res?;
         Ok(buf)
     }
 
@@ -528,7 +549,17 @@ impl ActivationClient {
 
     pub async fn recv(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        recv_tensor(sock).await
+        let res = recv_tensor(sock).await;
+        self.drop_connection_on_ceiling(res.as_ref().err());
+        res
+    }
+
+    /// See [`ActivationServer::drop_connection_on_ceiling`]: ceiling fire
+    /// is connection-fatal at the transport layer.
+    fn drop_connection_on_ceiling(&mut self, err: Option<&TransportError>) {
+        if matches!(err, Some(TransportError::FrameIdleCeiling(_))) {
+            self.sock = None; // drop closes the fd
+        }
     }
 
     pub async fn send_raw(&mut self, bytes: &[u8]) -> TransportResult<()> {
@@ -544,7 +575,9 @@ impl ActivationClient {
         }
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
         let mut buf = vec![0u8; n];
-        recv_exact_frame_start(sock, &mut buf).await?;
+        let res = recv_exact_frame_start(sock, &mut buf).await;
+        self.drop_connection_on_ceiling(res.as_ref().err());
+        res?;
         Ok(buf)
     }
 
@@ -733,13 +766,49 @@ mod tests {
         let got = h.await.unwrap();
         set_frame_idle_ceiling_secs(0);
         match got {
-            Err(TransportError::Io(e)) => assert_eq!(
-                e.kind(),
-                io::ErrorKind::TimedOut,
-                "ceiling must surface as the timed-out error class"
-            ),
-            other => panic!("expected timed-out io error, got {other:?}"),
+            Err(TransportError::FrameIdleCeiling(_)) => {}
+            other => panic!("expected FrameIdleCeiling, got {other:?}"),
         }
+    }
+
+    /// A ceiling fire must kill the connection: the next recv on the same
+    /// server fails fast with NotConnected, and a frame the black-holed
+    /// peer sends late must never be readable as a valid frame (it would
+    /// otherwise leak into the NEXT request — token frames carry no task
+    /// id).
+    #[tokio::test]
+    async fn ceiling_fire_is_connection_fatal() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_frame_idle_ceiling_secs(1);
+        set_activation_timeout_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        // Connect, then go silent — never send a byte.
+        let mut peer = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        server.accept().await.unwrap();
+        let first = server.recv().await;
+        assert!(
+            matches!(first, Err(TransportError::FrameIdleCeiling(_))),
+            "expected FrameIdleCeiling, got {first:?}"
+        );
+        // The abandoned frame arrives LATE, after the ceiling fired.
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        let _ = send_tensor(&mut peer, &tensor).await; // peer may already see RST
+                                                       // Subsequent use must fail fast on a dead connection — the late
+                                                       // frame must NOT come back as a valid frame.
+        let start = Instant::now();
+        let second = server.recv().await;
+        set_frame_idle_ceiling_secs(0);
+        set_activation_timeout_secs(0);
+        assert!(
+            matches!(second, Err(TransportError::NotConnected)),
+            "recv after ceiling fire must fail NotConnected, got {second:?}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "recv after ceiling fire must fail fast"
+        );
     }
 
     /// The ceiling must not erode the idle-tolerance guarantee: an idle

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -297,7 +297,8 @@ fn clamp_frame_idle_ceiling(
 }
 
 /// Whether a recv error leaves the socket unusable for subsequent reads, so
-/// the owner must drop it. Two cases, both leaving frame alignment lost:
+/// the owner must drop it. Cases, all leaving the link dead or frame
+/// alignment lost:
 ///
 /// * frame-START idle ceiling ([`TransportError::FrameIdleCeiling`]) — the
 ///   peer is connected but silent; a frame it sends later must never land in
@@ -306,14 +307,26 @@ fn clamp_frame_idle_ceiling(
 ///   [`recv_timeout`]; [`recv_exact`] surfaces this as `Io(TimedOut)`,
 ///   leaving a half-consumed frame on the wire that the next recv would read
 ///   as a corrupt header.
+/// * peer crash — a process dying hard sends TCP RST (and a send/half-close
+///   races as BrokenPipe/ConnectionAborted/UnexpectedEof). These surface as
+///   `Io(ConnectionReset | BrokenPipe | ConnectionAborted | UnexpectedEof)`;
+///   the socket is dead, so drop it now and let the next call fail fast with
+///   [`TransportError::NotConnected`] (the dominant dead-peer case).
 ///
-/// A clean EOF/reset is NOT fatal here: it surfaces as
-/// [`TransportError::SocketClosed`] (or a non-timeout `Io`), needs no drop,
-/// and the next call fails cleanly on its own. Pure, for testing.
+/// A clean EOF is NOT fatal here: it surfaces as
+/// [`TransportError::SocketClosed`], needs no drop, and the next call fails
+/// cleanly on its own. Pure, for testing.
 fn recv_error_is_connection_fatal(err: &TransportError) -> bool {
     match err {
         TransportError::FrameIdleCeiling(_) => true,
-        TransportError::Io(e) => e.kind() == io::ErrorKind::TimedOut,
+        TransportError::Io(e) => matches!(
+            e.kind(),
+            io::ErrorKind::TimedOut
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::ConnectionAborted
+                | io::ErrorKind::UnexpectedEof
+        ),
         _ => false,
     }
 }
@@ -903,9 +916,23 @@ mod tests {
         assert!(!recv_error_is_connection_fatal(
             &TransportError::SocketClosed
         ));
-        // A reset / other Io kind: NOT a timeout, NOT dropped here.
+        // Peer crash: RST / broken pipe / aborted / unexpected EOF all leave
+        // the socket dead — fatal so the owner drops it (the dominant
+        // dead-peer case).
+        for kind in [
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::BrokenPipe,
+            io::ErrorKind::ConnectionAborted,
+            io::ErrorKind::UnexpectedEof,
+        ] {
+            assert!(
+                recv_error_is_connection_fatal(&TransportError::Io(io::Error::new(kind, "peer"))),
+                "expected fatal: {kind:?}"
+            );
+        }
+        // An unrelated Io kind (e.g. would-block) is NOT fatal here.
         assert!(!recv_error_is_connection_fatal(&TransportError::Io(
-            io::Error::new(io::ErrorKind::ConnectionReset, "peer reset")
+            io::Error::new(io::ErrorKind::WouldBlock, "retryable")
         )));
     }
 
@@ -962,6 +989,46 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_millis(500),
             "recv after mid-frame stall must fail fast (socket already dropped)"
+        );
+    }
+
+    /// A peer process dying hard sends TCP RST, surfaced on the recv side as
+    /// `Io(ConnectionReset)` (the dominant dead-peer case). The owner must
+    /// treat that as connection-fatal and drop the socket, so the next recv
+    /// fails fast with NotConnected instead of retrying a dead link. Drives
+    /// the owner's drop path with the synthesized error a real RST produces
+    /// (forcing a true RST portably needs the unstable `set_linger` or an
+    /// extra socket crate). The kind→fatal mapping itself is proven by
+    /// `recv_error_fatal_classification`.
+    #[tokio::test]
+    async fn peer_rst_drops_socket_fast_fail() {
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let _peer = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        server.accept().await.unwrap();
+        assert!(server.client.is_some(), "precondition: connection accepted");
+
+        // The recv read returned ConnectionReset (peer RST). The owner drops
+        // the socket on this.
+        server.drop_connection_if_recv_fatal(Some(&TransportError::Io(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection reset by peer",
+        ))));
+        assert!(
+            server.client.is_none(),
+            "peer RST must drop the socket so the next call fails fast"
+        );
+
+        let start = Instant::now();
+        let next = server.recv().await;
+        assert!(
+            matches!(next, Err(TransportError::NotConnected)),
+            "recv after peer RST must fail NotConnected, got {next:?}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "recv after peer RST must fail fast"
         );
     }
 

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -284,7 +284,20 @@ fn resolve_frame_idle_ceiling(stored_plus_one: u64, env_secs: Option<u64>) -> Op
     (secs > 0).then(|| Duration::from_secs(secs))
 }
 
-/// Frame-start idle ceiling: config > `CASCADIA_FRAME_IDLE_CEILING_SECS` > 900s.
+/// An enabled ceiling below the strict per-frame recv timeout would make
+/// frame-START stricter than mid-frame (design inversion) and silently
+/// re-create the premature idle-kill the ceiling exists to avoid — floor
+/// the effective value at the recv timeout. `None` (no ceiling) passes
+/// through. Pure, for testing.
+fn clamp_frame_idle_ceiling(
+    configured: Option<Duration>,
+    recv_timeout: Duration,
+) -> Option<Duration> {
+    configured.map(|c| c.max(recv_timeout))
+}
+
+/// Frame-start idle ceiling: config > `CASCADIA_FRAME_IDLE_CEILING_SECS` > 900s,
+/// floored at [`recv_timeout`] when enabled (warns once when the floor engages).
 fn frame_idle_ceiling() -> Option<Duration> {
     use std::sync::OnceLock;
     static ENV: OnceLock<Option<u64>> = OnceLock::new(); // env read once
@@ -293,10 +306,22 @@ fn frame_idle_ceiling() -> Option<Duration> {
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
     });
-    resolve_frame_idle_ceiling(
+    let configured = resolve_frame_idle_ceiling(
         FRAME_IDLE_CEILING_SECS_PLUS_ONE.load(std::sync::atomic::Ordering::Relaxed),
         env,
-    )
+    );
+    let effective = clamp_frame_idle_ceiling(configured, recv_timeout());
+    if effective != configured {
+        static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+        if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            warn!(
+                configured = ?configured,
+                effective = ?effective,
+                "frame idle ceiling below the activation recv timeout; clamping up"
+            );
+        }
+    }
+    effective
 }
 
 /// Wait for the first byte of a NEW frame exempt from the per-frame recv
@@ -748,12 +773,38 @@ mod tests {
         assert_eq!(resolve_frame_idle_ceiling(1, Some(30)), None);
     }
 
+    #[test]
+    fn ceiling_clamped_to_recv_timeout_when_enabled() {
+        // ceiling below the recv timeout -> floored at the recv timeout
+        assert_eq!(
+            clamp_frame_idle_ceiling(Some(Duration::from_secs(5)), Duration::from_secs(60)),
+            Some(Duration::from_secs(60))
+        );
+        // ceiling above the recv timeout -> unchanged
+        assert_eq!(
+            clamp_frame_idle_ceiling(Some(Duration::from_secs(900)), Duration::from_secs(60)),
+            Some(Duration::from_secs(900))
+        );
+        // 0 = unbounded stays unbounded; the clamp never re-enables it
+        assert_eq!(
+            clamp_frame_idle_ceiling(None, Duration::from_secs(60)),
+            None
+        );
+        // raised activation timeout drags the default ceiling up with it
+        // (frame-start must never be stricter than mid-frame)
+        assert_eq!(
+            clamp_frame_idle_ceiling(Some(DEFAULT_FRAME_IDLE_CEILING), Duration::from_secs(1200)),
+            Some(Duration::from_secs(1200))
+        );
+    }
+
     /// A black-holed peer (connected, silent, no FIN/RST) must hit the
     /// frame-start idle ceiling instead of blocking recv forever.
     #[tokio::test]
     async fn frame_start_idle_ceiling_fires_on_silent_peer() {
         let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         set_frame_idle_ceiling_secs(1);
+        set_activation_timeout_secs(1); // keep the 1s ceiling under the clamp
         let mut server = ActivationServer::new("127.0.0.1", 0);
         server.start().await.unwrap();
         let port = server.port();
@@ -765,6 +816,7 @@ mod tests {
         let _sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let got = h.await.unwrap();
         set_frame_idle_ceiling_secs(0);
+        set_activation_timeout_secs(0);
         match got {
             Err(TransportError::FrameIdleCeiling(_)) => {}
             other => panic!("expected FrameIdleCeiling, got {other:?}"),

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -242,13 +242,77 @@ pub fn recv_timeout() -> Duration {
     )
 }
 
-/// Wait for the first byte of a NEW frame without a deadline, then read the
-/// remainder under the strict recv timeout. A pipeline stage is idle between
-/// requests by design — "no next frame yet" is not a failure, and treating it
-/// as one made every idle chain kill its own sockets on a timer. A dead peer
-/// still fails fast here via EOF/reset; only a silent black-hole peer waits.
+/// Default frame-start idle ceiling. Generous enough for legitimate long
+/// gaps between frames (cold compiles between stages, idle chains between
+/// requests) which the strict per-frame recv timeout must not kill; small
+/// enough that a black-holed peer — connected but silent, no FIN/RST —
+/// eventually surfaces as an error instead of pinning the stage forever.
+pub const DEFAULT_FRAME_IDLE_CEILING: Duration = Duration::from_secs(900);
+
+/// Config override for the frame-start idle ceiling, stored as secs+1 so
+/// 0 can mean "unset" while a configured 0 ("no ceiling") stays expressible.
+static FRAME_IDLE_CEILING_SECS_PLUS_ONE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Set the frame-start idle ceiling from node config (seconds); takes
+/// precedence over the env var. `0` disables the ceiling entirely (the
+/// historical unbounded idle wait).
+pub fn set_frame_idle_ceiling_secs(secs: u64) {
+    FRAME_IDLE_CEILING_SECS_PLUS_ONE
+        .store(secs.saturating_add(1), std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Precedence: config override > env > default; 0 at any level = no ceiling.
+/// Pure, for testing.
+fn resolve_frame_idle_ceiling(stored_plus_one: u64, env_secs: Option<u64>) -> Option<Duration> {
+    let secs = if stored_plus_one > 0 {
+        stored_plus_one - 1
+    } else {
+        match env_secs {
+            Some(s) => s,
+            None => return Some(DEFAULT_FRAME_IDLE_CEILING),
+        }
+    };
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// Frame-start idle ceiling: config > `CASCADIA_FRAME_IDLE_CEILING_SECS` > 900s.
+fn frame_idle_ceiling() -> Option<Duration> {
+    use std::sync::OnceLock;
+    static ENV: OnceLock<Option<u64>> = OnceLock::new(); // env read once
+    let env = *ENV.get_or_init(|| {
+        std::env::var("CASCADIA_FRAME_IDLE_CEILING_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+    });
+    resolve_frame_idle_ceiling(
+        FRAME_IDLE_CEILING_SECS_PLUS_ONE.load(std::sync::atomic::Ordering::Relaxed),
+        env,
+    )
+}
+
+/// Wait for the first byte of a NEW frame exempt from the per-frame recv
+/// timeout, then read the remainder under the strict recv timeout. A
+/// pipeline stage is idle between requests by design — "no next frame yet"
+/// is not a failure, and treating it as one made every idle chain kill its
+/// own sockets on a timer. A dead peer still fails fast here via EOF/reset;
+/// a silent black-hole peer (connected, no FIN/RST) is bounded only by the
+/// much larger [`frame_idle_ceiling`], which converts it into the same
+/// timed-out error class as the deadline'd recvs.
 async fn recv_exact_frame_start(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()> {
-    let n = sock.read(buf).await?;
+    let first_read = sock.read(buf);
+    let n = match frame_idle_ceiling() {
+        Some(ceiling) => match tokio::time::timeout(ceiling, first_read).await {
+            Ok(res) => res?,
+            Err(_) => {
+                return Err(TransportError::Io(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("frame-start idle ceiling hit after {ceiling:?} (black-holed peer?)"),
+                )))
+            }
+        },
+        None => first_read.await?,
+    };
     if n == 0 {
         return Err(TransportError::SocketClosed);
     }
@@ -628,5 +692,83 @@ mod tests {
         let got = h.await.unwrap();
         set_activation_timeout_secs(0);
         assert!(got.is_err(), "partial frame then stall must still time out");
+    }
+
+    #[test]
+    fn frame_idle_ceiling_precedence_config_over_env_over_default() {
+        // unset everywhere -> generous default
+        assert_eq!(
+            resolve_frame_idle_ceiling(0, None),
+            Some(DEFAULT_FRAME_IDLE_CEILING)
+        );
+        // no config -> env wins; env 0 = no ceiling
+        assert_eq!(
+            resolve_frame_idle_ceiling(0, Some(30)),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(resolve_frame_idle_ceiling(0, Some(0)), None);
+        // config (stored as secs+1) wins over env; configured 0 = no ceiling
+        assert_eq!(
+            resolve_frame_idle_ceiling(6, Some(30)),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(resolve_frame_idle_ceiling(1, Some(30)), None);
+    }
+
+    /// A black-holed peer (connected, silent, no FIN/RST) must hit the
+    /// frame-start idle ceiling instead of blocking recv forever.
+    #[tokio::test]
+    async fn frame_start_idle_ceiling_fires_on_silent_peer() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_frame_idle_ceiling_secs(1);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            server.recv().await
+        });
+        // Connect, then go silent — never send a byte.
+        let _sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let got = h.await.unwrap();
+        set_frame_idle_ceiling_secs(0);
+        match got {
+            Err(TransportError::Io(e)) => assert_eq!(
+                e.kind(),
+                io::ErrorKind::TimedOut,
+                "ceiling must surface as the timed-out error class"
+            ),
+            other => panic!("expected timed-out io error, got {other:?}"),
+        }
+    }
+
+    /// The ceiling must not erode the idle-tolerance guarantee: an idle
+    /// gap longer than the strict recv timeout but under the (generous)
+    /// ceiling still delivers the next frame intact.
+    #[tokio::test]
+    async fn generous_idle_ceiling_does_not_fire_on_idle_gap() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        set_frame_idle_ceiling_secs(60);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            server.recv().await
+        });
+        let mut client = ActivationClient::new("127.0.0.1", port);
+        client.connect().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(2500)).await; // idle > timeout
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        client.send(&tensor).await.unwrap();
+        let got = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        set_frame_idle_ceiling_secs(0);
+        assert!(
+            got.is_ok(),
+            "idle gap under the ceiling must not time out: {:?}",
+            got.err()
+        );
     }
 }

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -396,6 +396,17 @@ async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()>
     // multi-MB Llama hidden state over Thunderbolt, and small enough
     // that a wedged peer is detected within one or two heartbeats.
     // Waiting for a frame to BEGIN is exempt — see recv_exact_frame_start.
+    //
+    // NOTE: this is a single wall-clock bound over the WHOLE remaining
+    // buffer, not an idle/no-progress timeout. Assumption: inter-stage
+    // frames are small (hidden states, KB–MB), so 60 s wall-clock ≈ a
+    // genuine stall, not a slow-but-progressing transfer. A mid-frame
+    // timeout is now connection-fatal (the socket is dropped), so a
+    // slow-but-progressing LARGE transfer on a degraded link would be
+    // killed — acceptable at the current frame sizes. If large mid-frame
+    // transfers ever land (e.g. KV-cache blobs), switch to an idle/
+    // no-progress timeout (reset the deadline on each read that returns
+    // bytes) so progress, not total size, is what's bounded.
     let read_fut = async {
         let mut read = 0;
         while read < buf.len() {

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -296,6 +296,28 @@ fn clamp_frame_idle_ceiling(
     configured.map(|c| c.max(recv_timeout))
 }
 
+/// Whether a recv error leaves the socket unusable for subsequent reads, so
+/// the owner must drop it. Two cases, both leaving frame alignment lost:
+///
+/// * frame-START idle ceiling ([`TransportError::FrameIdleCeiling`]) — the
+///   peer is connected but silent; a frame it sends later must never land in
+///   the next request (token frames carry no task id).
+/// * MID-frame deadline — a frame began but stalled past the strict
+///   [`recv_timeout`]; [`recv_exact`] surfaces this as `Io(TimedOut)`,
+///   leaving a half-consumed frame on the wire that the next recv would read
+///   as a corrupt header.
+///
+/// A clean EOF/reset is NOT fatal here: it surfaces as
+/// [`TransportError::SocketClosed`] (or a non-timeout `Io`), needs no drop,
+/// and the next call fails cleanly on its own. Pure, for testing.
+fn recv_error_is_connection_fatal(err: &TransportError) -> bool {
+    match err {
+        TransportError::FrameIdleCeiling(_) => true,
+        TransportError::Io(e) => e.kind() == io::ErrorKind::TimedOut,
+        _ => false,
+    }
+}
+
 /// Frame-start idle ceiling: config > `CASCADIA_FRAME_IDLE_CEILING_SECS` > 900s,
 /// floored at [`recv_timeout`] when enabled (warns once when the floor engages).
 fn frame_idle_ceiling() -> Option<Duration> {
@@ -432,17 +454,18 @@ impl ActivationServer {
     pub async fn recv(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
         let res = recv_tensor(sock).await;
-        self.drop_connection_on_ceiling(res.as_ref().err());
+        self.drop_connection_if_recv_fatal(res.as_ref().err());
         res
     }
 
-    /// Ceiling fire is connection-fatal: drop the socket here, at the
-    /// transport layer, so the abandoned frame the black-holed peer may
-    /// send later can never be read into a different request (token
-    /// frames carry no task id). Subsequent calls fail fast with
+    /// A recv timeout is connection-fatal: drop the socket here, at the
+    /// transport layer, so a half-consumed or abandoned frame can never be
+    /// read into a different request (token frames carry no task id). Covers
+    /// both the frame-start idle ceiling and a mid-frame stall — see
+    /// [`recv_error_is_connection_fatal`]. Subsequent calls fail fast with
     /// [`TransportError::NotConnected`].
-    fn drop_connection_on_ceiling(&mut self, err: Option<&TransportError>) {
-        if matches!(err, Some(TransportError::FrameIdleCeiling(_))) {
+    fn drop_connection_if_recv_fatal(&mut self, err: Option<&TransportError>) {
+        if err.is_some_and(recv_error_is_connection_fatal) {
             self.client = None; // drop closes the fd
             self.accepted_addr = None;
         }
@@ -473,7 +496,7 @@ impl ActivationServer {
         let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
         let mut buf = vec![0u8; n];
         let res = recv_exact_frame_start(sock, &mut buf).await;
-        self.drop_connection_on_ceiling(res.as_ref().err());
+        self.drop_connection_if_recv_fatal(res.as_ref().err());
         res?;
         Ok(buf)
     }
@@ -575,14 +598,15 @@ impl ActivationClient {
     pub async fn recv(&mut self) -> TransportResult<(Tensor, TransferStats)> {
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
         let res = recv_tensor(sock).await;
-        self.drop_connection_on_ceiling(res.as_ref().err());
+        self.drop_connection_if_recv_fatal(res.as_ref().err());
         res
     }
 
-    /// See [`ActivationServer::drop_connection_on_ceiling`]: ceiling fire
-    /// is connection-fatal at the transport layer.
-    fn drop_connection_on_ceiling(&mut self, err: Option<&TransportError>) {
-        if matches!(err, Some(TransportError::FrameIdleCeiling(_))) {
+    /// See [`ActivationServer::drop_connection_if_recv_fatal`]: a recv
+    /// timeout (frame-start ceiling or mid-frame stall) is connection-fatal
+    /// at the transport layer.
+    fn drop_connection_if_recv_fatal(&mut self, err: Option<&TransportError>) {
+        if err.is_some_and(recv_error_is_connection_fatal) {
             self.sock = None; // drop closes the fd
         }
     }
@@ -601,7 +625,7 @@ impl ActivationClient {
         let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
         let mut buf = vec![0u8; n];
         let res = recv_exact_frame_start(sock, &mut buf).await;
-        self.drop_connection_on_ceiling(res.as_ref().err());
+        self.drop_connection_if_recv_fatal(res.as_ref().err());
         res?;
         Ok(buf)
     }
@@ -860,6 +884,83 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_millis(500),
             "recv after ceiling fire must fail fast"
+        );
+    }
+
+    #[test]
+    fn recv_error_fatal_classification() {
+        // Frame-start ceiling: fatal (black-holed peer).
+        assert!(recv_error_is_connection_fatal(
+            &TransportError::FrameIdleCeiling(Duration::from_secs(1))
+        ));
+        // Mid-frame deadline surfaces as Io(TimedOut): fatal (half frame
+        // left on the wire would desync the next read).
+        assert!(recv_error_is_connection_fatal(&TransportError::Io(
+            io::Error::new(io::ErrorKind::TimedOut, "recv_exact timed out")
+        )));
+        // Clean EOF: NOT fatal — the next call fails cleanly on its own.
+        assert!(!recv_error_is_connection_fatal(
+            &TransportError::SocketClosed
+        ));
+        // A reset / other Io kind: NOT a timeout, NOT dropped here.
+        assert!(!recv_error_is_connection_fatal(&TransportError::Io(
+            io::Error::new(io::ErrorKind::ConnectionReset, "peer reset")
+        )));
+    }
+
+    /// A mid-frame stall (header arrives, payload never does, past the recv
+    /// timeout) must be connection-fatal: the half-consumed frame leaves the
+    /// wire desynced, so the next recv must fail fast with NotConnected, and
+    /// a late completion of that frame must never be read back as valid.
+    #[tokio::test]
+    async fn mid_frame_stall_is_connection_fatal() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        // Keep the frame-start ceiling well above the recv timeout so the
+        // first read (the header) is NOT what fires — we want the mid-frame
+        // deadline to be the trigger.
+        set_frame_idle_ceiling_secs(60);
+        let mut server = ActivationServer::new("127.0.0.1", 0);
+        server.start().await.unwrap();
+        let port = server.port();
+        let mut peer = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        server.accept().await.unwrap();
+
+        // Send a complete, valid header for an 8-byte f32 [1,1,2] payload,
+        // then stall — never send the payload. recv_exact_frame_start reads
+        // the header, recv_tensor then blocks in recv_exact for the body.
+        let mut header = [0u8; HEADER_SIZE];
+        header[0..4].copy_from_slice(&8u32.to_be_bytes()); // payload_len
+        header[4..8].copy_from_slice(&(DType::F32 as u32).to_be_bytes());
+        header[8..12].copy_from_slice(&1u32.to_be_bytes());
+        header[12..16].copy_from_slice(&1u32.to_be_bytes());
+        header[16..20].copy_from_slice(&2u32.to_be_bytes());
+        peer.write_all(&header).await.unwrap();
+        peer.flush().await.unwrap();
+
+        let first = server.recv().await;
+        assert!(
+            matches!(&first, Err(TransportError::Io(e)) if e.kind() == io::ErrorKind::TimedOut),
+            "expected mid-frame Io(TimedOut), got {first:?}"
+        );
+
+        // The peer finally sends the rest of the abandoned frame, late.
+        peer.write_all(&[0, 0, 128, 63, 0, 0, 0, 64]).await.ok();
+        peer.flush().await.ok();
+
+        // The socket must already be dead: the next recv fails fast with
+        // NotConnected, NOT a corrupt frame read from the late payload.
+        let start = Instant::now();
+        let second = server.recv().await;
+        set_activation_timeout_secs(0);
+        set_frame_idle_ceiling_secs(0);
+        assert!(
+            matches!(second, Err(TransportError::NotConnected)),
+            "recv after mid-frame stall must fail NotConnected, got {second:?}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "recv after mid-frame stall must fail fast (socket already dropped)"
         );
     }
 

--- a/docs/deploy/cascadia-worker.service
+++ b/docs/deploy/cascadia-worker.service
@@ -3,6 +3,11 @@ Description=Cascadia worker (rank %i)
 After=network-online.target
 Wants=network-online.target
 
+# Rate-limit restarts so a crash-loop on a config error doesn't churn.
+# systemd >=229 reads StartLimit* from [Unit], NOT [Service] (ignored there).
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
 [Service]
 Type=simple
 User=cascadia
@@ -32,10 +37,10 @@ KillSignal=SIGTERM
 TimeoutStopSec=30
 
 # Restart on crash, but back off so we don't churn on a config error.
+# (StartLimitIntervalSec / StartLimitBurst live in [Unit] above — systemd
+# ignores them under [Service].)
 Restart=on-failure
 RestartSec=5
-StartLimitIntervalSec=60
-StartLimitBurst=3
 
 # Resource isolation. Uncomment / tighten for production.
 # LimitNOFILE=65535


### PR DESCRIPTION
Upstream half of enterprise issue [labscommunity/cascadia-enterprise#34](https://github.com/labscommunity/cascadia-enterprise/issues/34). Reliability fixes to the pipeline-parallel engine / transport / runner so a dead or misbehaving peer is **detected and recovered cleanly** instead of wedging, corrupting the next request, or hot-spinning.

## What changed

- **Visible step failures.** `Engine::step` now returns `EngineResult` (was infallible) — a failing step is surfaced, not swallowed into an eternal spin. The error carries the failed `TaskId`, so one task's failure can't terminate an unrelated concurrent task's stream.
- **Real `cancel`** on `OvRuntimeEngine` (was a no-op) — frees the engine slot on abandon instead of draining to `max_tokens`.
- **Frame-start idle ceiling** for black-holed peers: bounds the wait for a frame's first byte (config > env > 900s default; `0` = unbounded), clamped to ≥ the activation recv timeout so it can't re-create a premature kill.
- **Connection-fatal teardown.** A peer crash (TCP RST), a mid-frame stall, or a ceiling fire now drops the socket and is classified fatal — so a late/abandoned frame can never be misread into the next request, and the relay loop **exits for a clean supervisor rebuild** instead of spinning. Covers `ov-runtime`, `dist-spec`, and `sparse-moe`.
- **Relay-loop throttle.** A persistently-failing `step()` backs off instead of pegging a core + flooding logs.

## Reviewer notes

- Connection-fatal classification is string-matched on flattened transport errors (the existing pattern in this repo); the socket is dropped at its owner, and `EngineError::is_connection_fatal()` + the dist-spec worker classifier are kept in sync.
- `recv_exact` uses a whole-buffer wall-clock timeout, not an idle/no-progress one — correct for today's small inter-stage frames (wall-clock ≈ stall); an idle timeout is a noted follow-up if large mid-frame transfers (e.g. future KV blobs) land.
- Dead-peer recovery relies on systemd `Restart=on-failure` (`docs/deploy/cascadia-worker.service` updated to put `StartLimit*` in `[Unit]` so the burst cap applies).

## How to test

No hardware needed. Build the `cascadia` binary first — the `cascadia-tests-e2e` harness spawns it (`target/debug/cascadia`), and a bare `cargo test --workspace` / `just check` does not build bins:

```bash
cargo build -p cascadia
```

```bash
cargo test --workspace
```

Key areas:

```bash
cargo test -p cascadia-transport
```

ceiling-fatal / peer-RST / mid-frame-stall fatal, clamp/resolver units, idle stress.

```bash
cargo test -p cascadia-runner
```

relay dead-peer exit, persistently-failing-step throttle, step-`Err` task attribution.

## Base

Base `pawan/configurable-activation-timeout`. Lands in the runtime pinned rev; enterprise (cascadia-enterprise#37) then bumps the pin to consume it.

