### PR TITLE
feat(sparse-moe): run MiniMax-M2 on Intel iGPUs via router-split

### DIFF
--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -221,6 +221,19 @@ pub struct WorkerArgs {
     #[arg(long)]
     pub total: u32,
 
+    /// First transformer layer this stage holds (global, 0-based, inclusive).
+    /// Together with --layer-end, pins an explicit asymmetric layer split
+    /// instead of the default even split across ranks — e.g. a high-RAM CPU
+    /// node holding most layers while small iGPU nodes hold a few each.
+    /// `0/0` (both default) = even split. MiniMax-M2 sparse-moe only.
+    #[arg(long, default_value_t = 0)]
+    pub layer_start: u32,
+
+    /// One-past-the-last transformer layer this stage holds (global,
+    /// exclusive). `0` = unset (even split). See --layer-start.
+    #[arg(long, default_value_t = 0)]
+    pub layer_end: u32,
+
     /// HF model id or local model directory.
     #[arg(long)]
     pub model: String,
@@ -457,6 +470,8 @@ impl WorkerArgs {
         WorkerArgs {
             rank: 0,
             total: 1,
+            layer_start: 0,
+            layer_end: 0,
             model,
             listen: ":9100".into(),
             next: None,
@@ -960,8 +975,8 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
 
     let shard = ShardSpec {
         model_id: args.model.clone(),
-        layer_start: 0,
-        layer_end: 0,
+        layer_start: args.layer_start,
+        layer_end: args.layer_end,
         total_layers: 0,
         device: args.device.clone(),
         is_first_stage: is_first,

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -362,6 +362,10 @@ impl Builder for SparseMoEBuilder {
             let cfg = self.config.clone();
             let total = cfg.total.max(1);
             let rank = cfg.rank.min(total - 1);
+            // Explicit per-rank layer range from the ShardSpec (CLI
+            // --layer-start/--layer-end). `layer_end == 0` means "unset" →
+            // load_staged falls back to the even split.
+            let (layer_start, layer_end) = (shard.layer_start, shard.layer_end);
             let opts = resolve_runner_options(&cfg);
             let cap = opts.max_cached_experts;
             let plugin_for_worker = plugin.clone();
@@ -379,6 +383,9 @@ impl Builder for SparseMoEBuilder {
                         cap,
                         rank,
                         total,
+                        layer_start,
+                        layer_end,
+                        false, // force_split: production splits by device, not forced
                     )
                 });
             let ov_runner = match join.join() {

--- a/crates/cascadia-engine-sparse-moe/src/manifest.rs
+++ b/crates/cascadia-engine-sparse-moe/src/manifest.rs
@@ -104,6 +104,25 @@ impl Manifest {
             .join("openvino_model.xml")
     }
 
+    /// Path to the GPU-friendly shell-core IR for layer `lid` (attention +
+    /// KV, no router) — produced by `tools/split_m2_shells.py`. Present only
+    /// when the shells have been split for non-CPU (iGPU/NPU) execution.
+    pub fn shell_core_xml(&self, model_dir: &Path, lid: u32) -> PathBuf {
+        model_dir
+            .join("shells")
+            .join(format!("layer_{:02}", lid))
+            .join("shell_core.xml")
+    }
+
+    /// Path to the CPU router IR for layer `lid` (`apn_in` -> routing
+    /// ids/weights), the sibling of [`Self::shell_core_xml`].
+    pub fn router_xml(&self, model_dir: &Path, lid: u32) -> PathBuf {
+        model_dir
+            .join("shells")
+            .join(format!("layer_{:02}", lid))
+            .join("router.xml")
+    }
+
     /// Path to one per-(layer, expert) IR.
     pub fn expert_xml(&self, model_dir: &Path, lid: u32, eid: u32) -> PathBuf {
         model_dir

--- a/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
+++ b/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
@@ -334,17 +334,43 @@ impl OvMoeRunner {
         let is_last = rank == total - 1;
         let all_ids = manifest.ov_layer_ids();
         let n = all_ids.len();
-        let per = n / total as usize;
-        let rem = n % total as usize;
-        let r = rank as usize;
-        let start = r * per + r.min(rem);
-        let cnt = per + if r < rem { 1 } else { 0 };
-        if cnt == 0 {
+        // Layer slice. Default: an even split across ranks. Override:
+        // `CASCADIA_M2_LAYER_RANGE=start:end` (global, half-open) pins this
+        // rank's layers explicitly, so an asymmetric ring is possible — e.g.
+        // a high-RAM CPU node holding most layers while a small iGPU node
+        // holds a few. The ranges must partition `0..num_layers` contiguously
+        // in rank order (the driver streams hidden states down the chain).
+        let layer_ids: Vec<u32> = match std::env::var("CASCADIA_M2_LAYER_RANGE").ok() {
+            Some(spec) => {
+                let parse = || -> Option<(u32, u32)> {
+                    let (a, b) = spec.split_once(':')?;
+                    Some((a.trim().parse().ok()?, b.trim().parse().ok()?))
+                };
+                let (s, e) = parse().ok_or_else(|| {
+                    OvMoeError::Internal(format!(
+                        "CASCADIA_M2_LAYER_RANGE={spec:?} must be 'start:end' (half-open)"
+                    ))
+                })?;
+                all_ids
+                    .iter()
+                    .copied()
+                    .filter(|&l| l >= s && l < e)
+                    .collect()
+            }
+            None => {
+                let per = n / total as usize;
+                let rem = n % total as usize;
+                let r = rank as usize;
+                let start = r * per + r.min(rem);
+                let cnt = per + if r < rem { 1 } else { 0 };
+                all_ids[start..start + cnt].to_vec()
+            }
+        };
+        if layer_ids.is_empty() {
             return Err(OvMoeError::Internal(format!(
-                "rank {rank}/{total} would hold zero of {n} layers; reduce total"
+                "rank {rank}/{total} holds zero of {n} layers (check CASCADIA_M2_LAYER_RANGE / total)"
             )));
         }
-        let layer_ids: Vec<u32> = all_ids[start..start + cnt].to_vec();
 
         info!(
             arch = %manifest.arch,

--- a/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
+++ b/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
@@ -270,15 +270,28 @@ impl OvMoeRunner {
         plugin: PluginConfig,
         max_cached_experts: Option<NonZeroUsize>,
     ) -> Result<Self, OvMoeError> {
-        Self::load_staged(model_dir, device, plugin, max_cached_experts, 0, 1)
+        Self::load_staged(
+            model_dir,
+            device,
+            plugin,
+            max_cached_experts,
+            0,
+            1,
+            0,
+            0,
+            false,
+        )
     }
 
     /// Load this rank's contiguous slice of the model for pipeline-parallel
     /// inference. Rank 0 owns the embedding (`layer0` IR); the last rank
-    /// owns the head; every rank owns an even slice of the transformer
-    /// shells (+ their experts). `total == 1` loads the whole model — the
-    /// path [`Self::load`] uses. The hidden state flows rank→rank as F32
-    /// over `cascadia-transport`; each rank keeps only its own layers' KV.
+    /// owns the head. The layer slice is `[layer_start, layer_end)` (global,
+    /// half-open) when `layer_end > layer_start` — an explicit, possibly
+    /// asymmetric split — otherwise an even split across ranks. `total == 1`
+    /// loads the whole model (the path [`Self::load`] uses). The hidden
+    /// state flows rank→rank as F32 over `cascadia-transport`; each rank
+    /// keeps only its own layers' KV.
+    #[allow(clippy::too_many_arguments)]
     pub fn load_staged(
         model_dir: PathBuf,
         device: &str,
@@ -286,6 +299,9 @@ impl OvMoeRunner {
         max_cached_experts: Option<NonZeroUsize>,
         rank: u32,
         total: u32,
+        layer_start: u32,
+        layer_end: u32,
+        force_split: bool,
     ) -> Result<Self, OvMoeError> {
         let manifest = Manifest::load(&model_dir)?;
         if !manifest.is_ov_shell() {
@@ -334,41 +350,30 @@ impl OvMoeRunner {
         let is_last = rank == total - 1;
         let all_ids = manifest.ov_layer_ids();
         let n = all_ids.len();
-        // Layer slice. Default: an even split across ranks. Override:
-        // `CASCADIA_M2_LAYER_RANGE=start:end` (global, half-open) pins this
-        // rank's layers explicitly, so an asymmetric ring is possible — e.g.
-        // a high-RAM CPU node holding most layers while a small iGPU node
-        // holds a few. The ranges must partition `0..num_layers` contiguously
-        // in rank order (the driver streams hidden states down the chain).
-        let layer_ids: Vec<u32> = match std::env::var("CASCADIA_M2_LAYER_RANGE").ok() {
-            Some(spec) => {
-                let parse = || -> Option<(u32, u32)> {
-                    let (a, b) = spec.split_once(':')?;
-                    Some((a.trim().parse().ok()?, b.trim().parse().ok()?))
-                };
-                let (s, e) = parse().ok_or_else(|| {
-                    OvMoeError::Internal(format!(
-                        "CASCADIA_M2_LAYER_RANGE={spec:?} must be 'start:end' (half-open)"
-                    ))
-                })?;
-                all_ids
-                    .iter()
-                    .copied()
-                    .filter(|&l| l >= s && l < e)
-                    .collect()
-            }
-            None => {
-                let per = n / total as usize;
-                let rem = n % total as usize;
-                let r = rank as usize;
-                let start = r * per + r.min(rem);
-                let cnt = per + if r < rem { 1 } else { 0 };
-                all_ids[start..start + cnt].to_vec()
-            }
+        // Layer slice. With an explicit `[layer_start, layer_end)` (global,
+        // half-open; from the CLI --layer-start/--layer-end) we pin this
+        // rank's layers — enabling an asymmetric ring (e.g. a high-RAM CPU
+        // node holding most layers, small iGPU nodes a few each). The ranges
+        // must partition `0..num_layers` contiguously in rank order (the
+        // driver streams hidden states down the chain). Otherwise (both 0)
+        // an even split by rank/total.
+        let layer_ids: Vec<u32> = if layer_end > layer_start {
+            all_ids
+                .iter()
+                .copied()
+                .filter(|&l| l >= layer_start && l < layer_end)
+                .collect()
+        } else {
+            let per = n / total as usize;
+            let rem = n % total as usize;
+            let r = rank as usize;
+            let start = r * per + r.min(rem);
+            let cnt = per + if r < rem { 1 } else { 0 };
+            all_ids[start..start + cnt].to_vec()
         };
         if layer_ids.is_empty() {
             return Err(OvMoeError::Internal(format!(
-                "rank {rank}/{total} holds zero of {n} layers (check CASCADIA_M2_LAYER_RANGE / total)"
+                "rank {rank}/{total} holds zero of {n} layers (check --layer-start/--layer-end / total)"
             )));
         }
 
@@ -400,8 +405,12 @@ impl OvMoeRunner {
         // device and the split graphs exist (`tools/split_m2_shells.py`),
         // load the GPU-friendly `shell_core` on the device and the carved
         // `router` on the CPU plugin. On CPU the monolithic shell is used.
-        let split = !device.eq_ignore_ascii_case("CPU")
-            && manifest.shell_core_xml(&model_dir, layer_ids[0]).exists();
+        // Split the shell into shell_core (device) + router (CPU) for non-CPU
+        // execution. `force_split` also forces it on CPU — used by the
+        // split-path test to validate the carve is numerically identical to
+        // the monolithic shell without needing a GPU.
+        let split = manifest.shell_core_xml(&model_dir, layer_ids[0]).exists()
+            && (force_split || !device.eq_ignore_ascii_case("CPU"));
 
         let mut shells = Vec::with_capacity(layer_ids.len());
         let routers = if split {

--- a/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
+++ b/crates/cascadia-engine-sparse-moe/src/ov_moe.rs
@@ -19,6 +19,14 @@
 //! per-expert OpenVINO IR (`ov_ir`) or flat int4 binaries fed to the
 //! cascadia-int4-gemm AVX-512 kernel (`int4_bin`, no per-call OV overhead).
 //!
+//! **Intel iGPU note:** the MoE router subgraph (sigmoid + TopK + Gather)
+//! makes the OpenVINO GPU plugin emit a kernel that fails at runtime with
+//! `CL_OUT_OF_RESOURCES` (it can wedge the OpenCL context); the attention/KV
+//! core runs on the iGPU fine. So when targeting a non-CPU device and the
+//! shells have been split by `tools/split_m2_shells.py`, this runner loads
+//! the GPU-friendly `shell_core` on the device and the carved `router` on
+//! the CPU plugin (the router is trivial compute). See [`OvMoeRunner`].
+//!
 //! Because the graphs carry their own shapes, this path is fully
 //! dimension-agnostic — the same code runs the tiny synthetic M2 used by
 //! the correctness test and the full 230B model. Single-stage (whole model)
@@ -106,28 +114,43 @@ fn out_idx(rt: &Runtime, name: &str) -> Result<usize, OvMoeError> {
     Err(OvMoeError::MissingOutput(name.to_string(), have))
 }
 
-/// Resolved output-port indices for a shell graph (same layout every layer).
+/// Output-port indices for the attention/KV part of a shell — present in
+/// both the monolithic shell and the GPU-friendly `shell_core` split.
 #[derive(Clone, Copy)]
-struct ShellPorts {
+struct CorePorts {
     apn: usize,
     residual: usize,
     shared: usize,
-    ids: usize,
-    weights: usize,
     present_k: usize,
     present_v: usize,
 }
 
-impl ShellPorts {
+impl CorePorts {
     fn resolve(rt: &Runtime) -> Result<Self, OvMoeError> {
         Ok(Self {
             apn: out_idx(rt, "attn_out_post_norm")?,
             residual: out_idx(rt, "attn_residual")?,
             shared: out_idx(rt, "shared_expert_out")?,
-            ids: out_idx(rt, "routing_ids")?,
-            weights: out_idx(rt, "routing_weights")?,
             present_k: out_idx(rt, "present_k")?,
             present_v: out_idx(rt, "present_v")?,
+        })
+    }
+}
+
+/// Output-port indices for the MoE router (top-k ids + weights). Resolved
+/// from the monolithic shell (CPU path) or the carved `router` graph (the
+/// non-CPU split, where the router runs on the CPU plugin).
+#[derive(Clone, Copy)]
+struct RouterPorts {
+    ids: usize,
+    weights: usize,
+}
+
+impl RouterPorts {
+    fn resolve(rt: &Runtime) -> Result<Self, OvMoeError> {
+        Ok(Self {
+            ids: out_idx(rt, "routing_ids")?,
+            weights: out_idx(rt, "routing_weights")?,
         })
     }
 }
@@ -212,8 +235,16 @@ pub struct OvMoeRunner {
     /// (`is_last`); `None` on upstream ranks, which forward the hidden
     /// state downstream instead of producing logits.
     head: Option<Runtime>,
+    /// Per-layer shells. Either the monolithic shell (CPU / no split) or the
+    /// GPU-friendly `shell_core` (attention + KV, no router) when running on
+    /// a non-CPU device with split graphs present.
     shells: Vec<Runtime>,
-    shell_ports: ShellPorts,
+    /// Per-layer router graphs compiled on the CPU plugin, used only in the
+    /// split path (the MoE router wedges the Intel GPU plugin). `None` in the
+    /// monolithic path, where the router outputs come from `shells`.
+    routers: Option<Vec<Runtime>>,
+    core_ports: CorePorts,
+    router_ports: RouterPorts,
     layer_ids: Vec<u32>,
 
     experts: ExpertCache,
@@ -337,14 +368,47 @@ impl OvMoeRunner {
             None
         };
 
+        // iGPU/NPU path: the MoE router subgraph wedges the Intel GPU plugin
+        // (CL_OUT_OF_RESOURCES — it can even brick the OpenCL context), but
+        // the attention/KV core runs there fine. When targeting a non-CPU
+        // device and the split graphs exist (`tools/split_m2_shells.py`),
+        // load the GPU-friendly `shell_core` on the device and the carved
+        // `router` on the CPU plugin. On CPU the monolithic shell is used.
+        let split = !device.eq_ignore_ascii_case("CPU")
+            && manifest.shell_core_xml(&model_dir, layer_ids[0]).exists();
+
         let mut shells = Vec::with_capacity(layer_ids.len());
-        for &lid in &layer_ids {
-            shells.push(compile(manifest.shell_xml(&model_dir, lid))?);
-        }
-        let shell_ports = ShellPorts::resolve(&shells[0])?;
+        let routers = if split {
+            // The router is tiny + static (no growing past_k), so it needs no
+            // SNIPPETS workaround on the CPU plugin.
+            let cpu_plugin = PluginConfig::new();
+            let mut routers = Vec::with_capacity(layer_ids.len());
+            for &lid in &layer_ids {
+                let core_xml = manifest.shell_core_xml(&model_dir, lid);
+                let router_xml = manifest.router_xml(&model_dir, lid);
+                if !router_xml.exists() {
+                    return Err(OvMoeError::MissingFile(router_xml));
+                }
+                shells.push(compile(core_xml)?);
+                routers.push(Runtime::compile(&utf8(&router_xml)?, "CPU", &cpu_plugin)?);
+            }
+            Some(routers)
+        } else {
+            for &lid in &layer_ids {
+                shells.push(compile(manifest.shell_xml(&model_dir, lid))?);
+            }
+            None
+        };
+        let core_ports = CorePorts::resolve(&shells[0])?;
+        let router_ports = match &routers {
+            Some(rs) => RouterPorts::resolve(&rs[0])?,
+            None => RouterPorts::resolve(&shells[0])?,
+        };
         info!(
-            "compiled {} shells (embed={}, head={})",
+            "compiled {} shells on {} (router_split={}, embed={}, head={})",
             shells.len(),
+            device,
+            split,
             is_first,
             is_last
         );
@@ -386,7 +450,9 @@ impl OvMoeRunner {
             embed,
             head,
             shells,
-            shell_ports,
+            routers,
+            core_ports,
+            router_ports,
             layer_ids,
             experts,
             kv,
@@ -534,16 +600,37 @@ impl OvMoeRunner {
                 sh.set_input("past_seq_len", DType::I64, &[], i64_as_bytes(&pos_i))?;
                 sh.infer()?;
             }
-            let ports = self.shell_ports;
-            let sh = &self.shells[idx];
-            let apn = bytes_to_f32(&sh.output(ports.apn)?.2);
-            let residual = bytes_to_f32(&sh.output(ports.residual)?.2);
-            let shared = bytes_to_f32(&sh.output(ports.shared)?.2);
-            let ids_out = bytes_to_i64(&sh.output(ports.ids)?.2);
-            let weights = bytes_to_f32(&sh.output(ports.weights)?.2);
-            let present_k = bytes_to_f32(&sh.output(ports.present_k)?.2);
-            let present_v = bytes_to_f32(&sh.output(ports.present_v)?.2);
+            let cp = self.core_ports;
+            let rp = self.router_ports;
+            let (apn, residual, shared, present_k, present_v) = {
+                let sh = &self.shells[idx];
+                (
+                    bytes_to_f32(&sh.output(cp.apn)?.2),
+                    bytes_to_f32(&sh.output(cp.residual)?.2),
+                    bytes_to_f32(&sh.output(cp.shared)?.2),
+                    bytes_to_f32(&sh.output(cp.present_k)?.2),
+                    bytes_to_f32(&sh.output(cp.present_v)?.2),
+                )
+            };
             self.kv[idx].append(&present_k, &present_v, kv, d);
+
+            // Routing ids/weights: from the carved CPU router graph when the
+            // shells are split for non-CPU execution, else from the shell.
+            let (ids_out, weights) = if let Some(routers) = self.routers.as_mut() {
+                let rt = &mut routers[idx];
+                rt.set_input("apn_in", DType::F32, &[1, 1, h], f32_as_bytes(&apn))?;
+                rt.infer()?;
+                (
+                    bytes_to_i64(&rt.output(rp.ids)?.2),
+                    bytes_to_f32(&rt.output(rp.weights)?.2),
+                )
+            } else {
+                let sh = &self.shells[idx];
+                (
+                    bytes_to_i64(&sh.output(rp.ids)?.2),
+                    bytes_to_f32(&sh.output(rp.weights)?.2),
+                )
+            };
 
             let mut moe = vec![0.0f32; h];
             for k in 0..self.top_k.min(ids_out.len()) {

--- a/crates/cascadia-engine-sparse-moe/tests/minimax_m2_eval.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/minimax_m2_eval.rs
@@ -74,6 +74,79 @@ fn minimax_m2_tiny_matches_hf_reference() {
     );
 }
 
+/// iGPU router-split correctness gate (runs on CPU). When the shells have
+/// been split by `tools/split_m2_shells.py`, running shell_core + the carved
+/// CPU router must be byte-identical to the monolithic shell — the property
+/// the iGPU path relies on (only the device differs in production). Forces
+/// the split on CPU (`force_split = true`) so it needs no GPU and runs in CI.
+/// Gated on `M2_MODEL_DIR`; skips if the split files aren't present.
+#[test]
+fn minimax_m2_split_path_matches_monolithic() {
+    let Some(model_dir) = env_dir("M2_MODEL_DIR") else {
+        eprintln!("M2_MODEL_DIR not set / missing; skipping split-path test");
+        return;
+    };
+    let core0 = model_dir
+        .join("shells")
+        .join("layer_00")
+        .join("shell_core.xml");
+    if !core0.exists() {
+        eprintln!("shell_core.xml absent (run tools/split_m2_shells.py); skipping split-path test");
+        return;
+    }
+    let reference: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(model_dir.join("reference.json")).expect("read reference.json"),
+    )
+    .expect("parse reference.json");
+    let prompt: Vec<u32> = reference["prompt_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_u64().unwrap() as u32)
+        .collect();
+    let greedy: Vec<u32> = reference["greedy_tokens"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_u64().unwrap() as u32)
+        .collect();
+    let n_new = greedy.len() - prompt.len();
+
+    // Monolithic shell (CPU).
+    let mut mono = OvMoeRunner::load(model_dir.clone(), "CPU", PluginConfig::new(), None)
+        .expect("load monolithic");
+    let mono_gen = mono
+        .generate_argmax(&prompt, n_new)
+        .expect("monolithic generate");
+
+    // shell_core + carved CPU router, forced on CPU.
+    let mut split = OvMoeRunner::load_staged(
+        model_dir.clone(),
+        "CPU",
+        PluginConfig::new(),
+        None,
+        0,
+        1,
+        0,
+        0,
+        true,
+    )
+    .expect("load split");
+    let split_gen = split
+        .generate_argmax(&prompt, n_new)
+        .expect("split generate");
+
+    eprintln!("monolithic: {mono_gen:?}");
+    eprintln!("split     : {split_gen:?}");
+    assert_eq!(
+        split_gen, mono_gen,
+        "shell_core + CPU router must match the monolithic shell byte-for-byte"
+    );
+    let mut full = prompt.clone();
+    full.extend_from_slice(&split_gen);
+    assert_eq!(full, greedy, "split path must match the HF reference");
+}
+
 /// Pipeline-parallel correctness gate: the SAME tiny model split across two
 /// ranks (rank 0 = embed + first half of the layers, rank 1 = second half +
 /// head) must reproduce the canonical HF greedy stream — i.e. slicing the
@@ -106,12 +179,30 @@ fn minimax_m2_two_rank_pipeline_matches_hf_reference() {
         .collect();
 
     let device = std::env::var("CASCADIA_DEVICE").unwrap_or_else(|_| "CPU".to_string());
-    let mut r0 =
-        OvMoeRunner::load_staged(model_dir.clone(), &device, PluginConfig::new(), None, 0, 2)
-            .expect("load rank 0 slice");
-    let mut r1 =
-        OvMoeRunner::load_staged(model_dir.clone(), &device, PluginConfig::new(), None, 1, 2)
-            .expect("load rank 1 slice");
+    let mut r0 = OvMoeRunner::load_staged(
+        model_dir.clone(),
+        &device,
+        PluginConfig::new(),
+        None,
+        0,
+        2,
+        0,
+        0,
+        false,
+    )
+    .expect("load rank 0 slice");
+    let mut r1 = OvMoeRunner::load_staged(
+        model_dir.clone(),
+        &device,
+        PluginConfig::new(),
+        None,
+        1,
+        2,
+        0,
+        0,
+        false,
+    )
+    .expect("load rank 1 slice");
     assert!(
         r0.is_first() && !r0.is_last(),
         "rank 0 should own the embedding but not the head"

--- a/tools/export_minimax_m2.py
+++ b/tools/export_minimax_m2.py
@@ -351,6 +351,11 @@ def convert_and_save(wrapper, example_inputs, out_xml: Path, dyn_axes,
 # --------------------------------------------------------------------------
 # Model loading
 # --------------------------------------------------------------------------
+# Number of layers for the --tiny synthetic model; overridden by --tiny-layers
+# in main(). Module global so tiny_config() stays arg-free.
+_TINY_LAYERS = 2
+
+
 def tiny_config():
     """Small but architecturally-faithful M2 config for the correctness test."""
     from transformers import MiniMaxM2Config
@@ -358,7 +363,7 @@ def tiny_config():
         vocab_size=256,
         hidden_size=128,
         intermediate_size=64,          # expert FFN dim
-        num_hidden_layers=2,
+        num_hidden_layers=_TINY_LAYERS,
         num_attention_heads=4,
         num_key_value_heads=2,
         head_dim=32,
@@ -747,6 +752,9 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--model", help="path/hub id of MiniMax-M2 (FP8)")
     ap.add_argument("--tiny", action="store_true", help="export a synthetic small M2")
+    ap.add_argument("--tiny-layers", type=int, default=2,
+                    help="number of layers for --tiny (default 2; use more to test "
+                         "pipeline-parallel splits with one rank per node)")
     ap.add_argument("--out", required=True)
     ap.add_argument("--layers", default="", help="subset e.g. 0-3 (debug); default all")
     ap.add_argument("--no-quant", action="store_true", help="skip INT4 (fp32 weights)")
@@ -776,6 +784,8 @@ def main():
 
     if not args.tiny and not args.model:
         ap.error("need --model or --tiny")
+    global _TINY_LAYERS
+    _TINY_LAYERS = args.tiny_layers
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)

--- a/tools/int4bin_to_ovir.py
+++ b/tools/int4bin_to_ovir.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Build a per-node M2 model dir whose experts are fp16 ov_ir (iGPU-runnable).
+
+The full MiniMax-M2 export uses `int4_bin` experts — a flat int4 layout fed to
+the cascadia-int4-gemm AVX-512 CPU kernel. That kernel can't run on a NUC
+(no AVX-512), and the iGPU needs OpenVINO graphs anyway. This tool converts a
+chosen subset of layers' int4_bin experts into fp16 `ov_ir` expert IRs
+(dequantizing the int4 nibbles, no FP8 source required) and assembles a node
+model dir: ov_ir manifest + the (copied) shell IRs + converted experts + the
+head (for the last pipeline rank).
+
+Pair with `tools/split_m2_shells.py` (run on the output dir) to produce the
+shell_core/router split the iGPU path needs, then point a `cascadia worker`
+rank at this dir with `CASCADIA_M2_LAYER_RANGE=<start>:<end>` matching the
+layers converted here.
+
+Usage:
+  python tools/int4bin_to_ovir.py --src /media/.../m2/export \
+      --layers 60,61 --out /tmp/m2_nuc_charlie --head
+"""
+import argparse
+import json
+import os
+import shutil
+
+import numpy as np
+import openvino as ov
+from openvino import Model, Type, PartialShape
+from openvino import opset15 as ops
+
+GROUP = 32  # int4_bin group size (cols per bf16 scale)
+
+
+def _bf16_bits_to_f32(u16):
+    return (u16.astype(np.uint32) << 16).view(np.float32)
+
+
+def _dequant(packed: bytes, scale: bytes, out: int, inn: int) -> np.ndarray:
+    """int4_bin packed (out*in/2 u8) + bf16 group scales -> fp32 [out, in]."""
+    ng = inn // GROUP
+    p = np.frombuffer(packed, dtype=np.uint8).reshape(out, inn // 2)
+    s = _bf16_bits_to_f32(np.frombuffer(scale, dtype="<u2").reshape(out, ng))
+    q = np.empty((out, inn), dtype=np.int32)
+    q[:, 0::2] = (p & 0x0F).astype(np.int32)   # even cols = low nibble
+    q[:, 1::2] = (p >> 4).astype(np.int32)     # odd cols = high nibble
+    q -= 8
+    w = q.astype(np.float32).reshape(out, ng, GROUP) * s[:, :, None]
+    return w.reshape(out, inn)
+
+
+def _read_expert_bin(path, hidden, inter):
+    b = np.fromfile(path, dtype=np.uint8)
+    gp = inter * (hidden // 2)
+    gs = inter * (hidden // GROUP) * 2
+    dp = hidden * (inter // 2)
+    ds = hidden * (inter // GROUP) * 2
+    o = 0
+    def take(n):
+        nonlocal o
+        s = b[o:o + n].tobytes(); o += n; return s
+    gate = _dequant(take(gp), take(gs), inter, hidden)   # [inter, hidden]
+    up   = _dequant(take(gp), take(gs), inter, hidden)   # [inter, hidden]
+    down = _dequant(take(dp), take(ds), hidden, inter)   # [hidden, inter]
+    return gate, up, down
+
+
+def _expert_model(gate, up, down, hidden, inter):
+    """fp16 SwiGLU expert: x[1,1,H] -> down(silu(gate(x))*up(x)) [1,1,H]."""
+    x = ops.parameter(PartialShape([1, 1, hidden]), Type.f32, name="x")
+    x.get_output_tensor(0).set_names({"x"})
+    xb = ops.convert(x, Type.f16)
+    gW = ops.constant(gate.astype(np.float16))   # [inter, hidden]
+    uW = ops.constant(up.astype(np.float16))
+    dW = ops.constant(down.astype(np.float16))   # [hidden, inter]
+    g = ops.matmul(xb, gW, False, True)          # [1,1,inter]
+    u = ops.matmul(xb, uW, False, True)
+    act = ops.multiply(ops.multiply(g, ops.sigmoid(g)), u)
+    y = ops.convert(ops.matmul(act, dW, False, True), Type.f32)  # [1,1,hidden]
+    y.get_output_tensor(0).set_names({"y"})
+    return Model([y], [x])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True, help="full int4_bin M2 export dir")
+    ap.add_argument("--layers", required=True, help="comma layer ids to convert, e.g. 60,61")
+    ap.add_argument("--out", required=True, help="output node model dir")
+    ap.add_argument("--head", action="store_true", help="copy head/ (last pipeline rank)")
+    args = ap.parse_args()
+
+    man = json.load(open(os.path.join(args.src, "manifest.json")))
+    hidden = man["hidden_size"]
+    inter = man["expert_intermediate"]
+    nexp = man["num_experts"]
+    layers = [int(x) for x in args.layers.split(",") if x.strip() != ""]
+    os.makedirs(args.out, exist_ok=True)
+
+    # ov_ir manifest (same dims/arch; experts are now OV graphs)
+    man["experts_format"] = "ov_ir"
+    json.dump(man, open(os.path.join(args.out, "manifest.json"), "w"))
+
+    for lid in layers:
+        # shell IR (already OV; split_m2_shells.py runs on this dir afterwards)
+        sdst = os.path.join(args.out, "shells", f"layer_{lid:02d}")
+        os.makedirs(sdst, exist_ok=True)
+        for ext in ("xml", "bin"):
+            src = os.path.join(args.src, "shells", f"layer_{lid:02d}", f"openvino_model.{ext}")
+            if os.path.exists(src):
+                shutil.copy(src, sdst)
+        # experts: int4_bin .bin -> fp16 ov_ir IR
+        for eid in range(nexp):
+            binp = os.path.join(args.src, "experts", f"layer_{lid:02d}", f"expert_{eid:03d}.bin")
+            gate, up, down = _read_expert_bin(binp, hidden, inter)
+            edst = os.path.join(args.out, "experts", f"layer_{lid:02d}", f"expert_{eid:03d}")
+            os.makedirs(edst, exist_ok=True)
+            ov.save_model(_expert_model(gate, up, down, hidden, inter),
+                          os.path.join(edst, "openvino_model.xml"), compress_to_fp16=False)
+        print(f"layer {lid}: converted {nexp} experts + copied shell", flush=True)
+
+    if args.head:
+        hsrc = os.path.join(args.src, "head")
+        if os.path.isdir(hsrc):
+            shutil.copytree(hsrc, os.path.join(args.out, "head"), dirs_exist_ok=True)
+            print("copied head/", flush=True)
+    print(f"done -> {args.out}  (now run split_m2_shells.py on it)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/split_m2_shells.py
+++ b/tools/split_m2_shells.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Split MiniMax-M2 OV-IR shells into a GPU-friendly core + a CPU router.
+
+The MoE router subgraph (gate MatMul -> sigmoid -> +e_score_correction_bias
+-> TopK -> Gather -> renorm) makes the OpenVINO Intel GPU plugin emit a
+kernel that fails at runtime with CL_OUT_OF_RESOURCES (and wedges the
+OpenCL context). The attention + KV part of the same shell runs on the
+iGPU fine. So for iGPU execution we carve each shell into two graphs:
+
+  shell_core.xml : x, past_k, past_v, past_seq_len
+                   -> attn_out_post_norm, attn_residual,
+                      shared_expert_out, present_k, present_v
+                   (runs on the iGPU)
+  router.xml     : apn_in (= attn_out_post_norm)
+                   -> routing_ids, routing_weights
+                   (runs on the CPU; trivial compute)
+
+`OvMoeRunner` loads these instead of the monolithic shell when the target
+device is not CPU and the split files exist. The router input is named
+`apn_in` with the same shape/type as `attn_out_post_norm`.
+
+Usage:
+  python tools/split_m2_shells.py --model-dir /path/to/m2_export
+  (idempotent; skips layers already split unless --force)
+"""
+import argparse
+import os
+
+import openvino as ov
+from openvino import Model
+from openvino import opset15 as ops
+
+CORE_OUTPUTS = [
+    "attn_out_post_norm",
+    "attn_residual",
+    "shared_expert_out",
+    "present_k",
+    "present_v",
+]
+ROUTER_OUTPUTS = ["routing_ids", "routing_weights"]
+
+
+def _out(model, name):
+    for o in model.outputs:
+        if name in o.get_names():
+            return o
+    raise SystemExit(f"output {name!r} not found (have {[list(o.get_names()) for o in model.outputs]})")
+
+
+def split_one(core, shell_xml, out_dir, force):
+    core_xml = os.path.join(out_dir, "shell_core.xml")
+    router_xml = os.path.join(out_dir, "router.xml")
+    if not force and os.path.exists(core_xml) and os.path.exists(router_xml):
+        return "skip"
+
+    # shell_core: keep the 5 non-router outputs; OV prunes the router subgraph.
+    m = core.read_model(shell_xml)
+    keep = [_out(m, n).get_node() for n in CORE_OUTPUTS]
+    shell_core = Model(keep, m.get_parameters())
+    shell_core.set_friendly_name("m2_shell_core")
+    ov.save_model(shell_core, core_xml, compress_to_fp16=False)
+
+    # router: replace the attn_out_post_norm tensor with an `apn_in` input;
+    # OV prunes the attention subgraph, leaving gate->sigmoid->topk->gather.
+    r = core.read_model(shell_xml)
+    apn_src = _out(r, "attn_out_post_norm").get_node().input_value(0)
+    apn_in = ops.parameter(apn_src.get_partial_shape(), apn_src.get_element_type(), name="apn_in")
+    apn_in.get_output_tensor(0).set_names({"apn_in"})
+    rewired = 0
+    for ti in list(apn_src.get_target_inputs()):
+        if ti.get_node().get_type_name() != "Result":
+            ti.replace_source_output(apn_in.output(0))
+            rewired += 1
+    if rewired == 0:
+        raise SystemExit(f"{shell_xml}: found no router consumer of attn_out_post_norm")
+    router = Model([_out(r, n).get_node() for n in ROUTER_OUTPUTS], [apn_in])
+    router.set_friendly_name("m2_router")
+    ov.save_model(router, router_xml, compress_to_fp16=False)
+    return "split"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-dir", required=True, help="M2 export dir (has shells/layer_NN/openvino_model.xml)")
+    ap.add_argument("--force", action="store_true", help="re-split layers even if split files exist")
+    args = ap.parse_args()
+
+    shells_dir = os.path.join(args.model_dir, "shells")
+    if not os.path.isdir(shells_dir):
+        raise SystemExit(f"no shells/ under {args.model_dir}")
+    core = ov.Core()
+    n_split = n_skip = 0
+    for layer in sorted(os.listdir(shells_dir)):
+        d = os.path.join(shells_dir, layer)
+        xml = os.path.join(d, "openvino_model.xml")
+        if not os.path.exists(xml):
+            continue
+        res = split_one(core, xml, d, args.force)
+        if res == "split":
+            n_split += 1
+        else:
+            n_skip += 1
+    print(f"done: {n_split} split, {n_skip} skipped (already present). "
+          f"OvMoeRunner uses shell_core.xml/router.xml on non-CPU devices.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Lets MiniMax-M2 shells execute on Intel iGPUs (Arc / Xe), so NUC iGPUs can be pipeline stages. Stacked on #85 (pipeline-parallel); retarget to `main` after #85.

## Why

The M2 shell's **MoE router** subgraph (gate MatMul → sigmoid → +`e_score_correction_bias` → TopK → Gather → renorm) makes the OpenVINO Intel GPU plugin emit a kernel that fails at runtime with `CL_OUT_OF_RESOURCES` — and can wedge the OpenCL context until a cold reboot. This reproduces on OpenVINO **2026.1.0, 2026.2.1 (latest stable), and 2026.3.0-nightly**, and is an open upstream bug (openvinotoolkit/openvino#35723, plus #25141/#28919/#32665 closed without a fix). Diagnosis (runtime-graph dump + IR bisection) showed the **attention/KV core, embed, experts, and head all run on the iGPU fine** — only the router fails.

## How

Carve each shell into two graphs:
- `shell_core.xml`: `x, past_k, past_v, past_seq_len → attn_out_post_norm, attn_residual, shared_expert_out, present_k, present_v` (runs on the iGPU)
- `router.xml`: `apn_in → routing_ids, routing_weights` (runs on the CPU plugin; trivial compute)

`tools/split_m2_shells.py` post-processes an export (OV graph surgery: replace the `attn_out_post_norm` tensor with an `apn_in` Parameter for the router; output-prune the router from the core). Validated byte-exact vs the monolithic shell.

`OvMoeRunner`: when the target device is not CPU **and** `shell_core.xml` exists, it compiles `shell_core` on the device and `router` on the CPU plugin; `forward_layers` reads the 5 core outputs from the shell and runs the router separately for ids/weights. On CPU (or without split files) the monolithic shell path is unchanged. `ShellPorts` → `CorePorts` + `RouterPorts`; manifest gains `shell_core_xml`/`router_xml`. Also `--tiny-layers` to size the synthetic model for N-rank pipeline tests.

## Validation (Panther Lake NUCs, Arc B390)

- **Python e2e on a NUC iGPU**: tiny M2 split (core+experts+head on GPU, router on CPU) reproduces the canonical HF greedy stream **exactly**.
- **Real cascadia binary, single-stage on a NUC iGPU**: log shows `compiled N shells on GPU (router_split=true)`; output matches the CPU reference.
- **3-node pipeline**: miner **CPU** (rank0, embed+layers) + two NUC **iGPUs** (rank1, rank2+head), 4-layer tiny model, over the network — generated end-to-end; both NUC logs confirm `compiled shells on GPU (router_split=true)`.

## Scope note

Only small models fit the NUCs; the full 230B M2 still can't run there (`int4_bin` experts need AVX-512; 16 GB iGPU; RAM). This is a small-model / multi-node-iGPU capability, not a path for production-scale M2.

## Test

```bash
python tools/split_m2_shells.py --model-dir /path/to/m2_export
cascadia worker --engine sparse-moe --model /path/to/m2_export --device GPU ...
```