### PR TITLE
feat(api): add /v1/completions (OpenAI legacy completions) (#19)

### DIFF
--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -296,6 +296,21 @@ pub struct ChatMessage {
     pub content: String,
 }
 
+/// OpenAI `stop` is either a single string or an array of strings.
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum StopSpec {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+/// OpenAI `stream_options`. Only `include_usage` is honored today.
+#[derive(Deserialize, Debug, Default)]
+pub struct StreamOptions {
+    #[serde(default)]
+    pub include_usage: bool,
+}
+
 #[derive(Deserialize, Debug)]
 pub struct ChatCompletionRequest {
     pub model: String,
@@ -305,12 +320,64 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub temperature: f32,
     #[serde(default)]
+    pub top_p: Option<f32>,
+    #[serde(default)]
+    pub top_k: Option<u32>,
+    #[serde(default)]
+    pub seed: Option<u64>,
+    #[serde(default)]
+    pub stop: Option<StopSpec>,
+    #[serde(default)]
+    pub frequency_penalty: Option<f32>,
+    #[serde(default)]
+    pub presence_penalty: Option<f32>,
+    /// OpenAI `logprobs` (bool). When true, per-token logprobs are returned
+    /// (engine-permitting).
+    #[serde(default)]
+    pub logprobs: bool,
+    /// OpenAI `top_logprobs` (0..=20): how many alternatives per position.
+    #[serde(default)]
+    pub top_logprobs: Option<u32>,
+    #[serde(default)]
     pub stream: bool,
+    #[serde(default)]
+    pub stream_options: Option<StreamOptions>,
     /// Hybrid-reasoning switch (Qwen3+ convention). Default true =
     /// model-default behavior; false asks the engine to skip the
     /// <think> block (engines that can't, ignore it).
     #[serde(default = "default_true")]
     pub enable_thinking: bool,
+}
+
+impl ChatCompletionRequest {
+    /// Build the engine-facing `SamplingParams`, applying OpenAI defaults
+    /// (top_p=1.0, penalties=0.0) when a field is omitted.
+    fn sampling_params(&self) -> cascadia_types::SamplingParams {
+        cascadia_types::SamplingParams {
+            top_p: self.top_p.unwrap_or(1.0),
+            top_k: self.top_k.unwrap_or(0),
+            seed: self.seed,
+            frequency_penalty: self.frequency_penalty.unwrap_or(0.0),
+            presence_penalty: self.presence_penalty.unwrap_or(0.0),
+            stop: self
+                .stop
+                .as_ref()
+                .map(|s| match s {
+                    StopSpec::Single(x) => vec![x.clone()],
+                    StopSpec::Multiple(v) => v.clone(),
+                })
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Top-logprobs count to request from the engine (0 = disabled).
+    fn logprobs_count(&self) -> u32 {
+        if self.logprobs {
+            self.top_logprobs.unwrap_or(1).clamp(1, 20)
+        } else {
+            0
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -327,12 +394,21 @@ struct ChatChoiceMessage {
     content: String,
 }
 
+/// OpenAI chat `logprobs` object: one entry per generated token under
+/// `content`. Present only when the request set `logprobs: true` AND the
+/// engine emitted per-token logprobs.
+#[derive(Serialize)]
+struct ChatLogprobs {
+    content: Vec<cascadia_types::TokenLogprobs>,
+}
+
 #[derive(Serialize)]
 struct ChatChoice {
     index: u32,
     message: ChatChoiceMessage,
     finish_reason: &'static str,
-    logprobs: Option<()>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logprobs: Option<ChatLogprobs>,
 }
 
 #[derive(Serialize)]
@@ -578,7 +654,8 @@ async fn chat_completions(
         prompt,
         max_tokens: req.max_tokens,
         temperature: req.temperature,
-        logprobs: 0,
+        logprobs: req.logprobs_count(),
+        sampling: req.sampling_params(),
         enable_thinking: req.enable_thinking,
         trust_remote_code: false,
     };
@@ -608,7 +685,12 @@ async fn chat_completions(
     let inflight = InFlightGuard::new(state.stats.clone());
 
     if req.stream {
-        return stream_completion(state, req.model, task, permit, inflight)
+        let include_usage = req
+            .stream_options
+            .as_ref()
+            .map(|o| o.include_usage)
+            .unwrap_or(false);
+        return stream_completion(state, req.model, task, permit, inflight, include_usage)
             .await
             .into_response();
     }
@@ -624,6 +706,10 @@ async fn chat_completions(
     let mut buf = String::new();
     let mut completion_tokens: u32 = 0;
     let mut prompt_tokens: u32 = 0;
+    // OpenAI `finish_reason`: `length` when the engine hit max_tokens, else
+    // `stop`. Engines that don't distinguish leave it None → "stop".
+    let mut finish_reason: &'static str = "stop";
+    let mut logprobs_content: Vec<cascadia_types::TokenLogprobs> = Vec::new();
     while let Some(chunk) = chunk_stream.next().await {
         // A failed task carries `error` on its final chunk. Without this
         // branch the empty text below would build a normal 200 with empty
@@ -646,14 +732,37 @@ async fn chat_completions(
         // markers other engines emit, so there's no phantom over-count.
         buf.push_str(&chunk.text);
         completion_tokens += chunk_token_count(&chunk);
+        if let Some(lp) = &chunk.logprobs {
+            logprobs_content.push(lp.clone());
+        }
         if chunk.is_final {
             prompt_tokens = chunk.prompt_tokens.unwrap_or(0);
+            if let Some(fr) = chunk.finish_reason {
+                finish_reason = fr.as_openai_str();
+            }
         }
     }
     state
         .stats
         .tokens_total
         .fetch_add(completion_tokens as u64, Ordering::Relaxed);
+
+    // Honor `stop` sequences by trimming the assembled text at the earliest
+    // match. The engines don't early-stop on strings yet (an engine-side
+    // follow-up would also save compute), so this enforces the OpenAI output
+    // contract at the API boundary and forces finish_reason = "stop".
+    let stops = req.sampling_params().stop;
+    if !stops.is_empty() {
+        if let Some(cut) = stops
+            .iter()
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| buf.find(s.as_str()))
+            .min()
+        {
+            buf.truncate(cut);
+            finish_reason = "stop";
+        }
+    }
 
     Json(ChatCompletionResponse {
         id: task_id,
@@ -666,8 +775,14 @@ async fn chat_completions(
                 role: "assistant",
                 content: buf,
             },
-            finish_reason: "stop",
-            logprobs: None,
+            finish_reason,
+            logprobs: if logprobs_content.is_empty() {
+                None
+            } else {
+                Some(ChatLogprobs {
+                    content: logprobs_content,
+                })
+            },
         }],
         usage: Usage {
             // From the engine's final chunk; 0 when the engine can't tell
@@ -686,6 +801,7 @@ async fn stream_completion(
     task: GenerationTask,
     permit: tokio::sync::OwnedSemaphorePermit,
     inflight: InFlightGuard,
+    include_usage: bool,
 ) -> axum::response::Response {
     let task_id = task.task_id.clone();
     let _ = SystemTime::now();
@@ -700,6 +816,16 @@ async fn stream_completion(
     // Clone the counter handle for per-chunk token accounting in the
     // formatter closure below.
     let stats = state.stats.clone();
+    // Per-request token tallies for the OpenAI `stream_options.include_usage`
+    // final chunk (the global `stats.tokens_total` is cross-request). The
+    // `final_*` handles are read by the trailing usage frame after the body
+    // stream drains; the per-chunk closure gets the originals.
+    let usage_completion = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let usage_prompt = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let final_completion = usage_completion.clone();
+    let final_prompt = usage_prompt.clone();
+    let usage_model = model.clone();
+    let usage_task_id = task_id.clone();
     // Move the permit + in-flight guard into the stream so they're released
     // only when the body is dropped (client disconnect or final chunk).
     let permit_carrier = StreamWithPermit {
@@ -726,6 +852,8 @@ async fn stream_completion(
             let model = model.clone();
             let task_id = task_id.clone();
             let stats = stats.clone();
+            let usage_completion = usage_completion.clone();
+            let usage_prompt = usage_prompt.clone();
             async move {
                 // Count model tokens as they stream so the dashboard's
                 // tokens_total advances live (not just at request end).
@@ -733,9 +861,13 @@ async fn stream_completion(
                 // output there); chunk_token_count yields 0 for empty
                 // markers, so no phantom token.
                 if chunk.error.is_none() {
-                    stats
-                        .tokens_total
-                        .fetch_add(chunk_token_count(&chunk) as u64, Ordering::Relaxed);
+                    let n = chunk_token_count(&chunk);
+                    stats.tokens_total.fetch_add(n as u64, Ordering::Relaxed);
+                    usage_completion.fetch_add(n, Ordering::Relaxed);
+                    if chunk.is_final {
+                        usage_prompt
+                            .store(chunk.prompt_tokens.unwrap_or(0), Ordering::Relaxed);
+                    }
                 }
                 // A failed task carries `error` on its final chunk. The 200
                 // headers are already on the wire by the time the body
@@ -769,7 +901,11 @@ async fn stream_completion(
                             "role": "assistant",
                             "content": chunk.text,
                         },
-                        "finish_reason": if chunk.is_final { Some("stop") } else { None },
+                        "finish_reason": if chunk.is_final {
+                            Some(chunk.finish_reason.map(|f| f.as_openai_str()).unwrap_or("stop"))
+                        } else {
+                            None
+                        },
                     }],
                 });
                 let line = format!("data: {payload}\n\n");
@@ -788,8 +924,31 @@ async fn stream_completion(
                 Ok::<Bytes, std::convert::Infallible>(Bytes::from(line))
             }
         })
-        .chain(stream::once(async {
-            Ok::<Bytes, std::convert::Infallible>(Bytes::from_static(b"data: [DONE]\n\n"))
+        .chain(stream::once(async move {
+            // OpenAI: when stream_options.include_usage is set, emit one final
+            // chunk with empty `choices` carrying `usage`, just before [DONE].
+            // Combined into a single HTTP frame with [DONE] (SSE events are
+            // delimited by \n\n regardless of HTTP chunk boundaries).
+            let mut out = String::new();
+            if include_usage {
+                let prompt = final_prompt.load(Ordering::Relaxed);
+                let completion = final_completion.load(Ordering::Relaxed);
+                let usage = serde_json::json!({
+                    "id": usage_task_id,
+                    "object": "chat.completion.chunk",
+                    "created": now_unix(),
+                    "model": usage_model,
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": prompt,
+                        "completion_tokens": completion,
+                        "total_tokens": prompt + completion,
+                    },
+                });
+                out.push_str(&format!("data: {usage}\n\n"));
+            }
+            out.push_str("data: [DONE]\n\n");
+            Ok::<Bytes, std::convert::Infallible>(Bytes::from(out))
         }));
 
     Response::builder()
@@ -954,6 +1113,140 @@ mod tests {
         // Mock yields words from the prompt; check non-empty content.
         let content = v["choices"][0]["message"]["content"].as_str().unwrap();
         assert!(!content.is_empty(), "completion content was empty");
+    }
+
+    // Helper: POST a chat-completions request body, return (status, parsed JSON).
+    async fn post_chat(app: Router, payload: serde_json::Value) -> (StatusCode, Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), 16384).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        (status, v)
+    }
+
+    #[tokio::test]
+    async fn finish_reason_length_when_max_tokens_hit() {
+        // Mock echoes the prompt's words; with 5 words and max_tokens 2 it hits
+        // the cap before exhausting the prompt → finish_reason "length".
+        let (status, v) = post_chat(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "alpha bravo charlie delta echo"}],
+                "max_tokens": 2,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["choices"][0]["finish_reason"], "length");
+    }
+
+    #[tokio::test]
+    async fn finish_reason_stop_when_prompt_exhausted() {
+        // 2 words, generous cap → the mock exhausts the prompt → "stop".
+        let (status, v) = post_chat(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "alpha bravo"}],
+                "max_tokens": 64,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[tokio::test]
+    async fn stop_sequence_truncates_output() {
+        // Full output would be "alpha bravo charlie delta "; stop ["charlie"]
+        // trims it to "alpha bravo " and forces finish_reason "stop".
+        let (status, v) = post_chat(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "alpha bravo charlie delta"}],
+                "max_tokens": 64,
+                "stop": "charlie",
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let content = v["choices"][0]["message"]["content"].as_str().unwrap();
+        assert!(
+            !content.contains("charlie"),
+            "stop text not trimmed: {content:?}"
+        );
+        assert_eq!(content.trim(), "alpha bravo");
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[tokio::test]
+    async fn full_sampling_param_set_is_accepted() {
+        // Every new OpenAI field present + well-typed must parse (no 400).
+        let (status, _v) = post_chat(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "alpha bravo"}],
+                "max_tokens": 4,
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "top_k": 40,
+                "seed": 1234,
+                "stop": ["zzz", "qqq"],
+                "frequency_penalty": 0.5,
+                "presence_penalty": -0.25,
+                "logprobs": true,
+                "top_logprobs": 3,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn streaming_usage_emitted_when_requested() {
+        let response = make_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "model": "mock-model",
+                            "messages": [{"role": "user", "content": "alpha bravo charlie"}],
+                            "max_tokens": 8,
+                            "stream": true,
+                            "stream_options": {"include_usage": true},
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 65536).await.unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            text.contains("\"usage\""),
+            "no usage frame in stream: {text}"
+        );
+        assert!(text.contains("\"completion_tokens\""));
+        assert!(text.trim_end().ends_with("data: [DONE]"));
     }
 
     #[tokio::test]

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -501,6 +501,13 @@ struct CompletionChoice {
     text: String,
     index: u32,
     finish_reason: &'static str,
+    // NOTE: the real OpenAI *legacy* completions `logprobs` object has a
+    // different shape than chat's (`{tokens, token_logprobs, top_logprobs,
+    // text_offset}` vs chat's `{content: [...]}`). We reuse the chat-style
+    // `ChatLogprobs` here for now; it's moot until an engine actually emits
+    // per-token logprobs (none do yet — same deferral as #14), at which point
+    // converting to the legacy schema is the follow-up. The field is omitted
+    // entirely when empty, so a legacy client sees no malformed object today.
     #[serde(skip_serializing_if = "Option::is_none")]
     logprobs: Option<ChatLogprobs>,
 }
@@ -1747,6 +1754,40 @@ mod tests {
         let text = v["choices"][0]["text"].as_str().unwrap();
         assert_eq!(text.trim(), "alpha bravo");
         assert_eq!(v["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[tokio::test]
+    async fn completions_finish_reason_length_when_capped() {
+        // 5 prompt words, max_tokens 2 → hits the cap → "length" (the forked
+        // finish_reason path must preserve length just like the chat path).
+        let (status, v) = post_completions(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "prompt": "alpha bravo charlie delta echo",
+                "max_tokens": 2,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["choices"][0]["finish_reason"], "length");
+    }
+
+    #[tokio::test]
+    async fn completions_engine_error_returns_503() {
+        // The mock fails a task whose prompt contains `__engine_error__`. The
+        // forked non-streaming error branch must surface that as a 5xx, not a
+        // 200 with empty text.
+        let (status, _v) = post_completions(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "prompt": "__engine_error__",
+                "max_tokens": 8,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -53,13 +53,12 @@ pub const DEFAULT_MAX_PROMPT_BYTES: usize = 32 * 1024;
 pub use cascadia_types::ApiStats;
 
 /// Tokens a chunk contributes to the cumulative counter. The engine's
-/// `n_tokens` is authoritative when set (spec-decode reports 1..=K+1);
-/// otherwise the per-chunk convention is "one token per non-empty chunk"
-/// (see `Chunk::n_tokens` docs). An empty chunk — the no-text final
-/// marker mock/runtime engines emit — contributes 0 so it isn't counted
-/// as a phantom token. (ov-genai delivers its whole response on a single
-/// final chunk with no `n_tokens`, so it counts as 1 here — approximate,
-/// since that engine tokenizes internally and reports no token count.)
+/// `n_tokens` is authoritative when set (spec-decode reports 1..=K+1;
+/// ov-genai sets it on its single final chunk so `usage` reflects the
+/// real generated count — issue #55); otherwise the per-chunk convention
+/// is "one token per non-empty chunk" (see `Chunk::n_tokens` docs). An
+/// empty chunk — the no-text final marker mock/runtime engines emit —
+/// contributes 0 so it isn't counted as a phantom token.
 fn chunk_token_count(chunk: &cascadia_types::Chunk) -> u32 {
     chunk
         .n_tokens
@@ -672,7 +671,7 @@ async fn chat_completions(
         }],
         usage: Usage {
             // From the engine's final chunk; 0 when the engine can't tell
-            // (e.g. ov-genai tokenizes inside the pipeline).
+            // (e.g. an engine that reports no prompt-token count).
             prompt_tokens,
             completion_tokens,
             total_tokens: prompt_tokens + completion_tokens,
@@ -852,9 +851,33 @@ mod tests {
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
     use cascadia_engine_mock::MockBuilder;
-    use cascadia_types::{PeerLayout, ShardSpec};
+    use cascadia_types::{Chunk, PeerLayout, ShardSpec};
     use serde_json::Value;
     use tower::ServiceExt;
+
+    // Guards the contract the ov-genai usage fix (#55) depends on: when an
+    // engine sets `n_tokens` on a single text-bearing final chunk, that count
+    // is authoritative (not the "1 per chunk" fallback), so `usage` reflects
+    // the real generated-token count rather than 0/1.
+    #[test]
+    fn chunk_token_count_honors_engine_count() {
+        // ov-genai's shape: whole response on one final chunk, n_tokens set.
+        let c = Chunk::final_marker("t", "The capital of France is Paris.").with_n_tokens(8);
+        assert_eq!(chunk_token_count(&c), 8);
+
+        // Same shape WITHOUT n_tokens falls back to 1 (the pre-#55 behavior
+        // that under-counted ov-genai) — documents why the engine must set it.
+        let c = Chunk::final_marker("t", "The capital of France is Paris.");
+        assert_eq!(chunk_token_count(&c), 1);
+
+        // Empty final marker (mock/runtime) contributes 0 — no phantom token.
+        let c = Chunk::final_marker("t", "");
+        assert_eq!(chunk_token_count(&c), 0);
+
+        // A normal per-token chunk counts as 1.
+        let c = Chunk::token("t", 123, "Paris");
+        assert_eq!(chunk_token_count(&c), 1);
+    }
 
     async fn make_app() -> Router {
         let mut runner = Runner::new(Box::new(MockBuilder::new()));

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -247,6 +247,7 @@ pub fn make_router_with_stats(
         .route("/health", get(health))
         .route("/v1/models", get(list_models))
         .route("/v1/chat/completions", post(chat_completions))
+        .route("/v1/completions", post(completions))
         .route("/v1/cancel/:task_id", post(cancel))
         .with_state(state)
         // Cap the JSON body so an attacker can't OOM the server with
@@ -425,6 +426,92 @@ struct ChatCompletionResponse {
     created: i64,
     model: String,
     choices: Vec<ChatChoice>,
+    usage: Usage,
+}
+
+// --- Legacy /v1/completions (OpenAI-compatible) -------------------------
+
+/// OpenAI `prompt` is a single string or an array of strings.
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum PromptSpec {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CompletionRequest {
+    pub model: String,
+    pub prompt: PromptSpec,
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: u32,
+    #[serde(default)]
+    pub temperature: f32,
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    #[serde(default)]
+    pub top_k: Option<u32>,
+    #[serde(default)]
+    pub seed: Option<u64>,
+    #[serde(default)]
+    pub stop: Option<StopSpec>,
+    #[serde(default)]
+    pub frequency_penalty: Option<f32>,
+    #[serde(default)]
+    pub presence_penalty: Option<f32>,
+    #[serde(default)]
+    pub logprobs: Option<u32>,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub stream_options: Option<StreamOptions>,
+    /// Prepend the prompt to the returned text (OpenAI `echo`).
+    #[serde(default)]
+    pub echo: bool,
+}
+
+impl CompletionRequest {
+    fn sampling_params(&self) -> cascadia_types::SamplingParams {
+        cascadia_types::SamplingParams {
+            top_p: self.top_p.unwrap_or(1.0),
+            top_k: self.top_k.unwrap_or(0),
+            seed: self.seed,
+            frequency_penalty: self.frequency_penalty.unwrap_or(0.0),
+            presence_penalty: self.presence_penalty.unwrap_or(0.0),
+            stop: self
+                .stop
+                .as_ref()
+                .map(|s| match s {
+                    StopSpec::Single(x) => vec![x.clone()],
+                    StopSpec::Multiple(v) => v.clone(),
+                })
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Legacy `logprobs` is an integer count (number of top logprobs), unlike
+    /// the chat endpoint's bool. 0 / None disables.
+    fn logprobs_count(&self) -> u32 {
+        self.logprobs.unwrap_or(0).min(20)
+    }
+}
+
+#[derive(Serialize)]
+struct CompletionChoice {
+    text: String,
+    index: u32,
+    finish_reason: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logprobs: Option<ChatLogprobs>,
+}
+
+#[derive(Serialize)]
+struct CompletionResponse {
+    id: String,
+    object: &'static str,
+    created: i64,
+    model: String,
+    choices: Vec<CompletionChoice>,
     usage: Usage,
 }
 
@@ -793,6 +880,299 @@ async fn chat_completions(
         },
     })
     .into_response()
+}
+
+/// OpenAI-compatible legacy `/v1/completions`. A raw-`prompt` sibling of
+/// `/v1/chat/completions` — no chat-template render, returns `text` instead
+/// of a `message`. Reuses the same sampling/finish_reason/usage path.
+async fn completions(
+    State(state): State<AppState>,
+    Json(req): Json<CompletionRequest>,
+) -> axum::response::Response {
+    // Multi-prompt batching needs cross-task batching infra the engines don't
+    // have yet (one task per step). Reject the array form with a clean 400.
+    let prompt = match &req.prompt {
+        PromptSpec::Single(s) => s.clone(),
+        PromptSpec::Multiple(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "multi-prompt batching not yet supported; submit one prompt per request"
+                })),
+            )
+                .into_response();
+        }
+    };
+    let task_id = format!("cmpl-{}", Uuid::new_v4().simple());
+    if prompt.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "no prompt content: `prompt` is empty" })),
+        )
+            .into_response();
+    }
+    if prompt.len() > state.max_prompt_bytes {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "error": format!(
+                    "prompt is {} bytes; max allowed is {} (max_prompt_bytes)",
+                    prompt.len(),
+                    state.max_prompt_bytes,
+                )
+            })),
+        )
+            .into_response();
+    }
+    let task = GenerationTask {
+        task_id: task_id.clone(),
+        // Raw prompt — the legacy endpoint does NOT apply a chat template.
+        prompt: prompt.clone(),
+        max_tokens: req.max_tokens,
+        temperature: req.temperature,
+        logprobs: req.logprobs_count(),
+        sampling: req.sampling_params(),
+        enable_thinking: false,
+        trust_remote_code: false,
+    };
+
+    let permit = match state.permits.clone().try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "engine at capacity; retry after current requests complete"
+                })),
+            )
+                .into_response();
+        }
+    };
+    state.stats.requests_total.fetch_add(1, Ordering::Relaxed);
+    let inflight = InFlightGuard::new(state.stats.clone());
+
+    if req.stream {
+        let include_usage = req
+            .stream_options
+            .as_ref()
+            .map(|o| o.include_usage)
+            .unwrap_or(false);
+        let echo_prefix = if req.echo { Some(prompt) } else { None };
+        return stream_text_completion(
+            state,
+            req.model,
+            task,
+            echo_prefix,
+            permit,
+            inflight,
+            include_usage,
+        )
+        .await
+        .into_response();
+    }
+
+    let _permit = permit;
+    let _inflight = inflight;
+    let mut chunk_stream = match state.runner.generate(task) {
+        Ok(s) => s,
+        Err(err) => return engine_error_response(err),
+    };
+    let mut buf = String::new();
+    let mut completion_tokens: u32 = 0;
+    let mut prompt_tokens: u32 = 0;
+    let mut finish_reason: &'static str = "stop";
+    let mut logprobs_content: Vec<cascadia_types::TokenLogprobs> = Vec::new();
+    while let Some(chunk) = chunk_stream.next().await {
+        if let Some(reason) = &chunk.error {
+            warn!(task = %task_id, reason = %reason, "engine failed task; returning 503");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "error": reason })),
+            )
+                .into_response();
+        }
+        buf.push_str(&chunk.text);
+        completion_tokens += chunk_token_count(&chunk);
+        if let Some(lp) = &chunk.logprobs {
+            logprobs_content.push(lp.clone());
+        }
+        if chunk.is_final {
+            prompt_tokens = chunk.prompt_tokens.unwrap_or(0);
+            if let Some(fr) = chunk.finish_reason {
+                finish_reason = fr.as_openai_str();
+            }
+        }
+    }
+    state
+        .stats
+        .tokens_total
+        .fetch_add(completion_tokens as u64, Ordering::Relaxed);
+
+    // Stop-sequence truncation (same as the chat path).
+    let stops = req.sampling_params().stop;
+    if !stops.is_empty() {
+        if let Some(cut) = stops
+            .iter()
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| buf.find(s.as_str()))
+            .min()
+        {
+            buf.truncate(cut);
+            finish_reason = "stop";
+        }
+    }
+
+    // `echo`: prepend the (raw) prompt to the returned text.
+    let text = if req.echo {
+        format!("{prompt}{buf}")
+    } else {
+        buf
+    };
+
+    Json(CompletionResponse {
+        id: task_id,
+        object: "text_completion",
+        created: now_unix(),
+        model: req.model,
+        choices: vec![CompletionChoice {
+            text,
+            index: 0,
+            finish_reason,
+            logprobs: if logprobs_content.is_empty() {
+                None
+            } else {
+                Some(ChatLogprobs {
+                    content: logprobs_content,
+                })
+            },
+        }],
+        usage: Usage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+        },
+    })
+    .into_response()
+}
+
+/// SSE variant of `/v1/completions`: emits `text_completion` chunks with
+/// `choices[].text` deltas. `echo_prefix`, when set, is prepended to the very
+/// first content frame.
+async fn stream_text_completion(
+    state: AppState,
+    model: String,
+    task: GenerationTask,
+    echo_prefix: Option<String>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+    inflight: InFlightGuard,
+    include_usage: bool,
+) -> axum::response::Response {
+    let task_id = task.task_id.clone();
+    let chunk_stream = match state.runner.generate(task) {
+        Ok(s) => s,
+        Err(err) => {
+            warn!(error = %err, "completions-stream: generate failed");
+            return engine_error_response(err);
+        }
+    };
+    let stats = state.stats.clone();
+    let usage_completion = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let usage_prompt = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let final_completion = usage_completion.clone();
+    let final_prompt = usage_prompt.clone();
+    let usage_model = model.clone();
+    let usage_task_id = task_id.clone();
+    // First-frame flag for `echo` (prepend the prompt once).
+    let echo_pending = Arc::new(std::sync::Mutex::new(echo_prefix));
+    let permit_carrier = StreamWithPermit {
+        inner: chunk_stream,
+        _permit: permit,
+        _inflight: inflight,
+    };
+    let body_stream = permit_carrier
+        .then(move |chunk| {
+            let model = model.clone();
+            let task_id = task_id.clone();
+            let stats = stats.clone();
+            let usage_completion = usage_completion.clone();
+            let usage_prompt = usage_prompt.clone();
+            let echo_pending = echo_pending.clone();
+            async move {
+                if chunk.error.is_none() {
+                    let n = chunk_token_count(&chunk);
+                    stats.tokens_total.fetch_add(n as u64, Ordering::Relaxed);
+                    usage_completion.fetch_add(n, Ordering::Relaxed);
+                    if chunk.is_final {
+                        usage_prompt.store(chunk.prompt_tokens.unwrap_or(0), Ordering::Relaxed);
+                    }
+                }
+                if let Some(reason) = &chunk.error {
+                    warn!(task = %task_id, reason = %reason, "engine failed task mid-stream; emitting SSE error");
+                    let payload = serde_json::json!({
+                        "id": task_id,
+                        "object": "error",
+                        "error": { "message": reason, "type": "engine_error" },
+                    });
+                    tokio::task::yield_now().await;
+                    return Ok::<Bytes, std::convert::Infallible>(Bytes::from(format!("data: {payload}\n\n")));
+                }
+                // Prepend the echo prefix to the first content frame, once.
+                let mut text = chunk.text.clone();
+                if let Some(prefix) = echo_pending.lock().unwrap().take() {
+                    text = format!("{prefix}{text}");
+                }
+                let payload = serde_json::json!({
+                    "id": task_id,
+                    "object": "text_completion",
+                    "created": now_unix(),
+                    "model": model,
+                    "n_tokens": chunk.n_tokens.unwrap_or(1),
+                    "choices": [{
+                        "index": 0,
+                        "text": text,
+                        "finish_reason": if chunk.is_final {
+                            Some(chunk.finish_reason.map(|f| f.as_openai_str()).unwrap_or("stop"))
+                        } else {
+                            None
+                        },
+                    }],
+                });
+                let line = format!("data: {payload}\n\n");
+                tokio::task::yield_now().await;
+                Ok::<Bytes, std::convert::Infallible>(Bytes::from(line))
+            }
+        })
+        .chain(stream::once(async move {
+            let mut out = String::new();
+            if include_usage {
+                let prompt = final_prompt.load(Ordering::Relaxed);
+                let completion = final_completion.load(Ordering::Relaxed);
+                let usage = serde_json::json!({
+                    "id": usage_task_id,
+                    "object": "text_completion",
+                    "created": now_unix(),
+                    "model": usage_model,
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": prompt,
+                        "completion_tokens": completion,
+                        "total_tokens": prompt + completion,
+                    },
+                });
+                out.push_str(&format!("data: {usage}\n\n"));
+            }
+            out.push_str("data: [DONE]\n\n");
+            Ok::<Bytes, std::convert::Infallible>(Bytes::from(out))
+        }));
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header("x-accel-buffering", "no")
+        .body(Body::from_stream(body_stream))
+        .unwrap()
+        .into_response()
 }
 
 async fn stream_completion(
@@ -1247,6 +1627,126 @@ mod tests {
         );
         assert!(text.contains("\"completion_tokens\""));
         assert!(text.trim_end().ends_with("data: [DONE]"));
+    }
+
+    async fn post_completions(app: Router, payload: serde_json::Value) -> (StatusCode, Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), 16384).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        (status, v)
+    }
+
+    #[tokio::test]
+    async fn completions_returns_text_completion() {
+        // Mock echoes prompt words verbatim (no chat template applied).
+        let (status, v) = post_completions(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "prompt": "alpha bravo charlie",
+                "max_tokens": 64,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(v["object"], "text_completion");
+        let text = v["choices"][0]["text"].as_str().unwrap();
+        assert_eq!(text.trim(), "alpha bravo charlie");
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
+        assert_eq!(v["usage"]["completion_tokens"], 3);
+    }
+
+    #[tokio::test]
+    async fn completions_echo_prepends_prompt() {
+        let (status, v) = post_completions(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "prompt": "alpha bravo",
+                "max_tokens": 64,
+                "echo": true,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        // echo prepends the raw prompt to the (prompt-stripped) continuation.
+        let text = v["choices"][0]["text"].as_str().unwrap();
+        assert!(text.starts_with("alpha bravo"), "echo missing: {text:?}");
+    }
+
+    #[tokio::test]
+    async fn completions_streaming_emits_text_completion_and_done() {
+        let response = make_app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "model": "mock-model",
+                            "prompt": "alpha bravo charlie",
+                            "max_tokens": 8,
+                            "stream": true,
+                            "stream_options": {"include_usage": true},
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 65536).await.unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("\"text_completion\""), "wrong object: {text}");
+        assert!(text.contains("\"text\""), "no text delta: {text}");
+        assert!(text.contains("\"usage\""));
+        assert!(text.trim_end().ends_with("data: [DONE]"));
+    }
+
+    #[tokio::test]
+    async fn completions_multi_prompt_array_is_400() {
+        let (status, _v) = post_completions(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "prompt": ["one", "two"],
+                "max_tokens": 4,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn completions_honor_stop_and_finish_reason() {
+        let (status, v) = post_completions(
+            make_app().await,
+            serde_json::json!({
+                "model": "mock-model",
+                "prompt": "alpha bravo charlie delta",
+                "max_tokens": 64,
+                "stop": ["charlie"],
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let text = v["choices"][0]["text"].as_str().unwrap();
+        assert_eq!(text.trim(), "alpha bravo");
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
     }
 
     #[tokio::test]

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1298,6 +1298,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
             max_tokens: args.max_tokens,
             temperature: 0.0,
             logprobs: 0,
+            sampling: cascadia_types::SamplingParams::default(),
             enable_thinking: false,
             trust_remote_code: false,
         };

--- a/crates/cascadia-cli/src/profile.rs
+++ b/crates/cascadia-cli/src/profile.rs
@@ -337,6 +337,7 @@ pub fn probe_device(device: &str, args: &ProfileDevicesArgs) -> DeviceResult {
         num_assistant_tokens: 0,
         max_ngram_size: 0,
         skip_chat_template: false,
+        ..Default::default()
     };
 
     // Warmup. Failure here is fatal for this device (we can't trust

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -48,7 +48,19 @@ impl Engine for MockEngine {
         let max = task.max_tokens.max(1) as usize;
         let words: Vec<&str> = task.prompt.split_whitespace().collect();
         if emitted >= max || emitted >= words.len() {
-            return vec![(task.task_id.clone(), Chunk::final_marker(task.task_id, ""))];
+            // Distinguish the stop reason like a real engine: exhausting the
+            // prompt's words is a natural `stop`; hitting the token cap first
+            // is `length`. Lets the API's finish_reason path be tested without
+            // a real model.
+            let reason = if emitted >= words.len() {
+                cascadia_types::FinishReason::Stop
+            } else {
+                cascadia_types::FinishReason::Length
+            };
+            return vec![(
+                task.task_id.clone(),
+                Chunk::final_marker(task.task_id, "").with_finish_reason(reason),
+            )];
         }
         let token = words[emitted].to_string();
         let chunk = Chunk::token(&task.task_id, emitted as i64, token + " ");

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1301,6 +1301,7 @@ impl Engine for OvDistSpecEngine {
                         n_tokens: Some(1),
                         prompt_tokens: None,
                         error: None,
+                        finish_reason: None,
                     },
                 )]
             }
@@ -1332,6 +1333,7 @@ impl Engine for OvDistSpecEngine {
                                 n_tokens: Some(n_tokens),
                                 prompt_tokens: None,
                                 error: None,
+                                finish_reason: None,
                             },
                         )]
                     }
@@ -1505,6 +1507,7 @@ impl OvDistSpecEngine {
                 n_tokens: if n_tokens > 0 { Some(n_tokens) } else { None },
                 prompt_tokens: None,
                 error: None,
+                finish_reason: None,
             },
         )]
     }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -912,6 +912,7 @@ impl Gemma4Engine {
                 n_tokens: None,
                 prompt_tokens: None,
                 error: None,
+                finish_reason: None,
             }
         } else {
             Chunk::token(task_id.clone(), next_token as i64, delta)

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -18,7 +18,10 @@ use std::time::Instant;
 use async_trait::async_trait;
 use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
 use cascadia_ov_genai_shim::{Error as OvError, GenConfig, LlmPipeline, PluginConfig};
-use cascadia_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec, TaskId};
+use cascadia_types::{
+    Chunk, FinishReason, GenerationTask, LoadProgress, PeerLayout, SamplingParams, ShardSpec,
+    TaskId,
+};
 use futures::stream;
 use tracing::{info, warn};
 
@@ -243,7 +246,10 @@ pub struct OvGenaiEngine {
 impl Engine for OvGenaiEngine {
     fn warmup(&mut self) {
         let cfg = self.gen_config(
-            /*max_tokens*/ 4, /*temperature*/ 0.0, /*enable_thinking*/ false,
+            /*max_tokens*/ 4,
+            /*temperature*/ 0.0,
+            /*enable_thinking*/ false,
+            &SamplingParams::default(),
         );
         match self.pipe.generate("Hi", &cfg) {
             Ok(_) => info!(
@@ -279,14 +285,16 @@ impl Engine for OvGenaiEngine {
             return Vec::new();
         }
         let task = self.pending.remove(0);
+        let max_new = if task.max_tokens > 0 {
+            task.max_tokens
+        } else {
+            self.max_tokens_default
+        };
         let cfg = self.gen_config(
-            if task.max_tokens > 0 {
-                task.max_tokens
-            } else {
-                self.max_tokens_default
-            },
+            max_new,
             task.temperature,
             task.enable_thinking,
+            &task.sampling,
         );
 
         let started = Instant::now();
@@ -330,7 +338,18 @@ impl Engine for OvGenaiEngine {
         // (`skip_chat_template`) and a slight undercount when ov-genai
         // applies its own template internally (the template wrapping isn't
         // counted). None when the tokenizer is unavailable.
-        let mut chunk = Chunk::final_marker(task.task_id.clone(), text).with_n_tokens(tokens);
+        // finish_reason: ov-genai's GenResult doesn't report why it stopped,
+        // so infer — reaching the token cap is `length`, anything short of it
+        // (EOS / stop) is `stop`. Exact for the common case; an EOS landing
+        // exactly at the cap reports `length` (OpenAI is also ambiguous here).
+        let finish = if tokens >= max_new {
+            FinishReason::Length
+        } else {
+            FinishReason::Stop
+        };
+        let mut chunk = Chunk::final_marker(task.task_id.clone(), text)
+            .with_n_tokens(tokens)
+            .with_finish_reason(finish);
         if let Some(prompt_tokens) = self.pipe.count_tokens(&task.prompt) {
             chunk = chunk.with_prompt_tokens(prompt_tokens);
         }
@@ -339,7 +358,13 @@ impl Engine for OvGenaiEngine {
 }
 
 impl OvGenaiEngine {
-    fn gen_config(&self, max_tokens: u32, temperature: f32, enable_thinking: bool) -> GenConfig {
+    fn gen_config(
+        &self,
+        max_tokens: u32,
+        temperature: f32,
+        enable_thinking: bool,
+        sampling: &SamplingParams,
+    ) -> GenConfig {
         let do_sample = temperature > 0.0;
         let mut cfg = GenConfig {
             max_new_tokens: max_tokens,
@@ -352,6 +377,18 @@ impl OvGenaiEngine {
             // ov-genai to skip its own apply. Thinking-ON keeps ov-genai's
             // native templating (the legacy join the API emitted), untouched.
             skip_chat_template: self.prompt_pretemplated && !enable_thinking,
+            // OpenAI sampling knobs (#14). top_p/top_k take effect in the
+            // sampling regime (do_sample, i.e. temperature > 0); penalties and
+            // seed are forwarded regardless.
+            top_p: if sampling.top_p > 0.0 {
+                sampling.top_p.min(1.0)
+            } else {
+                1.0
+            },
+            top_k: sampling.top_k,
+            frequency_penalty: sampling.frequency_penalty,
+            presence_penalty: sampling.presence_penalty,
+            seed: sampling.seed,
         };
         if self.speculative_k > 0 {
             cfg.num_assistant_tokens = self.speculative_k;

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -322,7 +322,18 @@ impl Engine for OvGenaiEngine {
             "task done"
         );
 
-        let chunk = Chunk::final_marker(task.task_id.clone(), text);
+        // Carry the real token counts on the final chunk so the API's
+        // `usage` block is populated (issue #55 — previously always 0 for
+        // this engine because the whole response lands on one chunk with no
+        // per-token count). `prompt_tokens` is the rendered-prompt token
+        // count; it is exact when the API pre-templated the prompt
+        // (`skip_chat_template`) and a slight undercount when ov-genai
+        // applies its own template internally (the template wrapping isn't
+        // counted). None when the tokenizer is unavailable.
+        let mut chunk = Chunk::final_marker(task.task_id.clone(), text).with_n_tokens(tokens);
+        if let Some(prompt_tokens) = self.pipe.count_tokens(&task.prompt) {
+            chunk = chunk.with_prompt_tokens(prompt_tokens);
+        }
         vec![(task.task_id, chunk)]
     }
 }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1020,6 +1020,9 @@ impl OvRuntimeEngine {
                 n_tokens: None,
                 prompt_tokens: None,
                 error: None,
+                // ov-runtime doesn't yet distinguish length vs stop here; the
+                // API falls back to "stop" (unchanged behavior). #14 follow-up.
+                finish_reason: None,
             }
         } else {
             Chunk::token(task_id.clone(), next_token as i64, delta)

--- a/crates/cascadia-engine-sparse-moe/src/dist.rs
+++ b/crates/cascadia-engine-sparse-moe/src/dist.rs
@@ -80,10 +80,16 @@ use crate::sampling::SamplingConfig;
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FrameKind {
-    Forward = 0x53_4D_45_02,      // "SME\x02"
+    // Forward / ForwardBatch carry the SamplingConfig block, which grew from
+    // 28 to 40 bytes when top_k + frequency/presence penalties were added
+    // (#14). Their codes were bumped (0x02→0x04, 0x03→0x05) so a peer running
+    // the old 28-byte layout trips the unknown-kind check in `parse_kind`
+    // instead of mis-reading the larger frame. Reset/Token carry no sampling
+    // and keep their codes.
+    Forward = 0x53_4D_45_04,      // "SME\x04" — was 0x02 (28-byte sampling)
     Reset = 0x53_4D_45_10,        // "SME\x10"
     Token = 0x53_4D_45_20,        // "SME\x20"
-    ForwardBatch = 0x53_4D_45_03, // "SME\x03" — batched K-step verify
+    ForwardBatch = 0x53_4D_45_05, // "SME\x05" — was 0x03; batched K-step verify
     TokenBatch = 0x53_4D_45_21,   // "SME\x21" — batched K-step response
 }
 
@@ -162,10 +168,12 @@ fn tensor_to_hidden(t: &Tensor) -> TransportResult<(Vec<f32>, [u32; 3])> {
     Ok((out, t.shape))
 }
 
-/// On-wire encoding of `SamplingConfig`. Fixed 28 bytes BE; the `seed`
+/// On-wire encoding of `SamplingConfig`. Fixed 40 bytes BE; the `seed`
 /// field uses 0 as the sentinel for "no seed" (the engine treats 0 as
-/// invalid anyway — `init_rng` clamps to `max(seed, 1)`).
-pub const SAMPLING_WIRE_BYTES: usize = 28;
+/// invalid anyway — `init_rng` clamps to `max(seed, 1)`). Bytes 28..40 were
+/// added in #14 (top_k + frequency/presence penalties); the Forward frame
+/// kind was bumped alongside so a 28-byte peer fails fast.
+pub const SAMPLING_WIRE_BYTES: usize = 40;
 
 pub fn encode_sampling(cfg: &SamplingConfig, out: &mut [u8; SAMPLING_WIRE_BYTES]) {
     out[0..4].copy_from_slice(&cfg.temperature.to_be_bytes());
@@ -174,6 +182,9 @@ pub fn encode_sampling(cfg: &SamplingConfig, out: &mut [u8; SAMPLING_WIRE_BYTES]
     out[12..20].copy_from_slice(&(cfg.repetition_window as u64).to_be_bytes());
     let seed = cfg.seed.unwrap_or(0);
     out[20..28].copy_from_slice(&seed.to_be_bytes());
+    out[28..32].copy_from_slice(&cfg.top_k.to_be_bytes());
+    out[32..36].copy_from_slice(&cfg.frequency_penalty.to_be_bytes());
+    out[36..40].copy_from_slice(&cfg.presence_penalty.to_be_bytes());
 }
 
 pub fn decode_sampling(bytes: &[u8; SAMPLING_WIRE_BYTES]) -> SamplingConfig {
@@ -204,9 +215,25 @@ pub fn decode_sampling(bytes: &[u8; SAMPLING_WIRE_BYTES]) -> SamplingConfig {
     let seed_raw = u64::from_be_bytes([
         bytes[20], bytes[21], bytes[22], bytes[23], bytes[24], bytes[25], bytes[26], bytes[27],
     ]);
+    let top_k = u32::from_be_bytes([bytes[28], bytes[29], bytes[30], bytes[31]]);
+    // Penalties may legitimately be negative (OpenAI range -2.0..=2.0), so
+    // only guard NaN here rather than clamping to a min like the others.
+    let frequency_penalty = sanitize_f32(
+        f32::from_be_bytes([bytes[32], bytes[33], bytes[34], bytes[35]]),
+        0.0,
+        f32::NEG_INFINITY,
+    );
+    let presence_penalty = sanitize_f32(
+        f32::from_be_bytes([bytes[36], bytes[37], bytes[38], bytes[39]]),
+        0.0,
+        f32::NEG_INFINITY,
+    );
     SamplingConfig {
         temperature,
         top_p,
+        top_k,
+        frequency_penalty,
+        presence_penalty,
         repetition_penalty,
         repetition_window: rep_window,
         seed: if seed_raw == 0 { None } else { Some(seed_raw) },

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -19,7 +19,9 @@ use async_trait::async_trait;
 use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
 use cascadia_ov_genai_shim::PluginConfig;
 use cascadia_transport::{ActivationClient, ActivationServer};
-use cascadia_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec, TaskId};
+use cascadia_types::{
+    Chunk, FinishReason, GenerationTask, LoadProgress, PeerLayout, ShardSpec, TaskId,
+};
 use futures::stream;
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex as TokioMutex;
@@ -641,18 +643,34 @@ impl Builder for SparseMoEBuilder {
     }
 }
 
-/// Build a SamplingConfig for one task. Currently the only knob the
-/// public `GenerationTask` surface exposes is `temperature`; the rest
-/// are hard-coded to defaults that have worked well in K2.6 evals.
-/// Lifted out so the single-stage and multi-stage entry paths can't
-/// drift.
+/// Build a SamplingConfig for one task from the request's `temperature` +
+/// `SamplingParams` (top_p / top_k / seed / frequency & presence penalty).
+/// `repetition_penalty` / `repetition_window` are K2.6-tuned defaults not
+/// exposed on the OpenAI surface. Lifted out so the single-stage and
+/// multi-stage entry paths can't drift.
+/// Infer the OpenAI `finish_reason` for a completed decode: hitting the token
+/// cap is `length`; stopping short of it (EOS / stop sequence) is `stop`. The
+/// runner returns the generated ids excluding EOS, so `n >= max_new` means the
+/// cap was the limiter. An EOS landing exactly at the cap reports `length`.
+fn finish_reason_for(n_tokens: usize, max_new: usize) -> FinishReason {
+    if n_tokens >= max_new {
+        FinishReason::Length
+    } else {
+        FinishReason::Stop
+    }
+}
+
 fn sampling_from_task(task: &GenerationTask) -> crate::sampling::SamplingConfig {
+    let s = &task.sampling;
     crate::sampling::SamplingConfig {
         temperature: task.temperature.max(0.0),
-        top_p: 1.0,
+        top_p: if s.top_p > 0.0 { s.top_p.min(1.0) } else { 1.0 },
+        top_k: s.top_k,
+        frequency_penalty: s.frequency_penalty,
+        presence_penalty: s.presence_penalty,
         repetition_penalty: 1.05,
         repetition_window: 64,
-        seed: None,
+        seed: s.seed,
     }
 }
 
@@ -960,6 +978,7 @@ impl SparseMoEEngine {
         );
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
+        chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
         vec![(task.task_id.clone(), chunk)]
     }
 
@@ -1063,6 +1082,7 @@ impl SparseMoEEngine {
         );
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
+        chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
         vec![(task.task_id.clone(), chunk)]
     }
 
@@ -1887,6 +1907,7 @@ impl OvMoeEngine {
         );
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
+        chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
         vec![(task.task_id.clone(), chunk)]
     }
 
@@ -2019,6 +2040,7 @@ impl OvMoeEngine {
         );
         let mut chunk = Chunk::final_marker(id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
+        chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
         vec![(id, chunk)]
     }
 

--- a/crates/cascadia-engine-sparse-moe/src/sampling.rs
+++ b/crates/cascadia-engine-sparse-moe/src/sampling.rs
@@ -10,6 +10,16 @@ pub struct SamplingConfig {
     pub temperature: f32,
     /// Nucleus (top-p). 0.0 or 1.0 → disabled.
     pub top_p: f32,
+    /// Top-k truncation. 0 → disabled. Keeps only the k highest-probability
+    /// tokens before nucleus sampling.
+    pub top_k: u32,
+    /// OpenAI frequency penalty: subtract `frequency_penalty * count(token)`
+    /// from each logit, scaled by how often the token already appeared.
+    /// 0.0 → disabled.
+    pub frequency_penalty: f32,
+    /// OpenAI presence penalty: subtract `presence_penalty` once from any
+    /// logit whose token already appeared at all. 0.0 → disabled.
+    pub presence_penalty: f32,
     /// Repetition penalty α applied to logits of recently-emitted tokens.
     /// 1.0 → no penalty. Typical values: 1.05–1.3. See "CTRL: A Conditional
     /// Transformer Language Model for Controllable Generation" (Keskar et
@@ -28,6 +38,9 @@ impl Default for SamplingConfig {
         Self {
             temperature: 0.0,
             top_p: 1.0,
+            top_k: 0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
             repetition_penalty: 1.0,
             repetition_window: 0,
             seed: None,
@@ -56,6 +69,23 @@ pub fn sample(logits: &[f32], history: &[i64], cfg: &SamplingConfig, rng_state: 
         }
     }
 
+    // OpenAI frequency / presence penalties (subtractive, on logits). Applied
+    // over the full running history. Gated so there's zero cost when unused.
+    if cfg.frequency_penalty != 0.0 || cfg.presence_penalty != 0.0 {
+        let mut seen = std::collections::HashSet::new();
+        for &tok in history.iter() {
+            let i = tok as usize;
+            if i < work.len() {
+                // frequency: once per occurrence => count * penalty in total.
+                work[i] -= cfg.frequency_penalty;
+                // presence: once per distinct token.
+                if seen.insert(tok) {
+                    work[i] -= cfg.presence_penalty;
+                }
+            }
+        }
+    }
+
     // Greedy fallback.
     if cfg.temperature <= 0.0 {
         return argmax(&work);
@@ -76,6 +106,36 @@ pub fn sample(logits: &[f32], history: &[i64], cfg: &SamplingConfig, rng_state: 
     }
     for v in work.iter_mut() {
         *v /= sum;
+    }
+
+    // Top-k. Disabled at 0. Keep the k highest-probability tokens, zero the
+    // rest, renormalize. Applied before top-p (k bounds the candidate set,
+    // p then trims within it — matches common samplers).
+    if cfg.top_k > 0 && (cfg.top_k as usize) < work.len() {
+        let k = cfg.top_k as usize;
+        let mut idx: Vec<usize> = (0..work.len()).collect();
+        idx.sort_by(|&a, &b| {
+            work[b]
+                .partial_cmp(&work[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let mut keep = vec![false; work.len()];
+        for &i in idx.iter().take(k) {
+            keep[i] = true;
+        }
+        let mut renorm = 0.0f32;
+        for (i, v) in work.iter_mut().enumerate() {
+            if keep[i] {
+                renorm += *v;
+            } else {
+                *v = 0.0;
+            }
+        }
+        if renorm > 0.0 {
+            for v in work.iter_mut() {
+                *v /= renorm;
+            }
+        }
     }
 
     // Top-p (nucleus). Disabled when p ∈ {0, 1}.
@@ -202,6 +262,49 @@ mod tests {
         // After penalty: logit[5] = 10.0 / 10.0 = 1.0. logit[3] = 2.0
         // wins. Greedy → 3.
         assert_eq!(sample(&l, &history, &cfg, &mut s), 3);
+    }
+
+    #[test]
+    fn frequency_penalty_demotes_repeated_token_greedy() {
+        // logit[5] highest; history has 5 three times. A frequency penalty of
+        // 2.0 subtracts 3*2=6 → logit[5]=10-6=4, below logit[3]=5. Greedy → 3.
+        let mut l = vec![0.0_f32; 10];
+        l[5] = 10.0;
+        l[3] = 5.0;
+        let history = vec![5_i64, 5, 5];
+        let mut s = 1;
+        let mut cfg = SamplingConfig::default();
+        cfg.frequency_penalty = 2.0;
+        assert_eq!(sample(&l, &history, &cfg, &mut s), 3);
+    }
+
+    #[test]
+    fn presence_penalty_is_count_independent() {
+        // Presence subtracts once regardless of count. logit[5]=10, history has
+        // 5 five times; presence 1.5 → logit[5]=8.5 (not 10-5*1.5). Still > 8.
+        let mut l = vec![0.0_f32; 10];
+        l[5] = 10.0;
+        l[3] = 8.0;
+        let history = vec![5_i64, 5, 5, 5, 5];
+        let mut s = 1;
+        let mut cfg = SamplingConfig::default();
+        cfg.presence_penalty = 1.5;
+        assert_eq!(sample(&l, &history, &cfg, &mut s), 5);
+    }
+
+    #[test]
+    fn top_k_one_forces_argmax_under_temperature() {
+        // With top_k=1, only the single highest-prob token survives, so even
+        // with temperature on, sampling must return the argmax deterministically.
+        let mut l = vec![1.0_f32; 8];
+        l[4] = 5.0;
+        let mut s = 12345;
+        let mut cfg = SamplingConfig::default();
+        cfg.temperature = 1.0;
+        cfg.top_k = 1;
+        for _ in 0..20 {
+            assert_eq!(sample(&l, &[], &cfg, &mut s), 4);
+        }
     }
 
     #[test]

--- a/crates/cascadia-engine-sparse-moe/tests/dist_wire.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/dist_wire.rs
@@ -52,6 +52,7 @@ async fn forward_frame_round_trips_hidden_state() {
         repetition_penalty: 1.15,
         repetition_window: 256,
         seed: Some(0x1234_5678_9abc_def0),
+        ..SamplingConfig::default()
     };
     let cfg_for_assert = cfg.clone();
 
@@ -101,10 +102,13 @@ fn sampling_wire_round_trips_defaults_and_explicit_values() {
     assert_eq!(back.repetition_window, cfg.repetition_window);
     assert_eq!(back.seed, None);
 
-    // Explicit fields including a seed.
+    // Explicit fields including a seed + the #14 sampling knobs.
     let cfg = SamplingConfig {
         temperature: 0.8,
         top_p: 0.95,
+        top_k: 40,
+        frequency_penalty: 0.5,
+        presence_penalty: -0.25,
         repetition_penalty: 1.1,
         repetition_window: 1024,
         seed: Some(42),
@@ -114,9 +118,26 @@ fn sampling_wire_round_trips_defaults_and_explicit_values() {
     let back = decode_sampling(&bytes);
     assert_eq!(back.temperature, cfg.temperature);
     assert_eq!(back.top_p, cfg.top_p);
+    assert_eq!(back.top_k, cfg.top_k);
+    assert_eq!(back.frequency_penalty, cfg.frequency_penalty);
+    assert_eq!(back.presence_penalty, cfg.presence_penalty);
     assert_eq!(back.repetition_penalty, cfg.repetition_penalty);
     assert_eq!(back.repetition_window, cfg.repetition_window);
     assert_eq!(back.seed, cfg.seed);
+
+    // The Forward frame kind was bumped to a new code alongside the wider
+    // sampling block so a 28-byte-layout peer fails fast (#14).
+    assert_eq!(
+        FrameKind::from_code(0x53_4D_45_04),
+        Some(FrameKind::Forward)
+    );
+    assert_eq!(
+        FrameKind::from_code(0x53_4D_45_05),
+        Some(FrameKind::ForwardBatch)
+    );
+    // The old 28-byte Forward/ForwardBatch codes are now unknown → rejected.
+    assert_eq!(FrameKind::from_code(0x53_4D_45_02), None);
+    assert_eq!(FrameKind::from_code(0x53_4D_45_03), None);
 }
 
 #[tokio::test]
@@ -232,6 +253,7 @@ async fn forward_batch_frame_round_trips_k4() {
         repetition_penalty: 1.0,
         repetition_window: 0,
         seed: Some(42),
+        ..SamplingConfig::default()
     };
     let cfg_for_assert = cfg.clone();
     let past_seq_len_start: u32 = 13;
@@ -393,15 +415,19 @@ async fn forward_batch_rejects_mismatched_shape() {
 
 #[test]
 fn frame_kind_codes_remain_stable() {
-    // Old peers (pre-PR #11) only know Forward/Reset/Token. Adding
-    // ForwardBatch/TokenBatch must not alter the existing codes — a
-    // pre-PR #11 worker still decodes a Forward correctly. This pins
-    // the wire codes so a future refactor can't drift them silently.
-    assert_eq!(FrameKind::Forward as u32, 0x53_4D_45_02);
+    // This pins the wire codes so a future refactor can't drift them silently.
+    // Reset/Token carry no sampling block and keep their original codes.
+    // Forward/ForwardBatch were bumped 0x02→0x04 / 0x03→0x05 in #14 when the
+    // sampling block grew 28→40 bytes, so a peer on the old layout fails fast
+    // at parse_kind rather than mis-reading the wider frame.
+    assert_eq!(FrameKind::Forward as u32, 0x53_4D_45_04);
     assert_eq!(FrameKind::Reset as u32, 0x53_4D_45_10);
     assert_eq!(FrameKind::Token as u32, 0x53_4D_45_20);
-    assert_eq!(FrameKind::ForwardBatch as u32, 0x53_4D_45_03);
+    assert_eq!(FrameKind::ForwardBatch as u32, 0x53_4D_45_05);
     assert_eq!(FrameKind::TokenBatch as u32, 0x53_4D_45_21);
+    // The retired 28-byte-layout codes must now be rejected as unknown.
+    assert_eq!(FrameKind::from_code(0x53_4D_45_02), None);
+    assert_eq!(FrameKind::from_code(0x53_4D_45_03), None);
 
     // And round-trip every variant through from_code.
     for k in [

--- a/crates/cascadia-engine-sparse-moe/tests/minimax_m2_eval.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/minimax_m2_eval.rs
@@ -335,6 +335,7 @@ fn minimax_m2_full_generate_smoke() {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0),
         seed: Some(42),
+        ..cascadia_engine_sparse_moe::SamplingConfig::default()
     };
     eprintln!(
         "sampling: temp={} top_p={} rep_penalty={} rep_window={}",

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -270,6 +270,23 @@ void cascadia_genconfig_set_max_ngram_size(cascadia_genconfig_t* cfg, uint32_t v
 void cascadia_genconfig_set_apply_chat_template(cascadia_genconfig_t* cfg, int32_t enabled) {
     if (cfg) cfg->cfg.apply_chat_template = enabled != 0;
 }
+// OpenAI-compatible sampling knobs (#14). All map to standard public fields
+// of ov::genai::GenerationConfig; trivial assignments that cannot throw.
+void cascadia_genconfig_set_top_p(cascadia_genconfig_t* cfg, float v) {
+    if (cfg) cfg->cfg.top_p = v;
+}
+void cascadia_genconfig_set_top_k(cascadia_genconfig_t* cfg, uint32_t v) {
+    if (cfg) cfg->cfg.top_k = static_cast<size_t>(v);
+}
+void cascadia_genconfig_set_frequency_penalty(cascadia_genconfig_t* cfg, float v) {
+    if (cfg) cfg->cfg.frequency_penalty = v;
+}
+void cascadia_genconfig_set_presence_penalty(cascadia_genconfig_t* cfg, float v) {
+    if (cfg) cfg->cfg.presence_penalty = v;
+}
+void cascadia_genconfig_set_rng_seed(cascadia_genconfig_t* cfg, uint64_t v) {
+    if (cfg) cfg->cfg.rng_seed = static_cast<size_t>(v);
+}
 
 int32_t cascadia_pipeline_generate(
     cascadia_pipeline_t* handle, const char* prompt, const cascadia_genconfig_t* cfg,

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -88,6 +88,13 @@ void cascadia_genconfig_set_max_ngram_size(cascadia_genconfig_t* cfg, uint32_t v
 // When enabled==0 the pipeline skips its internal chat-template apply (caller
 // pre-rendered the template, e.g. to honor enable_thinking). Default: apply.
 void cascadia_genconfig_set_apply_chat_template(cascadia_genconfig_t* cfg, int32_t enabled);
+// OpenAI-compatible sampling knobs (#14): map to ov::genai::GenerationConfig
+// fields top_p / top_k / frequency_penalty / presence_penalty / rng_seed.
+void cascadia_genconfig_set_top_p(cascadia_genconfig_t* cfg, float v);
+void cascadia_genconfig_set_top_k(cascadia_genconfig_t* cfg, uint32_t v);
+void cascadia_genconfig_set_frequency_penalty(cascadia_genconfig_t* cfg, float v);
+void cascadia_genconfig_set_presence_penalty(cascadia_genconfig_t* cfg, float v);
+void cascadia_genconfig_set_rng_seed(cascadia_genconfig_t* cfg, uint64_t v);
 
 // ---- Generation -----------------------------------------------------------
 

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -112,6 +112,11 @@ mod sys {
             cfg: *mut cascadia_genconfig_t,
             enabled: i32,
         );
+        pub fn cascadia_genconfig_set_top_p(cfg: *mut cascadia_genconfig_t, v: f32);
+        pub fn cascadia_genconfig_set_top_k(cfg: *mut cascadia_genconfig_t, v: u32);
+        pub fn cascadia_genconfig_set_frequency_penalty(cfg: *mut cascadia_genconfig_t, v: f32);
+        pub fn cascadia_genconfig_set_presence_penalty(cfg: *mut cascadia_genconfig_t, v: f32);
+        pub fn cascadia_genconfig_set_rng_seed(cfg: *mut cascadia_genconfig_t, v: u64);
 
         pub fn cascadia_pipeline_generate(
             handle: *mut cascadia_pipeline_t,
@@ -275,6 +280,14 @@ pub struct GenConfig {
     /// the caller pre-rendered the template (e.g. to honor enable_thinking).
     /// Default false = apply (matches OV's `apply_chat_template = true`).
     pub skip_chat_template: bool,
+    /// OpenAI-compatible sampling knobs (#14). Forwarded to the matching
+    /// `ov::genai::GenerationConfig` fields. Defaults (top_p=1.0 via the
+    /// builder, penalties=0, top_k=0, seed=None) are no-ops.
+    pub top_p: f32,
+    pub top_k: u32,
+    pub frequency_penalty: f32,
+    pub presence_penalty: f32,
+    pub seed: Option<u64>,
 }
 
 /// Optional plugin-config knob (CACHE_DIR, KV_CACHE_PRECISION, etc.).
@@ -459,6 +472,19 @@ impl LlmPipeline {
                 raw_cfg,
                 if cfg.skip_chat_template { 0 } else { 1 },
             );
+            // OpenAI-compatible sampling knobs (#14). top_p / penalties take
+            // their OV defaults (1.0 / 0.0) when unset, so setting them is a
+            // no-op; top_k=0 and seed=None mean "disabled" so only forward
+            // when explicitly chosen (OV treats top_k=0 as no truncation).
+            sys::cascadia_genconfig_set_top_p(raw_cfg, cfg.top_p);
+            if cfg.top_k > 0 {
+                sys::cascadia_genconfig_set_top_k(raw_cfg, cfg.top_k);
+            }
+            sys::cascadia_genconfig_set_frequency_penalty(raw_cfg, cfg.frequency_penalty);
+            sys::cascadia_genconfig_set_presence_penalty(raw_cfg, cfg.presence_penalty);
+            if let Some(seed) = cfg.seed {
+                sys::cascadia_genconfig_set_rng_seed(raw_cfg, seed);
+            }
             let mut text_p: *mut c_char = ptr::null_mut();
             let mut tok_count: u32 = 0;
             let rc = sys::cascadia_pipeline_generate(

--- a/crates/cascadia-types/src/chunk.rs
+++ b/crates/cascadia-types/src/chunk.rs
@@ -20,6 +20,31 @@ pub struct TokenLogprobs {
     pub top_logprobs: Vec<TopLogprob>,
 }
 
+/// Why a generation ended. Set on the FINAL chunk by engines that can tell
+/// the difference; maps to OpenAI's `finish_reason`.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    /// EOS token emitted or a stop sequence matched.
+    Stop,
+    /// `max_tokens` reached before a natural stop.
+    Length,
+    /// Client disconnected or an explicit cancel arrived.
+    Cancelled,
+}
+
+impl FinishReason {
+    /// OpenAI wire string. `Cancelled` has no OpenAI equivalent — report it
+    /// as `stop` per the streaming spec (a server SHOULD end cleanly when the
+    /// client goes away); surface `cancelled` only in metrics.
+    pub fn as_openai_str(self) -> &'static str {
+        match self {
+            FinishReason::Stop | FinishReason::Cancelled => "stop",
+            FinishReason::Length => "length",
+        }
+    }
+}
+
 /// One token (or final marker) produced by an engine for a task.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Chunk {
@@ -52,6 +77,12 @@ pub struct Chunk {
     /// loud (5xx). `None` on every normal token/final chunk.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Why generation ended. Set on the FINAL chunk by engines that can tell
+    /// `length` (hit max_tokens) from `stop` (EOS / stop sequence). `None` on
+    /// non-final chunks and on engines that don't distinguish — the API then
+    /// falls back to `"stop"` (the historical behavior).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
 }
 
 impl Chunk {
@@ -65,6 +96,7 @@ impl Chunk {
             n_tokens: None,
             prompt_tokens: None,
             error: None,
+            finish_reason: None,
         }
     }
 
@@ -78,6 +110,7 @@ impl Chunk {
             n_tokens: None,
             prompt_tokens: None,
             error: None,
+            finish_reason: None,
         }
     }
 
@@ -94,11 +127,18 @@ impl Chunk {
             n_tokens: None,
             prompt_tokens: None,
             error: Some(reason.into()),
+            finish_reason: None,
         }
     }
 
     pub fn with_prompt_tokens(mut self, n: u32) -> Self {
         self.prompt_tokens = Some(n);
+        self
+    }
+
+    /// Tag the final chunk with why generation stopped (length vs stop).
+    pub fn with_finish_reason(mut self, reason: FinishReason) -> Self {
+        self.finish_reason = Some(reason);
         self
     }
 

--- a/crates/cascadia-types/src/chunk.rs
+++ b/crates/cascadia-types/src/chunk.rs
@@ -101,4 +101,13 @@ impl Chunk {
         self.prompt_tokens = Some(n);
         self
     }
+
+    /// Record how many model tokens this chunk's `text` condenses. Engines
+    /// that deliver a whole response on one chunk (ov-genai) set this so the
+    /// API's `usage.completion_tokens` reflects the real count instead of
+    /// the "one token per chunk" fallback. See `Chunk::n_tokens` docs.
+    pub fn with_n_tokens(mut self, n: u32) -> Self {
+        self.n_tokens = Some(n);
+        self
+    }
 }

--- a/crates/cascadia-types/src/lib.rs
+++ b/crates/cascadia-types/src/lib.rs
@@ -13,10 +13,10 @@ pub mod shard;
 pub mod stats;
 pub mod task;
 
-pub use chunk::{Chunk, TokenLogprobs, TopLogprob};
+pub use chunk::{Chunk, FinishReason, TokenLogprobs, TopLogprob};
 pub use error::Error;
 pub use load::LoadProgress;
 pub use peer::{PeerEndpoint, PeerLayout};
 pub use shard::{ShardPlan, ShardSpec};
 pub use stats::ApiStats;
-pub use task::{GenerationTask, TaskId};
+pub use task::{GenerationTask, SamplingParams, TaskId};

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -3,6 +3,53 @@ use serde::{Deserialize, Serialize};
 /// Stable per-request identifier propagated end-to-end.
 pub type TaskId = String;
 
+/// OpenAI-compatible sampling knobs, bundled so they thread through the API,
+/// `GenerationTask`, and every engine as one unit. Engines that don't support
+/// a given field ignore it. `temperature` and `max_tokens` stay on
+/// `GenerationTask` itself (they predate this struct and have many call sites).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SamplingParams {
+    /// Nucleus sampling. 1.0 (or 0.0) disables. Maps to OpenAI `top_p`.
+    #[serde(default = "default_top_p")]
+    pub top_p: f32,
+    /// Top-k truncation. 0 disables. Maps to OpenAI `top_k` (non-standard but
+    /// widely supported).
+    #[serde(default)]
+    pub top_k: u32,
+    /// PRNG seed. None → system entropy. Maps to OpenAI `seed`.
+    #[serde(default)]
+    pub seed: Option<u64>,
+    /// Penalize tokens by how often they already appeared (count-scaled).
+    /// 0.0 disables. Maps to OpenAI `frequency_penalty` (range -2.0..=2.0).
+    #[serde(default)]
+    pub frequency_penalty: f32,
+    /// Penalize tokens that appeared at all (presence, not count). 0.0
+    /// disables. Maps to OpenAI `presence_penalty` (range -2.0..=2.0).
+    #[serde(default)]
+    pub presence_penalty: f32,
+    /// Stop sequences. Generation halts (and the stop text is trimmed) when
+    /// any of these is produced. Maps to OpenAI `stop` (string or array).
+    #[serde(default)]
+    pub stop: Vec<String>,
+}
+
+fn default_top_p() -> f32 {
+    1.0
+}
+
+impl Default for SamplingParams {
+    fn default() -> Self {
+        Self {
+            top_p: 1.0,
+            top_k: 0,
+            seed: None,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            stop: Vec::new(),
+        }
+    }
+}
+
 /// One generation request, end-to-end.
 ///
 /// Engines that don't support a given option silently ignore it — the API
@@ -18,6 +65,11 @@ pub struct GenerationTask {
     /// Number of top logprobs to return per token. 0 = disabled.
     #[serde(default)]
     pub logprobs: u32,
+    /// OpenAI-compatible sampling knobs (top_p / top_k / seed / penalties /
+    /// stop). `temperature` above and `max_tokens` stay separate for
+    /// historical reasons.
+    #[serde(default)]
+    pub sampling: SamplingParams,
     /// When true, the engine should expose chain-of-thought / reasoning
     /// tokens if the model supports it (DeepSeek V3.1, Qwen3, GLM-4.7,
     /// etc.).
@@ -41,6 +93,7 @@ impl GenerationTask {
             max_tokens: default_max_tokens(),
             temperature: 0.0,
             logprobs: 0,
+            sampling: SamplingParams::default(),
             enable_thinking: false,
             trust_remote_code: false,
         }
@@ -53,6 +106,11 @@ impl GenerationTask {
 
     pub fn with_temperature(mut self, temperature: f32) -> Self {
         self.temperature = temperature;
+        self
+    }
+
+    pub fn with_sampling(mut self, sampling: SamplingParams) -> Self {
+        self.sampling = sampling;
         self
     }
 }


### PR DESCRIPTION
Closes #19.

> **Stacks on #91 (#14) → #90 (#55).** Cut from `feat/sampling-params-14`, so it contains those commits too. Merge order: #90 → #91 → this. The #19 change is the top commit (`8989b4e`), a single-file addition to `crates/cascadia-api/src/lib.rs`.

Adds the OpenAI-compatible legacy `/v1/completions` endpoint — a raw-`prompt` sibling of `/v1/chat/completions`. No chat-template render; returns `text` instead of a `message`. Reuses #14's sampling / `finish_reason` / usage / stop-sequence / streaming-usage machinery.

## Behavior
- **Single prompt only.** A `prompt` array returns a clean `400` ("multi-prompt batching not yet supported") — the engines run one task per step; batching is future work.
- **`echo: true`** prepends the raw prompt to the returned text (non-streaming, and as the first SSE frame when streaming).
- **Streaming** emits `text_completion` chunks with `choices[].text` deltas + an optional final `usage` frame (`stream_options.include_usage`).
- **`logprobs`** (legacy integer count) threads through to the task; per-engine emission is the same deferred follow-up as #14.

## Tests (stub build, mock engine)
- ✅ `text_completion` object shape + `usage.completion_tokens`
- ✅ `echo` prepends the prompt
- ✅ multi-prompt array → 400
- ✅ stop-sequence truncation + `finish_reason`
- ✅ streaming `text_completion` deltas + `usage` + `[DONE]`

`cargo fmt` clean; `cargo test -p cascadia-api` green (20 tests). No engine-path changes, so no hardware needed for this PR specifically (it rides on whatever the underlying engine produces).