### PR TITLE
test(e2e): sharded multi-stage pipeline tests (loopback + cross-node via fleet)

### DIFF
--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -130,11 +130,16 @@ impl MockPipeline {
             let is_last = rank == stages - 1;
             let mut args: Vec<String> = vec![
                 "worker".into(),
-                "--rank".into(), rank.to_string(),
-                "--total".into(), stages.to_string(),
-                "--engine".into(), "mock".into(),
-                "--model".into(), "mock-model".into(),
-                "--log-level".into(), "warn".into(),
+                "--rank".into(),
+                rank.to_string(),
+                "--total".into(),
+                stages.to_string(),
+                "--engine".into(),
+                "mock".into(),
+                "--model".into(),
+                "mock-model".into(),
+                "--log-level".into(),
+                "warn".into(),
             ];
             if !is_first {
                 args.push("--listen".into());
@@ -159,7 +164,10 @@ impl MockPipeline {
             // Give the stage a moment to bind before its upstream connects.
             tokio::time::sleep(Duration::from_millis(400)).await;
         }
-        Self { api_port, stages: procs }
+        Self {
+            api_port,
+            stages: procs,
+        }
     }
 
     pub async fn wait_for_health(&self, timeout: Duration) -> bool {
@@ -294,7 +302,11 @@ mod tests {
             .send()
             .await
             .expect("post chat to pipeline entry");
-        assert!(r.status().is_success(), "pipeline chat status: {}", r.status());
+        assert!(
+            r.status().is_success(),
+            "pipeline chat status: {}",
+            r.status()
+        );
         let v: serde_json::Value = r.json().await.unwrap();
         assert_eq!(v["choices"][0]["message"]["role"], "assistant");
         let content = v["choices"][0]["message"]["content"]
@@ -328,8 +340,8 @@ mod tests {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect();
-        let remote_bin =
-            std::env::var("CASCADIA_REMOTE_BIN").unwrap_or_else(|_| "C:/cascadia/cascadia.exe".into());
+        let remote_bin = std::env::var("CASCADIA_REMOTE_BIN")
+            .unwrap_or_else(|_| "C:/cascadia/cascadia.exe".into());
         // Defaults give a mock run; set CASCADIA_ENGINE/MODEL/DEVICE for a real
         // sharded model (e.g. ov-runtime + a shard dir + GPU).
         let engine = std::env::var("CASCADIA_ENGINE").unwrap_or_else(|_| "mock".into());
@@ -354,7 +366,10 @@ mod tests {
             .expect("topology up");
         assert!(up.status().is_success(), "topology up: {}", up.status());
         let up: serde_json::Value = up.json().await.unwrap();
-        let entry = up["entry_url"].as_str().expect("entry_url in response").to_string();
+        let entry = up["entry_url"]
+            .as_str()
+            .expect("entry_url in response")
+            .to_string();
 
         // Run the request, capturing the outcome so teardown always happens.
         let outcome: Result<(), String> = async {

--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -101,6 +101,95 @@ impl Drop for CascadiaProc {
     }
 }
 
+/// A multi-stage mock pipeline spawned on loopback (one process per stage).
+///
+/// Exercises the full sharded path — pipeline wiring, the activation transport
+/// between stages, and request routing — with the mock engine, so it needs no
+/// model weights or GPU and is deterministic. This is the single-machine
+/// version of a sharded deployment; the cross-node version is driven by the
+/// fleet (see `multi_node_pipeline_via_fleet`).
+pub struct MockPipeline {
+    pub api_port: u16,
+    pub stages: Vec<Child>,
+}
+
+impl MockPipeline {
+    /// Spawn an N-stage mock pipeline on 127.0.0.1, downstream-first (each
+    /// upstream needs its downstream listening before it connects).
+    pub async fn spawn(stages: usize) -> Self {
+        assert!(stages >= 1, "need at least one stage");
+        let bin = binary_path();
+        assert!(bin.exists(), "cascadia binary not built ({:?})", bin);
+
+        let api_port = pick_free_port();
+        let listen_ports: Vec<u16> = (0..stages).map(|_| pick_free_port()).collect();
+        let mut procs = Vec::with_capacity(stages);
+
+        for rank in (0..stages).rev() {
+            let is_first = rank == 0;
+            let is_last = rank == stages - 1;
+            let mut args: Vec<String> = vec![
+                "worker".into(),
+                "--rank".into(), rank.to_string(),
+                "--total".into(), stages.to_string(),
+                "--engine".into(), "mock".into(),
+                "--model".into(), "mock-model".into(),
+                "--log-level".into(), "warn".into(),
+            ];
+            if !is_first {
+                args.push("--listen".into());
+                args.push(format!("127.0.0.1:{}", listen_ports[rank]));
+            }
+            if !is_last {
+                args.push("--next".into());
+                args.push(format!("127.0.0.1:{}", listen_ports[rank + 1]));
+            }
+            if is_first {
+                args.push("--api".into());
+                args.push(format!("127.0.0.1:{api_port}"));
+            }
+            let child = Command::new(&bin)
+                .args(&args)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .kill_on_drop(true)
+                .spawn()
+                .expect("spawn pipeline stage");
+            procs.push(child);
+            // Give the stage a moment to bind before its upstream connects.
+            tokio::time::sleep(Duration::from_millis(400)).await;
+        }
+        Self { api_port, stages: procs }
+    }
+
+    pub async fn wait_for_health(&self, timeout: Duration) -> bool {
+        let client = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:{}/health", self.api_port);
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Ok(r) = client.get(&url).send().await {
+                if r.status().is_success() {
+                    return true;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        false
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.api_port, path)
+    }
+}
+
+impl Drop for MockPipeline {
+    fn drop(&mut self) {
+        for c in &mut self.stages {
+            let _ = c.start_kill();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,5 +268,122 @@ mod tests {
                 r.status()
             );
         }
+    }
+
+    /// Sharded pipeline on one machine (loopback): two mock stages wired
+    /// rank 0 (entry+API) -> rank 1. Exercises the activation transport and
+    /// request routing through the chain without weights/GPU. Runs in CI.
+    #[tokio::test]
+    async fn multi_stage_mock_pipeline_loopback() {
+        let pipe = MockPipeline::spawn(2).await;
+        assert!(
+            pipe.wait_for_health(Duration::from_secs(20)).await,
+            "2-stage pipeline entry did not become healthy"
+        );
+
+        let client = reqwest::Client::new();
+        let body = serde_json::json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "alpha bravo charlie"}],
+            "max_tokens": 2,
+            "stream": false,
+        });
+        let r = client
+            .post(pipe.url("/v1/chat/completions"))
+            .json(&body)
+            .send()
+            .await
+            .expect("post chat to pipeline entry");
+        assert!(r.status().is_success(), "pipeline chat status: {}", r.status());
+        let v: serde_json::Value = r.json().await.unwrap();
+        assert_eq!(v["choices"][0]["message"]["role"], "assistant");
+        let content = v["choices"][0]["message"]["content"]
+            .as_str()
+            .expect("content string");
+        assert!(!content.is_empty(), "pipeline produced empty completion");
+    }
+
+    /// Cross-node sharded e2e: brings up an N-stage topology across real fleet
+    /// nodes via the control plane, runs a request through it, tears down.
+    /// Gated behind CASCADIA_MULTINODE=1 (live fleet only). Requires env:
+    ///   CASCADIA_FLEET_CONTROL  http://<control-plane>:8765
+    ///   CASCADIA_FLEET_TOKEN    shared fleet token
+    ///   CASCADIA_FLEET_NODES    ordered node_ids, comma-separated (rank 0 first)
+    ///   CASCADIA_REMOTE_BIN     path to the cascadia binary on the nodes
+    #[tokio::test]
+    async fn multi_node_pipeline_via_fleet() {
+        if std::env::var("CASCADIA_MULTINODE").ok().as_deref() != Some("1") {
+            eprintln!("skipping multi_node_pipeline_via_fleet (set CASCADIA_MULTINODE=1)");
+            return;
+        }
+        let control = std::env::var("CASCADIA_FLEET_CONTROL").expect("CASCADIA_FLEET_CONTROL");
+        let token = std::env::var("CASCADIA_FLEET_TOKEN").expect("CASCADIA_FLEET_TOKEN");
+        let nodes: Vec<String> = std::env::var("CASCADIA_FLEET_NODES")
+            .expect("CASCADIA_FLEET_NODES")
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let remote_bin =
+            std::env::var("CASCADIA_REMOTE_BIN").unwrap_or_else(|_| "C:/cascadia/cascadia.exe".into());
+        let name = "e2e-multinode";
+        let command = format!(
+            "{remote_bin} worker --engine mock --model mock-model --log-level warn \
+             --rank {{rank}} --total {{total}} {{listen_flag}} {{next_flag}} {{api_flag}}"
+        );
+        let client = reqwest::Client::new();
+
+        let up = client
+            .post(format!("{control}/topology/up"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({"name": name, "nodes": nodes, "command": command}))
+            .send()
+            .await
+            .expect("topology up");
+        assert!(up.status().is_success(), "topology up: {}", up.status());
+        let up: serde_json::Value = up.json().await.unwrap();
+        let entry = up["entry_url"].as_str().expect("entry_url in response").to_string();
+
+        // Run the request, capturing the outcome so teardown always happens.
+        let outcome: Result<(), String> = async {
+            let deadline = Instant::now() + Duration::from_secs(60);
+            let mut healthy = false;
+            while Instant::now() < deadline {
+                if let Ok(r) = client.get(format!("{entry}/health")).send().await {
+                    if r.status().is_success() {
+                        healthy = true;
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            if !healthy {
+                return Err(format!("pipeline entry {entry} never became healthy"));
+            }
+            let r = client
+                .post(format!("{entry}/v1/chat/completions"))
+                .json(&serde_json::json!({
+                    "model": "mock-model",
+                    "messages": [{"role": "user", "content": "hello world"}],
+                    "max_tokens": 2,
+                }))
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if !r.status().is_success() {
+                return Err(format!("chat status {}", r.status()));
+            }
+            Ok(())
+        }
+        .await;
+
+        let _ = client
+            .post(format!("{control}/topology/down"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({"name": name, "nodes": nodes}))
+            .send()
+            .await;
+
+        outcome.expect("multi-node pipeline request failed");
     }
 }

--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -310,6 +310,10 @@ mod tests {
     ///   CASCADIA_FLEET_TOKEN    shared fleet token
     ///   CASCADIA_FLEET_NODES    ordered node_ids, comma-separated (rank 0 first)
     ///   CASCADIA_REMOTE_BIN     path to the cascadia binary on the nodes
+    /// Optional (defaults to a mock run; set for a real sharded model):
+    ///   CASCADIA_ENGINE  engine, default "mock" (e.g. "ov-runtime")
+    ///   CASCADIA_MODEL   model id / shard dir on the nodes, default "mock-model"
+    ///   CASCADIA_DEVICE  device for OV engines, e.g. "GPU" (omitted for mock)
     #[tokio::test]
     async fn multi_node_pipeline_via_fleet() {
         if std::env::var("CASCADIA_MULTINODE").ok().as_deref() != Some("1") {
@@ -326,9 +330,17 @@ mod tests {
             .collect();
         let remote_bin =
             std::env::var("CASCADIA_REMOTE_BIN").unwrap_or_else(|_| "C:/cascadia/cascadia.exe".into());
+        // Defaults give a mock run; set CASCADIA_ENGINE/MODEL/DEVICE for a real
+        // sharded model (e.g. ov-runtime + a shard dir + GPU).
+        let engine = std::env::var("CASCADIA_ENGINE").unwrap_or_else(|_| "mock".into());
+        let model = std::env::var("CASCADIA_MODEL").unwrap_or_else(|_| "mock-model".into());
+        let device_flag = match std::env::var("CASCADIA_DEVICE") {
+            Ok(d) if !d.is_empty() => format!("--device {d}"),
+            _ => String::new(),
+        };
         let name = "e2e-multinode";
         let command = format!(
-            "{remote_bin} worker --engine mock --model mock-model --log-level warn \
+            "{remote_bin} worker --engine {engine} --model {model} {device_flag} --log-level warn \
              --rank {{rank}} --total {{total}} {{listen_flag}} {{next_flag}} {{api_flag}}"
         );
         let client = reqwest::Client::new();


### PR DESCRIPTION
Lets us test **sharded / pipeline-parallel deployments** in this repo.

- **`MockPipeline`** harness spawns an N-stage mock pipeline (one process per stage), wiring rank 0 (entry + `--api`) → … → last, started downstream-first.
- **`multi_stage_mock_pipeline_loopback`** — a 2-stage chain on loopback that exercises the activation transport and request routing through the pipeline with the mock engine (no weights/GPU, deterministic). **Runs in CI** (built + passing locally). This covers the sharding/transport/routing logic on one machine.
- **`multi_node_pipeline_via_fleet`** — brings up a *cross-node* topology across real AI-PC nodes via the fleet control plane's `/topology` API, runs a request through it, tears down. Gated behind `CASCADIA_MULTINODE=1` (live fleet only); swap `--engine mock` for `ov-runtime` + a sharded model dir for real-model runs.

Depends on the fleet-side orchestration in `cascadia-fleet#2` (`/topology` API + the `pull_artifact` deploy fix for staging shards). See `cascadia-fleet/docs/MULTINODE_TESTING.md`.