### PR TITLE
feat(transport): opt-in QUIC activation transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "cascadia-ov-genai-shim",
  "cascadia-runner",
  "cascadia-topology",
+ "cascadia-transport",
  "cascadia-types",
  "clap",
  "clap_complete",
@@ -465,6 +466,9 @@ name = "cascadia-transport"
 version = "0.1.1"
 dependencies = [
  "bytes",
+ "quinn",
+ "rcgen",
+ "rustls",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -735,6 +739,12 @@ checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_builder"
@@ -1778,6 +1788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2132,18 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2710,6 +2744,25 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -3772,6 +3825,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/cascadia-cli/Cargo.toml
+++ b/crates/cascadia-cli/Cargo.toml
@@ -8,12 +8,17 @@ repository.workspace = true
 description = "cascadia CLI — worker, run, shard, doctor, discover, engines subcommands."
 
 [features]
-default = []
+default = ["quic"]
 openvino = [
     "cascadia-engine-openvino/openvino",
     "cascadia-engine-sparse-moe/openvino",
     "cascadia-ov-genai-shim/openvino",
 ]
+# Opt-in QUIC activation transport (`cascadia worker --transport quic`).
+# On by default so the shipped binary supports the flag out of the box;
+# build `--no-default-features` (re-adding any features you need) to drop
+# the quinn/rustls/rcgen dependency entirely.
+quic = ["cascadia-transport/quic"]
 # Embed the built SPA (crates/cascadia-dashboard/web/dist) into the binary.
 # Off by default so a fresh `cargo build` doesn't require `npm run build`
 # to have been run first. With this on, `cascadia worker --api` serves the
@@ -28,6 +33,7 @@ cascadia-engine-openvino = { workspace = true }
 cascadia-engine-sparse-moe = { workspace = true }
 cascadia-ov-genai-shim = { workspace = true }
 cascadia-runner = { workspace = true }
+cascadia-transport = { workspace = true }
 cascadia-api = { workspace = true }
 cascadia-dashboard = { workspace = true }
 cascadia-discovery = { workspace = true }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -217,6 +217,29 @@ pub enum EngineKind {
     Qwen36Moe,
 }
 
+/// Inter-stage activation transport substrate.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransportArg {
+    /// Raw length-prefixed TCP relay (default). Byte-identical to Python
+    /// cascadia; lowest overhead on a clean LAN / Thunderbolt fabric.
+    Tcp,
+    /// The same framing over an encrypted QUIC (UDP + TLS 1.3) stream.
+    /// Encrypts every hop and rides out packet loss on lossy/WAN links.
+    /// Requires a build with the `quic` cargo feature (on by default);
+    /// selecting it in a `--no-default-features` build fails loudly at
+    /// startup rather than silently downgrading.
+    Quic,
+}
+
+impl From<TransportArg> for cascadia_transport::TransportKind {
+    fn from(t: TransportArg) -> Self {
+        match t {
+            TransportArg::Tcp => cascadia_transport::TransportKind::Tcp,
+            TransportArg::Quic => cascadia_transport::TransportKind::Quic,
+        }
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct WorkerArgs {
     /// 0-based stage index.
@@ -247,6 +270,13 @@ pub struct WorkerArgs {
     /// Bind address for the upstream-receiving socket (default :9100).
     #[arg(long, default_value = ":9100")]
     pub listen: String,
+
+    /// Inter-stage activation transport: `tcp` (default) or `quic`.
+    /// The whole pipeline ring must agree — set the same value on every
+    /// stage. `quic` encrypts each hop and tolerates lossy/WAN links; it
+    /// needs a build with the `quic` cargo feature (on by default).
+    #[arg(long, value_enum, default_value_t = TransportArg::Tcp)]
+    pub transport: TransportArg,
 
     /// Downstream peer (host:port) — required for non-last stages.
     #[arg(long)]
@@ -545,6 +575,8 @@ impl WorkerArgs {
             layer_end: 0,
             model,
             listen: ":9100".into(),
+            // Single-node `run` has no inter-stage hop; transport is moot.
+            transport: TransportArg::Tcp,
             next: None,
             api: Some(api),
             device,
@@ -1239,8 +1271,14 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         total = args.total,
         device = %args.device,
         model = %args.model,
+        transport = ?args.transport,
         "cascadia worker starting"
     );
+
+    // Select the activation substrate process-wide before any engine
+    // builder constructs a transport. The whole ring must agree; the
+    // operator sets --transport identically on every stage.
+    cascadia_transport::set_transport_kind(args.transport.into());
 
     let (listen_host, listen_port) = parse_addr(&args.listen, "0.0.0.0")?;
 

--- a/crates/cascadia-transport/Cargo.toml
+++ b/crates/cascadia-transport/Cargo.toml
@@ -5,10 +5,36 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "TCP activation tensor relay between pipeline stages — length-prefixed tensor wire format."
+description = "Activation tensor relay between pipeline stages — length-prefixed tensor wire format (TCP default; optional QUIC)."
+
+[features]
+default = []
+# Opt-in QUIC (UDP + TLS 1.3) backend for the activation relay. Off by
+# default: the TCP path keeps the exact length-prefixed wire format and
+# pulls no extra deps. Enable to make `--transport quic` selectable at runtime.
+quic = ["dep:quinn", "dep:rustls", "dep:rcgen"]
 
 [dependencies]
 tokio = { workspace = true }
 bytes = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
+
+# QUIC backend (feature `quic` only). quinn 0.11 + rustls 0.23 on the ring
+# provider (no aws-lc-rs C build); rcgen mints the ephemeral self-signed
+# cert. rustls is already in the tree via reqwest's rustls-tls, so this
+# only adds quinn + rcgen to a `--features quic` build.
+quinn = { version = "0.11", default-features = false, features = [
+    "runtime-tokio",
+    "rustls-ring",
+    "log",
+], optional = true }
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+    "tls12",
+], optional = true }
+rcgen = { version = "0.13", default-features = false, features = [
+    "crypto",
+    "ring",
+], optional = true }

--- a/crates/cascadia-transport/examples/transport_bench.rs
+++ b/crates/cascadia-transport/examples/transport_bench.rs
@@ -1,0 +1,130 @@
+//! Payload-sweep micro-benchmark for the activation transport (TCP vs QUIC).
+//!
+//! Isolates transport cost from model compute. A server echoes tensors; a
+//! client ping-pongs fixed-size frames across a size sweep and reports p50/
+//! p90/p99/mean round-trip latency + derived MB/s. Fitting `rtt ~ a + b*bytes`
+//! per transport splits **per-frame** cost (intercept `a`: userspace datapath,
+//! ACK/flow-control bookkeeping, pacing) from **per-byte** cost (slope `b`:
+//! TLS AEAD crypto + userspace reassembly copies).
+//!
+//! Build:
+//!   cargo build --release --example transport_bench --features quic
+//! Run (server first, then client — same `<tcp|quic>` on both):
+//!   transport_bench server <tcp|quic> <bind_host> <port>
+//!   transport_bench client <tcp|quic> <server_host> <port>
+//!
+//! The connection is established once and reused across the whole sweep, so
+//! the numbers are warm steady-state (handshake excluded).
+
+use std::time::Instant;
+
+use cascadia_transport::{ActivationClient, ActivationServer, DType, Tensor, TransportKind};
+
+/// (payload_bytes, iters). Fewer iters at large sizes to bound wall-clock;
+/// still enough samples for a stable p99.
+const SWEEP: &[(usize, usize)] = &[
+    (64, 5000),
+    (1024, 5000),
+    (4096, 3000),
+    (16384, 2000),
+    (65536, 1000),
+    (262144, 500),
+    (1048576, 200),
+];
+
+fn parse_kind(s: &str) -> TransportKind {
+    match s {
+        "quic" => TransportKind::Quic,
+        "tcp" => TransportKind::Tcp,
+        other => panic!("transport must be tcp|quic, got {other}"),
+    }
+}
+
+/// i8 `[1,1,N]` => data length == N, so the wire payload is exactly N bytes
+/// (recv validates shape * dtype_size == payload_len).
+fn make_tensor(nbytes: usize) -> Tensor {
+    Tensor::new(DType::I8, [1, 1, nbytes as u32], vec![0x5a; nbytes])
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 5 {
+        eprintln!("usage: transport_bench <server|client> <tcp|quic> <host> <port>");
+        std::process::exit(2);
+    }
+    let role = args[1].as_str();
+    let kind = parse_kind(&args[2]);
+    let host = args[3].clone();
+    let port: u16 = args[4].parse().expect("port");
+
+    match role {
+        "server" => run_server(kind, &host, port).await,
+        "client" => run_client(kind, &host, port).await,
+        other => panic!("role must be server|client, got {other}"),
+    }
+}
+
+async fn run_server(kind: TransportKind, host: &str, port: u16) {
+    let mut server = ActivationServer::new_with_kind(host, port, kind);
+    server.start().await.expect("server start");
+    eprintln!("[server] {kind:?} listening on {host}:{}", server.port());
+    server.accept().await.expect("server accept");
+    eprintln!("[server] client connected; echoing until it closes");
+    loop {
+        match server.recv().await {
+            Ok((t, _)) => {
+                if let Err(e) = server.send(&t).await {
+                    eprintln!("[server] send err: {e}");
+                    break;
+                }
+            }
+            Err(_) => {
+                eprintln!("[server] client closed; exiting");
+                break;
+            }
+        }
+    }
+}
+
+async fn run_client(kind: TransportKind, host: &str, port: u16) {
+    let mut client = ActivationClient::new_with_kind(host, port, kind);
+    client.connect().await.expect("client connect");
+    eprintln!("[client] {kind:?} connected to {host}:{port}");
+    let kname = if kind == TransportKind::Quic {
+        "quic"
+    } else {
+        "tcp"
+    };
+    println!("transport,bytes,iters,p50_us,p90_us,p99_us,mean_us,mb_per_s");
+    for &(nbytes, iters) in SWEEP {
+        let t = make_tensor(nbytes);
+        let warm = (iters / 20).max(50);
+        for _ in 0..warm {
+            client.send(&t).await.unwrap();
+            client.recv().await.unwrap();
+        }
+        let mut us = Vec::with_capacity(iters);
+        for _ in 0..iters {
+            let t0 = Instant::now();
+            client.send(&t).await.unwrap();
+            let _ = client.recv().await.unwrap();
+            us.push(t0.elapsed().as_secs_f64() * 1e6);
+        }
+        us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let pct = |q: f64| us[((us.len() as f64 * q) as usize).min(us.len() - 1)];
+        let mean: f64 = us.iter().sum::<f64>() / us.len() as f64;
+        // A round-trip moves the payload twice; report goodput over mean RTT.
+        let mb_s = (2.0 * nbytes as f64) / (mean / 1e6) / (1024.0 * 1024.0);
+        println!(
+            "{kname},{nbytes},{iters},{:.1},{:.1},{:.1},{:.1},{:.1}",
+            pct(0.50),
+            pct(0.90),
+            pct(0.99),
+            mean,
+            mb_s
+        );
+    }
+    client.close().await;
+    eprintln!("[client] done");
+}

--- a/crates/cascadia-transport/examples/transport_bench.rs
+++ b/crates/cascadia-transport/examples/transport_bench.rs
@@ -96,10 +96,23 @@ async fn run_client(kind: TransportKind, host: &str, port: u16) {
     } else {
         "tcp"
     };
+    // Optional overrides for targeted runs (e.g. under netem, where a full
+    // sweep at 20 ms RTT would take minutes): `BENCH_ITERS` caps iterations
+    // per size; `BENCH_ONLY_BYTES` restricts the sweep to one payload size.
+    let iters_cap: Option<usize> = std::env::var("BENCH_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    let only: Option<usize> = std::env::var("BENCH_ONLY_BYTES")
+        .ok()
+        .and_then(|s| s.parse().ok());
     println!("transport,bytes,iters,p50_us,p90_us,p99_us,mean_us,mb_per_s");
     for &(nbytes, iters) in SWEEP {
+        if only.is_some_and(|o| o != nbytes) {
+            continue;
+        }
+        let iters = iters_cap.map(|c| c.min(iters)).unwrap_or(iters);
         let t = make_tensor(nbytes);
-        let warm = (iters / 20).max(50);
+        let warm = (iters / 20).max(10);
         for _ in 0..warm {
             client.send(&t).await.unwrap();
             client.recv().await.unwrap();

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -223,6 +223,33 @@ pub struct TransferStats {
     pub bytes: usize,
 }
 
+/// Whether per-hop transfer-stats logging is on (env `CASCADIA_TRANSPORT_STATS`
+/// set to a non-empty, non-`0` value). Read once.
+fn stats_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("CASCADIA_TRANSPORT_STATS")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
+/// Emit one `tracing` event per tensor hop when [`stats_enabled`]. `dir` is
+/// `"send"` or `"recv"`. Lets a real pipeline run surface transport-only
+/// timings (bytes + wall-clock ms), isolated from engine compute, so the
+/// per-frame vs per-byte TCP/QUIC split can be measured on real traffic.
+fn log_hop(dir: &'static str, stats: &TransferStats) {
+    if stats_enabled() {
+        info!(
+            target: "cascadia_transport::stats",
+            dir,
+            bytes = stats.bytes,
+            elapsed_ms = stats.elapsed_ms,
+        );
+    }
+}
+
 /// Send a tensor over a connected stream.
 ///
 /// Generic over any [`AsyncWrite`] sink so the identical framing rides
@@ -243,10 +270,12 @@ pub async fn send_tensor<W: AsyncWrite + Unpin + ?Sized>(
     sock.write_all(&tensor.data).await?;
     sock.flush().await?;
 
-    Ok(TransferStats {
+    let stats = TransferStats {
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
         bytes: HEADER_SIZE + tensor.data.len(),
-    })
+    };
+    log_hop("send", &stats);
+    Ok(stats)
 }
 
 /// Receive a tensor from a connected stream.
@@ -352,6 +381,7 @@ async fn recv_tensor_inner<R: AsyncRead + Unpin + ?Sized>(
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
         bytes: HEADER_SIZE + payload_len as usize,
     };
+    log_hop("recv", &stats);
     Ok((tensor, stats))
 }
 

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -14,15 +14,35 @@
 //!
 //! This is intentionally simple — raw TCP, point-to-point. It is the
 //! data plane between adjacent pipeline stages.
+//!
+//! ## Transports
+//!
+//! Two substrates carry the identical framing above:
+//!
+//! * **TCP** (default) — a raw length-prefixed byte stream, byte-identical
+//!   to `cascadia/worker/transport.py`.
+//! * **QUIC** (`quic` cargo feature, opt-in) — the same framing over a
+//!   single long-lived bidirectional [`quinn`] stream (UDP + TLS 1.3).
+//!   Encrypts every hop and rides out packet loss on lossy/WAN links;
+//!   opt-in because userspace QUIC costs more CPU/packet than kernel TCP
+//!   on a clean LAN. Selected process-wide via [`set_transport_kind`] —
+//!   the whole pipeline ring must agree on one substrate.
+//!
+//! The [`ActivationServer`] / [`ActivationClient`] public API is identical
+//! across both; only the constructor's [`TransportKind`] differs.
 
 use std::io;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::{Duration, Instant};
 
 use thiserror::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{info, warn};
+
+#[cfg(feature = "quic")]
+mod quic;
 
 pub const HEADER_SIZE: usize = 20;
 pub const MAX_RANK: usize = 3;
@@ -44,10 +64,66 @@ pub const MAX_TENSOR_BYTES: usize = 256 * 1024 * 1024;
 /// gigabyte of "control bytes".
 pub const MAX_RAW_BYTES: usize = 64 * 1024;
 
+/// Wire substrate for the activation relay.
+///
+/// `Tcp` is the default and is byte-identical to Python cascadia. `Quic`
+/// runs the same framing over an encrypted QUIC stream and requires the
+/// `quic` cargo feature — selecting it in a build without that feature
+/// fails loudly at [`ActivationServer::start`] / [`ActivationClient::connect`]
+/// rather than silently downgrading.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TransportKind {
+    #[default]
+    Tcp,
+    Quic,
+}
+
+impl TransportKind {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::Quic,
+            _ => Self::Tcp,
+        }
+    }
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Tcp => 0,
+            Self::Quic => 1,
+        }
+    }
+}
+
+/// Process-wide default transport, consulted by [`ActivationServer::new`] /
+/// [`ActivationClient::new`]. Mirrors the [`set_activation_timeout_secs`]
+/// global: a worker runs exactly one pipeline stage over one substrate, so
+/// the choice is a process-level setting, set once at startup from the CLI
+/// flag before any transport is constructed.
+static DEFAULT_TRANSPORT_KIND: AtomicU8 = AtomicU8::new(0);
+
+/// Select the default transport for every subsequently-constructed
+/// [`ActivationServer`] / [`ActivationClient`]. Call once at worker startup
+/// (before the engine builder connects) — the whole ring must agree.
+pub fn set_transport_kind(kind: TransportKind) {
+    DEFAULT_TRANSPORT_KIND.store(kind.as_u8(), Ordering::Relaxed);
+}
+
+/// The current process-wide default transport.
+pub fn transport_kind() -> TransportKind {
+    TransportKind::from_u8(DEFAULT_TRANSPORT_KIND.load(Ordering::Relaxed))
+}
+
 #[derive(Debug, Error)]
 pub enum TransportError {
     #[error("socket closed during recv")]
     SocketClosed,
+
+    #[error(
+        "QUIC transport requested but not compiled in — rebuild with the `quic` cargo feature"
+    )]
+    QuicUnavailable,
+
+    #[error("quic error: {0}")]
+    Quic(String),
 
     #[error("tensor rank > {MAX_RANK} not supported (got {0} dims)")]
     RankTooHigh(usize),
@@ -148,7 +224,13 @@ pub struct TransferStats {
 }
 
 /// Send a tensor over a connected stream.
-pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResult<TransferStats> {
+///
+/// Generic over any [`AsyncWrite`] sink so the identical framing rides
+/// either a [`TcpStream`] or a `quinn` [`SendStream`](quic).
+pub async fn send_tensor<W: AsyncWrite + Unpin + ?Sized>(
+    sock: &mut W,
+    tensor: &Tensor,
+) -> TransportResult<TransferStats> {
     let start = Instant::now();
     let mut header = [0u8; HEADER_SIZE];
     header[0..4].copy_from_slice(&(tensor.data.len() as u32).to_be_bytes());
@@ -174,7 +256,11 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
 /// Also cross-checks the per-element count against the declared
 /// payload length so a peer can't claim `shape=[u32::MAX, ...]` to
 /// trigger overflow downstream.
-pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
+///
+/// Generic over any [`AsyncRead`] source (TCP or a `quinn` `RecvStream`).
+pub async fn recv_tensor<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
+) -> TransportResult<(Tensor, TransferStats)> {
     recv_tensor_inner(sock, None).await
 }
 
@@ -190,7 +276,9 @@ pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, Trans
 /// step loop for the whole idle ceiling with the task slot held
 /// (overload-backlog Item 5: forwarded-to head wedges, task never
 /// finalizes).
-pub async fn recv_tensor_reply(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
+pub async fn recv_tensor_reply<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
+) -> TransportResult<(Tensor, TransferStats)> {
     recv_tensor_inner(sock, Some(recv_timeout())).await
 }
 
@@ -207,8 +295,8 @@ pub const PREFILL_REPLY_TIMEOUT_FACTOR: u32 = 10;
 /// [`recv_tensor_reply`] with the widened prefill budget. Use for the token
 /// reply to a multi-token (prefill) hidden state; everything else uses
 /// `recv_tensor_reply`.
-pub async fn recv_tensor_reply_prefill(
-    sock: &mut TcpStream,
+pub async fn recv_tensor_reply_prefill<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
 ) -> TransportResult<(Tensor, TransferStats)> {
     // saturating_mul: an absurdly large configured base must clamp, not
     // panic the engine thread (Duration's Mul panics on overflow).
@@ -219,8 +307,8 @@ pub async fn recv_tensor_reply_prefill(
     .await
 }
 
-async fn recv_tensor_inner(
-    sock: &mut TcpStream,
+async fn recv_tensor_inner<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
     deadline_first_byte: Option<Duration>,
 ) -> TransportResult<(Tensor, TransferStats)> {
     let start = Instant::now();
@@ -422,7 +510,10 @@ fn frame_idle_ceiling() -> Option<Duration> {
 /// [`TransportError::FrameIdleCeiling`] — distinguishable from the
 /// per-frame deadline's `Io(TimedOut)` so the wrappers can treat it as
 /// connection-fatal.
-async fn recv_exact_frame_start(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()> {
+async fn recv_exact_frame_start<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
+    buf: &mut [u8],
+) -> TransportResult<()> {
     let first_read = sock.read(buf);
     let n = match frame_idle_ceiling() {
         Some(ceiling) => match tokio::time::timeout(ceiling, first_read).await {
@@ -440,7 +531,10 @@ async fn recv_exact_frame_start(sock: &mut TcpStream, buf: &mut [u8]) -> Transpo
     Ok(())
 }
 
-async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()> {
+async fn recv_exact<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
+    buf: &mut [u8],
+) -> TransportResult<()> {
     // DEFAULT_TIMEOUT bounds total wall-clock time we'll wait for `buf`
     // to fill. A peer that opens a connection and stops sending — or
     // sends one byte per second — must not be able to pin a worker
@@ -462,8 +556,8 @@ async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()>
     recv_exact_within(sock, buf, recv_timeout()).await
 }
 
-async fn recv_exact_within(
-    sock: &mut TcpStream,
+async fn recv_exact_within<R: AsyncRead + Unpin + ?Sized>(
+    sock: &mut R,
     buf: &mut [u8],
     to: Duration,
 ) -> TransportResult<()> {
@@ -487,21 +581,123 @@ async fn recv_exact_within(
     }
 }
 
-/// TCP server that receives activations from upstream.
+/// Write all bytes then flush an async sink. Shared by `send_raw` across
+/// both substrates.
+async fn write_all_flush<W: AsyncWrite + Unpin + ?Sized>(
+    sock: &mut W,
+    bytes: &[u8],
+) -> TransportResult<()> {
+    sock.write_all(bytes).await?;
+    sock.flush().await?;
+    Ok(())
+}
+
+/// A live point-to-point connection over either substrate. Both variants
+/// carry the identical byte-framing; the enum just routes each read/write
+/// to the right half of the underlying socket (a `TcpStream` is its own
+/// reader and writer; a QUIC stream is a `SendStream` + `RecvStream` pair).
+enum Conn {
+    Tcp(TcpStream),
+    #[cfg(feature = "quic")]
+    Quic(quic::QuicConn),
+}
+
+impl Conn {
+    async fn send_tensor(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
+        match self {
+            Conn::Tcp(s) => send_tensor(s, tensor).await,
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => send_tensor(&mut q.send, tensor).await,
+        }
+    }
+
+    async fn recv_tensor(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        match self {
+            Conn::Tcp(s) => recv_tensor(s).await,
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => recv_tensor(&mut q.recv).await,
+        }
+    }
+
+    async fn recv_tensor_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        match self {
+            Conn::Tcp(s) => recv_tensor_reply(s).await,
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => recv_tensor_reply(&mut q.recv).await,
+        }
+    }
+
+    async fn recv_tensor_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
+        match self {
+            Conn::Tcp(s) => recv_tensor_reply_prefill(s).await,
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => recv_tensor_reply_prefill(&mut q.recv).await,
+        }
+    }
+
+    async fn send_raw(&mut self, bytes: &[u8]) -> TransportResult<()> {
+        match self {
+            Conn::Tcp(s) => write_all_flush(s, bytes).await,
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => write_all_flush(&mut q.send, bytes).await,
+        }
+    }
+
+    async fn recv_raw(&mut self, n: usize) -> TransportResult<Vec<u8>> {
+        let mut buf = vec![0u8; n];
+        match self {
+            Conn::Tcp(s) => recv_exact_frame_start(s, &mut buf).await?,
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => recv_exact_frame_start(&mut q.recv, &mut buf).await?,
+        }
+        Ok(buf)
+    }
+
+    async fn shutdown(&mut self) {
+        match self {
+            Conn::Tcp(s) => {
+                let _ = s.shutdown().await;
+            }
+            #[cfg(feature = "quic")]
+            Conn::Quic(q) => q.shutdown(),
+        }
+    }
+}
+
+/// A bound listener over either substrate.
+enum Listener {
+    Tcp(TcpListener),
+    #[cfg(feature = "quic")]
+    Quic(quic::QuicListener),
+}
+
+/// Server that receives activations from the upstream stage. Binds a TCP
+/// listener or a QUIC endpoint depending on its [`TransportKind`].
 pub struct ActivationServer {
     bind_host: String,
     bind_port: u16,
-    listener: Option<TcpListener>,
-    client: Option<TcpStream>,
+    kind: TransportKind,
+    listener: Option<Listener>,
+    client: Option<Conn>,
     accepted_addr: Option<SocketAddr>,
     actual_port: u16,
 }
 
 impl ActivationServer {
+    /// Construct a server using the process-wide default transport (see
+    /// [`set_transport_kind`]). Call `set_transport_kind` before this.
     pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self::new_with_kind(host, port, transport_kind())
+    }
+
+    /// Construct a server pinned to a specific transport, independent of
+    /// the process-wide default. Used by tests and callers that want to
+    /// force a substrate.
+    pub fn new_with_kind(host: impl Into<String>, port: u16, kind: TransportKind) -> Self {
         Self {
             bind_host: host.into(),
             bind_port: port,
+            kind,
             listener: None,
             client: None,
             accepted_addr: None,
@@ -510,12 +706,30 @@ impl ActivationServer {
     }
 
     pub async fn start(&mut self) -> TransportResult<()> {
-        let listener = TcpListener::bind((self.bind_host.as_str(), self.bind_port)).await?;
-        self.actual_port = listener.local_addr()?.port();
-        self.listener = Some(listener);
+        match self.kind {
+            TransportKind::Tcp => {
+                let listener = TcpListener::bind((self.bind_host.as_str(), self.bind_port)).await?;
+                self.actual_port = listener.local_addr()?.port();
+                self.listener = Some(Listener::Tcp(listener));
+            }
+            TransportKind::Quic => {
+                #[cfg(feature = "quic")]
+                {
+                    let listener =
+                        quic::QuicListener::bind(&self.bind_host, self.bind_port).await?;
+                    self.actual_port = listener.local_port();
+                    self.listener = Some(Listener::Quic(listener));
+                }
+                #[cfg(not(feature = "quic"))]
+                {
+                    return Err(TransportError::QuicUnavailable);
+                }
+            }
+        }
         info!(
             host = %self.bind_host,
             port = self.actual_port,
+            transport = ?self.kind,
             "ActivationServer listening"
         );
         Ok(())
@@ -527,22 +741,32 @@ impl ActivationServer {
 
     pub async fn accept(&mut self) -> TransportResult<()> {
         let listener = self.listener.as_ref().ok_or(TransportError::NotStarted)?;
-        let (sock, addr) = listener.accept().await?;
-        sock.set_nodelay(true).ok();
+        let (conn, addr) = match listener {
+            Listener::Tcp(l) => {
+                let (sock, addr) = l.accept().await?;
+                sock.set_nodelay(true).ok();
+                (Conn::Tcp(sock), addr)
+            }
+            #[cfg(feature = "quic")]
+            Listener::Quic(ep) => {
+                let (qc, addr) = ep.accept().await?;
+                (Conn::Quic(qc), addr)
+            }
+        };
         info!(peer = %addr, "ActivationServer accepted connection");
-        self.client = Some(sock);
+        self.client = Some(conn);
         self.accepted_addr = Some(addr);
         Ok(())
     }
 
     pub async fn recv(&mut self) -> TransportResult<(Tensor, TransferStats)> {
-        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        let res = recv_tensor(sock).await;
+        let conn = self.client.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_tensor().await;
         self.drop_connection_if_recv_fatal(res.as_ref().err());
         res
     }
 
-    /// A recv timeout is connection-fatal: drop the socket here, at the
+    /// A recv timeout is connection-fatal: drop the connection here, at the
     /// transport layer, so a half-consumed or abandoned frame can never be
     /// read into a different request (token frames carry no task id). Covers
     /// both the frame-start idle ceiling and a mid-frame stall — see
@@ -557,12 +781,12 @@ impl ActivationServer {
 
     /// Mid-task reply recv — strict deadline on the first byte. See
     /// [`recv_tensor_reply`] for the call-site rule. A failed reply
-    /// poisons the connection (see `poison`: the socket is dropped
+    /// poisons the connection (see `poison`: the connection is dropped
     /// and later calls fail fast with `NotConnected`; recover with a
     /// fresh connection).
     pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
-        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        let res = recv_tensor_reply(sock).await;
+        let conn = self.client.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_tensor_reply().await;
         if res.is_err() {
             self.poison().await;
         }
@@ -570,12 +794,12 @@ impl ActivationServer {
     }
 
     /// Prefill-budget reply recv — see [`recv_tensor_reply_prefill`].
-    /// A failed reply poisons the connection (see `poison`: the socket
-    /// is dropped and later calls fail fast with `NotConnected`;
-    /// recover with a fresh connection).
+    /// A failed reply poisons the connection (see `poison`: the
+    /// connection is dropped and later calls fail fast with
+    /// `NotConnected`; recover with a fresh connection).
     pub async fn recv_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
-        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        let res = recv_tensor_reply_prefill(sock).await;
+        let conn = self.client.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_tensor_reply_prefill().await;
         if res.is_err() {
             self.poison().await;
         }
@@ -589,25 +813,29 @@ impl ActivationServer {
     /// the connection so later calls fail fast with `NotConnected` instead
     /// of corrupting — recovery is a fresh connection, not reuse.
     async fn poison(&mut self) {
-        if let Some(mut s) = self.client.take() {
-            let _ = s.shutdown().await;
+        if let Some(mut conn) = self.client.take() {
+            conn.shutdown().await;
         }
         self.accepted_addr = None;
     }
 
     pub async fn send(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
-        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        send_tensor(sock, tensor).await
+        self.client
+            .as_mut()
+            .ok_or(TransportError::NotConnected)?
+            .send_tensor(tensor)
+            .await
     }
 
     /// Send raw bytes over the established connection. Used by the
     /// dist-spec engines to prefix tensor frames with control bytes
     /// (kind + logical_pos_start).
     pub async fn send_raw(&mut self, bytes: &[u8]) -> TransportResult<()> {
-        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        sock.write_all(bytes).await?;
-        sock.flush().await?;
-        Ok(())
+        self.client
+            .as_mut()
+            .ok_or(TransportError::NotConnected)?
+            .send_raw(bytes)
+            .await
     }
 
     /// Receive exactly `n` raw bytes from the established connection.
@@ -617,42 +845,74 @@ impl ActivationServer {
         if n > MAX_RAW_BYTES {
             return Err(TransportError::RawSizeTooLarge(n));
         }
-        let sock = self.client.as_mut().ok_or(TransportError::NotConnected)?;
-        let mut buf = vec![0u8; n];
-        let res = recv_exact_frame_start(sock, &mut buf).await;
+        let conn = self.client.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_raw(n).await;
         self.drop_connection_if_recv_fatal(res.as_ref().err());
-        res?;
-        Ok(buf)
+        res
     }
 
     pub async fn close(&mut self) {
-        if let Some(mut sock) = self.client.take() {
-            let _ = sock.shutdown().await;
+        if let Some(mut conn) = self.client.take() {
+            conn.shutdown().await;
         }
         self.listener = None;
         self.accepted_addr = None;
     }
 }
 
-/// TCP client that sends activations to downstream.
+/// Client that sends activations to the downstream stage. Dials over TCP
+/// or QUIC depending on its [`TransportKind`].
 pub struct ActivationClient {
     host: String,
     port: u16,
-    sock: Option<TcpStream>,
+    kind: TransportKind,
+    sock: Option<Conn>,
+    /// Kept alive for the connection's life so the QUIC connection driver
+    /// keeps running. `None` on the TCP path.
+    #[cfg(feature = "quic")]
+    endpoint: Option<quic::QuicClientEndpoint>,
 }
 
 impl ActivationClient {
+    /// Construct a client using the process-wide default transport (see
+    /// [`set_transport_kind`]).
     pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self::new_with_kind(host, port, transport_kind())
+    }
+
+    /// Construct a client pinned to a specific transport, independent of
+    /// the process-wide default.
+    pub fn new_with_kind(host: impl Into<String>, port: u16, kind: TransportKind) -> Self {
         Self {
             host: host.into(),
             port,
+            kind,
             sock: None,
+            #[cfg(feature = "quic")]
+            endpoint: None,
         }
     }
 
     /// Connect with retries until `timeout` elapses (mirrors the Python
     /// implementation's wait-for-peer behaviour during pipeline startup).
     pub async fn connect_with_timeout(&mut self, timeout: Duration) -> TransportResult<()> {
+        match self.kind {
+            TransportKind::Tcp => self.connect_tcp(timeout).await,
+            TransportKind::Quic => {
+                #[cfg(feature = "quic")]
+                {
+                    self.connect_quic(timeout).await
+                }
+                #[cfg(not(feature = "quic"))]
+                {
+                    let _ = timeout;
+                    Err(TransportError::QuicUnavailable)
+                }
+            }
+        }
+    }
+
+    async fn connect_tcp(&mut self, timeout: Duration) -> TransportResult<()> {
         let start = Instant::now();
         let deadline = start + timeout;
         // Tell the operator up-front what we're waiting on. Without this
@@ -673,7 +933,7 @@ impl ActivationClient {
                 Ok(sock) => {
                     sock.set_nodelay(true).ok();
                     info!(host = %self.host, port = self.port, "ActivationClient connected");
-                    self.sock = Some(sock);
+                    self.sock = Some(Conn::Tcp(sock));
                     return Ok(());
                 }
                 Err(err) => {
@@ -710,18 +970,75 @@ impl ActivationClient {
         Err(TransportError::ConnectTimeout(timeout))
     }
 
+    /// QUIC dial: bind an ephemeral client endpoint once, then retry the
+    /// handshake (each attempt bounded internally) until the downstream is
+    /// up or the deadline passes. Mirrors [`connect_tcp`]'s retry cadence.
+    #[cfg(feature = "quic")]
+    async fn connect_quic(&mut self, timeout: Duration) -> TransportResult<()> {
+        let start = Instant::now();
+        let deadline = start + timeout;
+        let addr = quic::resolve(&self.host, self.port).await?;
+        let endpoint = quic::QuicClientEndpoint::bind_for(addr).await?;
+        info!(
+            host = %self.host,
+            port = self.port,
+            timeout_s = timeout.as_secs(),
+            "waiting for downstream QUIC peer to accept (start the downstream worker first)"
+        );
+        let mut last_err: Option<TransportError> = None;
+        let mut next_progress = start + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            match endpoint.connect_once(addr).await {
+                Ok(conn) => {
+                    info!(host = %self.host, port = self.port, "ActivationClient connected (quic)");
+                    self.sock = Some(Conn::Quic(conn));
+                    self.endpoint = Some(endpoint);
+                    return Ok(());
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                    let now = Instant::now();
+                    if now >= next_progress {
+                        warn!(
+                            host = %self.host,
+                            port = self.port,
+                            waited_s = now.duration_since(start).as_secs(),
+                            timeout_s = timeout.as_secs(),
+                            "still waiting for downstream QUIC peer (not accepting yet)"
+                        );
+                        next_progress = now + Duration::from_secs(5);
+                    }
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
+        warn!(
+            host = %self.host,
+            port = self.port,
+            timeout_s = timeout.as_secs(),
+            last_error = ?last_err.as_ref().map(|e| e.to_string()),
+            "could not connect to downstream QUIC peer within timeout — check that the \
+             downstream worker is running with --transport quic, that its --listen port \
+             matches this --next, and that no firewall blocks the UDP port"
+        );
+        Err(last_err.unwrap_or(TransportError::ConnectTimeout(timeout)))
+    }
+
     pub async fn connect(&mut self) -> TransportResult<()> {
         self.connect_with_timeout(DEFAULT_CONNECT_TIMEOUT).await
     }
 
     pub async fn send(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
-        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        send_tensor(sock, tensor).await
+        self.sock
+            .as_mut()
+            .ok_or(TransportError::NotConnected)?
+            .send_tensor(tensor)
+            .await
     }
 
     pub async fn recv(&mut self) -> TransportResult<(Tensor, TransferStats)> {
-        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        let res = recv_tensor(sock).await;
+        let conn = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_tensor().await;
         self.drop_connection_if_recv_fatal(res.as_ref().err());
         res
     }
@@ -737,12 +1054,12 @@ impl ActivationClient {
 
     /// Mid-task reply recv — strict deadline on the first byte. See
     /// [`recv_tensor_reply`] for the call-site rule. A failed reply
-    /// poisons the connection (see `poison`: the socket is dropped
+    /// poisons the connection (see `poison`: the connection is dropped
     /// and later calls fail fast with `NotConnected`; recover with a
     /// fresh connection).
     pub async fn recv_reply(&mut self) -> TransportResult<(Tensor, TransferStats)> {
-        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        let res = recv_tensor_reply(sock).await;
+        let conn = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_tensor_reply().await;
         if res.is_err() {
             self.poison().await;
         }
@@ -750,12 +1067,12 @@ impl ActivationClient {
     }
 
     /// Prefill-budget reply recv — see [`recv_tensor_reply_prefill`].
-    /// A failed reply poisons the connection (see `poison`: the socket
-    /// is dropped and later calls fail fast with `NotConnected`;
-    /// recover with a fresh connection).
+    /// A failed reply poisons the connection (see `poison`: the
+    /// connection is dropped and later calls fail fast with
+    /// `NotConnected`; recover with a fresh connection).
     pub async fn recv_reply_prefill(&mut self) -> TransportResult<(Tensor, TransferStats)> {
-        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        let res = recv_tensor_reply_prefill(sock).await;
+        let conn = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_tensor_reply_prefill().await;
         if res.is_err() {
             self.poison().await;
         }
@@ -765,33 +1082,36 @@ impl ActivationClient {
     /// See [`ActivationServer::poison`]: a failed reply means unknown
     /// framing state — fail fast on reuse instead of corrupting.
     async fn poison(&mut self) {
-        if let Some(mut s) = self.sock.take() {
-            let _ = s.shutdown().await;
+        if let Some(mut conn) = self.sock.take() {
+            conn.shutdown().await;
         }
     }
 
     pub async fn send_raw(&mut self, bytes: &[u8]) -> TransportResult<()> {
-        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        sock.write_all(bytes).await?;
-        sock.flush().await?;
-        Ok(())
+        self.sock
+            .as_mut()
+            .ok_or(TransportError::NotConnected)?
+            .send_raw(bytes)
+            .await
     }
 
     pub async fn recv_raw(&mut self, n: usize) -> TransportResult<Vec<u8>> {
         if n > MAX_RAW_BYTES {
             return Err(TransportError::RawSizeTooLarge(n));
         }
-        let sock = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
-        let mut buf = vec![0u8; n];
-        let res = recv_exact_frame_start(sock, &mut buf).await;
+        let conn = self.sock.as_mut().ok_or(TransportError::NotConnected)?;
+        let res = conn.recv_raw(n).await;
         self.drop_connection_if_recv_fatal(res.as_ref().err());
-        res?;
-        Ok(buf)
+        res
     }
 
     pub async fn close(&mut self) {
-        if let Some(mut sock) = self.sock.take() {
-            let _ = sock.shutdown().await;
+        if let Some(mut conn) = self.sock.take() {
+            conn.shutdown().await;
+        }
+        #[cfg(feature = "quic")]
+        {
+            self.endpoint = None;
         }
     }
 }

--- a/crates/cascadia-transport/src/quic.rs
+++ b/crates/cascadia-transport/src/quic.rs
@@ -72,7 +72,7 @@ fn quic_err(context: &str, e: impl std::fmt::Display) -> TransportError {
     TransportError::Quic(format!("{context}: {e}"))
 }
 
-/// Shared transport params (keep-alive + idle timeout) for both ends.
+/// Shared transport params (keep-alive + idle timeout + flow control).
 fn transport_config() -> Arc<quinn::TransportConfig> {
     let mut tc = quinn::TransportConfig::default();
     tc.keep_alive_interval(Some(KEEP_ALIVE_INTERVAL));
@@ -80,13 +80,43 @@ fn transport_config() -> Arc<quinn::TransportConfig> {
     if let Ok(idle) = quinn::IdleTimeout::try_from(MAX_IDLE_TIMEOUT) {
         tc.max_idle_timeout(Some(idle));
     }
+    // Generous flow-control windows. With quinn's defaults a large activation
+    // frame stalls on MAX_STREAM_DATA / MAX_DATA credit round-trips — measured
+    // ~2.5 RTT for a 64 KiB frame at 20-50 ms RTT (netem). The relay is one
+    // long-lived connection per stage carrying frames up to MAX_TENSOR_BYTES,
+    // so a fixed multi-MiB window (cheap memory) lets a frame stream in ~1 RTT.
+    let stream_win: u32 = 16 * 1024 * 1024; // 16 MiB per stream
+    let conn_win: u32 = 32 * 1024 * 1024; // 32 MiB connection-wide
+    tc.stream_receive_window(stream_win.into());
+    tc.receive_window(conn_win.into());
+    tc.send_window(conn_win as u64);
     Arc::new(tc)
 }
 
 /// Explicit ring provider — avoids depending on a process-default
 /// `CryptoProvider` being installed (rustls 0.23 requires one otherwise).
+///
+/// `CASCADIA_QUIC_CIPHER` optionally pins the TLS 1.3 AEAD to `aesgcm` or
+/// `chacha`. Diagnostic knob: lets a benchmark measure crypto's share of the
+/// per-byte cost. Unset = rustls' normal preference (AES-GCM where AES-NI is
+/// present, which is every CPU we target).
 fn ring_provider() -> Arc<rustls::crypto::CryptoProvider> {
-    Arc::new(rustls::crypto::ring::default_provider())
+    use rustls::crypto::ring::cipher_suite::{
+        TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256,
+    };
+    let mut provider = rustls::crypto::ring::default_provider();
+    // AES-128-GCM must stay present regardless — QUIC derives its *initial*
+    // packet keys from it. The negotiated 1-RTT suite is the list head.
+    match std::env::var("CASCADIA_QUIC_CIPHER").as_deref() {
+        Ok("aesgcm") | Ok("aes") => {
+            provider.cipher_suites = vec![TLS13_AES_128_GCM_SHA256];
+        }
+        Ok("chacha") | Ok("chacha20") => {
+            provider.cipher_suites = vec![TLS13_CHACHA20_POLY1305_SHA256, TLS13_AES_128_GCM_SHA256];
+        }
+        _ => {}
+    }
+    Arc::new(provider)
 }
 
 /// Build a QUIC server config from a fresh ephemeral self-signed cert.

--- a/crates/cascadia-transport/src/quic.rs
+++ b/crates/cascadia-transport/src/quic.rs
@@ -90,6 +90,17 @@ fn transport_config() -> Arc<quinn::TransportConfig> {
     tc.stream_receive_window(stream_win.into());
     tc.receive_window(conn_win.into());
     tc.send_window(conn_win as u64);
+    // Larger initial congestion window. Flow-control windows alone did NOT
+    // fix the ~2.5-RTT penalty for a 64 KiB frame at 20-50 ms RTT (netem):
+    // the gate is slow-start (default initial cwnd ~14 KiB, restarted after
+    // each inter-request idle), not flow-control credit. Peers here are
+    // cooperating pipeline stages sending a frame per decode step after a
+    // compute-bound idle, so a bigger initial window lets a typical
+    // activation frame clear in ~1 RTT. Kept moderate (not multi-MiB) to
+    // avoid an over-aggressive first burst on a genuinely lossy path.
+    let mut cubic = quinn::congestion::CubicConfig::default();
+    cubic.initial_window(256 * 1024); // 256 KiB
+    tc.congestion_controller_factory(std::sync::Arc::new(cubic));
     Arc::new(tc)
 }
 

--- a/crates/cascadia-transport/src/quic.rs
+++ b/crates/cascadia-transport/src/quic.rs
@@ -1,0 +1,322 @@
+//! QUIC backend for the activation relay (feature `quic`).
+//!
+//! The pipeline framing (see the crate docs) is transport-agnostic: it is a
+//! plain ordered byte stream. QUIC gives us exactly that via a **single
+//! long-lived bidirectional stream** per connection, so the identical
+//! [`send_tensor`](crate::send_tensor) / [`recv_tensor`](crate::recv_tensor)
+//! framing rides a `quinn` [`SendStream`]/[`RecvStream`] unchanged.
+//!
+//! Design choices, and why:
+//!
+//! * **One bidi stream, not many.** The relay is a strictly-ordered
+//!   request/response byte pipe between two adjacent stages. QUIC's stream
+//!   multiplexing buys nothing here, so we mirror the TCP model: one stream,
+//!   framed by hand. The client `open_bi()`s it; the server `accept_bi()`s.
+//! * **1-byte connect preamble.** A QUIC stream is invisible to the peer
+//!   until the opener writes to it, and `accept_bi()` blocks until then.
+//!   The client always sends first in this protocol, but stage *readiness*
+//!   must fire at connection time (like a TCP accept), not at first-request
+//!   time — otherwise a middle stage's `connect()` would block until real
+//!   traffic flows. The client writes one [`PREAMBLE`] byte immediately
+//!   after `open_bi()`; the server reads+discards it in `accept()`, giving
+//!   TCP-parity accept semantics.
+//! * **Keep-alive < idle-timeout.** Pipeline stages are idle between
+//!   requests by design. Without keep-alive, QUIC's idle timeout would tear
+//!   an idle connection down. [`KEEP_ALIVE_INTERVAL`] PINGs reset the idle
+//!   timer on both ends, so a live-but-idle link stays up indefinitely,
+//!   while a genuinely dead peer is still detected within
+//!   [`MAX_IDLE_TIMEOUT`] (like a TCP RST/EOF, only faster than a stalled
+//!   TCP read).
+//! * **Self-signed + skip-verify.** Matches the locked zero-config P2P
+//!   design: every node mints an ephemeral self-signed cert; the client
+//!   accepts any cert. This encrypts the wire but does NOT authenticate the
+//!   peer (MITM-able) — acceptable for a v1 opt-in on trusted/tailscale
+//!   fabrics; peer authentication (pinned RPK) is a documented follow-up.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+use quinn::{ClientConfig, Connection, Endpoint, RecvStream, SendStream, ServerConfig};
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
+
+use crate::TransportError;
+
+/// ALPN protocol id. Set on both ends; a mismatched peer is rejected at
+/// the TLS layer.
+const ALPN: &[u8] = b"cascadia-quic/1";
+
+/// Written by the client right after `open_bi()` and consumed by the
+/// server in `accept()` — see the module docs.
+const PREAMBLE: u8 = 0x1c;
+
+/// PING cadence that keeps an idle relay alive. Must stay comfortably
+/// below [`MAX_IDLE_TIMEOUT`].
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Idle-timeout after which a silent peer's connection is torn down. With
+/// keep-alive at 10 s, a live link never reaches this; a dead peer does.
+const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Per-attempt bound on the QUIC handshake. UDP has no connection-refused,
+/// so a not-yet-listening downstream would otherwise hang until the idle
+/// timeout; this lets the caller's retry loop re-poll quickly instead.
+const HANDSHAKE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The server name presented in the TLS SNI. Arbitrary (the client skips
+/// verification) but must parse as a DNS name.
+const SERVER_NAME: &str = "cascadia";
+
+fn quic_err(context: &str, e: impl std::fmt::Display) -> TransportError {
+    TransportError::Quic(format!("{context}: {e}"))
+}
+
+/// Shared transport params (keep-alive + idle timeout) for both ends.
+fn transport_config() -> Arc<quinn::TransportConfig> {
+    let mut tc = quinn::TransportConfig::default();
+    tc.keep_alive_interval(Some(KEEP_ALIVE_INTERVAL));
+    // try_from only fails for absurd (multi-year) durations; ours is 30 s.
+    if let Ok(idle) = quinn::IdleTimeout::try_from(MAX_IDLE_TIMEOUT) {
+        tc.max_idle_timeout(Some(idle));
+    }
+    Arc::new(tc)
+}
+
+/// Explicit ring provider — avoids depending on a process-default
+/// `CryptoProvider` being installed (rustls 0.23 requires one otherwise).
+fn ring_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
+/// Build a QUIC server config from a fresh ephemeral self-signed cert.
+fn server_config() -> Result<ServerConfig, TransportError> {
+    let cert = rcgen::generate_simple_self_signed(vec![SERVER_NAME.to_string()])
+        .map_err(|e| quic_err("self-signed cert", e))?;
+    let cert_der: CertificateDer<'static> = cert.cert.der().clone();
+    let key = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+
+    let mut crypto = rustls::ServerConfig::builder_with_provider(ring_provider())
+        .with_safe_default_protocol_versions()
+        .map_err(|e| quic_err("server tls versions", e))?
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key.into())
+        .map_err(|e| quic_err("server single cert", e))?;
+    crypto.alpn_protocols = vec![ALPN.to_vec()];
+
+    let qsc = QuicServerConfig::try_from(crypto).map_err(|e| quic_err("quic server crypto", e))?;
+    let mut sc = ServerConfig::with_crypto(Arc::new(qsc));
+    sc.transport_config(transport_config());
+    Ok(sc)
+}
+
+/// Build a QUIC client config that accepts any server cert (skip-verify).
+fn client_config() -> Result<ClientConfig, TransportError> {
+    let mut crypto = rustls::ClientConfig::builder_with_provider(ring_provider())
+        .with_safe_default_protocol_versions()
+        .map_err(|e| quic_err("client tls versions", e))?
+        .dangerous()
+        .with_custom_certificate_verifier(SkipServerVerification::new())
+        .with_no_client_auth();
+    crypto.alpn_protocols = vec![ALPN.to_vec()];
+
+    let qcc = QuicClientConfig::try_from(crypto).map_err(|e| quic_err("quic client crypto", e))?;
+    let mut cc = ClientConfig::new(Arc::new(qcc));
+    cc.transport_config(transport_config());
+    Ok(cc)
+}
+
+/// Resolve `host:port` to a single socket address (first result).
+pub(crate) async fn resolve(host: &str, port: u16) -> Result<SocketAddr, TransportError> {
+    tokio::net::lookup_host((host, port))
+        .await
+        .map_err(TransportError::Io)?
+        .next()
+        .ok_or_else(|| TransportError::Quic(format!("no address for {host}:{port}")))
+}
+
+/// An unspecified bind address in the same family as `target`, so a v6
+/// downstream gets a v6 client socket and a v4 downstream a v4 one.
+fn unspecified_like(target: SocketAddr) -> SocketAddr {
+    match target {
+        SocketAddr::V4(_) => "0.0.0.0:0".parse().unwrap(),
+        SocketAddr::V6(_) => "[::]:0".parse().unwrap(),
+    }
+}
+
+/// A live QUIC connection carrying the one relay stream. Holds the
+/// `Connection` so its background driver stays alive for the stream's life.
+pub(crate) struct QuicConn {
+    pub send: SendStream,
+    pub recv: RecvStream,
+    _conn: Connection,
+}
+
+impl QuicConn {
+    /// Signal end-of-stream to the peer. Best-effort; the connection then
+    /// winds down when both ends drop or the idle timer fires.
+    ///
+    /// Note: unlike a TCP close (which flushes OS buffers via FIN), dropping
+    /// a QUIC `Connection` emits an immediate `CONNECTION_CLOSE` that can
+    /// truncate still-in-flight stream data. That is safe here because the
+    /// relay connection lives for the whole pipeline session and is only
+    /// closed after the final frame has been consumed by the reader — the
+    /// same lifetime the TCP path relies on.
+    pub(crate) fn shutdown(&mut self) {
+        let _ = self.send.finish();
+    }
+}
+
+/// Bound QUIC server endpoint (the listener half).
+pub(crate) struct QuicListener {
+    endpoint: Endpoint,
+}
+
+impl QuicListener {
+    pub(crate) async fn bind(host: &str, port: u16) -> Result<Self, TransportError> {
+        let addr = resolve(host, port).await?;
+        let endpoint =
+            Endpoint::server(server_config()?, addr).map_err(|e| quic_err("quic bind", e))?;
+        Ok(Self { endpoint })
+    }
+
+    pub(crate) fn local_port(&self) -> u16 {
+        self.endpoint
+            .local_addr()
+            .map(|a| a.port())
+            .unwrap_or_default()
+    }
+
+    /// Accept one connection and its single bidi stream, then consume the
+    /// client's connect preamble so the first real frame reads clean.
+    pub(crate) async fn accept(&self) -> Result<(QuicConn, SocketAddr), TransportError> {
+        let incoming = self
+            .endpoint
+            .accept()
+            .await
+            .ok_or_else(|| TransportError::Quic("endpoint closed".into()))?;
+        let conn = incoming.await.map_err(|e| quic_err("quic accept", e))?;
+        let addr = conn.remote_address();
+        let (send, mut recv) = conn
+            .accept_bi()
+            .await
+            .map_err(|e| quic_err("quic accept_bi", e))?;
+        // Consume the 1-byte preamble the client sent to materialise the
+        // stream. quinn's inherent `RecvStream::read_exact` errors if the
+        // peer finished/reset the stream before sending it.
+        let mut pre = [0u8; 1];
+        recv.read_exact(&mut pre)
+            .await
+            .map_err(|e| quic_err("quic preamble", e))?;
+        Ok((
+            QuicConn {
+                send,
+                recv,
+                _conn: conn,
+            },
+            addr,
+        ))
+    }
+}
+
+/// Bound QUIC client endpoint. Kept alive by the caller for the life of
+/// the connection so the connection driver keeps running.
+pub(crate) struct QuicClientEndpoint {
+    endpoint: Endpoint,
+}
+
+impl QuicClientEndpoint {
+    /// Bind an ephemeral client socket in the same address family as the
+    /// downstream target and install the skip-verify client config.
+    pub(crate) async fn bind_for(target: SocketAddr) -> Result<Self, TransportError> {
+        let mut endpoint = Endpoint::client(unspecified_like(target))
+            .map_err(|e| quic_err("quic client bind", e))?;
+        endpoint.set_default_client_config(client_config()?);
+        Ok(Self { endpoint })
+    }
+
+    /// One connect attempt: QUIC handshake, open the relay stream, send the
+    /// preamble. Bounded by [`HANDSHAKE_ATTEMPT_TIMEOUT`] so the caller's
+    /// retry loop re-polls quickly against a not-yet-listening peer.
+    pub(crate) async fn connect_once(&self, addr: SocketAddr) -> Result<QuicConn, TransportError> {
+        let connecting = self
+            .endpoint
+            .connect(addr, SERVER_NAME)
+            .map_err(|e| quic_err("quic connect", e))?;
+        let conn = match tokio::time::timeout(HANDSHAKE_ATTEMPT_TIMEOUT, connecting).await {
+            Ok(res) => res.map_err(|e| quic_err("quic handshake", e))?,
+            Err(_) => return Err(TransportError::Quic("handshake timed out".into())),
+        };
+        let (mut send, recv) = conn
+            .open_bi()
+            .await
+            .map_err(|e| quic_err("quic open_bi", e))?;
+        use tokio::io::AsyncWriteExt;
+        send.write_all(&[PREAMBLE])
+            .await
+            .map_err(|e| quic_err("quic preamble", e))?;
+        send.flush().await.map_err(|e| quic_err("quic flush", e))?;
+        Ok(QuicConn {
+            send,
+            recv,
+            _conn: conn,
+        })
+    }
+}
+
+/// Certificate verifier that accepts any server cert. Encrypts the wire
+/// without authenticating the peer — see the module docs' security note.
+/// Structure taken from quinn's `insecure_connection.rs` example.
+#[derive(Debug)]
+struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl SkipServerVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(ring_provider()))
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}

--- a/crates/cascadia-transport/tests/quic_roundtrip.rs
+++ b/crates/cascadia-transport/tests/quic_roundtrip.rs
@@ -1,0 +1,178 @@
+//! QUIC transport integration tests (feature `quic`).
+//!
+//! These are the real data-plane proof for the QUIC backend: they push
+//! actual tensors + control bytes through `ActivationServer`/`Client`
+//! pinned to [`TransportKind::Quic`] and assert byte-exact round-trips,
+//! including the exact `send_raw`/`recv_raw` + tensor interleave the
+//! dist-spec engines use on the wire.
+//!
+//! Run with:  cargo test -p cascadia-transport --features quic
+//! (the idle-survival test is `#[ignore]`d for speed — see its note).
+#![cfg(feature = "quic")]
+
+use std::time::Duration;
+
+use cascadia_transport::{ActivationClient, ActivationServer, DType, Tensor, TransportKind};
+
+fn quic_server(port: u16) -> ActivationServer {
+    ActivationServer::new_with_kind("127.0.0.1", port, TransportKind::Quic)
+}
+fn quic_client(port: u16) -> ActivationClient {
+    ActivationClient::new_with_kind("127.0.0.1", port, TransportKind::Quic)
+}
+
+#[tokio::test]
+async fn quic_roundtrip_f32_2d() {
+    let mut server = quic_server(0);
+    server.start().await.unwrap();
+    let port = server.port();
+
+    let h = tokio::spawn(async move {
+        server.accept().await.unwrap();
+        let (got, _) = server.recv().await.unwrap();
+        got
+    });
+
+    let mut client = quic_client(port);
+    client.connect().await.unwrap();
+    let payload = vec![0u8, 0, 128, 63, 0, 0, 0, 64]; // f32: 1.0, 2.0
+    let tensor = Tensor::from_2d(DType::F32, 1, 2, payload.clone());
+    client.send(&tensor).await.unwrap();
+
+    let got = h.await.unwrap();
+    assert_eq!(got.dtype, DType::F32);
+    assert_eq!(got.shape, [1, 1, 2]);
+    assert_eq!(got.data, payload);
+}
+
+#[tokio::test]
+async fn quic_roundtrip_i64_3d_large() {
+    let mut server = quic_server(0);
+    server.start().await.unwrap();
+    let port = server.port();
+    let h = tokio::spawn(async move {
+        server.accept().await.unwrap();
+        let (got, _) = server.recv().await.unwrap();
+        got
+    });
+    let mut client = quic_client(port);
+    client.connect().await.unwrap();
+    // A few hundred KiB to cross multiple QUIC packets/stream frames.
+    let payload: Vec<u8> = (0..8 * 16 * 512 * 8).map(|i| (i % 251) as u8).collect();
+    let tensor = Tensor::new(DType::I64, [8, 16, 512], payload.clone());
+    client.send(&tensor).await.unwrap();
+    let got = h.await.unwrap();
+    assert_eq!(got.shape, [8, 16, 512]);
+    assert_eq!(got.data, payload);
+}
+
+/// Exercises the exact dist-spec frame choreography over one QUIC bidi
+/// stream: client sends control bytes (`send_raw`) then two tensors, the
+/// server replies with a control byte + a tensor. Proves `send_raw` /
+/// `recv_raw` interleave correctly with tensor frames in BOTH directions.
+#[tokio::test]
+async fn quic_control_byte_interleave_bidirectional() {
+    const FORWARD: u32 = 1;
+    const LOGITS: u32 = 2;
+    let mut server = quic_server(0);
+    server.start().await.unwrap();
+    let port = server.port();
+
+    // The real relay keeps the connection open for the whole session (the
+    // run_relay_loop), tearing it down only after the last frame is
+    // consumed. QUIC — unlike TCP — drops in-flight stream data on an
+    // abrupt connection close, so the server must not return (and drop the
+    // connection) until the client has read the reply. This oneshot models
+    // that session lifetime; without it the test would race the close.
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+    let h = tokio::spawn(async move {
+        server.accept().await.unwrap();
+        // FORWARD frame: kind, logical_pos_start, attn, hidden.
+        let kind = u32::from_be_bytes(server.recv_raw(4).await.unwrap().try_into().unwrap());
+        assert_eq!(kind, FORWARD);
+        let pos = u32::from_be_bytes(server.recv_raw(4).await.unwrap().try_into().unwrap());
+        let (attn, _) = server.recv().await.unwrap();
+        let (hidden, _) = server.recv().await.unwrap();
+        // Reply: LOGITS kind + a logits tensor.
+        server.send_raw(&LOGITS.to_be_bytes()).await.unwrap();
+        let logits = Tensor::from_2d(DType::F32, 1, 4, vec![1u8; 16]);
+        server.send(&logits).await.unwrap();
+        let _ = done_rx.await; // hold the connection open until client is done
+        (pos, attn, hidden)
+    });
+
+    let mut client = quic_client(port);
+    client.connect().await.unwrap();
+    client.send_raw(&FORWARD.to_be_bytes()).await.unwrap();
+    client.send_raw(&7u32.to_be_bytes()).await.unwrap();
+    let attn = Tensor::new(DType::I64, [1, 1, 3], vec![1u8; 24]);
+    let hidden = Tensor::new(DType::F16, [1, 2, 4], vec![2u8; 16]);
+    client.send(&attn).await.unwrap();
+    client.send(&hidden).await.unwrap();
+    let reply_kind = u32::from_be_bytes(client.recv_raw(4).await.unwrap().try_into().unwrap());
+    assert_eq!(reply_kind, LOGITS);
+    let (logits, _) = client.recv().await.unwrap();
+
+    let _ = done_tx.send(()); // client done — server may now tear down
+    let (pos, got_attn, got_hidden) = h.await.unwrap();
+    assert_eq!(pos, 7);
+    assert_eq!(got_attn.shape, [1, 1, 3]);
+    assert_eq!(got_attn.data, vec![1u8; 24]);
+    assert_eq!(got_hidden.shape, [1, 2, 4]);
+    assert_eq!(got_hidden.data, vec![2u8; 16]);
+    assert_eq!(logits.shape, [1, 1, 4]);
+    assert_eq!(logits.data, vec![1u8; 16]);
+}
+
+/// A tensor sent over QUIC must decode to exactly what the same tensor
+/// decodes to over TCP — the substrate is transparent to the framing.
+#[tokio::test]
+async fn quic_and_tcp_decode_identically() {
+    async fn roundtrip(kind: TransportKind, tensor: &Tensor) -> Tensor {
+        let mut server = ActivationServer::new_with_kind("127.0.0.1", 0, kind);
+        server.start().await.unwrap();
+        let port = server.port();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            server.recv().await.unwrap().0
+        });
+        let mut client = ActivationClient::new_with_kind("127.0.0.1", port, kind);
+        client.connect().await.unwrap();
+        client.send(tensor).await.unwrap();
+        h.await.unwrap()
+    }
+
+    let tensor = Tensor::new(DType::F16, [1, 3, 5], (0..30).collect());
+    let over_tcp = roundtrip(TransportKind::Tcp, &tensor).await;
+    let over_quic = roundtrip(TransportKind::Quic, &tensor).await;
+    assert_eq!(over_tcp, over_quic);
+    assert_eq!(over_quic, tensor);
+}
+
+/// A pipeline stage is idle between requests. QUIC keep-alive must hold an
+/// otherwise-silent connection open across a gap longer than the keep-alive
+/// interval (10 s), so the next frame still arrives. `#[ignore]` because it
+/// sleeps ~11 s; run with `--ignored` when touching the QUIC timeout config.
+#[tokio::test]
+#[ignore = "sleeps ~11s to cross the QUIC keep-alive interval"]
+async fn quic_survives_idle_gap_past_keepalive() {
+    let mut server = quic_server(0);
+    server.start().await.unwrap();
+    let port = server.port();
+    let h = tokio::spawn(async move {
+        server.accept().await.unwrap();
+        server.recv().await
+    });
+    let mut client = quic_client(port);
+    client.connect().await.unwrap();
+    // Idle past the 10 s keep-alive interval (but under the 30 s idle cap).
+    tokio::time::sleep(Duration::from_secs(11)).await;
+    let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+    client.send(&tensor).await.unwrap();
+    let got = h.await.unwrap();
+    assert!(
+        got.is_ok(),
+        "keep-alive should hold the idle QUIC link open: {:?}",
+        got.err()
+    );
+}

--- a/crates/cascadia/Cargo.toml
+++ b/crates/cascadia/Cargo.toml
@@ -8,9 +8,12 @@ repository.workspace = true
 description = "cascadia binary — distributed LLM inference for Intel hardware."
 
 [features]
-default = []
+default = ["quic"]
 openvino = ["cascadia-cli/openvino"]
 dashboard-embed = ["cascadia-cli/dashboard-embed"]
+# QUIC activation transport (`cascadia worker --transport quic`). On by
+# default; `--no-default-features` yields a lean TCP-only binary.
+quic = ["cascadia-cli/quic"]
 
 [[bin]]
 name = "cascadia"

--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -122,9 +122,16 @@ pub struct MockPipeline {
 }
 
 impl MockPipeline {
-    /// Spawn an N-stage mock pipeline on 127.0.0.1, downstream-first (each
-    /// upstream needs its downstream listening before it connects).
+    /// Spawn an N-stage mock pipeline on 127.0.0.1 over the default (TCP)
+    /// transport.
     pub async fn spawn(stages: usize) -> Self {
+        Self::spawn_with_transport(stages, "tcp").await
+    }
+
+    /// Spawn an N-stage mock pipeline on 127.0.0.1, downstream-first (each
+    /// upstream needs its downstream listening before it connects), passing
+    /// `--transport {transport}` to every stage.
+    pub async fn spawn_with_transport(stages: usize, transport: &str) -> Self {
         assert!(stages >= 1, "need at least one stage");
         let bin = binary_path();
         assert!(bin.exists(), "cascadia binary not built ({:?})", bin);
@@ -146,6 +153,8 @@ impl MockPipeline {
                 "mock".into(),
                 "--model".into(),
                 "mock-model".into(),
+                "--transport".into(),
+                transport.into(),
                 "--log-level".into(),
                 "warn".into(),
             ];
@@ -323,6 +332,45 @@ mod tests {
             .as_str()
             .expect("content string");
         assert!(!content.is_empty(), "pipeline produced empty completion");
+    }
+
+    /// Same 2-stage loopback pipeline as above but launched with
+    /// `--transport quic` on every stage. This is a *wiring* smoke test: it
+    /// proves the flag parses, `set_transport_kind` runs, the quic-enabled
+    /// binary starts, and the pipeline forms and serves. It does NOT prove
+    /// QUIC data flow — the mock engine's `connect()` is a no-op and never
+    /// crosses a tensor, so no QUIC endpoint is created here. The real
+    /// QUIC data-plane proof lives in cascadia-transport's `quic_roundtrip`
+    /// integration tests; end-to-end QUIC over a real engine needs
+    /// hardware/models and is validated on the fleet like other engines.
+    #[tokio::test]
+    async fn multi_stage_mock_pipeline_loopback_quic() {
+        let pipe = MockPipeline::spawn_with_transport(2, "quic").await;
+        assert!(
+            pipe.wait_for_health(Duration::from_secs(20)).await,
+            "2-stage --transport quic pipeline entry did not become healthy"
+        );
+
+        let client = reqwest::Client::new();
+        let body = serde_json::json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "alpha bravo charlie"}],
+            "max_tokens": 2,
+            "stream": false,
+        });
+        let r = client
+            .post(pipe.url("/v1/chat/completions"))
+            .json(&body)
+            .send()
+            .await
+            .expect("post chat to quic pipeline entry");
+        assert!(
+            r.status().is_success(),
+            "quic pipeline chat status: {}",
+            r.status()
+        );
+        let v: serde_json::Value = r.json().await.unwrap();
+        assert_eq!(v["choices"][0]["message"]["role"], "assistant");
     }
 
     /// Cross-node sharded e2e: brings up an N-stage topology across real fleet


### PR DESCRIPTION
## What

Adds a **QUIC (UDP + TLS 1.3) substrate** for the inter-stage activation relay, selectable at runtime with `cascadia worker --transport quic`. **TCP stays the default** and remains byte-identical to Python cascadia's `transport.py`. QUIC is additive and opt-in behind the `quic` cargo feature.

Validated end-to-end on real Intel NUCs and characterized with a purpose-built micro-benchmark under `tc netem`. Headline: on a clean LAN QUIC costs ~4% (expected); **under ≥1% loss QUIC wins decisively** (up to 3.3× at 5% loss, with far better tail latency). Full data in the PR comments; summary below.

## Why QUIC

The relay is a single ordered point-to-point byte pipe between adjacent pipeline stages, so QUIC's stream-multiplexing / head-of-line-avoidance wins are **muted** (we deliberately use one stream). The gains that matter for cascadia:

- **Encryption on every hop** by default (TLS 1.3), vs plaintext TCP.
- **Loss resilience on lossy/WAN links** — directly relevant to the topology layer's premise that a 50 ms WAN hop craters throughput; QUIC recovers from loss without a TCP-style congestion collapse. **Measured** — see the crossover table.
- **Faster dead-peer detection** via keep-alive PINGs + idle timeout.

Cost: userspace QUIC burns more CPU/packet than kernel TCP on a clean LAN. So **TCP stays default**; QUIC is opt-in for untrusted/WAN paths.

## Design

- **Framing reused verbatim.** The tensor wire helpers (`send_tensor`/`recv_tensor`/…) are now generic over `AsyncRead`/`AsyncWrite`, so the identical length-prefixed format rides either a `TcpStream` or a `quinn` bidi stream. Zero wire changes on the TCP path.
- **One long-lived bidirectional stream per connection**, mirroring the TCP byte stream. `send_raw`/`recv_raw` control bytes interleave with tensor frames exactly as the dist-spec engines expect.
- **1-byte connect preamble** → **TCP-parity accept semantics** (stage readiness fires at connection time, not first-request time, so a middle stage's `connect()` doesn't block until traffic flows).
- **Keep-alive (10 s) < idle-timeout (30 s)** so an idle pipeline stage stays connected while a dead peer is still detected.
- **Self-signed + skip-verify TLS** (zero-config P2P): encrypts the hop but does **not** authenticate the peer (MITM-able) — see follow-ups.
- **Process-wide `TransportKind` selector**, set once at worker startup (mirrors the `set_activation_timeout_secs` global). The whole ring agrees on one substrate, so **all five transport-using engines pick it up with no per-engine change**.
- **Flow-control + congestion tuning:** stream/connection receive + send windows widened to 16/32 MiB, and a moderate 256 KiB initial congestion window (`CubicConfig`) so a large activation frame clears in ~1–1.5 RTT instead of stalling in slow-start on a high-latency link (see benchmarks). Kept moderate to avoid an over-aggressive first burst on a genuinely lossy path.

Stack: `quinn 0.11` + `rustls 0.23` on the **ring** provider (no aws-lc-rs C build) + `rcgen 0.13` for the cert. `rustls` was already in the tree via `reqwest`, so a `--features quic` build only adds `quinn` + `rcgen`.

## Feature flag

`quic` is **on by default in the `cascadia` binary** so the flag works out of the box; build `--no-default-features` for a lean TCP-only binary with no quinn dependency. Selecting `--transport quic` in a non-quic build fails loudly at startup (`QuicUnavailable`). The `cascadia-transport` crate's own default keeps `quic` off.

## Validation & benchmarks

**Correctness** (`cargo test -p cascadia-transport --features quic`): tensor round-trips (small + multi-packet), the exact dist-spec control-byte + tensor interleave **both directions**, TCP/QUIC decode parity, and an 11 s keep-alive idle-survival test. No TCP regression: transport + `idle_recv_stress`, `cascadia-runner` (65), sparse-moe wire, and dist-spec `forward_roundtrip`/`logits_response_roundtrip` all green. `fmt`/`clippy` clean.

**Real hardware, end-to-end** — 2-stage Llama-3.2-1B int4 (`ov-runtime`, CPU) across two Intel NUCs on the same LAN, identical greedy request over each transport:

| transport | tok/s | notes |
|---|---|---|
| TCP  | ~31.5–32.0 | two interleaved runs |
| QUIC | 30.6 | ~4% slower; identical output |

The ~4% is expected — on a clean sub-ms LAN the transport is only ~2–4% of per-token time, so even a 2–3× transport tax dilutes to ~4%. TCP-default is right for co-located hops.

**Transport micro-benchmark** (`examples/transport_bench.rs`, payload sweep 64 B–1 MB, isolates transport from compute):
- *Per-frame* (64 B, loopback): QUIC ~2× TCP → userspace datapath/bookkeeping.
- *Per-byte* (loopback): QUIC ~40× TCP → per-datagram syscalls + copies dominate. A cipher pin (AES-GCM 5533 µs vs ChaCha20 6566 µs on 1 MiB) bounds **crypto at only ~10–20%** of the per-byte cost; copies/datapath are the rest.

**Loss/latency crossover** (`tc netem`, isolated veth+netns, 64 KiB frame, lower = better):

| condition | TCP mean (p99) | QUIC mean (p99) | winner |
|---|---|---|---|
| clean / latency-only (small frames) | — | — | **TCP** (≈ equal at ≥20 ms RTT) |
| 1% loss, 20 ms RTT | 116 ms (371 ms) | 67 ms (136 ms) | **QUIC 1.7×** |
| 3% loss, 20 ms RTT | 246 ms (584 ms) | 93 ms (192 ms) | **QUIC 2.6×** |
| 5% loss, 20 ms RTT | 419 ms (**1.34 s**) | 126 ms (382 ms) | **QUIC 3.3×** |

By ~1% loss QUIC pulls ahead; under 5% loss TCP's p99 hits 1.34 s (RTO + head-of-line stalls) vs QUIC's 382 ms. This is the WAN/lossy regime the feature exists for.

**Why QUIC is slower on a clean link — hypotheses tested:**

| # | hypothesis | verdict |
|---|---|---|
| H1 | userspace datapath / syscalls / no offload | confirmed (per-frame ~2× on loopback) |
| H2 | flow-control / congestion-control | **flow-control refuted** (window bump = no change); the large-frame-under-latency penalty is **slow-start** — a 256 KiB initial cwnd cuts 64 KiB @ 20–50 ms RTT from ~2.5 to ~1.5 RTT |
| H3 | send pacing | leading candidate for the residual ~0.5 RTT (next to test: pacer disabled) |
| H4 | AEAD crypto (per-byte) | confirmed but **~10–20% minority** |
| H5 | copies / no offload (per-byte) | confirmed **dominant** (~80%) |
| — | handshake, keep-alive | ruled out |

Full experiment detail, tables, and methodology are in the PR comments.

## Diagnostics / tooling added

- `examples/transport_bench.rs` — ping-pong payload-sweep bench over the real transport (`tcp|quic`), p50/p90/p99 RTT + goodput; `BENCH_ITERS` / `BENCH_ONLY_BYTES` for targeted runs.
- `CASCADIA_TRANSPORT_STATS` — env-gated per-hop send/recv stats logging (isolates transport timing on a real model run).
- `CASCADIA_QUIC_CIPHER` — pins the TLS 1.3 AEAD (`aesgcm|chacha`) for crypto-cost measurement.

## Follow-ups

Done since the first draft: real-engine end-to-end validation (NUCs); crypto-vs-copy split; the "flow-control" investigation (→ slow-start, tuned).

Still deferred:
- **Send-pacing (H3)** — close out the residual ~0.5 RTT for large frames under latency (disable/tune the pacer).
- **Peer authentication** (pinned raw-public-key) — current cut encrypts but does not authenticate; needs a key-distribution story in discovery.
- **Graceful QUIC close** — session-lived connection makes abrupt-close truncation a non-issue today; documented in `quic.rs`.
