### PR TITLE
test(e2e): multi-node pipeline review follow-ups

### DIFF
--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -6,7 +6,10 @@
 //!
 //! Run via:
 //!     cargo build -p cascadia
-//!     cargo test -p cascadia-tests-e2e -- --test-threads=1
+//!     cargo test -p cascadia-tests-e2e
+//!
+//! Every test binds ephemeral ports (see [`pick_free_port`]), so they run
+//! in parallel safely — `--test-threads=1` is not required.
 
 use std::net::TcpListener;
 use std::path::PathBuf;
@@ -15,6 +18,11 @@ use std::time::{Duration, Instant};
 use tokio::process::{Child, Command};
 
 /// Find a free TCP port to avoid collisions when tests run in parallel.
+///
+/// There is an unavoidable TOCTOU window: the port is free when we drop the
+/// listener but could be claimed by another process before the caller binds
+/// it. The pick→spawn gap is small and the ephemeral range is large, so
+/// collisions are vanishingly rare — this is the standard bind-to-`:0` trick.
 pub fn pick_free_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
     let port = listener.local_addr().unwrap().port();
@@ -161,8 +169,10 @@ impl MockPipeline {
                 .spawn()
                 .expect("spawn pipeline stage");
             procs.push(child);
-            // Give the stage a moment to bind before its upstream connects.
-            tokio::time::sleep(Duration::from_millis(400)).await;
+            // No inter-stage sleep needed: stages are spawned downstream-first
+            // and the activation transport retries its connect (every 500ms up
+            // to DEFAULT_CONNECT_TIMEOUT = 30s), so an upstream simply waits out
+            // the gap until its downstream is bound and accepting.
         }
         Self {
             api_port,
@@ -390,7 +400,7 @@ mod tests {
             let r = client
                 .post(format!("{entry}/v1/chat/completions"))
                 .json(&serde_json::json!({
-                    "model": "mock-model",
+                    "model": model,
                     "messages": [{"role": "user", "content": "hello world"}],
                     "max_tokens": 2,
                 }))


### PR DESCRIPTION
Follow-up nits from the review of #83 (now merged). All changes are in `tests-e2e/src/lib.rs`; no behavior change to the harness.

- **Remove the per-stage 400ms bind sleep** in `MockPipeline::spawn`. Stages are spawned downstream-first and the activation transport already retries its connect (every 500ms up to `DEFAULT_CONNECT_TIMEOUT` = 30s), so the fixed sleep was redundant. The loopback test now runs in ~0.1s (was ~0.8s) and stayed green across repeated runs.
- **Fleet test uses the parameterized `model`** in the chat request instead of a hardcoded `"mock-model"`, matching the worker's `--model` and the `CASCADIA_MODEL` override. (The API only echoes `req.model`, so this was cosmetic — but now consistent for real-model runs.)
- **Document the `pick_free_port` TOCTOU window** so the bind-to-`:0` race is acknowledged rather than surprising.
- **Drop the stale `--test-threads=1`** from the module docs — every test binds ephemeral ports, so parallel execution is safe.

## Verification
- `cargo fmt --all -- --check` clean, `cargo clippy -p cascadia-tests-e2e --all-targets` clean
- `cargo build -p cascadia` + `cargo test -p cascadia-tests-e2e` — all 4 e2e tests pass
- `multi_stage_mock_pipeline_loopback` run 5× consecutively, green each time

## Deliberately out of scope
The AI-PC CI flake (`can't find crate for tokenizers` from shared `CARGO_HOME` cache contention on the self-hosted Windows runner) is an infra issue, not a code one, and is left for a separate change to the workflow/runner config.