### PR TITLE
docs(cli): document full OpenVINO --device string forms (#12)

### DIFF
--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -250,7 +250,18 @@ pub struct WorkerArgs {
     #[arg(long)]
     pub api: Option<String>,
 
-    /// Device hint: CPU / GPU / NPU.
+    /// OpenVINO device target. Forwarded verbatim to ov::Core::compile_model.
+    ///
+    /// Valid forms:
+    ///   CPU                       host CPU
+    ///   GPU, GPU.0, GPU.1, ...    a specific GPU (iGPU is .0 by convention)
+    ///   NPU, NPU.0, ...           Neural Processing Unit (Lunar Lake / later)
+    ///   AUTO                      let OpenVINO pick
+    ///   MULTI:GPU.1,GPU.0,CPU     round-robin across devices
+    ///   HETERO:GPU.1,CPU          split the graph by op affinity
+    ///   BATCH:GPU                 auto-batch (throughput-favored)
+    ///
+    /// Run `cascadia doctor` to see which devices OpenVINO can see on this host.
     #[arg(long, default_value = "CPU")]
     pub device: String,
 
@@ -285,6 +296,7 @@ pub struct WorkerArgs {
     pub draft_model: Option<String>,
 
     /// Device for the draft model (default: same as --device).
+    /// Accepts the same OpenVINO device forms as --device.
     #[arg(long)]
     pub draft_device: Option<String>,
 
@@ -440,6 +452,8 @@ pub struct RunArgs {
 
     /// Device hint: GPU / CPU / NPU. Defaults to GPU — run `cascadia
     /// doctor` first to confirm the iGPU is visible to OpenVINO.
+    /// Also accepts indexed/compound OpenVINO forms (GPU.N, AUTO,
+    /// MULTI:, HETERO:, BATCH:) — see `cascadia worker --help`.
     #[arg(long, default_value = "GPU")]
     pub device: String,
 

--- a/crates/cascadia-types/src/shard.rs
+++ b/crates/cascadia-types/src/shard.rs
@@ -14,7 +14,10 @@ pub struct ShardSpec {
     pub layer_start: u32,
     pub layer_end: u32,
     pub total_layers: u32,
-    /// OV device hint: `"CPU"`, `"GPU"`, `"NPU"`.
+    /// OV device hint. Forwarded verbatim to `ov::Core::compile_model`.
+    /// Valid forms: `"CPU"`, `"GPU"`, `"GPU.N"`, `"NPU"`, `"NPU.N"`,
+    /// `"AUTO"`, `"MULTI:dev1,dev2,..."`, `"HETERO:dev1,dev2,..."`,
+    /// `"BATCH:dev"`. See `cascadia doctor` for available devices.
     pub device: String,
     pub is_first_stage: bool,
     pub is_last_stage: bool,


### PR DESCRIPTION
Closes #12.

`--device` is forwarded verbatim to `ov::Core::compile_model`, which accepts a richer set of specifiers than the `CPU / GPU / NPU` the help text listed — `GPU.N`, `NPU.N`, `AUTO`, `MULTI:`, `HETERO:`, `BATCH:`. This documents them on `worker --device`, `worker --draft-device`, `run --device`, and the `ShardSpec::device` field, and points operators at `cascadia doctor` for device enumeration.

### Why this closes #12 (most of it already landed)
#12 bundled five cleanups; four are already done or made redundant since it was filed:
- ✅ (1) `--device` help enum — **this PR**
- ✅ (2) device enumeration — `cascadia doctor` already enumerates OV devices (#53); a separate `engines --probe-devices` would duplicate it
- ✅ (3) dead `openvino*` workspace pins — removed in #77 (Part A)
- ✅ (4) OV version pin — README now pins OpenVINO GenAI **2026.2+** (#78)
- ✅ (5) `shard.rs` device-string doc — **this PR**

Doc-only change. `cargo fmt --check` and `cargo check -p cascadia-cli -p cascadia-types` are clean.