### PR TITLE
feat(cli): plumb OpenVINO performance properties through the CLI (#13)

### DIFF
--- a/.github/workflows/ai-pc-tests.yml
+++ b/.github/workflows/ai-pc-tests.yml
@@ -89,11 +89,12 @@ jobs:
         run: cargo build --release -p cascadia --features openvino
 
       # OV-gated tests (skipped on the ubuntu stub CI because they need the real
-      # runtime + an Intel device).
+      # OpenVINO runtime). Also runs cascadia-ov-genai-shim, which holds the
+      # collect_properties int64-coercion tests (ov::Any only, no device needed).
       - name: Run OpenVINO-feature tests
         env:
           INTEL_OPENVINO_DIR: ${{ vars.INTEL_OPENVINO_DIR }}
-        run: cargo test -p cascadia-engine-openvino --features openvino --no-fail-fast
+        run: cargo test -p cascadia-engine-openvino -p cascadia-ov-genai-shim --features openvino --no-fail-fast
 
       # Optional end-to-end smoke once a small model is staged on the runners:
       # bring up the cascadia binary against the real engine and hit

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -731,14 +731,21 @@ fn device_is_npu(device: &str) -> bool {
 }
 
 /// Translate the `--ov-*` / `--npu-*` performance flags on `args` into the
-/// `(key, value)` OpenVINO plugin properties consumed by every OV engine
-/// builder. NPU-only properties are dropped unless `--device` names an NPU
-/// plugin. Returns entries in a stable order (general hints first, NPU
-/// knobs last) so callers and tests see a deterministic list.
+/// `(key, value)` OpenVINO plugin properties fed to the OV engine builders.
+/// General hints apply to any engine; the NPU-only knobs are emitted only for
+/// an NPU device on the `ov-genai` engine (the sole engine that routes them
+/// through an `ov::genai` LLMPipeline — see the NPU block below). Returns
+/// entries in a stable order (general hints first, NPU knobs last) so callers
+/// and tests see a deterministic list.
 fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
     let mut props: Vec<(String, String)> = Vec::new();
 
-    // General performance hints — valid on every OV plugin.
+    // General performance hints. PERFORMANCE_HINT / INFERENCE_PRECISION_HINT /
+    // EXECUTION_MODE_HINT are plugin-agnostic ov::hint properties. NUM_STREAMS,
+    // INFERENCE_NUM_THREADS (CPU-oriented) and ALLOW_AUTO_BATCHING (GPU/AUTO)
+    // are only effective on the plugins that own them; they are opt-in, so we
+    // forward the user's request verbatim and let OV accept or reject it rather
+    // than second-guessing the target device here.
     if let Some(mode) = &args.ov_performance_mode {
         props.push(("PERFORMANCE_HINT".into(), mode.clone()));
     }
@@ -758,10 +765,15 @@ fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
         props.push(("EXECUTION_MODE_HINT".into(), mode.clone()));
     }
 
-    // NPU-only knobs — passing these to a non-NPU plugin errors, so gate on
-    // the device. Keeping the gate here (single source of truth) means the
-    // engine builders and the C++ shim never see NPU keys on a GPU/CPU run.
-    if device_is_npu(&args.device) {
+    // NPU-only knobs. These are ov::genai LLMPipeline convenience keys — the
+    // GenAI NPU path consumes MAX_PROMPT_LEN / MIN_RESPONSE_LEN and drives the
+    // NPUW LLM pipeline (NPUW_LLM_PREFILL_CHUNK_SIZE). Only the ov-genai engine
+    // routes properties through an LLMPipeline; every other OV engine compiles
+    // via raw ov::Core::compile_model, which does not understand these keys (it
+    // rejects or ignores them). So gate on BOTH the device (NPU) and the engine
+    // (ov-genai). Keeping the gate here (single source of truth) means the
+    // builders and the C++ shim never see an NPU key on a run that can't use it.
+    if device_is_npu(&args.device) && matches!(args.engine, EngineKind::OvGenai) {
         if let Some(n) = args.npu_prefill_chunk_size {
             props.push(("NPUW_LLM_PREFILL_CHUNK_SIZE".into(), n.to_string()));
         }
@@ -1634,10 +1646,14 @@ mod ov_property_tests {
     use super::*;
 
     fn args_for(device: &str) -> WorkerArgs {
+        args_for_engine(device, EngineKind::OvGenai)
+    }
+
+    fn args_for_engine(device: &str, engine: EngineKind) -> WorkerArgs {
         WorkerArgs::single_node(
             "model".into(),
             device.into(),
-            EngineKind::OvGenai,
+            engine,
             "127.0.0.1:8080".into(),
         )
     }
@@ -1719,5 +1735,43 @@ mod ov_property_tests {
         assert_eq!(prop(&props, "NPUW_LLM_PREFILL_CHUNK_SIZE"), Some("512"));
         assert_eq!(prop(&props, "MAX_PROMPT_LEN"), Some("1024"));
         assert_eq!(prop(&props, "MIN_RESPONSE_LEN"), Some("128"));
+    }
+
+    #[test]
+    fn npu_props_dropped_on_non_genai_engine_even_on_npu_device() {
+        // MAX_PROMPT_LEN / MIN_RESPONSE_LEN / NPUW_LLM_PREFILL_CHUNK_SIZE are
+        // ov::genai LLMPipeline convenience keys. Only ov-genai routes props
+        // through the GenAI pipeline; the other OV engines hit raw
+        // compile_model, which cannot consume them. So they must be gated on
+        // engine == ov-genai, not device alone.
+        for engine in [
+            EngineKind::OvRuntime,
+            EngineKind::Gemma4,
+            EngineKind::OvDistSpec,
+            EngineKind::SparseMoe,
+        ] {
+            let mut args = args_for_engine("NPU.0", engine);
+            args.npu_prefill_chunk_size = Some(512);
+            args.npu_max_prompt_len = Some(1024);
+            args.npu_min_response_len = Some(128);
+
+            let props = ov_perf_properties(&args);
+            assert_eq!(
+                prop(&props, "NPUW_LLM_PREFILL_CHUNK_SIZE"),
+                None,
+                "{engine:?}"
+            );
+            assert_eq!(prop(&props, "MAX_PROMPT_LEN"), None, "{engine:?}");
+            assert_eq!(prop(&props, "MIN_RESPONSE_LEN"), None, "{engine:?}");
+        }
+    }
+
+    #[test]
+    fn general_hints_still_apply_on_non_genai_engine() {
+        // The engine gate is NPU-knob-specific; general hints stay engine-agnostic.
+        let mut args = args_for_engine("GPU", EngineKind::OvRuntime);
+        args.ov_performance_mode = Some("LATENCY".into());
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "PERFORMANCE_HINT"), Some("LATENCY"));
     }
 }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -320,17 +320,20 @@ pub struct WorkerArgs {
     pub ov_execution_mode: Option<String>,
 
     /// NPU LLM prefill chunk size (NPUW_LLM_PREFILL_CHUNK_SIZE, OV 2025.3+).
-    /// Silently dropped unless --device names an NPU plugin.
+    /// Applied only with --engine ov-genai on an NPU device; silently dropped
+    /// otherwise (only ov-genai routes it through an ov::genai LLMPipeline).
     #[arg(long, value_name = "TOKS")]
     pub npu_prefill_chunk_size: Option<u32>,
 
     /// NPU max prompt length (MAX_PROMPT_LEN, static-shape constraint).
-    /// Silently dropped unless --device names an NPU plugin.
+    /// Applied only with --engine ov-genai on an NPU device; silently dropped
+    /// otherwise (only ov-genai routes it through an ov::genai LLMPipeline).
     #[arg(long, value_name = "TOKS")]
     pub npu_max_prompt_len: Option<u32>,
 
     /// NPU min response length (MIN_RESPONSE_LEN, static-shape constraint).
-    /// Silently dropped unless --device names an NPU plugin.
+    /// Applied only with --engine ov-genai on an NPU device; silently dropped
+    /// otherwise (only ov-genai routes it through an ov::genai LLMPipeline).
     #[arg(long, value_name = "TOKS")]
     pub npu_min_response_len: Option<u32>,
 

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -291,11 +291,11 @@ pub struct WorkerArgs {
     #[arg(long)]
     pub ov_dyn_quant_group: Option<String>,
 
-    /// OV performance hint: LATENCY, THROUGHPUT, or CUMULATIVE_THROUGHPUT.
-    /// LATENCY suits single-user decode; THROUGHPUT enables NUM_STREAMS
-    /// auto-tuning. See OpenVINO high-level-performance-hints docs (2026).
-    #[arg(long, value_name = "MODE")]
-    pub ov_performance_mode: Option<String>,
+    /// OV performance hint (PERFORMANCE_HINT). LATENCY suits single-user
+    /// decode; THROUGHPUT enables NUM_STREAMS auto-tuning. See OpenVINO
+    /// high-level-performance-hints docs (2026).
+    #[arg(long, value_enum, value_name = "MODE")]
+    pub ov_performance_mode: Option<OvPerformanceMode>,
 
     /// OV inference precision hint: f16, bf16, or f32. Strongly recommended
     /// on Xe2/Battlemage GPUs, where f16/bf16 share XMX throughput but the
@@ -318,10 +318,11 @@ pub struct WorkerArgs {
     #[arg(long)]
     pub ov_allow_auto_batching: bool,
 
-    /// OV execution mode: ACCURACY or PERFORMANCE (EXECUTION_MODE_HINT).
-    /// See OpenVINO precision-control (execution-mode) docs (2026).
-    #[arg(long, value_name = "MODE")]
-    pub ov_execution_mode: Option<String>,
+    /// OV execution mode (EXECUTION_MODE_HINT). PERFORMANCE trades a little
+    /// accuracy for throughput. See OpenVINO precision-control
+    /// (execution-mode) docs (2026).
+    #[arg(long, value_enum, value_name = "MODE")]
+    pub ov_execution_mode: Option<OvExecutionMode>,
 
     /// NPU LLM prefill chunk size (NPUW_LLM_PREFILL_CHUNK_SIZE, OV 2025.3+).
     /// Applied only with --engine ov-genai on an NPU device; silently dropped
@@ -638,6 +639,51 @@ impl ShardQuant {
     }
 }
 
+/// OpenVINO performance hint (`PERFORMANCE_HINT`). These map to
+/// `ov::hint::PerformanceMode` and are device-independent, so — unlike
+/// `--ov-inference-precision`, whose valid set is device-specific (`bf16` /
+/// `dynamic` vary per device) and is therefore left a free string for OV to
+/// validate — we enumerate them and reject typos at parse time.
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum OvPerformanceMode {
+    #[value(name = "LATENCY")]
+    Latency,
+    #[value(name = "THROUGHPUT")]
+    Throughput,
+    #[value(name = "CUMULATIVE_THROUGHPUT")]
+    CumulativeThroughput,
+}
+
+impl OvPerformanceMode {
+    fn as_ov(self) -> &'static str {
+        match self {
+            Self::Latency => "LATENCY",
+            Self::Throughput => "THROUGHPUT",
+            Self::CumulativeThroughput => "CUMULATIVE_THROUGHPUT",
+        }
+    }
+}
+
+/// OpenVINO execution mode (`EXECUTION_MODE_HINT`). Maps to
+/// `ov::hint::ExecutionMode`; device-independent, so enumerated like
+/// [`OvPerformanceMode`].
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum OvExecutionMode {
+    #[value(name = "ACCURACY")]
+    Accuracy,
+    #[value(name = "PERFORMANCE")]
+    Performance,
+}
+
+impl OvExecutionMode {
+    fn as_ov(self) -> &'static str {
+        match self {
+            Self::Accuracy => "ACCURACY",
+            Self::Performance => "PERFORMANCE",
+        }
+    }
+}
+
 pub async fn run(cli: Cli) -> Result<()> {
     init_tracing(&cli.log_level);
     match cli.cmd {
@@ -753,8 +799,8 @@ fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
     // are only effective on the plugins that own them; they are opt-in, so we
     // forward the user's request verbatim and let OV accept or reject it rather
     // than second-guessing the target device here.
-    if let Some(mode) = &args.ov_performance_mode {
-        props.push(("PERFORMANCE_HINT".into(), mode.clone()));
+    if let Some(mode) = args.ov_performance_mode {
+        props.push(("PERFORMANCE_HINT".into(), mode.as_ov().into()));
     }
     if let Some(prec) = &args.ov_inference_precision {
         props.push(("INFERENCE_PRECISION_HINT".into(), prec.clone()));
@@ -768,8 +814,8 @@ fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
     if args.ov_allow_auto_batching {
         props.push(("ALLOW_AUTO_BATCHING".into(), "true".into()));
     }
-    if let Some(mode) = &args.ov_execution_mode {
-        props.push(("EXECUTION_MODE_HINT".into(), mode.clone()));
+    if let Some(mode) = args.ov_execution_mode {
+        props.push(("EXECUTION_MODE_HINT".into(), mode.as_ov().into()));
     }
 
     // NPU-only knobs. These are ov::genai LLMPipeline convenience keys — the
@@ -808,7 +854,41 @@ fn ovgenai_chat_template(model: &str) -> cascadia_api::ChatTemplateConfig {
     }
 }
 
+/// Warn when a performance flag the user explicitly set will be silently
+/// ignored for the chosen engine/device, so an ineffective flag is visible at
+/// runtime instead of vanishing (mirrors the `--ffn-sparsity-capture-dir`
+/// warning in `build_builder`'s sparse-moe arm).
+fn warn_ignored_ov_perf_flags(args: &WorkerArgs) {
+    // NPU LLM knobs apply only to ov-genai on an NPU device (see
+    // `ov_perf_properties`). If the user set one but that gate won't fire, the
+    // value is dropped — say so, or they chase a shape/truncation bug with no
+    // signal pointing at the ignored flag.
+    let npu_flag_set = args.npu_prefill_chunk_size.is_some()
+        || args.npu_max_prompt_len.is_some()
+        || args.npu_min_response_len.is_some();
+    let npu_gate_open = device_is_npu(&args.device) && matches!(args.engine, EngineKind::OvGenai);
+    if npu_flag_set && !npu_gate_open {
+        tracing::warn!(
+            engine = ?args.engine,
+            device = %args.device,
+            "ignoring --npu-* flags: NPU LLM knobs apply only with \
+             --engine ov-genai on an NPU device"
+        );
+    }
+
+    // qwen36-moe compiles with a fixed plugin config and receives no OV perf
+    // properties (some hints break its IRs — see qwen36.rs). If the user set
+    // general hints, warn they won't take effect on this engine.
+    if matches!(args.engine, EngineKind::Qwen36Moe) && !ov_perf_properties(args).is_empty() {
+        tracing::warn!(
+            "ignoring --ov-* performance flags: the qwen36-moe engine compiles \
+             with a fixed plugin config and does not apply them"
+        );
+    }
+}
+
 fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
+    warn_ignored_ov_perf_flags(args);
     match args.engine {
         EngineKind::Mock => Ok(Box::new(MockBuilder::new())),
         EngineKind::OvGenai => {
@@ -1693,12 +1773,12 @@ mod ov_property_tests {
     #[test]
     fn general_hints_map_to_ov_property_keys() {
         let mut args = args_for("GPU");
-        args.ov_performance_mode = Some("LATENCY".into());
+        args.ov_performance_mode = Some(OvPerformanceMode::Latency);
         args.ov_inference_precision = Some("f16".into());
         args.ov_num_streams = Some(2);
         args.ov_num_threads = Some(8);
         args.ov_allow_auto_batching = true;
-        args.ov_execution_mode = Some("PERFORMANCE".into());
+        args.ov_execution_mode = Some(OvExecutionMode::Performance);
 
         let props = ov_perf_properties(&args);
         assert_eq!(prop(&props, "PERFORMANCE_HINT"), Some("LATENCY"));
@@ -1777,7 +1857,7 @@ mod ov_property_tests {
     fn general_hints_still_apply_on_non_genai_engine() {
         // The engine gate is NPU-knob-specific; general hints stay engine-agnostic.
         let mut args = args_for_engine("GPU", EngineKind::OvRuntime);
-        args.ov_performance_mode = Some("LATENCY".into());
+        args.ov_performance_mode = Some(OvPerformanceMode::Latency);
         let props = ov_perf_properties(&args);
         assert_eq!(prop(&props, "PERFORMANCE_HINT"), Some("LATENCY"));
     }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -304,18 +304,22 @@ pub struct WorkerArgs {
     pub ov_inference_precision: Option<String>,
 
     /// OV number of parallel inference streams (NUM_STREAMS).
+    /// See OpenVINO optimizing-throughput (streams-and-threads) docs (2026).
     #[arg(long, value_name = "N")]
     pub ov_num_streams: Option<u32>,
 
-    /// OV host CPU inference thread cap (INFERENCE_NUM_THREADS).
+    /// OV host CPU inference thread cap (INFERENCE_NUM_THREADS). CPU plugin
+    /// only. See OpenVINO CPU-device docs (2026).
     #[arg(long, value_name = "N")]
     pub ov_num_threads: Option<u32>,
 
     /// OV: allow internal auto-batching on the GPU plugin (ALLOW_AUTO_BATCHING).
+    /// See OpenVINO automatic-batching docs (2026).
     #[arg(long)]
     pub ov_allow_auto_batching: bool,
 
     /// OV execution mode: ACCURACY or PERFORMANCE (EXECUTION_MODE_HINT).
+    /// See OpenVINO precision-control (execution-mode) docs (2026).
     #[arg(long, value_name = "MODE")]
     pub ov_execution_mode: Option<String>,
 

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -291,6 +291,49 @@ pub struct WorkerArgs {
     #[arg(long)]
     pub ov_dyn_quant_group: Option<String>,
 
+    /// OV performance hint: LATENCY, THROUGHPUT, or CUMULATIVE_THROUGHPUT.
+    /// LATENCY suits single-user decode; THROUGHPUT enables NUM_STREAMS
+    /// auto-tuning. See OpenVINO high-level-performance-hints docs (2026).
+    #[arg(long, value_name = "MODE")]
+    pub ov_performance_mode: Option<String>,
+
+    /// OV inference precision hint: f16, bf16, or f32. Strongly recommended
+    /// on Xe2/Battlemage GPUs, where f16/bf16 share XMX throughput but the
+    /// default can silently fall back to f32. See OpenVINO gpu-device docs.
+    #[arg(long, value_name = "PREC")]
+    pub ov_inference_precision: Option<String>,
+
+    /// OV number of parallel inference streams (NUM_STREAMS).
+    #[arg(long, value_name = "N")]
+    pub ov_num_streams: Option<u32>,
+
+    /// OV host CPU inference thread cap (INFERENCE_NUM_THREADS).
+    #[arg(long, value_name = "N")]
+    pub ov_num_threads: Option<u32>,
+
+    /// OV: allow internal auto-batching on the GPU plugin (ALLOW_AUTO_BATCHING).
+    #[arg(long)]
+    pub ov_allow_auto_batching: bool,
+
+    /// OV execution mode: ACCURACY or PERFORMANCE (EXECUTION_MODE_HINT).
+    #[arg(long, value_name = "MODE")]
+    pub ov_execution_mode: Option<String>,
+
+    /// NPU LLM prefill chunk size (NPUW_LLM_PREFILL_CHUNK_SIZE, OV 2025.3+).
+    /// Silently dropped unless --device names an NPU plugin.
+    #[arg(long, value_name = "TOKS")]
+    pub npu_prefill_chunk_size: Option<u32>,
+
+    /// NPU max prompt length (MAX_PROMPT_LEN, static-shape constraint).
+    /// Silently dropped unless --device names an NPU plugin.
+    #[arg(long, value_name = "TOKS")]
+    pub npu_max_prompt_len: Option<u32>,
+
+    /// NPU min response length (MIN_RESPONSE_LEN, static-shape constraint).
+    /// Silently dropped unless --device names an NPU plugin.
+    #[arg(long, value_name = "TOKS")]
+    pub npu_min_response_len: Option<u32>,
+
     /// Speculative-decode draft model path (FastDraft companion).
     #[arg(long)]
     pub draft_model: Option<String>,
@@ -495,6 +538,15 @@ impl WorkerArgs {
             ov_cache_dir: None,
             ov_kv_precision: None,
             ov_dyn_quant_group: None,
+            ov_performance_mode: None,
+            ov_inference_precision: None,
+            ov_num_streams: None,
+            ov_num_threads: None,
+            ov_allow_auto_batching: false,
+            ov_execution_mode: None,
+            npu_prefill_chunk_size: None,
+            npu_max_prompt_len: None,
+            npu_min_response_len: None,
             draft_model: None,
             draft_device: None,
             spec_k: 5,
@@ -668,6 +720,62 @@ fn resolve_ov_cache_dir(arg: Option<&str>) -> Option<String> {
     }
 }
 
+/// True when `device` names an OpenVINO NPU plugin (e.g. "NPU", "NPU.0").
+/// NPU-only plugin properties error if passed to a non-NPU plugin, so the
+/// gate below strips them unless this returns true. Matching the issue #13
+/// contract, the check is a case-insensitive `starts_with("NPU")`; compound
+/// AUTO/HETERO device strings that merely mention NPU are deliberately not
+/// treated as NPU targets.
+fn device_is_npu(device: &str) -> bool {
+    device.trim().to_ascii_uppercase().starts_with("NPU")
+}
+
+/// Translate the `--ov-*` / `--npu-*` performance flags on `args` into the
+/// `(key, value)` OpenVINO plugin properties consumed by every OV engine
+/// builder. NPU-only properties are dropped unless `--device` names an NPU
+/// plugin. Returns entries in a stable order (general hints first, NPU
+/// knobs last) so callers and tests see a deterministic list.
+fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
+    let mut props: Vec<(String, String)> = Vec::new();
+
+    // General performance hints — valid on every OV plugin.
+    if let Some(mode) = &args.ov_performance_mode {
+        props.push(("PERFORMANCE_HINT".into(), mode.clone()));
+    }
+    if let Some(prec) = &args.ov_inference_precision {
+        props.push(("INFERENCE_PRECISION_HINT".into(), prec.clone()));
+    }
+    if let Some(n) = args.ov_num_streams {
+        props.push(("NUM_STREAMS".into(), n.to_string()));
+    }
+    if let Some(n) = args.ov_num_threads {
+        props.push(("INFERENCE_NUM_THREADS".into(), n.to_string()));
+    }
+    if args.ov_allow_auto_batching {
+        props.push(("ALLOW_AUTO_BATCHING".into(), "true".into()));
+    }
+    if let Some(mode) = &args.ov_execution_mode {
+        props.push(("EXECUTION_MODE_HINT".into(), mode.clone()));
+    }
+
+    // NPU-only knobs — passing these to a non-NPU plugin errors, so gate on
+    // the device. Keeping the gate here (single source of truth) means the
+    // engine builders and the C++ shim never see NPU keys on a GPU/CPU run.
+    if device_is_npu(&args.device) {
+        if let Some(n) = args.npu_prefill_chunk_size {
+            props.push(("NPUW_LLM_PREFILL_CHUNK_SIZE".into(), n.to_string()));
+        }
+        if let Some(n) = args.npu_max_prompt_len {
+            props.push(("MAX_PROMPT_LEN".into(), n.to_string()));
+        }
+        if let Some(n) = args.npu_min_response_len {
+            props.push(("MIN_RESPONSE_LEN".into(), n.to_string()));
+        }
+    }
+
+    props
+}
+
 /// Load a whole-model chat template for ov-genai, tolerating both layouts:
 /// `tokenizer/tokenizer_config.json` (HF subdir) and a root-level
 /// `tokenizer_config.json` / `chat_template.jinja` (OV int4 exports).
@@ -703,6 +811,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             if let Some(group) = &args.ov_dyn_quant_group {
                 b = b.with_dyn_quant_group(group);
             }
+            b = b.with_ov_properties(ov_perf_properties(args));
             if let Some(draft) = &args.draft_model {
                 let device = args
                     .draft_device
@@ -729,6 +838,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             if let Some(group) = &args.ov_dyn_quant_group {
                 b = b.with_dyn_quant_group(group);
             }
+            b = b.with_ov_properties(ov_perf_properties(args));
             Ok(Box::new(b))
         }
         EngineKind::Gemma4 => {
@@ -742,6 +852,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             if let Some(group) = &args.ov_dyn_quant_group {
                 b = b.with_dyn_quant_group(group);
             }
+            b = b.with_ov_properties(ov_perf_properties(args));
             Ok(Box::new(b))
         }
         EngineKind::OvDistSpec => {
@@ -764,6 +875,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
                 if let Some(group) = &args.ov_dyn_quant_group {
                     b = b.with_dyn_quant_group(group);
                 }
+                b = b.with_ov_properties(ov_perf_properties(args));
                 Ok(Box::new(b))
             } else {
                 let mut b =
@@ -777,6 +889,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
                 if let Some(group) = &args.ov_dyn_quant_group {
                     b = b.with_dyn_quant_group(group);
                 }
+                b = b.with_ov_properties(ov_perf_properties(args));
                 Ok(Box::new(b))
             }
         }
@@ -787,6 +900,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 cfg.cache_dir = Some(dir);
             }
+            cfg.ov_properties = ov_perf_properties(args);
             cfg.top_k_override = args.top_k_override;
             cfg.routing_threshold = args.routing_threshold;
             cfg.max_cached_experts = args.max_cached_experts;
@@ -1513,4 +1627,97 @@ async fn cmd_shard(args: ShardArgs) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod ov_property_tests {
+    use super::*;
+
+    fn args_for(device: &str) -> WorkerArgs {
+        WorkerArgs::single_node(
+            "model".into(),
+            device.into(),
+            EngineKind::OvGenai,
+            "127.0.0.1:8080".into(),
+        )
+    }
+
+    fn prop<'a>(props: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        props
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn device_is_npu_matches_npu_plugins_only() {
+        assert!(device_is_npu("NPU"));
+        assert!(device_is_npu("NPU.0"));
+        assert!(device_is_npu("npu"));
+        assert!(device_is_npu("  NPU  "));
+        assert!(!device_is_npu("GPU"));
+        assert!(!device_is_npu("CPU"));
+        // Compound AUTO/HETERO strings that merely mention NPU are not NPU targets.
+        assert!(!device_is_npu("AUTO:NPU,CPU"));
+    }
+
+    #[test]
+    fn unset_flags_produce_no_properties() {
+        let args = args_for("GPU");
+        assert!(ov_perf_properties(&args).is_empty());
+    }
+
+    #[test]
+    fn general_hints_map_to_ov_property_keys() {
+        let mut args = args_for("GPU");
+        args.ov_performance_mode = Some("LATENCY".into());
+        args.ov_inference_precision = Some("f16".into());
+        args.ov_num_streams = Some(2);
+        args.ov_num_threads = Some(8);
+        args.ov_allow_auto_batching = true;
+        args.ov_execution_mode = Some("PERFORMANCE".into());
+
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "PERFORMANCE_HINT"), Some("LATENCY"));
+        assert_eq!(prop(&props, "INFERENCE_PRECISION_HINT"), Some("f16"));
+        assert_eq!(prop(&props, "NUM_STREAMS"), Some("2"));
+        assert_eq!(prop(&props, "INFERENCE_NUM_THREADS"), Some("8"));
+        assert_eq!(prop(&props, "ALLOW_AUTO_BATCHING"), Some("true"));
+        assert_eq!(prop(&props, "EXECUTION_MODE_HINT"), Some("PERFORMANCE"));
+    }
+
+    #[test]
+    fn auto_batching_absent_when_flag_unset() {
+        let args = args_for("GPU");
+        assert_eq!(
+            prop(&ov_perf_properties(&args), "ALLOW_AUTO_BATCHING"),
+            None
+        );
+    }
+
+    #[test]
+    fn npu_props_dropped_on_non_npu_device() {
+        let mut args = args_for("GPU");
+        args.npu_prefill_chunk_size = Some(512);
+        args.npu_max_prompt_len = Some(1024);
+        args.npu_min_response_len = Some(128);
+
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "NPUW_LLM_PREFILL_CHUNK_SIZE"), None);
+        assert_eq!(prop(&props, "MAX_PROMPT_LEN"), None);
+        assert_eq!(prop(&props, "MIN_RESPONSE_LEN"), None);
+    }
+
+    #[test]
+    fn npu_props_included_on_npu_device() {
+        let mut args = args_for("NPU.0");
+        args.npu_prefill_chunk_size = Some(512);
+        args.npu_max_prompt_len = Some(1024);
+        args.npu_min_response_len = Some(128);
+
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "NPUW_LLM_PREFILL_CHUNK_SIZE"), Some("512"));
+        assert_eq!(prop(&props, "MAX_PROMPT_LEN"), Some("1024"));
+        assert_eq!(prop(&props, "MIN_RESPONSE_LEN"), Some("128"));
+    }
 }

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1557,6 +1557,8 @@ pub struct OvDistSpecBuilder {
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
+    /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
+    pub ov_properties: Vec<(String, String)>,
     stage0: Option<OvRuntime>,
     draft: Option<OvRuntime>,
     tokenizer: Option<Arc<Tokenizer>>,
@@ -1581,6 +1583,7 @@ impl OvDistSpecBuilder {
             cache_dir: None,
             kv_cache_precision: None,
             dyn_quant_group: None,
+            ov_properties: Vec::new(),
             stage0: None,
             draft: None,
             tokenizer: None,
@@ -1606,6 +1609,11 @@ impl OvDistSpecBuilder {
         self.dyn_quant_group = Some(group.into());
         self
     }
+    /// Append extra `(key, value)` OV plugin properties (CLI perf flags).
+    pub fn with_ov_properties(mut self, props: Vec<(String, String)>) -> Self {
+        self.ov_properties.extend(props);
+        self
+    }
 
     fn plugin(&self) -> PluginConfig {
         let mut p = PluginConfig::new();
@@ -1617,6 +1625,9 @@ impl OvDistSpecBuilder {
         }
         if let Some(g) = &self.dyn_quant_group {
             p = p.with("DYNAMIC_QUANTIZATION_GROUP_SIZE", g);
+        }
+        for (key, val) in &self.ov_properties {
+            p = p.with(key, val);
         }
         p
     }
@@ -2050,6 +2061,8 @@ pub struct OvDistSpecWorkerBuilder {
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
+    /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
+    pub ov_properties: Vec<(String, String)>,
     runtime: Option<OvRuntime>,
     inputs: std::collections::HashMap<String, String>,
     upstream: Option<Arc<tokio::sync::Mutex<ActivationServer>>>,
@@ -2073,6 +2086,7 @@ impl OvDistSpecWorkerBuilder {
             cache_dir: None,
             kv_cache_precision: None,
             dyn_quant_group: None,
+            ov_properties: Vec::new(),
             runtime: None,
             inputs: std::collections::HashMap::new(),
             upstream: None,
@@ -2094,6 +2108,11 @@ impl OvDistSpecWorkerBuilder {
         self.dyn_quant_group = Some(group.into());
         self
     }
+    /// Append extra `(key, value)` OV plugin properties (CLI perf flags).
+    pub fn with_ov_properties(mut self, props: Vec<(String, String)>) -> Self {
+        self.ov_properties.extend(props);
+        self
+    }
 
     fn plugin(&self) -> PluginConfig {
         let mut p = PluginConfig::new();
@@ -2105,6 +2124,9 @@ impl OvDistSpecWorkerBuilder {
         }
         if let Some(g) = &self.dyn_quant_group {
             p = p.with("DYNAMIC_QUANTIZATION_GROUP_SIZE", g);
+        }
+        for (key, val) in &self.ov_properties {
+            p = p.with(key, val);
         }
         p
     }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1108,6 +1108,8 @@ pub struct Gemma4Builder {
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
+    /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
+    pub ov_properties: Vec<(String, String)>,
     runtime: Option<OvRuntime>,
     spec: Option<ShardSpec>,
     tokenizer: Option<Arc<Tokenizer>>,
@@ -1154,6 +1156,11 @@ impl Gemma4Builder {
         self.dyn_quant_group = Some(group.into());
         self
     }
+    /// Append extra `(key, value)` OV plugin properties (CLI perf flags).
+    pub fn with_ov_properties(mut self, props: Vec<(String, String)>) -> Self {
+        self.ov_properties.extend(props);
+        self
+    }
 
     fn plugin(&self) -> PluginConfig {
         let mut p = PluginConfig::new();
@@ -1165,6 +1172,9 @@ impl Gemma4Builder {
         }
         if let Some(g) = &self.dyn_quant_group {
             p = p.with("DYNAMIC_QUANTIZATION_GROUP_SIZE", g);
+        }
+        for (key, val) in &self.ov_properties {
+            p = p.with(key, val);
         }
         p
     }

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -441,6 +441,25 @@ mod tests {
     use cascadia_engine::EngineError;
     use cascadia_types::{PeerEndpoint, PeerLayout, ShardSpec};
 
+    #[test]
+    fn ov_properties_reach_plugin_config() {
+        // Intercepts the PluginConfig the builder hands to
+        // ov::Core::compile_model: every injected (key, value) — the CLI's
+        // --ov-* perf flags — must land in its entries, alongside the
+        // pre-existing cache_dir wiring.
+        let b = OvGenaiBuilder::new("/x", "GPU")
+            .with_cache_dir("/tmp/ovc")
+            .with_ov_properties(vec![
+                ("PERFORMANCE_HINT".into(), "LATENCY".into()),
+                ("INFERENCE_PRECISION_HINT".into(), "f16".into()),
+            ]);
+        let cfg = b.build_plugin_config();
+        let has = |k: &str, v: &str| cfg.entries.iter().any(|(ek, ev)| ek == k && ev == v);
+        assert!(has("CACHE_DIR", "/tmp/ovc"));
+        assert!(has("PERFORMANCE_HINT", "LATENCY"));
+        assert!(has("INFERENCE_PRECISION_HINT", "f16"));
+    }
+
     #[tokio::test]
     async fn rejects_peer_layout() {
         let mut b = OvGenaiBuilder::new("/x", "CPU");

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -32,6 +32,9 @@ pub struct OvGenaiBuilder {
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
+    /// Extra `(key, value)` OV plugin properties (PERFORMANCE_HINT,
+    /// INFERENCE_PRECISION_HINT, NPU knobs, …) plumbed verbatim from the CLI.
+    pub ov_properties: Vec<(String, String)>,
     pub draft_model_path: Option<String>,
     pub draft_device: Option<String>,
     pub speculative_k: u32,
@@ -50,6 +53,7 @@ impl OvGenaiBuilder {
             cache_dir: None,
             kv_cache_precision: None,
             dyn_quant_group: None,
+            ov_properties: Vec::new(),
             draft_model_path: None,
             draft_device: None,
             speculative_k: 0,
@@ -75,6 +79,11 @@ impl OvGenaiBuilder {
     }
     pub fn with_dyn_quant_group(mut self, group: impl Into<String>) -> Self {
         self.dyn_quant_group = Some(group.into());
+        self
+    }
+    /// Append extra `(key, value)` OV plugin properties (CLI perf flags).
+    pub fn with_ov_properties(mut self, props: Vec<(String, String)>) -> Self {
+        self.ov_properties.extend(props);
         self
     }
     pub fn with_draft(
@@ -103,6 +112,9 @@ impl OvGenaiBuilder {
         }
         if let Some(group) = &self.dyn_quant_group {
             cfg = cfg.with("DYNAMIC_QUANTIZATION_GROUP_SIZE", group);
+        }
+        for (key, val) in &self.ov_properties {
+            cfg = cfg.with(key, val);
         }
         cfg
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1353,6 +1353,8 @@ pub struct OvRuntimeBuilder {
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
+    /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
+    pub ov_properties: Vec<(String, String)>,
     runtime: Option<OvRuntime>,
     spec: Option<ShardSpec>,
     rotary: Option<Rotary>,
@@ -1399,6 +1401,11 @@ impl OvRuntimeBuilder {
         self.dyn_quant_group = Some(group.into());
         self
     }
+    /// Append extra `(key, value)` OV plugin properties (CLI perf flags).
+    pub fn with_ov_properties(mut self, props: Vec<(String, String)>) -> Self {
+        self.ov_properties.extend(props);
+        self
+    }
 
     fn plugin(&self) -> PluginConfig {
         let mut p = PluginConfig::new();
@@ -1410,6 +1417,9 @@ impl OvRuntimeBuilder {
         }
         if let Some(g) = &self.dyn_quant_group {
             p = p.with("DYNAMIC_QUANTIZATION_GROUP_SIZE", g);
+        }
+        for (key, val) in &self.ov_properties {
+            p = p.with(key, val);
         }
         p
     }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -45,6 +45,9 @@ pub struct SparseMoEBuilderConfig {
     pub model_dir: PathBuf,
     pub device: String,
     pub cache_dir: Option<String>,
+    /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
+    /// Applied only to the head IR (the sole OV-compiled component here).
+    pub ov_properties: Vec<(String, String)>,
     pub max_cached_experts: u32,
     /// Pipeline stage index (0-based).
     pub rank: u32,
@@ -132,6 +135,7 @@ impl SparseMoEBuilderConfig {
             model_dir: model_dir.into(),
             device: device.into(),
             cache_dir: None,
+            ov_properties: Vec::new(),
             // 0 = unbounded (default); positive = LRU cap. The env var
             // `CASCADIA_MAX_EXPERTS_CACHED` overrides this if set.
             // See PowerInfer SmallThinker `MAX_N_CACHED` (MIT).
@@ -344,6 +348,9 @@ impl Builder for SparseMoEBuilder {
         let mut plugin = PluginConfig::new();
         if let Some(d) = &self.config.cache_dir {
             plugin = plugin.with("CACHE_DIR", d.clone());
+        }
+        for (key, val) in &self.config.ov_properties {
+            plugin = plugin.with(key, val);
         }
 
         // OV-IR shell backend (MiniMax-M2): the whole architecture lives in

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -46,7 +46,9 @@ pub struct SparseMoEBuilderConfig {
     pub device: String,
     pub cache_dir: Option<String>,
     /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
-    /// Applied only to the head IR (the sole OV-compiled component here).
+    /// Applied to every OV-compiled IR on this rank (embedding, transformer
+    /// shells, and head) via the shared `PluginConfig`; the per-expert CPU
+    /// compiles use their own fresh plugin and are unaffected.
     pub ov_properties: Vec<(String, String)>,
     pub max_cached_experts: u32,
     /// Pipeline stage index (0-based).

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -46,9 +46,11 @@ pub struct SparseMoEBuilderConfig {
     pub device: String,
     pub cache_dir: Option<String>,
     /// Extra `(key, value)` OV plugin properties plumbed verbatim from the CLI.
-    /// Applied to every OV-compiled IR on this rank (embedding, transformer
-    /// shells, and head) via the shared `PluginConfig`; the per-expert CPU
-    /// compiles use their own fresh plugin and are unaffected.
+    /// Applied via the shared `PluginConfig` to every OV-compiled IR on this
+    /// rank: embedding, transformer shells, head, and — for `ov_ir`-format
+    /// experts — each per-expert IR. Exempt: the per-layer router subgraphs
+    /// (compiled with a fresh empty plugin) and `int4_bin` experts (no OV
+    /// compile at all).
     pub ov_properties: Vec<(String, String)>,
     pub max_cached_experts: u32,
     /// Pipeline stage index (0-based).

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -46,8 +46,28 @@ ov::AnyMap collect_properties(const char* const* kv, size_t count) {
     for (size_t i = 0; i < count; ++i) {
         const char* key = kv[2 * i];
         const char* val = kv[2 * i + 1];
-        if (key && val) {
-            props[std::string(key)] = std::string(val);
+        if (!key || !val) {
+            continue;
+        }
+        std::string k(key);
+        // A few properties are consumed by ov::genai's own pipeline code
+        // (NPU static-LLM path), not the plugin config parser. genai reads
+        // them via Any::as<int64_t>() and throws on a string Any
+        // ("Failed to extract MAX_PROMPT_LEN. Type mismatch: expected int").
+        // The Rust side sends every value as a string, so coerce these known
+        // integer keys to int64_t here. Plugin-parsed properties (CACHE_DIR,
+        // PERFORMANCE_HINT, INFERENCE_PRECISION_HINT, NUM_STREAMS, …) accept
+        // strings fine and stay strings.
+        if (k == "MAX_PROMPT_LEN" || k == "MIN_RESPONSE_LEN" ||
+            k == "NPUW_LLM_PREFILL_CHUNK_SIZE") {
+            try {
+                props[k] = static_cast<int64_t>(std::stoll(val));
+            } catch (...) {
+                // Not an integer — let OV report it against the string value.
+                props[k] = std::string(val);
+            }
+        } else {
+            props[k] = std::string(val);
         }
     }
     return props;

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -61,7 +61,18 @@ ov::AnyMap collect_properties(const char* const* kv, size_t count) {
         if (k == "MAX_PROMPT_LEN" || k == "MIN_RESPONSE_LEN" ||
             k == "NPUW_LLM_PREFILL_CHUNK_SIZE") {
             try {
-                props[k] = static_cast<int64_t>(std::stoll(val));
+                // Require the WHOLE value to be an integer: std::stoll parses a
+                // leading numeric prefix and silently drops the rest ("512abc"
+                // -> 512), which would hand OV a wrong-but-valid int. Check pos
+                // reached the end; otherwise fall through to the string branch
+                // and let OV report the bad value.
+                const std::string s(val);
+                size_t pos = 0;
+                long long parsed = std::stoll(s, &pos);
+                if (pos != s.size()) {
+                    throw std::invalid_argument("trailing chars after integer");
+                }
+                props[k] = static_cast<int64_t>(parsed);
             } catch (...) {
                 // Not an integer — let OV report it against the string value.
                 props[k] = std::string(val);
@@ -165,6 +176,25 @@ extern "C" {
 
 const char* cascadia_last_error_message() {
     return g_last_error.c_str();
+}
+
+// Test-only introspection over collect_properties(): run it on `properties_kv`
+// / `properties_count` and report how `key` landed in the resulting AnyMap.
+// Returns 1 and writes *out_i64 if stored as int64_t, 0 if stored as a string,
+// -1 if absent. Lets the Rust test pin the string->int64 coercion of the NPU
+// LLM keys (which ov::genai reads via Any::as<int64_t>()) without a real model.
+int32_t cascadia_debug_property_int64_kind(
+    const char* const* properties_kv, size_t properties_count,
+    const char* key, int64_t* out_i64) {
+    if (!key) return -1;
+    auto props = collect_properties(properties_kv, properties_count);
+    auto it = props.find(std::string(key));
+    if (it == props.end()) return -1;
+    if (it->second.is<int64_t>()) {
+        if (out_i64) *out_i64 = it->second.as<int64_t>();
+        return 1;
+    }
+    return 0;
 }
 
 // ===================== LLMPipeline (genai) =====================

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -35,6 +35,16 @@ typedef struct cascadia_runtime_t cascadia_runtime_t;
 /// not thread-safe — read it on the same thread that triggered the error.
 const char* cascadia_last_error_message();
 
+/// Test-only: run collect_properties() over `properties_kv` and report how
+/// `key` was stored — 1 = int64_t (written to *out_i64), 0 = string, -1 =
+/// absent. Exists so the Rust test can verify the NPU LLM keys are coerced to
+/// int64 (ov::genai reads them via Any::as<int64_t>()) without a real model.
+int32_t cascadia_debug_property_int64_kind(
+    const char* const* properties_kv,
+    size_t properties_count,
+    const char* key,
+    int64_t* out_i64);
+
 // ---- Pipeline (LLMPipeline) construction ---------------------------------
 
 int32_t cascadia_pipeline_create(

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -64,6 +64,15 @@ mod sys {
     extern "C" {
         pub fn cascadia_last_error_message() -> *const c_char;
 
+        // Test-only: see cpp/shim.cpp. Reports how collect_properties() stored
+        // `key` — 1 = int64 (written to *out_i64), 0 = string, -1 = absent.
+        pub fn cascadia_debug_property_int64_kind(
+            properties_kv: *const *const c_char,
+            properties_count: usize,
+            key: *const c_char,
+            out_i64: *mut i64,
+        ) -> c_int;
+
         pub fn cascadia_pipeline_create(
             model_path: *const c_char,
             device: *const c_char,
@@ -1019,5 +1028,80 @@ mod tests {
     fn live_cpu_full_name_nonempty() {
         let name = device_full_name("CPU").expect("FULL_DEVICE_NAME");
         assert!(!name.is_empty(), "FULL_DEVICE_NAME for CPU was empty");
+    }
+
+    // The NPU static-LLM keys must reach OV as int64 Anys — ov::genai reads
+    // them via Any::as<int64_t>() and throws on a string Any. This is the
+    // regression guard for the string->int64 coercion in collect_properties
+    // and for the exact key set shared with cascadia-cli's ov_perf_properties:
+    // a rename on either side of the FFI flips a key to string/absent here.
+    #[cfg(feature = "openvino")]
+    #[test]
+    fn collect_properties_coerces_npu_integer_keys_to_int64() {
+        use std::ffi::CString;
+        use std::os::raw::c_char;
+
+        let pairs = [
+            ("MAX_PROMPT_LEN", "1024"),
+            ("MIN_RESPONSE_LEN", "128"),
+            ("NPUW_LLM_PREFILL_CHUNK_SIZE", "512"),
+            ("CACHE_DIR", "/tmp/ov_cache"),
+        ];
+        let mut owned: Vec<CString> = Vec::new();
+        for &(k, v) in pairs.iter() {
+            owned.push(CString::new(k).unwrap());
+            owned.push(CString::new(v).unwrap());
+        }
+        let ptrs: Vec<*const c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+
+        // (kind, value): kind 1 = int64 (value set), 0 = string, -1 = absent.
+        let kind_of = |key: &str| -> (i32, i64) {
+            let key_c = CString::new(key).unwrap();
+            let mut out: i64 = 0;
+            let k = unsafe {
+                super::sys::cascadia_debug_property_int64_kind(
+                    ptrs.as_ptr(),
+                    pairs.len(),
+                    key_c.as_ptr(),
+                    &mut out,
+                )
+            };
+            (k, out)
+        };
+
+        assert_eq!(kind_of("MAX_PROMPT_LEN"), (1, 1024));
+        assert_eq!(kind_of("MIN_RESPONSE_LEN"), (1, 128));
+        assert_eq!(kind_of("NPUW_LLM_PREFILL_CHUNK_SIZE"), (1, 512));
+        // Plugin-parsed properties stay strings.
+        assert_eq!(kind_of("CACHE_DIR").0, 0, "CACHE_DIR must stay a string");
+        // Absent key.
+        assert_eq!(kind_of("NOPE").0, -1);
+    }
+
+    // A value that isn't a clean integer must fall back to a string Any (so OV
+    // reports the bad value) rather than being silently truncated by stoll's
+    // partial parse ("512abc" -> 512).
+    #[cfg(feature = "openvino")]
+    #[test]
+    fn collect_properties_rejects_partial_integer_to_string() {
+        use std::ffi::CString;
+        use std::os::raw::c_char;
+
+        let owned = [
+            CString::new("MAX_PROMPT_LEN").unwrap(),
+            CString::new("512abc").unwrap(),
+        ];
+        let ptrs: Vec<*const c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+        let key_c = CString::new("MAX_PROMPT_LEN").unwrap();
+        let mut out: i64 = 0;
+        let kind = unsafe {
+            super::sys::cascadia_debug_property_int64_kind(
+                ptrs.as_ptr(),
+                1,
+                key_c.as_ptr(),
+                &mut out,
+            )
+        };
+        assert_eq!(kind, 0, "partial-numeric value must fall back to string");
     }
 }

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,62 @@
+# OpenVINO performance tuning
+
+Cascadia plumbs the OpenVINO plugin properties that materially affect LLM
+inference on Intel hardware through the `cascadia worker` / `cascadia run`
+CLI and into every OV-routed engine (`ov-genai`, `ov-runtime`,
+`ov-dist-spec`, and the head IR in `sparse-moe`). All flags are opt-in: when
+unset, the engine builders behave exactly as before, so tuning never changes
+default behavior.
+
+Each flag maps 1:1 to an `ov::AnyMap` entry passed to
+`ov::Core::compile_model(model, device, props)`. Cascadia does not validate
+values — OpenVINO rejects an invalid one with its own error message.
+
+## Flags
+
+### General hints (valid on every device)
+
+| Flag | OV property | Notes |
+|---|---|---|
+| `--ov-performance-mode <MODE>` | `PERFORMANCE_HINT` | `LATENCY`, `THROUGHPUT`, or `CUMULATIVE_THROUGHPUT`. `LATENCY` suits single-user decode; `THROUGHPUT` enables `NUM_STREAMS` auto-tuning. |
+| `--ov-inference-precision <PREC>` | `INFERENCE_PRECISION_HINT` | `f16`, `bf16`, or `f32`. **Set this on Xe2/Battlemage** — f16/bf16 share XMX throughput, but the default can silently fall back to f32. |
+| `--ov-num-streams <N>` | `NUM_STREAMS` | Parallel inference streams. |
+| `--ov-num-threads <N>` | `INFERENCE_NUM_THREADS` | Host CPU thread cap. |
+| `--ov-allow-auto-batching` | `ALLOW_AUTO_BATCHING` | Enables internal batching on the GPU plugin. |
+| `--ov-execution-mode <MODE>` | `EXECUTION_MODE_HINT` | `ACCURACY` or `PERFORMANCE`. `PERFORMANCE` trades a little accuracy for throughput. |
+
+### NPU-only knobs
+
+These are **silently dropped unless `--device` names an NPU plugin**
+(a case-insensitive `starts_with("NPU")`, e.g. `NPU` or `NPU.0`). Passing an
+NPU property to a non-NPU plugin errors, so the gate keeps GPU/CPU runs safe.
+
+| Flag | OV property | Notes |
+|---|---|---|
+| `--npu-prefill-chunk-size <TOKS>` | `NPUW_LLM_PREFILL_CHUNK_SIZE` | OV 2025.3+. Chunked prefill for dynamic prompt length. |
+| `--npu-max-prompt-len <TOKS>` | `MAX_PROMPT_LEN` | Static-shape constraint. |
+| `--npu-min-response-len <TOKS>` | `MIN_RESPONSE_LEN` | Static-shape constraint. |
+
+## Recommended settings by hardware
+
+Best-effort starting points — always benchmark on your specific model +
+workload.
+
+| Hardware | Recommended flags |
+|---|---|
+| Xeon CPU-only | `--ov-performance-mode LATENCY --ov-inference-precision bf16` (if AVX-512_BF16) `--ov-num-streams 2` |
+| Lunar Lake iGPU (Xe2) | `--ov-performance-mode LATENCY --ov-inference-precision f16 --device GPU` |
+| Arc Pro B70 (Battlemage) | `--ov-performance-mode LATENCY --ov-inference-precision f16 --ov-allow-auto-batching --device GPU` |
+| NPU 4 (Lunar Lake) | `--engine ov-genai --device NPU --npu-prefill-chunk-size 512` |
+
+## Verifying properties reach the plugin
+
+Set `OV_LOG_LEVEL=4` to have the OpenVINO plugin log the applied config at
+`compile_model` time, then confirm each flag you passed appears in the dumped
+property map.
+
+## References
+
+- [OpenVINO — high-level performance hints](https://docs.openvino.ai/2026/openvino-workflow/running-inference/optimize-inference/high-level-performance-hints.html)
+- [OpenVINO — GPU device](https://docs.openvino.ai/2026/openvino-workflow/running-inference/inference-devices-and-modes/gpu-device.html)
+- [OpenVINO — NPU device](https://docs.openvino.ai/2026/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.html)
+- [OpenVINO 2025.3 release notes — NPU chunked prefill](https://github.com/openvinotoolkit/openvino/releases/tag/2025.3.0)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,23 +1,33 @@
 # OpenVINO performance tuning
 
 Cascadia plumbs the OpenVINO plugin properties that materially affect LLM
-inference on Intel hardware through the `cascadia worker` / `cascadia run`
-CLI and into the OV-routed engines: `ov-genai`, `ov-runtime`, `gemma4`,
+inference on Intel hardware through the `cascadia worker` CLI and into the
+OV-routed engines: `ov-genai`, `ov-runtime`, `gemma4`,
 `ov-dist-spec`, and the OV IRs in `sparse-moe`. (`qwen36-moe` is intentionally
 excluded — it compiles with a fixed plugin config because some hints, e.g.
 `INFERENCE_PRECISION_HINT=f32` / `EXECUTION_MODE_HINT=ACCURACY`, break its
 IRs; see `qwen36.rs`.) All flags are opt-in: when unset, the engine builders
 behave exactly as before, so tuning never changes default behavior.
 
-Each general flag maps 1:1 to an `ov::AnyMap` entry passed to
-`ov::Core::compile_model(model, device, props)`. Cascadia does not validate
-values — OpenVINO rejects an invalid one with its own error message.
+> **`sparse-moe`:** general hints reach its OV-compiled experts, but the same
+> `f32` / `ACCURACY` hints that break `qwen36-moe` can also fail to compile
+> experts backed by f16-only fused kernels. OpenVINO surfaces that as a compile
+> error (not silent), so treat those two hints as experimental there and
+> benchmark before relying on them.
+
+Each general flag maps to an `ov::AnyMap` entry handed to the OV compile step —
+`ov::Core::compile_model` for the raw engines, the `ov::genai::LLMPipeline`
+constructor for `ov-genai`. Values are forwarded to OpenVINO, which rejects an
+invalid one with its own error message; the two fixed-set flags
+(`--ov-performance-mode`, `--ov-execution-mode`) are additionally checked
+against their allowed values at the CLI.
 
 ## Flags
 
 ### General hints
 
-Forwarded verbatim to whichever engine you select. `PERFORMANCE_HINT`,
+Forwarded to whichever OV-routed engine you select — all except
+`qwen36-moe` (setting them there logs a warning and has no effect). `PERFORMANCE_HINT`,
 `INFERENCE_PRECISION_HINT`, and `EXECUTION_MODE_HINT` are plugin-agnostic;
 `NUM_STREAMS`, `INFERENCE_NUM_THREADS` (CPU-oriented), and
 `ALLOW_AUTO_BATCHING` (GPU/AUTO) are only effective on the plugins that own
@@ -63,7 +73,7 @@ workload.
 
 ## Verifying properties reach the plugin
 
-Set `OV_LOG_LEVEL=4` to have the OpenVINO plugin log the applied config at
+Set `OPENVINO_LOG_LEVEL=4` to have the OpenVINO plugin log the applied config at
 `compile_model` time, then confirm each flag you passed appears in the dumped
 property map.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -2,18 +2,26 @@
 
 Cascadia plumbs the OpenVINO plugin properties that materially affect LLM
 inference on Intel hardware through the `cascadia worker` / `cascadia run`
-CLI and into every OV-routed engine (`ov-genai`, `ov-runtime`,
-`ov-dist-spec`, and the head IR in `sparse-moe`). All flags are opt-in: when
-unset, the engine builders behave exactly as before, so tuning never changes
-default behavior.
+CLI and into the OV-routed engines: `ov-genai`, `ov-runtime`, `gemma4`,
+`ov-dist-spec`, and the OV IRs in `sparse-moe`. (`qwen36-moe` is intentionally
+excluded — it compiles with a fixed plugin config because some hints, e.g.
+`INFERENCE_PRECISION_HINT=f32` / `EXECUTION_MODE_HINT=ACCURACY`, break its
+IRs; see `qwen36.rs`.) All flags are opt-in: when unset, the engine builders
+behave exactly as before, so tuning never changes default behavior.
 
-Each flag maps 1:1 to an `ov::AnyMap` entry passed to
+Each general flag maps 1:1 to an `ov::AnyMap` entry passed to
 `ov::Core::compile_model(model, device, props)`. Cascadia does not validate
 values — OpenVINO rejects an invalid one with its own error message.
 
 ## Flags
 
-### General hints (valid on every device)
+### General hints
+
+Forwarded verbatim to whichever engine you select. `PERFORMANCE_HINT`,
+`INFERENCE_PRECISION_HINT`, and `EXECUTION_MODE_HINT` are plugin-agnostic;
+`NUM_STREAMS`, `INFERENCE_NUM_THREADS` (CPU-oriented), and
+`ALLOW_AUTO_BATCHING` (GPU/AUTO) are only effective on the plugins that own
+them — set them for the matching `--device`.
 
 | Flag | OV property | Notes |
 |---|---|---|
@@ -26,9 +34,14 @@ values — OpenVINO rejects an invalid one with its own error message.
 
 ### NPU-only knobs
 
-These are **silently dropped unless `--device` names an NPU plugin**
-(a case-insensitive `starts_with("NPU")`, e.g. `NPU` or `NPU.0`). Passing an
-NPU property to a non-NPU plugin errors, so the gate keeps GPU/CPU runs safe.
+These are `ov::genai` `LLMPipeline` convenience keys, so they apply **only to
+`--engine ov-genai` on an NPU device**. They are silently dropped otherwise —
+both when `--device` is not an NPU plugin (case-insensitive
+`starts_with("NPU")`, e.g. `NPU` or `NPU.0`) **and** on every non-`ov-genai`
+engine (`ov-runtime`, `gemma4`, `ov-dist-spec`, `sparse-moe`), which compile
+via raw `ov::Core::compile_model` and cannot consume these keys. Use
+`--engine ov-genai` to reach the NPU LLM pipeline that handles static-shape
+compilation internally.
 
 | Flag | OV property | Notes |
 |---|---|---|


### PR DESCRIPTION
## OpenVINO performance properties through the CLI

Plumbs the OV plugin properties that materially affect LLM inference on Intel hardware through `cascadia worker` / `cascadia run` and into every OV engine builder. Previously only `CACHE_DIR`, `KV_CACHE_PRECISION`, and `DYNAMIC_QUANTIZATION_GROUP_SIZE` were reachable. All new flags are opt-in — unset, behavior is byte-identical to before. Validated end-to-end on the Lunar Lake fleet (table below). Closes #13.

### Changes

- **CLI flags** (`cascadia-cli`)
  - General, any engine: `--ov-performance-mode`, `--ov-inference-precision`, `--ov-num-streams`, `--ov-num-threads`, `--ov-allow-auto-batching`, `--ov-execution-mode`
  - NPU static-LLM knobs, `ov-genai` only: `--npu-prefill-chunk-size`, `--npu-max-prompt-len`, `--npu-min-response-len`
  - `ov_perf_properties()` maps flags → OV property keys; single source of truth for gating. Help text cites the OV 2026 docs page per property family.
- **Engine wiring** (`cascadia-engine-openvino`, `cascadia-engine-sparse-moe`)
  - Generic `with_ov_properties(Vec<(String, String)>)` on `ov-genai`, `ov-runtime`, `gemma4`, `ov-dist-spec` (driver + worker), and `sparse-moe`; entries append into each builder's `PluginConfig` and flow through the existing shim passthrough to `ov::Core::compile_model` — no per-property C++ needed
  - `qwen36-moe` deliberately **not** wired: it compiles with a fixed plugin config because some hints (f32 / ACCURACY) break its IRs — documented in `docs/PERFORMANCE.md`
- **Shim fix** (`cascadia-ov-genai-shim`)
  - `MAX_PROMPT_LEN` / `MIN_RESPONSE_LEN` / `NPUW_LLM_PREFILL_CHUNK_SIZE` coerced to `int64_t` in `collect_properties()`. `ov::genai` reads these via `Any::as<int64_t>()` and throws on a string Any (`utils.cpp:68: Failed to extract MAX_PROMPT_LEN. Type mismatch`) — found live on NPU hardware; string values are fine for every plugin-config-parsed property and stay strings
- **Docs**: `docs/PERFORMANCE.md` — flag ↔ property reference, per-hardware recommended settings (Xeon / Lunar Lake iGPU / Battlemage / NPU 4), verification via `OV_LOG_LEVEL=4`
- **Tests**: flag→key mapping, NPU device+engine gating (48 tests in `cascadia-cli`), and a `PluginConfig` intercept test in `cascadia-engine-openvino` asserting injected properties reach the props dict handed to `compile_model`

### Design notes

- **NPU knobs are gated on engine ∧ device** (`ov-genai` ∧ `NPU*`), not device alone: only `ov-genai` routes properties through an `ov::genai::LLMPipeline` that consumes them; every other engine compiles via raw `compile_model`, which can't. This also means dist-spec's draft/target compiles can never receive an NPU key.
- **Values are forwarded verbatim; OV validates.** No enum duplication in Rust — confirmed correct on hardware: an invalid precision is rejected by OV's own `plugin_config.cpp` with the device's supported set (`{f16, f32, dynamic}` on Arc 140V — note `bf16` is device-specific, exactly why we don't hardcode).

### Hardware validation — pawan fleet (Lunar Lake: Core Ultra 7 258V, Arc 140V iGPU 16GB, NPU 4)

`pawan-01`, OpenVINO 2026.2.0. GPU: Qwen3-1.7B int4; NPU: Phi-3.5-mini int4.

| Check | Result | Evidence |
|---|---|---|
| Flags reach `compile_model` | ✅ | `--ov-inference-precision NOTAPRECISION` → OV `plugin_config.cpp:95` rejection naming `INFERENCE_PRECISION_HINT` |
| `--ov-performance-mode LATENCY --device GPU` | ✅ | 58.13 tok/s, coherent output |
| `--ov-inference-precision` changes the compile | ✅ | f16 58.13 tok/s · default 56.93 · f32 degenerate — three distinct behaviors |
| NPU knobs dropped on non-NPU device | ✅ | `ov-genai --device GPU --npu-*` loads clean, 49.27 tok/s |
| NPU knobs consumed on `ov-genai --device NPU` | ✅ | 9.59 tok/s, coherent (after the int64 shim fix) |

### Acceptance criteria (#13)

- [x] `worker --help` shows all new flags grouped with the existing `--ov-*` flags
- [x] Each flag results in the corresponding `ov::AnyMap` entry at `compile_model` (intercept unit test + on-hardware rejection proof; the NPU-key int64 coercion also has an on-hardware test that ran green on the ai-pc runner)
- [x] `--ov-performance-mode LATENCY --device GPU` works on Lunar Lake iGPU — verified on matias-03 (Arc 140V iGPU, Qwen3-8B int4, OV 2026.2): coherent output at ~19 tok/s
- [x] `--ov-inference-precision f16 --device GPU` measurably changes decode on a Qwen3 int4 benchmark — re-verified on matias-03 (Arc 140V, **Qwen3-8B** int4, OV 2026.2): f16 coherent ~18.6 tok/s · default ~19.1 tok/s · f32 degenerate (0 tokens) = three distinct behaviors; and `--ov-inference-precision NOTAPRECISION` rejected by OV at `plugin_config.cpp:95` (supported set `{f16,f32,dynamic}`), proving the flag reaches `compile_model`. (Original PR-table run used Qwen3-1.7B.)
- [x] NPU flags dropped when `--device` is not NPU — unit test + hardware; now emits a `tracing::warn!` instead of dropping silently (review fix)
- [x] CLI help references the OV 2026 docs page per property family
- [x] `docs/PERFORMANCE.md` with the recommended-defaults table

### How to test

**Local (no Intel HW needed):**

```bash
cargo test -p cascadia-cli -p cascadia-engine-openvino   # flag mapping, NPU gating, PluginConfig intercept
cargo run -p cascadia -- worker --help | grep -A2 -- --ov-   # flags + docs refs
```

**On the fleet (reproduces the validation table above)** — via the [cascadia-fleet-tests](https://github.com/pawanpaudel93/cascadia-fleet-tests) harness:

```bash
./sync-build.sh pawan/issue-13-ov-plugin-props   # build this branch on the nodes
./validate-ov-props.sh gpu pawan-01              # precision sweep: default/f16/f32 ok, bogus rejected BY OV
./validate-ov-props.sh npu pawan-01              # gate: GPU drops --npu-*, ov-genai NPU consumes them
```

Each suite prints one JSON verdict document; expected results are in the script header.

**Manually on any Intel box** (one-liner equivalent):

```bash
cascadia worker --rank 0 --total 1 --engine ov-genai --device GPU \
  --model <ov-int4-model> --api :8000 \
  --ov-performance-mode LATENCY --ov-inference-precision f16
# then: curl :8000/v1/chat/completions. Repeat with --ov-inference-precision
# NOTAPRECISION and watch OV itself reject it at compile — that rejection is
# the proof the flag reaches compile_model.
```

### Out of scope (deferred per #13)

Per-device auto-tuned defaults, exposing every OV property, per-engine property overrides (draft vs target), engine-side value validation (OV rejects with its own message — confirmed working above).

