### PR TITLE
fix(ov-genai): populate /v1/chat/completions usage token counts (#55)

### DIFF
--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -53,13 +53,12 @@ pub const DEFAULT_MAX_PROMPT_BYTES: usize = 32 * 1024;
 pub use cascadia_types::ApiStats;
 
 /// Tokens a chunk contributes to the cumulative counter. The engine's
-/// `n_tokens` is authoritative when set (spec-decode reports 1..=K+1);
-/// otherwise the per-chunk convention is "one token per non-empty chunk"
-/// (see `Chunk::n_tokens` docs). An empty chunk — the no-text final
-/// marker mock/runtime engines emit — contributes 0 so it isn't counted
-/// as a phantom token. (ov-genai delivers its whole response on a single
-/// final chunk with no `n_tokens`, so it counts as 1 here — approximate,
-/// since that engine tokenizes internally and reports no token count.)
+/// `n_tokens` is authoritative when set (spec-decode reports 1..=K+1;
+/// ov-genai sets it on its single final chunk so `usage` reflects the
+/// real generated count — issue #55); otherwise the per-chunk convention
+/// is "one token per non-empty chunk" (see `Chunk::n_tokens` docs). An
+/// empty chunk — the no-text final marker mock/runtime engines emit —
+/// contributes 0 so it isn't counted as a phantom token.
 fn chunk_token_count(chunk: &cascadia_types::Chunk) -> u32 {
     chunk
         .n_tokens
@@ -672,7 +671,7 @@ async fn chat_completions(
         }],
         usage: Usage {
             // From the engine's final chunk; 0 when the engine can't tell
-            // (e.g. ov-genai tokenizes inside the pipeline).
+            // (e.g. an engine that reports no prompt-token count).
             prompt_tokens,
             completion_tokens,
             total_tokens: prompt_tokens + completion_tokens,
@@ -852,9 +851,33 @@ mod tests {
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
     use cascadia_engine_mock::MockBuilder;
-    use cascadia_types::{PeerLayout, ShardSpec};
+    use cascadia_types::{Chunk, PeerLayout, ShardSpec};
     use serde_json::Value;
     use tower::ServiceExt;
+
+    // Guards the contract the ov-genai usage fix (#55) depends on: when an
+    // engine sets `n_tokens` on a single text-bearing final chunk, that count
+    // is authoritative (not the "1 per chunk" fallback), so `usage` reflects
+    // the real generated-token count rather than 0/1.
+    #[test]
+    fn chunk_token_count_honors_engine_count() {
+        // ov-genai's shape: whole response on one final chunk, n_tokens set.
+        let c = Chunk::final_marker("t", "The capital of France is Paris.").with_n_tokens(8);
+        assert_eq!(chunk_token_count(&c), 8);
+
+        // Same shape WITHOUT n_tokens falls back to 1 (the pre-#55 behavior
+        // that under-counted ov-genai) — documents why the engine must set it.
+        let c = Chunk::final_marker("t", "The capital of France is Paris.");
+        assert_eq!(chunk_token_count(&c), 1);
+
+        // Empty final marker (mock/runtime) contributes 0 — no phantom token.
+        let c = Chunk::final_marker("t", "");
+        assert_eq!(chunk_token_count(&c), 0);
+
+        // A normal per-token chunk counts as 1.
+        let c = Chunk::token("t", 123, "Paris");
+        assert_eq!(chunk_token_count(&c), 1);
+    }
 
     async fn make_app() -> Router {
         let mut runner = Runner::new(Box::new(MockBuilder::new()));

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -322,7 +322,18 @@ impl Engine for OvGenaiEngine {
             "task done"
         );
 
-        let chunk = Chunk::final_marker(task.task_id.clone(), text);
+        // Carry the real token counts on the final chunk so the API's
+        // `usage` block is populated (issue #55 — previously always 0 for
+        // this engine because the whole response lands on one chunk with no
+        // per-token count). `prompt_tokens` is the rendered-prompt token
+        // count; it is exact when the API pre-templated the prompt
+        // (`skip_chat_template`) and a slight undercount when ov-genai
+        // applies its own template internally (the template wrapping isn't
+        // counted). None when the tokenizer is unavailable.
+        let mut chunk = Chunk::final_marker(task.task_id.clone(), text).with_n_tokens(tokens);
+        if let Some(prompt_tokens) = self.pipe.count_tokens(&task.prompt) {
+            chunk = chunk.with_prompt_tokens(prompt_tokens);
+        }
         vec![(task.task_id, chunk)]
     }
 }

--- a/crates/cascadia-types/src/chunk.rs
+++ b/crates/cascadia-types/src/chunk.rs
@@ -101,4 +101,13 @@ impl Chunk {
         self.prompt_tokens = Some(n);
         self
     }
+
+    /// Record how many model tokens this chunk's `text` condenses. Engines
+    /// that deliver a whole response on one chunk (ov-genai) set this so the
+    /// API's `usage.completion_tokens` reflects the real count instead of
+    /// the "one token per chunk" fallback. See `Chunk::n_tokens` docs.
+    pub fn with_n_tokens(mut self, n: u32) -> Self {
+        self.n_tokens = Some(n);
+        self
+    }
 }


### PR DESCRIPTION
Closes #55.

## Problem
The **ov-genai** engine delivers its whole response on a single final `Chunk` and never set `n_tokens` / `prompt_tokens`. The API's usage accumulator (`chunk_token_count`) therefore counted that one chunk as a single token, so `/v1/chat/completions` returned `usage: {prompt_tokens: 0, completion_tokens: 0, total_tokens: 0}` — even though the engine already computes and logs the real count (`task done ... tokens=8`).

## Fix
Engine-side wiring only — the API already treats a set `n_tokens` as authoritative:
- `Chunk::with_n_tokens(n)` helper (mirrors the existing `with_prompt_tokens`).
- `OvGenaiEngine::step` sets `n_tokens` = generated-token count (the value already logged) and `prompt_tokens` = rendered-prompt token count (best-effort via the pipeline tokenizer).
- Refreshed two now-stale comments that claimed ov-genai reports no token count.

`prompt_tokens` is **exact** when the API pre-templated the prompt (`skip_chat_template` — the common `cascadia run` path) and a slight undercount when ov-genai applies its own chat template internally (the template wrapping isn't counted). `None` → 0 when the tokenizer is unavailable. Exact input-token accounting via OV `perf_metrics.get_num_input_tokens()` would need a small C++ shim addition — noted as a follow-up, not required for this fix.

## Tests
- New `chunk_token_count_honors_engine_count` unit test pins the contract: a text-bearing final chunk with `n_tokens` set counts as that value (not 1), `None` falls back to 1, empty marker → 0.
- `cargo test -p cascadia-types -p cascadia-engine-openvino -p cascadia-api` green (default/stub build); `cargo fmt --check` clean.

## Validation status (honest)
- ✅ Unit-tested + stub build compiles clean. The completion count is the same value the engine already logs as correct, so the fix is correct by construction.
- ⏳ **On-hardware confirmation pending** — building with `--features openvino` and re-running the original repro (`OpenVINO/TinyLlama-1.1B-Chat-v1.0-int4-ov` on an Intel AI PC) to confirm the live response shows `completion_tokens: 8` requires Intel hardware + OpenVINO, which this dev box doesn't have. Recommend confirming on the fleet before merge.

## Out of scope
Streaming `usage` (final SSE chunk gated on `stream_options.include_usage`) — depends on the `stream_options` plumbing in #14.