### PR TITLE
ci: security hardening (perms, SHA-pinned actions, cargo-deny gate)

### DIFF
--- a/.github/workflows/ai-pc-tests.yml
+++ b/.github/workflows/ai-pc-tests.yml
@@ -7,6 +7,15 @@
 #     (provisioned via cascadia-fleet — see that repo's docs/RUNNERS.md)
 #   - repository variable INTEL_OPENVINO_DIR pointing at the OpenVINO GenAI SDK
 #     root on the runners.
+#
+# SECURITY — fork PRs must NEVER run on the self-hosted runners. Untrusted fork
+# code here = arbitrary code execution on our hardware. The job-level `if` below
+# skips fork PRs, but a fork can edit that guard in its own PR, so it is
+# defense-in-depth only. The tamper-proof barriers live in repo/org settings and
+# MUST be on before this repo goes public: (1) require approval for all outside
+# collaborators; (2) keep these runners off fork-PR workflows (isolated org
+# runner group and/or ephemeral). Never add a `pull_request` job on
+# [self-hosted, ...] without the guard.
 
 name: AI-PC tests
 
@@ -46,11 +55,18 @@ jobs:
     runs-on: [self-hosted, ai-pc, windows]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      # Actions pinned to full commit SHAs (supply-chain hardening). The
+      # trailing comment records the tag for readability and manual bumps.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      # SHA-pinned: the `stable` channel now comes from `toolchain:`, not the ref.
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ai-pc-openvino
           cache-on-failure: true

--- a/.github/workflows/ai-pc-tests.yml
+++ b/.github/workflows/ai-pc-tests.yml
@@ -12,10 +12,19 @@
 # code here = arbitrary code execution on our hardware. The job-level `if` below
 # skips fork PRs, but a fork can edit that guard in its own PR, so it is
 # defense-in-depth only. The tamper-proof barriers live in repo/org settings and
-# MUST be on before this repo goes public: (1) require approval for all outside
-# collaborators; (2) keep these runners off fork-PR workflows (isolated org
-# runner group and/or ephemeral). Never add a `pull_request` job on
-# [self-hosted, ...] without the guard.
+# MUST be on before this repo goes public:
+#   (1) require approval for workflow runs from all outside collaborators;
+#   (2) keep these runners off fork-PR workflows (isolated org runner group
+#       and/or ephemeral);
+#   (3) enable branch protection on main with ci and cargo-deny as required
+#       checks. Caution if making THIS job required: the fork-PR guard and the
+#       paths filter both produce *skipped* runs, and skipped satisfies a
+#       required check — pair the paths filter with a same-name no-op job and
+#       decide explicitly whether skipped-equals-pass is acceptable;
+#   (4) after going public, verify the weekly security.yml cron stays enabled —
+#       GitHub auto-disables scheduled workflows in public repos after 60 days
+#       without repo activity.
+# Never add a `pull_request` job on [self-hosted, ...] without the guard.
 
 name: AI-PC tests
 
@@ -56,7 +65,9 @@ jobs:
     timeout-minutes: 45
     steps:
       # Actions pinned to full commit SHAs (supply-chain hardening). The
-      # trailing comment records the tag for readability and manual bumps.
+      # trailing comment records the tag (or channel branch, for
+      # dtolnay/rust-toolchain, which publishes no tags) for readability
+      # and manual bumps.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,33 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: this workflow only reads the repo to build and test.
+# Any job needing more must opt in explicitly.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: cargo test (stub)
     runs-on: ubuntu-latest
+    # Bound the job so a hang can't sit on a runner burning billed minutes.
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      # Actions pinned to full commit SHAs (supply-chain hardening). The
+      # trailing comment records the tag for readability and manual bumps.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        # SHA-pinned: the `stable` channel now comes from `toolchain:`, not the ref.
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
     timeout-minutes: 30
     steps:
       # Actions pinned to full commit SHAs (supply-chain hardening). The
-      # trailing comment records the tag for readability and manual bumps.
+      # trailing comment records the tag (or channel branch, for
+      # dtolnay/rust-toolchain, which publishes no tags) for readability
+      # and manual bumps.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 # Supply-chain security gate. Runs cargo-deny over the workspace to catch
-# RUSTSEC advisories, disallowed licenses, banned crates, and untrusted crate
-# sources. Runs on every push/PR to main AND on a weekly schedule — the cron
+# RUSTSEC advisories, disallowed licenses, dependency bans (wildcard version
+# requirements; no crates are name-banned yet), and untrusted crate sources.
+# Runs on every push/PR to main AND on a weekly schedule — the cron
 # re-checks a fixed dependency tree against a freshly-fetched advisory DB, so a
 # newly-disclosed CVE is surfaced even when no code changed.
 #

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,45 @@
+# Supply-chain security gate. Runs cargo-deny over the workspace to catch
+# RUSTSEC advisories, disallowed licenses, banned crates, and untrusted crate
+# sources. Runs on every push/PR to main AND on a weekly schedule — the cron
+# re-checks a fixed dependency tree against a freshly-fetched advisory DB, so a
+# newly-disclosed CVE is surfaced even when no code changed.
+#
+# Policy lives in deny.toml at the repo root; run `cargo deny check` locally to
+# reproduce.
+
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege: only needs to read the repo to scan the dependency tree.
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (advisories, licenses, bans, sources)
+    runs-on: ubuntu-latest
+    # Bound the job so a hang can't sit on a runner burning billed minutes.
+    timeout-minutes: 15
+    steps:
+      # Actions pinned to full commit SHAs (supply-chain hardening). The
+      # trailing comment records the tag for readability and manual bumps.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check all

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,9 +19,13 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+# Scope the group by event so a push to main can never cancel an in-flight
+# scheduled scan (or vice versa) — a cancelled scan reports grey, not red,
+# and its advisory verdict is silently lost. Only PR runs supersede each
+# other; push/schedule runs queue and all complete.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Least-privilege: only needs to read the repo to scan the dependency tree.
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -1632,9 +1632,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/crates/cascadia-api/Cargo.toml
+++ b/crates/cascadia-api/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-api"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-cli/Cargo.toml
+++ b/crates/cascadia-cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-cli"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-dashboard/Cargo.toml
+++ b/crates/cascadia-dashboard/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-dashboard"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-discovery/Cargo.toml
+++ b/crates/cascadia-discovery/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-discovery"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-download/Cargo.toml
+++ b/crates/cascadia-download/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-download"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-engine-mock/Cargo.toml
+++ b/crates/cascadia-engine-mock/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-engine-mock"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-engine-openvino/Cargo.toml
+++ b/crates/cascadia-engine-openvino/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-engine-openvino"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-engine-sparse-moe/Cargo.toml
+++ b/crates/cascadia-engine-sparse-moe/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-engine-sparse-moe"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-engine/Cargo.toml
+++ b/crates/cascadia-engine/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-engine"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-int4-gemm/Cargo.toml
+++ b/crates/cascadia-int4-gemm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-int4-gemm"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-ov-genai-shim/Cargo.toml
+++ b/crates/cascadia-ov-genai-shim/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-ov-genai-shim"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-runner/Cargo.toml
+++ b/crates/cascadia-runner/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-runner"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-topology/Cargo.toml
+++ b/crates/cascadia-topology/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-topology"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-transport/Cargo.toml
+++ b/crates/cascadia-transport/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-transport"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia-types/Cargo.toml
+++ b/crates/cascadia-types/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia-types"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cascadia/Cargo.toml
+++ b/crates/cascadia/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cascadia"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -9,13 +9,11 @@
 # turns CI red and forces a review.
 #
 # The list below is the *accepted baseline* — advisories present as of
-# 2026-07-02 that have no safe upgrade yet. Each is `unsound` or `unmaintained`
-# (there are no open `vulnerability`-class advisories). Bump the offending crate
-# when a patched release lands, then remove its entry here.
+# 2026-07-02 whose fix is not a compatible-version bump away. Each is `unsound`
+# or `unmaintained` (there are no open `vulnerability`-class advisories). Each
+# entry states its actual blocker; remove the entry when the blocker clears.
 ignore = [
-    "RUSTSEC-2026-0190", # anyhow 1.0.102 — unsound Error::downcast_mut(); no patched release yet.
-    "RUSTSEC-2026-0002", # lru 0.12.5 — IterMut Stacked-Borrows unsoundness; no patched release yet.
-    "RUSTSEC-2026-0186", # memmap2 0.9.10 — unchecked pointer offset; no patched release yet.
+    "RUSTSEC-2026-0002", # lru 0.12.5 — IterMut Stacked-Borrows unsoundness. Patched in 0.16.3+, but 0.12 → 0.16+ is a breaking upgrade of a direct dep (cascadia-engine-sparse-moe); ignore until that crate migrates.
     "RUSTSEC-2025-0119", # number_prefix 0.4.0 (unmaintained) — transitive via indicatif → hf-hub → cascadia-download; no safe upgrade.
     "RUSTSEC-2024-0436", # paste 1.0.15 (unmaintained) — transitive via tokenizers; no safe upgrade.
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -22,19 +22,18 @@ yanked = "deny"
 
 [licenses]
 # Cascadia ships Apache-2.0 (see workspace Cargo.toml). Allow the permissive
-# licenses common in the Rust ecosystem that are compatible with Apache-2.0
-# redistribution. Anything not on this list fails the build and must be
-# reviewed before being added.
+# licenses common in the Rust ecosystem, plus MPL-2.0 (weak copyleft,
+# file-scoped) — all compatible with Apache-2.0 redistribution. Only licenses
+# actually present in the tree are listed, so a green run has no unmatched-
+# allowance warnings; anything new fails the build and gets reviewed here.
 allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "MIT",
-    "MIT-0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Zlib",
     "MPL-2.0",
     "CDLA-Permissive-2.0",
@@ -55,7 +54,8 @@ allow-wildcard-paths = true
 multiple-versions = "warn"
 
 [sources]
-# Only pull from crates.io and explicitly-allowed git sources.
+# Only pull from crates.io and explicitly-allowed git sources (none currently
+# — add `allow-git` entries as needed).
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,64 @@
+# cargo-deny configuration — supply-chain gate for the Cascadia workspace.
+# Enforced in CI (.github/workflows/security.yml) and runnable locally:
+#   cargo deny check
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# Fail the build on any RUSTSEC advisory in the dependency tree. This is the
+# real security gate: a NEW vulnerability, unsound, or unmaintained advisory
+# turns CI red and forces a review.
+#
+# The list below is the *accepted baseline* — advisories present as of
+# 2026-07-02 that have no safe upgrade yet. Each is `unsound` or `unmaintained`
+# (there are no open `vulnerability`-class advisories). Bump the offending crate
+# when a patched release lands, then remove its entry here.
+ignore = [
+    "RUSTSEC-2026-0190", # anyhow 1.0.102 — unsound Error::downcast_mut(); no patched release yet.
+    "RUSTSEC-2026-0002", # lru 0.12.5 — IterMut Stacked-Borrows unsoundness; no patched release yet.
+    "RUSTSEC-2026-0186", # memmap2 0.9.10 — unchecked pointer offset; no patched release yet.
+    "RUSTSEC-2025-0119", # number_prefix 0.4.0 (unmaintained) — transitive via indicatif → hf-hub → cascadia-download; no safe upgrade.
+    "RUSTSEC-2024-0436", # paste 1.0.15 (unmaintained) — transitive via tokenizers; no safe upgrade.
+]
+# Never ship a version that has been yanked from the registry.
+yanked = "deny"
+
+[licenses]
+# Cascadia ships Apache-2.0 (see workspace Cargo.toml). Allow the permissive
+# licenses common in the Rust ecosystem that are compatible with Apache-2.0
+# redistribution. Anything not on this list fails the build and must be
+# reviewed before being added.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "MIT-0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+]
+# Require high confidence when detecting a crate's license from its text.
+confidence-threshold = 0.9
+
+# Cascadia's crates depend on each other with `version = "*"` path deps and
+# are not marked `publish = false`, so cargo-deny treats them as publishable
+# and flags the intra-workspace wildcards (allow-wildcard-paths can't exempt
+# "public" crates). Warn rather than fail: these are internal path deps, not
+# unpinned crates.io deps. To promote back to `deny`, add `publish = false` to
+# every non-published crate manifest so allow-wildcard-paths applies.
+[bans]
+wildcards = "warn"
+allow-wildcard-paths = true
+# Duplicate versions of the same crate bloat the tree and widen the audit
+# surface. Warn (don't fail) — transitive dep graphs make this hard to zero out.
+multiple-versions = "warn"
+
+[sources]
+# Only pull from crates.io and explicitly-allowed git sources.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -42,14 +42,13 @@ allow = [
 # Require high confidence when detecting a crate's license from its text.
 confidence-threshold = 0.9
 
-# Cascadia's crates depend on each other with `version = "*"` path deps and
-# are not marked `publish = false`, so cargo-deny treats them as publishable
-# and flags the intra-workspace wildcards (allow-wildcard-paths can't exempt
-# "public" crates). Warn rather than fail: these are internal path deps, not
-# unpinned crates.io deps. To promote back to `deny`, add `publish = false` to
-# every non-published crate manifest so allow-wildcard-paths applies.
+# Wildcard version requirements never gate an external dep — deny them.
+# Intra-workspace deps are bare `path` deps (no version, which Cargo treats as
+# `*`); allow-wildcard-paths exempts those because every workspace crate is
+# marked `publish = false`. Removing `publish = false` from a crate puts its
+# path deps back under this deny.
 [bans]
-wildcards = "warn"
+wildcards = "deny"
 allow-wildcard-paths = true
 # Duplicate versions of the same crate bloat the tree and widen the audit
 # surface. Warn (don't fail) — transitive dep graphs make this hard to zero out.


### PR DESCRIPTION
## CI security hardening

Hardens the GitHub Actions setup and adds a supply-chain scanning gate. No Rust source touched — workflows, `deny.toml`, and Cargo manifests/lockfile only (two semver-compatible dep bumps). All checks green (`ci`, AI-PC, `cargo-deny`).

### Changes
- **Workflow hardening** (`ci.yml`, `ai-pc-tests.yml`)
  - Least-privilege `permissions: contents: read`
  - Actions pinned to full commit SHAs (tag/channel kept in trailing comment); explicit `rust-toolchain` channel
  - `persist-credentials: false` on checkouts
  - Job `timeout-minutes` (30 / 15)
  - SECURITY block on the self-hosted workflow documenting the fork-PR threat + the full go-public checklist (approval for outside-collaborator runs, runner isolation, branch protection with required checks, cron re-verification)
- **Supply-chain gate** (`security.yml` + `deny.toml`)
  - `cargo deny check all` (advisories, licenses, bans, sources) on push, PR, and a weekly cron
  - License allow-list matches the Apache-2.0 posture and lists only licenses actually present in the tree (green runs carry no unmatched-allowance noise)
  - Advisory baseline: **3** documented ignores (`lru`, `number_prefix`, `paste`), each stating its concrete blocker; any **new** advisory fails CI
  - `wildcards = "deny"` — all workspace crates are `publish = false`, so intra-workspace path deps are exempt while an unpinned external dep fails CI
  - Workflow concurrency scoped by event so a push to main can never cancel an in-flight scheduled scan (a cancelled scan reports grey, not red)
- **Dependency bumps (from review)**: `anyhow` 1.0.102 → 1.0.103 and `memmap2` 0.9.10 → 0.9.11 — semver-compatible point releases that resolve RUSTSEC-2026-0190 / RUSTSEC-2026-0186, so those two ignores were dropped rather than baselined

---

## Follow-up settings (repo/org admin, via GitHub UI)

One-time settings changes, not code. Priority order — **P0 must be done before the repo goes public.** (This list is mirrored in the `ai-pc-tests.yml` header SECURITY block so it lives next to the workflow it protects.)

### P0 — Keep fork PRs off the self-hosted AI-PC runners *(before public)*
Highest-risk item: on a public repo a fork PR can run arbitrary code on the self-hosted runners. The in-workflow `if` guard is defense-in-depth only (a fork controls its own workflow file). Real barriers:
- **Require approval for all fork-PR runs.** Settings → Actions → General → under **Fork pull request workflows from outside collaborators**, select **Require approval for all external contributors**. (Public-repo default only gates first-time contributors — a loophole.)
- **Isolate the runners.** Organization → Settings → Actions → **Runner groups**: put the 3 AI-PC runners in a group scoped to selected repositories, with **Allow public repositories** turned **off**. Prefer ephemeral runners (one job → recycle). GitHub advises against self-hosted runners on public repos.

### P1 — Default token read-only + no self-approve *(now)*
Repo default is currently read/**write** with Actions PR self-approval enabled.
- Settings → Actions → General → **Workflow permissions** → select **Read repository contents and packages permissions**, and **uncheck** **Allow GitHub Actions to create and approve pull requests** → Save.

### P1 — Branch protection on `main` *(at go-public — not available on the current private/free plan)*
`main` has no protection today, so the checks are advisory only; branch protection requires the repo to be public (or a paid plan). Do this the same day as the flip:
- Settings → Branches → **Add branch protection rule** (Branch name pattern: `main`):
  - Check **Require a pull request before merging** → **Require approvals** (≥ 1).
  - Check **Require status checks to pass before merging** and **Require branches to be up to date before merging**, then search for and select **cargo test (stub)** and **cargo-deny (advisories, licenses, bans, sources)**.
  - Caution before also requiring the AI-PC job: its fork-PR guard and paths filter both produce *skipped* runs, and skipped satisfies a required check — pair the paths filter with a same-name no-op job and decide explicitly whether skipped-equals-pass is acceptable.

### P2 — Restrict allowed actions + enforce SHA pinning *(now)*
Currently any action is allowed and pinning isn't enforced.
- Settings → Actions → General → **Actions permissions** → select **Allow `labscommunity`, and select non-`labscommunity`, actions and reusable workflows**.
  - Check **Allow actions created by GitHub** and **Allow Marketplace actions by verified creators**.
  - Under the specified-actions patterns box, add: `EmbarkStudios/cargo-deny-action@*`, `dtolnay/rust-toolchain@*`, `Swatinem/rust-cache@*`.
- Enable **Require actions to be pinned to a full-length commit SHA** → Save.

### P3 — Dependabot alerts *(now)*
No `dependabot.yml` (deliberate — avoids PR noise). Keep CVE visibility via alerts instead.
- Settings → **Advanced Security** (labeled **Code security and analysis** on some plans) → set **Dependabot alerts** to **Enabled**.
- Periodically re-pin the action SHAs by hand (nothing auto-bumps them).
- After going public, verify the weekly `security.yml` cron stays enabled — GitHub auto-disables scheduled workflows in public repos after 60 days without repo activity.

### Baselined advisories to revisit
`deny.toml` ignores 3 advisories, each with its blocker stated inline:
- `lru` 0.12.5 (unsound) — patched in 0.16.3+, but that's a breaking upgrade of a direct dep of `cascadia-engine-sparse-moe`; remove when that crate migrates.
- `number_prefix` 0.4.0, `paste` 1.0.15 (unmaintained) — transitive, no patched versions exist.

(`anyhow` and `memmap2` were originally baselined too; review caught that patched point releases already existed, so this PR bumps them and drops those ignores instead.)

---

## Supply-chain hardening (future — out of scope for this PR)

This PR's `cargo-deny` gate blocks **known-advisory**, **untrusted-source**, and **disallowed-license** dependencies. It does **not** detect a novel/undisclosed malicious crate version or arbitrary malicious code. Deeper prevention, none of it wired today (separate PRs):

- **`cargo-vet`** — require each dependency + version bump to be audited/trusted before CI accepts it (importable audit sets from Mozilla/Google/etc.). Closes the zero-day-crate gap that `cargo-deny` can't.
- **Model provenance** — `cascadia-download` currently pulls HuggingFace snapshots via `hf-hub` with no integrity check; verify expected model checksums on download. A poisoned model file is its own supply-chain vector.
- **Release integrity** *(once a release/artifact pipeline exists — none today)* — SLSA build provenance (`actions/attest-build-provenance`) + artifact signing, and publish an SBOM (`cargo-sbom` / CycloneDX), since cascadia ships a binary.
- **Trim dependency surface** — `cargo-machete` for unused deps; fewer, well-known crates = fewer maintainers to compromise.

> Note: `main`'s HEAD still shows an old billing-era red run; it goes green once this merges (billing itself is already resolved — this PR's `ci` ran full length and passed).
