### PR TITLE
feat(sparse-moe): pipeline-parallel MiniMax-M2 across ranks

### DIFF
--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -349,19 +349,19 @@ impl Builder for SparseMoEBuilder {
         }
 
         // OV-IR shell backend (MiniMax-M2): the whole architecture lives in
-        // the traced graphs, so we run a dedicated single-stage runner
-        // instead of the K2.6 MLA kernel. Pipeline-parallel isn't wired for
-        // this backend yet (the K2.6 transport path assumes the Rust shell).
+        // the traced graphs, so we run a dedicated runner instead of the
+        // K2.6 MLA kernel. Single-stage loads the whole model; multi-stage
+        // (total > 1) loads a contiguous layer slice per rank and exchanges
+        // F32 hidden states over the same engine-agnostic dist wire protocol
+        // the K2.6 path uses (rank 0 embeds + drives, the last rank runs the
+        // head + sampler).
         let is_ov = Manifest::load(&self.config.model_dir)
             .map(|m| m.is_ov_shell())
             .unwrap_or(false);
         if is_ov {
-            if self.config.total > 1 {
-                return Err(EngineError::InvalidConfig(
-                    "ov_ir shell backend (MiniMax-M2) is single-stage only; total must be 1".into(),
-                ));
-            }
             let cfg = self.config.clone();
+            let total = cfg.total.max(1);
+            let rank = cfg.rank.min(total - 1);
             let opts = resolve_runner_options(&cfg);
             let cap = opts.max_cached_experts;
             let plugin_for_worker = plugin.clone();
@@ -372,24 +372,35 @@ impl Builder for SparseMoEBuilder {
                         "loading MiniMax-M2 (OV-IR sparse-MoE)",
                     ))
                     .ok();
-                    OvMoeRunner::load(cfg.model_dir.clone(), &cfg.device, plugin_for_worker, cap)
+                    OvMoeRunner::load_staged(
+                        cfg.model_dir.clone(),
+                        &cfg.device,
+                        plugin_for_worker,
+                        cap,
+                        rank,
+                        total,
+                    )
                 });
             let ov_runner = match join.join() {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => return Err(EngineError::Backend(format!("ov-moe load: {e}"))),
                 Err(_) => return Err(EngineError::Backend("ov-moe load worker panicked".into())),
             };
-            let tok_path = self.config.model_dir.join("tokenizer.json");
-            if tok_path.exists() {
-                self.tokenizer = Some(
-                    Tokenizer::from_file(&tok_path)
-                        .map_err(|e| EngineError::Backend(format!("load tokenizer.json: {e}")))?,
-                );
-            } else {
-                warn!(
-                    "no tokenizer.json at {} — engine will only accept pre-tokenized inputs",
-                    tok_path.display()
-                );
+            // The tokenizer is only needed on rank 0 (the API rank); worker
+            // ranks drive themselves from the hidden states on the wire.
+            if rank == 0 {
+                let tok_path = self.config.model_dir.join("tokenizer.json");
+                if tok_path.exists() {
+                    self.tokenizer =
+                        Some(Tokenizer::from_file(&tok_path).map_err(|e| {
+                            EngineError::Backend(format!("load tokenizer.json: {e}"))
+                        })?);
+                } else {
+                    warn!(
+                        "no tokenizer.json at {} — engine will only accept pre-tokenized inputs",
+                        tok_path.display()
+                    );
+                }
             }
             self.ov_runner = Some(ov_runner);
             let drained: Vec<LoadProgress> = rx.try_iter().collect();
@@ -502,13 +513,33 @@ impl Builder for SparseMoEBuilder {
 
     fn build(self: Box<Self>) -> EngineResult<Box<dyn Engine>> {
         if let Some(ov) = self.ov_runner {
-            if self.tokenizer.is_none() {
+            let total = self.config.total.max(1);
+            let rank = self.config.rank.min(total - 1);
+            // Only rank 0 (the API rank) needs a tokenizer; worker ranks
+            // drive themselves from the hidden states on the wire.
+            if rank == 0 && self.tokenizer.is_none() {
                 return Err(EngineError::Backend(
-                    "tokenizer.json missing (required for the MiniMax-M2 engine)".into(),
+                    "tokenizer.json missing (required for the MiniMax-M2 API rank)".into(),
                 ));
             }
-            info!("built MiniMax-M2 OV-IR engine (single-stage)");
-            return Ok(Box::new(OvMoeEngine::new(ov, self.tokenizer)));
+            let runtime_handle = tokio::runtime::Handle::try_current()
+                .map_err(|_| EngineError::Backend("Builder::build outside tokio context".into()))?;
+            if total > 1 {
+                info!(
+                    rank,
+                    total, "built MiniMax-M2 OV-IR engine (pipeline-parallel)"
+                );
+            } else {
+                info!("built MiniMax-M2 OV-IR engine (single-stage)");
+            }
+            return Ok(Box::new(OvMoeEngine::new(
+                ov,
+                self.tokenizer,
+                self.transport,
+                runtime_handle,
+                rank,
+                total,
+            )));
         }
         let runner = self.runner.ok_or(EngineError::NotLoaded)?;
         let total = self.config.total.max(1);
@@ -1742,52 +1773,76 @@ impl SparseMoEEngine {
 
 const OV_MAX_PENDING: usize = 64;
 
-/// Single-stage engine for the OV-IR shell backend (MiniMax-M2).
+/// Engine for the OV-IR shell backend (MiniMax-M2).
 ///
-/// Greedy-only for v1: `OvMoeRunner` argmaxes each step, so sampling
-/// config (temperature / penalties) is ignored. The whole architecture is
-/// baked into the exported OV graphs, so this engine just tokenizes, drives
-/// [`OvMoeRunner::generate_argmax`], and decodes — no pipeline transport.
+/// - **Single-stage** (`total == 1`): one engine holds the whole model and
+///   drives [`OvMoeRunner::generate`] end-to-end (the path the tiny
+///   correctness test and the 230B smoke exercise).
+/// - **Pipeline-parallel** (`total > 1`): each rank holds a contiguous
+///   layer slice. Rank 0 embeds the token, runs its shells, and ships the
+///   F32 hidden state downstream over `cascadia-transport`; middle ranks
+///   relay; the last rank runs the head + sampler and returns the token
+///   upstream. The wire protocol is the engine-agnostic [`crate::dist`]
+///   one the K2.6 path uses (Forward / Reset / Token frames). No
+///   spec-decode (M2 sends only per-token Forward frames).
 pub struct OvMoeEngine {
     runner: OvMoeRunner,
     tokenizer: Option<Tokenizer>,
     pending: VecDeque<GenerationTask>,
+    transport: StageTransport,
+    runtime_handle: tokio::runtime::Handle,
+    rank: u32,
+    total: u32,
+    /// Set on a worker rank when the upstream socket closes cleanly, so
+    /// `step_worker` doesn't hot-spin on `recv_kind_server` → `Ok(None)`.
+    peer_disconnected: bool,
+    /// Last-rank only: tokens this rank has sampled since the last `Reset`,
+    /// used as the repetition-penalty `history`. Like the K2.6 path, prompt
+    /// tokens are not mirrored here (they flow only as hidden states), so
+    /// the rep-penalty window covers generated tokens only. Greedy
+    /// (`repetition_penalty == 1.0`) is unaffected, so a greedy pipeline
+    /// run matches the single-stage greedy output exactly.
+    last_rank_history: Vec<i64>,
+    last_rank_rng: u64,
+    last_rank_rng_seeded: bool,
 }
 
 impl OvMoeEngine {
-    fn new(runner: OvMoeRunner, tokenizer: Option<Tokenizer>) -> Self {
+    fn new(
+        runner: OvMoeRunner,
+        tokenizer: Option<Tokenizer>,
+        transport: StageTransport,
+        runtime_handle: tokio::runtime::Handle,
+        rank: u32,
+        total: u32,
+    ) -> Self {
         Self {
             runner,
             tokenizer,
             pending: VecDeque::new(),
-        }
-    }
-}
-
-impl Engine for OvMoeEngine {
-    fn warmup(&mut self) {
-        if let Some(tok) = self.tokenizer.as_ref() {
-            let ids: Vec<u32> = tok
-                .encode("Hello", false)
-                .map(|e| e.get_ids().to_vec())
-                .unwrap_or_else(|_| vec![1]);
-            let _ = self.runner.generate_argmax(&ids, 1);
-            info!("warmup: generated 1 token (MiniMax-M2)");
+            transport,
+            runtime_handle,
+            rank,
+            total,
+            peer_disconnected: false,
+            last_rank_history: Vec::new(),
+            last_rank_rng: 0,
+            last_rank_rng_seeded: false,
         }
     }
 
-    fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
-        if self.pending.len() >= OV_MAX_PENDING {
-            return Err(EngineError::QueueFull {
-                queued: self.pending.len(),
-                cap: OV_MAX_PENDING,
-            });
-        }
-        self.pending.push_back(task);
-        Ok(())
+    /// Bridge sync `Engine::step` code to an async transport future (same
+    /// thread-local fast path the K2.6 engine uses on worker ranks).
+    fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
+        cascadia_runner::run_async(&self.runtime_handle, fut)
     }
 
-    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+    fn is_last(&self) -> bool {
+        self.transport.is_last()
+    }
+
+    /// Single-stage path: tokenize, run the whole model, decode.
+    fn step_single_stage(&mut self) -> Vec<(TaskId, Chunk)> {
         let task = match self.pending.pop_front() {
             Some(t) => t,
             None => return Vec::new(),
@@ -1826,6 +1881,292 @@ impl Engine for OvMoeEngine {
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
         vec![(task.task_id.clone(), chunk)]
+    }
+
+    /// Rank-0 driver: embed + run my shells, ship hidden downstream, await
+    /// the sampled token back. Returns the token the last rank sampled.
+    fn forward_one_token_first(
+        &mut self,
+        token: u32,
+        pos: usize,
+        cfg: &crate::sampling::SamplingConfig,
+        downstream: &Arc<TokioMutex<ActivationClient>>,
+    ) -> Result<i64, String> {
+        let hidden = self
+            .runner
+            .embed_token(token)
+            .map_err(|e| format!("embed: {e}"))?;
+        let hidden = self
+            .runner
+            .forward_layers(hidden, pos)
+            .map_err(|e| format!("forward: {e}"))?;
+        let h = self.runner.hidden_size() as u32;
+        self.block_on(async {
+            send_forward(downstream, pos as u32, cfg, &hidden, [1, 1, h])
+                .await
+                .map_err(|e| format!("send_forward: {e}"))?;
+            match recv_kind_client(downstream).await {
+                Ok(Some(FrameKind::Token)) => recv_token_body_client(downstream)
+                    .await
+                    .map_err(|e| format!("recv_token: {e}")),
+                Ok(Some(other)) => Err(format!("rank 0 expected Token, got {other:?}")),
+                Ok(None) => Err("downstream closed before Token".into()),
+                Err(e) => Err(format!("recv_kind: {e}")),
+            }
+        })
+    }
+
+    /// Rank-0 pipeline driver: tokenize, reset the ring, drive prefill +
+    /// decode one token per wire round-trip, decode, emit one final chunk.
+    fn step_first(&mut self) -> Vec<(TaskId, Chunk)> {
+        let task = match self.pending.pop_front() {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
+        let id = task.task_id.clone();
+        let Some(downstream) = self.transport.downstream.clone() else {
+            warn!(task = %id, "rank 0 has no downstream; cannot drive pipeline");
+            return vec![(id.clone(), Chunk::error(id, "rank 0 missing downstream"))];
+        };
+        if self.tokenizer.is_none() {
+            warn!(task = %id, "MiniMax-M2 rank 0 has no tokenizer");
+            return vec![(id.clone(), Chunk::final_marker(id, ""))];
+        }
+        let started = Instant::now();
+        let prompt_ids: Vec<u32> = match self
+            .tokenizer
+            .as_ref()
+            .unwrap()
+            .encode(task.prompt.as_str(), true)
+        {
+            Ok(enc) => enc.get_ids().to_vec(),
+            Err(e) => {
+                warn!(task = %id, "tokenizer encode failed: {e}");
+                return vec![(id.clone(), Chunk::final_marker(id, ""))];
+            }
+        };
+        if prompt_ids.is_empty() {
+            return vec![(id.clone(), Chunk::final_marker(id, ""))];
+        }
+        let max_new = task.max_tokens.max(1) as usize;
+        let cfg = sampling_from_task(&task);
+        let eos = self.runner.eos_token_ids().to_vec();
+
+        // Reset KV across the whole pipeline before the new generation.
+        self.runner.reset();
+        if let Err(e) = self.block_on(send_reset(&downstream)) {
+            warn!(task = %id, "send_reset failed: {e}");
+            return vec![(id.clone(), Chunk::error(id, format!("reset: {e}")))];
+        }
+
+        // Prefill: feed every prompt token. The sample produced after the
+        // LAST prompt token is the first generated token — matching
+        // `OvMoeRunner::generate_timed`.
+        let mut pos = 0usize;
+        let mut next: i64 = -1;
+        for &t in &prompt_ids {
+            match self.forward_one_token_first(t, pos, &cfg, &downstream) {
+                Ok(tok_back) => next = tok_back,
+                Err(e) => {
+                    warn!(task = %id, "prefill forward failed: {e}");
+                    return vec![(id.clone(), Chunk::error(id, e))];
+                }
+            }
+            pos += 1;
+        }
+
+        // Decode: like generate_timed, push the token then stop on max_new
+        // or EOS (the EOS token is included in the output).
+        let mut generated: Vec<u32> = Vec::with_capacity(max_new);
+        loop {
+            let next_u = next as u32;
+            generated.push(next_u);
+            if generated.len() >= max_new || eos.contains(&next_u) {
+                break;
+            }
+            match self.forward_one_token_first(next_u, pos, &cfg, &downstream) {
+                Ok(tok_back) => next = tok_back,
+                Err(e) => {
+                    warn!(task = %id, "decode forward failed; emitting partial output: {e}");
+                    break;
+                }
+            }
+            pos += 1;
+        }
+
+        let n_tokens = generated.len() as u32;
+        let text = self
+            .tokenizer
+            .as_ref()
+            .unwrap()
+            .decode(&generated, true)
+            .unwrap_or_default();
+        let elapsed = started.elapsed().as_secs_f64();
+        info!(
+            task = %id,
+            tokens = n_tokens,
+            total = self.total,
+            elapsed_s = elapsed,
+            tok_s = if elapsed > 0.0 { n_tokens as f64 / elapsed } else { 0.0 },
+            "task done (MiniMax-M2 pipeline-parallel)"
+        );
+        let mut chunk = Chunk::final_marker(id.clone(), text);
+        chunk.n_tokens = Some(n_tokens);
+        vec![(id, chunk)]
+    }
+
+    /// Worker rank (rank > 0): service one frame from upstream per call.
+    fn step_worker(&mut self) -> Vec<(TaskId, Chunk)> {
+        if self.peer_disconnected {
+            std::thread::sleep(WORKER_BACKOFF);
+            return Vec::new();
+        }
+        let Some(upstream) = self.transport.upstream.clone() else {
+            warn!("worker rank has no upstream socket");
+            std::thread::sleep(WORKER_BACKOFF);
+            return Vec::new();
+        };
+        let downstream = self.transport.downstream.clone();
+        let kind = match self.block_on(recv_kind_server(&upstream)) {
+            Ok(Some(k)) => k,
+            Ok(None) => {
+                self.peer_disconnected = true;
+                return Vec::new();
+            }
+            Err(e) => {
+                warn!("worker recv_kind failed: {e}");
+                std::thread::sleep(WORKER_BACKOFF);
+                return Vec::new();
+            }
+        };
+        let res = match kind {
+            FrameKind::Reset => {
+                self.runner.reset();
+                self.last_rank_history.clear();
+                self.last_rank_rng_seeded = false;
+                match downstream.as_ref() {
+                    Some(down) => self
+                        .block_on(forward_reset(down))
+                        .map_err(|e| format!("forward_reset: {e}")),
+                    None => Ok(()),
+                }
+            }
+            FrameKind::Forward => self.handle_forward(&upstream, downstream.as_ref()),
+            other => Err(format!(
+                "worker received unsupported frame {other:?} (MiniMax-M2 has no spec-decode batching)"
+            )),
+        };
+        if let Err(e) = res {
+            warn!("worker frame failed: {e}");
+            std::thread::sleep(WORKER_BACKOFF);
+        }
+        Vec::new()
+    }
+
+    /// Handle one Forward frame on a worker rank: run my shells, then
+    /// either (last rank) head + sample + Token upstream, or (middle rank)
+    /// relay the hidden downstream and pass the returned Token back up.
+    fn handle_forward(
+        &mut self,
+        upstream: &Arc<TokioMutex<ActivationServer>>,
+        downstream: Option<&Arc<TokioMutex<ActivationClient>>>,
+    ) -> Result<(), String> {
+        let (past_seq_len, sampling_cfg, hidden_f32, _shape) = self
+            .block_on(recv_forward_body_server(upstream))
+            .map_err(|e| format!("recv_forward_body: {e}"))?;
+        let pos = past_seq_len as usize;
+        let hidden = self
+            .runner
+            .forward_layers(hidden_f32, pos)
+            .map_err(|e| format!("forward: {e}"))?;
+        if self.is_last() {
+            let logits = self
+                .runner
+                .head_logits(&hidden)
+                .map_err(|e| format!("head: {e}"))?;
+            if !self.last_rank_rng_seeded {
+                self.last_rank_rng = crate::sampling::init_rng(sampling_cfg.seed);
+                self.last_rank_rng_seeded = true;
+            }
+            let token = crate::sampling::sample(
+                &logits,
+                &self.last_rank_history,
+                &sampling_cfg,
+                &mut self.last_rank_rng,
+            );
+            self.last_rank_history.push(token);
+            self.block_on(send_token_upstream(upstream, token))
+                .map_err(|e| format!("send_token: {e}"))?;
+            Ok(())
+        } else {
+            let down = downstream.ok_or("mid rank missing downstream")?;
+            let h = self.runner.hidden_size() as u32;
+            self.block_on(async {
+                send_forward(down, past_seq_len, &sampling_cfg, &hidden, [1, 1, h])
+                    .await
+                    .map_err(|e| format!("send_forward: {e}"))?;
+                match recv_kind_client(down).await {
+                    Ok(Some(FrameKind::Token)) => {
+                        let t = recv_token_body_client(down)
+                            .await
+                            .map_err(|e| format!("recv_token: {e}"))?;
+                        send_token_upstream(upstream, t)
+                            .await
+                            .map_err(|e| format!("relay token: {e}"))?;
+                        Ok(())
+                    }
+                    Ok(Some(other)) => Err(format!("mid rank expected Token, got {other:?}")),
+                    Ok(None) => Err("downstream closed before Token".into()),
+                    Err(e) => Err(format!("recv_kind: {e}")),
+                }
+            })
+        }
+    }
+}
+
+impl Engine for OvMoeEngine {
+    fn warmup(&mut self) {
+        // Only rank 0 (single-stage or the API rank) self-warms; worker
+        // ranks are warmed by the first real generation's prefill, which
+        // drives the whole ring in lockstep.
+        if self.total == 1 {
+            if let Some(tok) = self.tokenizer.as_ref() {
+                let ids: Vec<u32> = tok
+                    .encode("Hello", false)
+                    .map(|e| e.get_ids().to_vec())
+                    .unwrap_or_else(|_| vec![1]);
+                let _ = self.runner.generate_argmax(&ids, 1);
+                info!("warmup: generated 1 token (MiniMax-M2)");
+            }
+        }
+    }
+
+    fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
+        if self.rank != 0 {
+            return Err(EngineError::InvalidConfig(
+                "only rank 0 accepts tasks; worker ranks drive themselves from upstream frames"
+                    .into(),
+            ));
+        }
+        if self.pending.len() >= OV_MAX_PENDING {
+            return Err(EngineError::QueueFull {
+                queued: self.pending.len(),
+                cap: OV_MAX_PENDING,
+            });
+        }
+        self.pending.push_back(task);
+        Ok(())
+    }
+
+    fn step(&mut self) -> Vec<(TaskId, Chunk)> {
+        if self.total <= 1 {
+            return self.step_single_stage();
+        }
+        if self.rank == 0 {
+            self.step_first()
+        } else {
+            self.step_worker()
+        }
     }
 }
 

--- a/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
+++ b/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
@@ -271,7 +271,17 @@ impl OvMoeRunner {
         // exporter/Python reference sets SNIPPETS_MODE=DISABLE; the engine
         // must too. This was THE cause of the int4/int8/NF4 "degrades after
         // the first sentence" — not expert quantization.
-        let plugin = plugin.with("SNIPPETS_MODE", "DISABLE");
+        //
+        // SNIPPETS_MODE is a CPU-plugin option; the GPU plugin rejects it
+        // ("Option not found: SNIPPETS_MODE") and the snippets bug is
+        // CPU-specific anyway, so only set it when targeting CPU. This lets
+        // a pipeline rank run on an Intel iGPU (e.g. a NUC stage) while the
+        // CPU ranks keep the workaround.
+        let plugin = if device.eq_ignore_ascii_case("CPU") {
+            plugin.with("SNIPPETS_MODE", "DISABLE")
+        } else {
+            plugin
+        };
         let utf8 = |p: &PathBuf| -> Result<String, OvMoeError> {
             p.to_str()
                 .map(str::to_owned)

--- a/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
+++ b/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
@@ -21,7 +21,11 @@
 //!
 //! Because the graphs carry their own shapes, this path is fully
 //! dimension-agnostic — the same code runs the tiny synthetic M2 used by
-//! the correctness test and the full 230B model. Single-stage only.
+//! the correctness test and the full 230B model. Single-stage (whole model)
+//! and pipeline-parallel (a contiguous layer slice per rank, via
+//! [`OvMoeRunner::load_staged`] + [`OvMoeRunner::embed_token`] /
+//! [`OvMoeRunner::forward_layers`] / [`OvMoeRunner::head_logits`]) share
+//! this same per-layer math.
 
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -200,8 +204,14 @@ pub struct OvMoeRunner {
     device: String,
     plugin: PluginConfig,
 
-    embed: Runtime,
-    head: Runtime,
+    /// Embedding (`layer0`) IR — present only on the first rank
+    /// (`is_first`); `None` on downstream ranks, which receive the
+    /// already-embedded hidden state over the wire.
+    embed: Option<Runtime>,
+    /// Final norm + lm_head IR — present only on the last rank
+    /// (`is_last`); `None` on upstream ranks, which forward the hidden
+    /// state downstream instead of producing logits.
+    head: Option<Runtime>,
     shells: Vec<Runtime>,
     shell_ports: ShellPorts,
     layer_ids: Vec<u32>,
@@ -209,6 +219,9 @@ pub struct OvMoeRunner {
     experts: ExpertCache,
 
     kv: Vec<LayerKv>,
+    // pipeline-parallel role
+    is_first: bool,
+    is_last: bool,
     // cached dims
     hidden: usize,
     kv_heads: usize,
@@ -218,11 +231,30 @@ pub struct OvMoeRunner {
 }
 
 impl OvMoeRunner {
+    /// Load the whole model on one node (single-stage). Equivalent to
+    /// [`Self::load_staged`] with `rank=0, total=1`.
     pub fn load(
         model_dir: PathBuf,
         device: &str,
         plugin: PluginConfig,
         max_cached_experts: Option<NonZeroUsize>,
+    ) -> Result<Self, OvMoeError> {
+        Self::load_staged(model_dir, device, plugin, max_cached_experts, 0, 1)
+    }
+
+    /// Load this rank's contiguous slice of the model for pipeline-parallel
+    /// inference. Rank 0 owns the embedding (`layer0` IR); the last rank
+    /// owns the head; every rank owns an even slice of the transformer
+    /// shells (+ their experts). `total == 1` loads the whole model — the
+    /// path [`Self::load`] uses. The hidden state flows rank→rank as F32
+    /// over `cascadia-transport`; each rank keeps only its own layers' KV.
+    pub fn load_staged(
+        model_dir: PathBuf,
+        device: &str,
+        plugin: PluginConfig,
+        max_cached_experts: Option<NonZeroUsize>,
+        rank: u32,
+        total: u32,
     ) -> Result<Self, OvMoeError> {
         let manifest = Manifest::load(&model_dir)?;
         if !manifest.is_ov_shell() {
@@ -252,24 +284,60 @@ impl OvMoeRunner {
             Ok(Runtime::compile(&utf8(&p)?, device, &plugin)?)
         };
 
+        // Split the transformer shells into one contiguous slice per
+        // rank. Rank 0 also carries the embedding; the last rank also
+        // carries the head. The middle ranks are shells-only relays.
+        let total = total.max(1);
+        let rank = rank.min(total - 1);
+        let is_first = rank == 0;
+        let is_last = rank == total - 1;
+        let all_ids = manifest.ov_layer_ids();
+        let n = all_ids.len();
+        let per = n / total as usize;
+        let rem = n % total as usize;
+        let r = rank as usize;
+        let start = r * per + r.min(rem);
+        let cnt = per + if r < rem { 1 } else { 0 };
+        if cnt == 0 {
+            return Err(OvMoeError::Internal(format!(
+                "rank {rank}/{total} would hold zero of {n} layers; reduce total"
+            )));
+        }
+        let layer_ids: Vec<u32> = all_ids[start..start + cnt].to_vec();
+
         info!(
             arch = %manifest.arch,
             num_layers = manifest.num_layers,
             num_experts = manifest.num_experts,
             top_k = manifest.top_k,
-            "loading OV-IR sparse-MoE model (single-stage)"
+            rank,
+            total,
+            layers = format!("{}..{}", layer_ids.first().copied().unwrap_or(0), layer_ids.last().copied().unwrap_or(0)),
+            "loading OV-IR sparse-MoE model"
         );
 
-        let embed = compile(manifest.layer0_xml(&model_dir))?;
-        let head = compile(manifest.head_xml(&model_dir))?;
+        let embed = if is_first {
+            Some(compile(manifest.layer0_xml(&model_dir))?)
+        } else {
+            None
+        };
+        let head = if is_last {
+            Some(compile(manifest.head_xml(&model_dir))?)
+        } else {
+            None
+        };
 
-        let layer_ids = manifest.ov_layer_ids();
         let mut shells = Vec::with_capacity(layer_ids.len());
         for &lid in &layer_ids {
             shells.push(compile(manifest.shell_xml(&model_dir, lid))?);
         }
         let shell_ports = ShellPorts::resolve(&shells[0])?;
-        info!("compiled {} shells + embed + head", shells.len());
+        info!(
+            "compiled {} shells (embed={}, head={})",
+            shells.len(),
+            is_first,
+            is_last
+        );
 
         let expert_intermediate = manifest.expert_intermediate as usize;
         let experts = match manifest.experts_format.as_str() {
@@ -312,7 +380,25 @@ impl OvMoeRunner {
             layer_ids,
             experts,
             kv,
+            is_first,
+            is_last,
         })
+    }
+
+    /// True on the first rank (owns the embedding).
+    pub fn is_first(&self) -> bool {
+        self.is_first
+    }
+
+    /// True on the last rank (owns the head / produces logits).
+    pub fn is_last(&self) -> bool {
+        self.is_last
+    }
+
+    /// Hidden-state width (`hidden_size`) — the length of the F32 vector
+    /// exchanged between pipeline ranks.
+    pub fn hidden_size(&self) -> usize {
+        self.hidden
     }
 
     pub fn reset(&mut self) {
@@ -392,21 +478,30 @@ impl OvMoeRunner {
         Ok(bytes)
     }
 
-    /// One decode step: returns the raw logits for `token` at absolute
-    /// position `pos`, updating every layer's KV cache. The caller picks
-    /// the next token (argmax / sampling).
-    fn step_logits(&mut self, token: u32, pos: usize) -> Result<Vec<f32>, OvMoeError> {
+    /// Embed one token into a hidden state `[H]` (rank-0 / `is_first`
+    /// only). The downstream ranks receive this over the wire instead.
+    pub fn embed_token(&mut self, token: u32) -> Result<Vec<f32>, OvMoeError> {
+        let embed = self.embed.as_mut().ok_or_else(|| {
+            OvMoeError::Internal("embed_token on a rank without the embedding (not rank 0)".into())
+        })?;
+        let ids = [token as i64];
+        embed.set_input("input_ids", DType::I64, &[1, 1], i64_as_bytes(&ids))?;
+        embed.infer()?;
+        let (_, _, hb) = embed.output(0)?;
+        Ok(bytes_to_f32(&hb)) // [1,1,H]
+    }
+
+    /// Run this rank's shell+expert layers on the incoming hidden state at
+    /// absolute position `pos`, updating this rank's per-layer KV cache and
+    /// returning the outgoing hidden state `[H]`. Architecture-agnostic:
+    /// the same call drives single-stage (all layers) and each pipeline
+    /// rank (its slice). `pos` is the wire `past_seq_len`; the local KV
+    /// `seq` tracks it in lockstep across ranks.
+    pub fn forward_layers(&mut self, hidden: Vec<f32>, pos: usize) -> Result<Vec<f32>, OvMoeError> {
         let h = self.hidden;
         let kv = self.kv_heads;
         let d = self.head_dim;
-
-        // embed
-        let ids = [token as i64];
-        self.embed
-            .set_input("input_ids", DType::I64, &[1, 1], i64_as_bytes(&ids))?;
-        self.embed.infer()?;
-        let (_, _, hb) = self.embed.output(0)?;
-        let mut hidden = bytes_to_f32(&hb); // [1,1,H]
+        let mut hidden = hidden;
 
         for (idx, &lid) in self.layer_ids.clone().iter().enumerate() {
             let p = self.kv[idx].seq;
@@ -453,12 +548,31 @@ impl OvMoeRunner {
                 hidden[j] = residual[j] + shared[j] + moe[j];
             }
         }
+        Ok(hidden)
+    }
 
-        // head
-        self.head
-            .set_input("x", DType::F32, &[1, 1, h], f32_as_bytes(&hidden))?;
-        self.head.infer()?;
-        Ok(bytes_to_f32(&self.head.output(0)?.2))
+    /// Run the head (final norm + lm_head) on the hidden state, returning
+    /// the raw logits (last rank / `is_last` only). The caller samples.
+    pub fn head_logits(&mut self, hidden: &[f32]) -> Result<Vec<f32>, OvMoeError> {
+        let h = self.hidden;
+        let head = self.head.as_mut().ok_or_else(|| {
+            OvMoeError::Internal(
+                "head_logits on a rank without the head (not the last rank)".into(),
+            )
+        })?;
+        head.set_input("x", DType::F32, &[1, 1, h], f32_as_bytes(hidden))?;
+        head.infer()?;
+        Ok(bytes_to_f32(&head.output(0)?.2))
+    }
+
+    /// One single-stage decode step: returns the raw logits for `token` at
+    /// absolute position `pos`, updating every layer's KV cache. Composes
+    /// embed → layers → head, so the pipeline path and the single-stage
+    /// path run identical math. The caller picks the next token.
+    fn step_logits(&mut self, token: u32, pos: usize) -> Result<Vec<f32>, OvMoeError> {
+        let hidden = self.embed_token(token)?;
+        let hidden = self.forward_layers(hidden, pos)?;
+        self.head_logits(&hidden)
     }
 
     /// Generate with a sampling config (repetition penalty / temperature /

--- a/crates/cascadia-engine-sparse-moe/tests/minimax_m2_eval.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/minimax_m2_eval.rs
@@ -74,6 +74,119 @@ fn minimax_m2_tiny_matches_hf_reference() {
     );
 }
 
+/// Pipeline-parallel correctness gate: the SAME tiny model split across two
+/// ranks (rank 0 = embed + first half of the layers, rank 1 = second half +
+/// head) must reproduce the canonical HF greedy stream — i.e. slicing the
+/// model and threading the hidden state rank→rank is numerically identical
+/// to running it whole. Drives the runner slices directly (no sockets) so it
+/// isolates the layer-slice math; the wire format is covered by
+/// `dist_wire.rs` and the CLI loopback run. Gated on `M2_MODEL_DIR`.
+#[test]
+fn minimax_m2_two_rank_pipeline_matches_hf_reference() {
+    let Some(model_dir) = env_dir("M2_MODEL_DIR") else {
+        eprintln!("M2_MODEL_DIR not set / missing; skipping MiniMax-M2 pipeline test");
+        return;
+    };
+
+    let reference: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(model_dir.join("reference.json")).expect("read reference.json"),
+    )
+    .expect("parse reference.json");
+    let prompt: Vec<u32> = reference["prompt_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_u64().unwrap() as u32)
+        .collect();
+    let greedy: Vec<u32> = reference["greedy_tokens"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_u64().unwrap() as u32)
+        .collect();
+
+    let device = std::env::var("CASCADIA_DEVICE").unwrap_or_else(|_| "CPU".to_string());
+    let mut r0 =
+        OvMoeRunner::load_staged(model_dir.clone(), &device, PluginConfig::new(), None, 0, 2)
+            .expect("load rank 0 slice");
+    let mut r1 =
+        OvMoeRunner::load_staged(model_dir.clone(), &device, PluginConfig::new(), None, 1, 2)
+            .expect("load rank 1 slice");
+    assert!(
+        r0.is_first() && !r0.is_last(),
+        "rank 0 should own the embedding but not the head"
+    );
+    assert!(
+        r1.is_last() && !r1.is_first(),
+        "rank 1 should own the head but not the embedding"
+    );
+
+    let n_new = greedy.len() - prompt.len();
+    let generated = drive_two_rank_greedy(&mut r0, &mut r1, &prompt, n_new);
+
+    let mut full = prompt.clone();
+    full.extend_from_slice(&generated);
+    eprintln!("reference greedy : {greedy:?}");
+    eprintln!("2-rank   greedy  : {full:?}");
+    assert_eq!(
+        full, greedy,
+        "2-rank pipeline greedy stream must match the HF reference"
+    );
+}
+
+/// Greedy-drive two pipeline slices in-process: rank 0 embeds + runs its
+/// layers, hands the hidden state to rank 1, which runs its layers + head;
+/// the argmax of rank 1's logits is the next token. Mirrors
+/// [`OvMoeRunner::generate_argmax`] (default/greedy sampling), just with the
+/// layers split across two runners and the hidden state passed by value the
+/// way `cascadia-transport` carries it on the wire.
+fn drive_two_rank_greedy(
+    r0: &mut OvMoeRunner,
+    r1: &mut OvMoeRunner,
+    prompt: &[u32],
+    max_new: usize,
+) -> Vec<u32> {
+    // First-max-wins, matching crate::sampling::argmax used by the runner.
+    fn argmax(xs: &[f32]) -> u32 {
+        let mut best = 0u32;
+        let mut best_v = f32::NEG_INFINITY;
+        for (i, &v) in xs.iter().enumerate() {
+            if v > best_v {
+                best_v = v;
+                best = i as u32;
+            }
+        }
+        best
+    }
+    fn fwd(r0: &mut OvMoeRunner, r1: &mut OvMoeRunner, tok: u32, pos: usize) -> Vec<f32> {
+        let h = r0.embed_token(tok).expect("embed");
+        let h = r0.forward_layers(h, pos).expect("rank 0 layers");
+        let h = r1.forward_layers(h, pos).expect("rank 1 layers");
+        r1.head_logits(&h).expect("head")
+    }
+
+    r0.reset();
+    r1.reset();
+    let eos = r0.eos_token_ids().to_vec();
+    let mut pos = 0usize;
+    let mut logits = Vec::new();
+    for &t in prompt {
+        logits = fwd(r0, r1, t, pos);
+        pos += 1;
+    }
+    let mut out = Vec::with_capacity(max_new);
+    loop {
+        let next = argmax(&logits);
+        out.push(next);
+        if out.len() >= max_new || eos.contains(&next) {
+            break;
+        }
+        logits = fwd(r0, r1, next, pos);
+        pos += 1;
+    }
+    out
+}
+
 /// Real-model generation smoke test. Gated on `M2_GEN_DIR` pointing at a
 /// full MiniMax-M2 export (with tokenizer.json). There's no exact HF
 /// reference at 230B (won't fit in RAM), so this just confirms the Rust


### PR DESCRIPTION
## What

Lets the MiniMax-M2 OV-IR shell backend shard across ranks (pipeline-parallel), instead of single-stage only. Stacked on #65 (base `feat/minimax-m2`); retarget to `main` once #65 merges.

## How

Wires M2 into the **same** pipeline-parallel framework the K2.6 path already uses — the `dist` wire protocol (Forward/Reset/Token, F32 hidden `[1,1,H]`) is engine-agnostic, so M2 (H=3072) needed **zero** wire changes.

- `OvMoeRunner::load_staged(rank, total)`: each rank loads a contiguous even slice of the transformer shells (+ their experts); rank 0 also loads the embedding (`layer0`), the last rank also loads the head. `embed`/`head` become `Option`. `step_logits` is split into `embed_token` / `forward_layers(hidden, pos)` / `head_logits` so the whole-model runner and a per-rank slice run identical math. `load()` is now `load_staged(.., 0, 1)` — single-stage behavior unchanged.
- `OvMoeEngine` gains a multi-stage path mirroring `SparseMoEEngine`: rank 0 drives (embed → its layers → ship hidden downstream → await the sampled token), middle ranks relay, the last rank runs head + sampler and returns the token upstream. No spec-decode (M2 sends only per-token Forward frames). The Builder loads the per-rank slice, gates the tokenizer to rank 0, and passes transport/rank/total into the engine.

## Validation (miner, OpenVINO 2026.1)

- **Exact correctness** — new `minimax_m2_two_rank_pipeline_matches_hf_reference`: the tiny synthetic M2 split across 2 ranks reproduces the canonical HF greedy stream exactly (`[1,2,3,4,5,231,231,229,231,229,231]`). The single-stage tiny gate still passes (no regression).
- **Real distributed engine over TCP (tiny)** — two `cascadia worker` processes connect over sockets and load the correct slices (rank0 = embed+`0..0`, rank1 = `1..1`+head).
- **Real distributed engine over TCP (full 230B)** — the sharded model, served through the OpenAI API across 2 ranks, answered *"What is the capital of France?"* → `"answer": "Paris"` (12 tokens, ~0.087 tok/s). Exercises the whole `step_first` driver → `dist` frames → `step_worker`/`handle_forward` → last-rank head+sampler → Token-upstream → decode path end-to-end with the real model.

Loopback uses the identical transport code as a cross-host deployment (127.0.0.1 vs a LAN IP).

## Known limitation (v1, matches the K2.6 path)

The last rank's repetition-penalty `history` includes prefill-stage samples (it samples every Forward). Greedy (`repetition_penalty == 1.0`) is unaffected, so a greedy pipeline run matches single-stage exactly. Documented in the `OvMoeEngine` doc + `dist.rs`.

## Test

```bash
M2_MODEL_DIR=/path/to/tiny_m2 cargo test -p cascadia-engine-sparse-moe \
  --features openvino --test minimax_m2_eval -- --nocapture
```