### PR TITLE
feat: mDNS auto-ring formation for zero-config multi-node workers (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "chrono",
  "parking_lot",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",

--- a/crates/cascadia-cli/Cargo.toml
+++ b/crates/cascadia-cli/Cargo.toml
@@ -48,3 +48,4 @@ futures = { workspace = true }
 tempfile = { workspace = true }
 dirs = "5"
 sysinfo = "0.33"
+thiserror.workspace = true

--- a/crates/cascadia-cli/src/discover.rs
+++ b/crates/cascadia-cli/src/discover.rs
@@ -21,9 +21,8 @@ use clap::Parser;
 /// Browse the LAN for Cascadia peers and print what's advertising.
 #[derive(Parser, Debug, Clone)]
 pub struct DiscoverArgs {
-    /// Discovery namespace to browse. Peers in a different namespace are
-    /// ignored (matches the worker's namespace partitioning).
-    #[arg(long, default_value = "default")]
+    /// Discovery namespace to browse. Defaults to $CASCADIA_NAMESPACE or "default".
+    #[arg(long, default_value_t = crate::cluster_namespace())]
     pub namespace: String,
 
     /// How long to listen for peer announcements, in seconds. mDNS

--- a/crates/cascadia-cli/src/discover.rs
+++ b/crates/cascadia-cli/src/discover.rs
@@ -79,9 +79,9 @@ pub async fn cmd_discover(args: DiscoverArgs) -> Result<()> {
             args.namespace
         );
         println!();
-        println!("Note: workers do not yet advertise on the network automatically —");
-        println!("auto-ring formation is tracked in issue #52. For now, wire peers");
-        println!("manually with --listen / --next host:port.");
+        println!("Note: workers advertise automatically via mDNS auto-ring — run");
+        println!("`cascadia worker --cluster-size N` on every box (issue #89). You can");
+        println!("still wire peers manually with --listen / --next host:port instead.");
         return Ok(());
     }
 

--- a/crates/cascadia-cli/src/discover.rs
+++ b/crates/cascadia-cli/src/discover.rs
@@ -6,9 +6,11 @@
 //! `host:port` you'd pass to another worker's `--next`.
 //!
 //! It deliberately does NOT auto-assign ranks, agree on a stage count,
-//! or order peers into a pipeline — that full auto-ring formation is
-//! tracked separately (see issue #52, follow-ups). Today `worker` still
-//! takes explicit `--rank`/`--total`/`--next`; `discover` just removes
+//! or order peers into a pipeline itself — auto-ring formation now
+//! exists via `cascadia worker --cluster-size N` (issue #89), which
+//! elects ranks and forms the pipeline from discovered peers. `worker`
+//! still accepts explicit `--rank`/`--total`/`--next` as the manual
+//! path; `discover` remains the read-only browse tool that removes
 //! the "what's my peer's address?" guesswork.
 
 use std::time::Duration;

--- a/crates/cascadia-cli/src/election.rs
+++ b/crates/cascadia-cli/src/election.rs
@@ -491,3 +491,147 @@ mod elect_tests {
         assert!(!agreed(&m, &d, 3));
     }
 }
+
+#[cfg(test)]
+mod skew_tests {
+    use super::*;
+    fn n(id: &str, mem: u64) -> NodeInfo {
+        let mut x = NodeInfo::new(id, id, 9100);
+        x.memory_mb = mem;
+        x.model_hash = Some("h".into());
+        x.cluster_size = Some(3);
+        x.engines = vec!["ov-runtime".into()];
+        x
+    }
+
+    #[test]
+    fn ghost_with_changed_memory_never_silently_miswires() {
+        // Same node_id set {a,b,c}; observer A saw b@0 (stale ghost record),
+        // observer C saw b@16000. Digests differ -> unanimity impossible ->
+        // nobody commits (safe abort), never a mis-ranked ring.
+        let a_view = vec![n("a", 32000), n("b", 0), n("c", 8000)];
+        let c_view = vec![n("a", 32000), n("b", 16000), n("c", 8000)];
+        assert_ne!(member_digest(&a_view), member_digest(&c_view));
+    }
+
+    #[test]
+    fn fully_connected_over_n_all_fail_cardinality() {
+        let four = vec![n("a", 4), n("b", 3), n("c", 2), n("d", 1)];
+        let p = ElectParams {
+            self_id: "a".into(),
+            namespace: "default".into(),
+            model_hash: "h".into(),
+            engine: "ov-runtime".into(),
+            cluster_size: 3,
+        };
+        assert!(matches!(phase1_step(&four, &p), Step::TooMany(_)));
+        // And even if all four advertised the same 4-digest, agreed() with
+        // n=3 fails the len==N guard on every node -> symmetric abort.
+        let d = member_digest(&four);
+        let mut all = four.clone();
+        for x in &mut all {
+            x.ring_digest = Some(d.clone());
+        }
+        assert!(!agreed(&all, &d, 3));
+    }
+
+    #[test]
+    fn stable_exactly_n_all_agree_same_ring() {
+        let m = vec![n("a", 32000), n("b", 16000), n("c", 8000)];
+        let d = member_digest(&m);
+        let mut all = m.clone();
+        for x in &mut all {
+            x.ring_digest = Some(d.clone());
+        }
+        assert!(agreed(&all, &d, 3));
+        let ra = resolve_ring(&all, "a").unwrap();
+        let rb = resolve_ring(&all, "b").unwrap();
+        assert_eq!(ra.rank, 0);
+        assert_eq!(rb.rank, 1);
+        assert_eq!(ra.next, Some(("b".into(), 9100)));
+        assert_eq!(ra.coordinator_host, "a");
+        assert_eq!(rb.coordinator_host, "a");
+    }
+
+    #[test]
+    fn staggered_arrival_never_ready_before_n() {
+        // Scripted arrival: 1 then 2 then 3 participants; Ready fires only at 3.
+        let p = ElectParams {
+            self_id: "a".into(),
+            namespace: "default".into(),
+            model_hash: "h".into(),
+            engine: "ov-runtime".into(),
+            cluster_size: 3,
+        };
+        let s1 = vec![n("a", 3)];
+        let s2 = vec![n("a", 3), n("b", 2)];
+        let s3 = vec![n("a", 3), n("b", 2), n("c", 1)];
+        assert_eq!(phase1_step(&s1, &p), Step::Wait);
+        assert_eq!(phase1_step(&s2, &p), Step::Wait);
+        assert!(matches!(phase1_step(&s3, &p), Step::Ready(_)));
+    }
+}
+
+#[cfg(test)]
+mod elect_integration {
+    use super::*;
+    use cascadia_topology::Topology;
+
+    /// Three concurrent elect() instances over real mDNS must converge to one
+    /// consistent ring (ranks 0,1,2 exactly once, same coordinator) — this is
+    /// the simultaneous-startup acceptance check. Requires a multicast-capable
+    /// host: run with `cargo test -p cascadia-cli -- --ignored elect_integration`.
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore]
+    async fn three_concurrent_elections_converge() {
+        let ns = format!("test-{}", std::process::id());
+        // Fixture hash MUST be 16-hex: foreign records pass through the
+        // TXT decode's hex16 guard, which drops anything else.
+        let h = cascadia_types::hash::fnv1a_hex(b"itest");
+        let mut handles = Vec::new();
+        for (i, mem) in [(0u16, 32000u64), (1, 16000), (2, 8000)] {
+            let ns = ns.clone();
+            let h = h.clone();
+            handles.push(tokio::spawn(async move {
+                let mut node =
+                    cascadia_topology::NodeInfo::new(format!("itest-n{i}"), "127.0.0.1", 9100 + i);
+                node.namespace = ns.clone();
+                node.memory_mb = mem;
+                node.model_hash = Some(h.clone());
+                node.cluster_size = Some(3);
+                node.engines = vec!["mock".into()];
+                let topo = Topology::new();
+                topo.add_node(node.clone());
+                let mut disco =
+                    cascadia_discovery::DiscoveryService::new(topo.clone(), node.namespace.clone());
+                disco.start(node.clone()).unwrap();
+                let p = ElectParams {
+                    self_id: node.node_id.clone(),
+                    namespace: node.namespace.clone(),
+                    model_hash: h,
+                    engine: "mock".into(),
+                    cluster_size: 3,
+                };
+                let t = ElectTimeouts {
+                    discover: std::time::Duration::from_secs(30),
+                    agree: std::time::Duration::from_secs(15),
+                    settle: std::time::Duration::from_secs(1),
+                };
+                elect(&topo, &mut disco, &node, &p, &t).await
+            }));
+        }
+        let mut ranks = Vec::new();
+        let mut coordinators = Vec::new();
+        for hnd in handles {
+            let (ring, _digest) = hnd.await.unwrap().expect("election must converge");
+            ranks.push(ring.rank);
+            coordinators.push(ring.coordinator_host.clone());
+        }
+        ranks.sort_unstable();
+        assert_eq!(ranks, vec![0, 1, 2], "duplicate or gap rank");
+        assert!(
+            coordinators.windows(2).all(|w| w[0] == w[1]),
+            "coordinator disagreement"
+        );
+    }
+}

--- a/crates/cascadia-cli/src/election.rs
+++ b/crates/cascadia-cli/src/election.rs
@@ -284,7 +284,9 @@ pub async fn elect(
     // real mDNS). Note this instead of faking a clock here.
     const PHASE2_CEILING_MULT: u32 = 4;
     let phase2_start = tokio::time::Instant::now();
-    let phase2_ceiling = t.agree * PHASE2_CEILING_MULT;
+    // saturating_mul: `Duration * u32` panics on overflow; an absurd
+    // --agree-timeout (near u64::MAX secs) must not crash the node.
+    let phase2_ceiling = t.agree.saturating_mul(PHASE2_CEILING_MULT);
     loop {
         let members = current_members(topo, &me, p);
         if agreed(&members, &digest, p.cluster_size) {

--- a/crates/cascadia-cli/src/election.rs
+++ b/crates/cascadia-cli/src/election.rs
@@ -145,6 +145,8 @@ pub struct ElectTimeouts {
     pub settle: Duration,
 }
 
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
 /// Member view = participants from the topology, with self's entry overlaid
 /// (spec F5: self is injected explicitly, never via mDNS self-reflection).
 fn current_members(topo: &Topology, me: &NodeInfo, p: &ElectParams) -> Vec<NodeInfo> {
@@ -216,14 +218,15 @@ pub async fn elect(
                 ids
             )));
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(POLL_INTERVAL).await;
     };
 
     // ---- Phase 2: agree via digest ----
     let mut digest = member_digest(&members);
     me.ring_digest = Some(digest.clone());
-    // F5/livelock fix: our digest must be visible in the SAME view `agreed`
-    // reads. update_txt only informs peers; write the local topology too.
+    // Keep the local topology consistent with what we advertise —
+    // current_members overlays self from `me`, but other consumers (and any
+    // future refactor reading self from topo) must see the same digest.
     topo.add_node(me.clone());
     disco
         .update_txt(me.clone())
@@ -258,7 +261,7 @@ pub async fn elect(
                 p.namespace, digest, views
             )));
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 
@@ -298,8 +301,21 @@ mod tests {
             node("c", "h3", 8000),
         ];
         let want = resolve_ring(&base, "b").unwrap();
-        let shuffled = vec![base[2].clone(), base[0].clone(), base[1].clone()];
-        assert_eq!(resolve_ring(&shuffled, "b").unwrap(), want);
+        // All 6 permutations of the 3-element input must resolve "b" to the
+        // same assignment: resolve_ring sorts internally, so input order
+        // must never leak into the result.
+        const PERMS: [[usize; 3]; 6] = [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ];
+        for idxs in PERMS {
+            let shuffled: Vec<_> = idxs.iter().map(|&i| base[i].clone()).collect();
+            assert_eq!(resolve_ring(&shuffled, "b").unwrap(), want, "perm {idxs:?}");
+        }
     }
 
     #[test]
@@ -409,11 +425,16 @@ mod elect_tests {
     fn engine_mismatch_conflicts() {
         let mut m = vec![
             part("a", 1, "h", 3),
-            part("b", 1, "h", 3),
+            part("bad-engine-peer", 1, "h", 3),
             part("c", 1, "h", 3),
         ];
         m[1].engines = vec!["mock".into()];
-        assert!(matches!(phase1_step(&m, &params()), Step::Conflict(_)));
+        match phase1_step(&m, &params()) {
+            Step::Conflict(msg) => {
+                assert!(msg.contains("bad-engine-peer"), "offender not named: {msg}")
+            }
+            other => panic!("expected Conflict, got {other:?}"),
+        }
     }
     #[test]
     fn conflict_preempts_count() {
@@ -476,9 +497,8 @@ mod elect_tests {
     }
     #[test]
     fn agreement_fails_when_self_digest_missing() {
-        // Regression for the self-write-back livelock: if self's entry lacks
-        // the digest, unanimity must be false (which is why elect MUST write
-        // its digest into the local topology, not only the mDNS TXT).
+        // Regression for the self-write-back livelock: elect keeps topo
+        // consistent; if a view lacks self's digest, unanimity must fail.
         let mut m = vec![
             part("a", 1, "h", 3),
             part("b", 1, "h", 3),
@@ -581,6 +601,11 @@ mod elect_integration {
     /// consistent ring (ranks 0,1,2 exactly once, same coordinator) — this is
     /// the simultaneous-startup acceptance check. Requires a multicast-capable
     /// host: run with `cargo test -p cascadia-cli -- --ignored elect_integration`.
+    /// Note: single-host multi-daemon multicast often does NOT deliver in CI
+    /// containers/sandboxes (each daemon only sees itself) — run on a real
+    /// LAN. Ports 9100-9102 are SRV metadata only (no socket bind), so a
+    /// stray worker cannot EADDRINUSE this test; the unique namespace
+    /// isolates it.
     #[tokio::test(flavor = "multi_thread")]
     #[ignore]
     async fn three_concurrent_elections_converge() {
@@ -633,5 +658,6 @@ mod elect_integration {
             coordinators.windows(2).all(|w| w[0] == w[1]),
             "coordinator disagreement"
         );
+        // no explicit disco.close(): process exits after this #[ignore]d manual run
     }
 }

--- a/crates/cascadia-cli/src/election.rs
+++ b/crates/cascadia-cli/src/election.rs
@@ -1,5 +1,6 @@
 //! Auto-ring election (#89): pure ring resolution + membership digest, and
-//! the two-phase mDNS barrier. See docs/superpowers/specs/2026-07-01-mdns-auto-ring-design.md.
+//! the two-phase mDNS barrier. See issue #89 for the two-phase design
+//! (fixed-size barrier + membership-digest agreement).
 
 use cascadia_topology::NodeInfo;
 use cascadia_types::hash::fnv1a_hex;
@@ -171,13 +172,39 @@ pub async fn elect(
     let mut me = self_node.clone();
     let discover_deadline = tokio::time::Instant::now() + t.discover;
     let mut stable_since: Option<(String, tokio::time::Instant)> = None; // (digest, since)
+
+    // F2 diagnostic: whether the most recent step was over-subscribed
+    // (> N participants), so the discover-deadline abort can pick the
+    // "over-subscribed" message instead of the shortfall-shaped one. Set on
+    // every loop iteration before it is read, so no initial value is needed.
+    let mut last_over;
+    // F3 diagnostic: one-shot warn if a different host advertises our
+    // node_id (hostname+IP collision) — guarded so it doesn't spam every
+    // POLL_INTERVAL tick.
+    let mut warned_collision = false;
     let members = loop {
+        if !warned_collision {
+            if let Some(other) = topo
+                .nodes()
+                .iter()
+                .find(|n| n.node_id == me.node_id && (n.host != me.host || n.port != me.port))
+            {
+                tracing::warn!(
+                    node_id = %me.node_id,
+                    other_host = %other.host,
+                    other_port = other.port,
+                    "another host advertises this node_id (hostname+IP collision); ring cannot form — ensure one auto-ring worker per host"
+                );
+                warned_collision = true;
+            }
+        }
         let members = current_members(topo, &me, p);
         match phase1_step(&members, p) {
             Step::Conflict(msg) => return Err(RingError::Election(msg)),
             Step::Ready(_) => {
                 // Settle: the RESOLVED ORDER (member_digest — excludes
                 // last_seen churn) must hold for t.settle before Phase 2.
+                last_over = false;
                 let d = member_digest(&members);
                 match &stable_since {
                     Some((prev, since)) if *prev == d => {
@@ -197,6 +224,7 @@ pub async fn elect(
                     "more than N participants; waiting for prune"
                 );
                 stable_since = None;
+                last_over = true;
             }
             Step::Wait => {
                 tracing::info!(
@@ -205,10 +233,25 @@ pub async fn elect(
                     "waiting for peers"
                 );
                 stable_since = None;
+                last_over = false;
             }
         }
         if tokio::time::Instant::now() >= discover_deadline {
             let ids: Vec<String> = members.iter().map(|m| m.node_id.clone()).collect();
+            // The TooMany/over-subscribed classification itself is covered
+            // by the pure elect_tests::over_n_toomany and
+            // skew_tests::fully_connected_over_n_all_fail_cardinality tests;
+            // elect() isn't unit-tested, so this message branch is trusted
+            // rather than separately exercised.
+            if last_over || members.len() > p.cluster_size as usize {
+                return Err(RingError::Election(format!(
+                    "{} participants for --cluster-size {} in namespace '{}' (another cluster sharing this namespace? set CASCADIA_NAMESPACE): {:?}",
+                    members.len(),
+                    p.cluster_size,
+                    p.namespace,
+                    ids
+                )));
+            }
             return Err(RingError::Election(format!(
                 "discovered {} of {} participants in namespace '{}' after {:?}: {:?}",
                 members.len(),
@@ -233,6 +276,15 @@ pub async fn elect(
         .map_err(|e| RingError::Election(format!("cannot advertise digest (mDNS daemon): {e}")))?;
 
     let mut agree_deadline = tokio::time::Instant::now() + t.agree;
+    // Absolute Phase-2 bound: the restartable agree_deadline tolerates a single
+    // lost digest update, but a peer flapping its membership every < agree window
+    // would restart it forever. This hard ceiling guarantees elect() terminates.
+    // Instant-based, so not meaningfully unit-testable as a pure predicate;
+    // exercised only by the #[ignore]d elect_integration path (real time,
+    // real mDNS). Note this instead of faking a clock here.
+    const PHASE2_CEILING_MULT: u32 = 4;
+    let phase2_start = tokio::time::Instant::now();
+    let phase2_ceiling = t.agree * PHASE2_CEILING_MULT;
     loop {
         let members = current_members(topo, &me, p);
         if agreed(&members, &digest, p.cluster_size) {
@@ -250,6 +302,12 @@ pub async fn elect(
                 tracing::warn!(error = %e, "digest re-advertise failed; peers may not converge");
             }
             agree_deadline = tokio::time::Instant::now() + t.agree; // restart window
+        }
+        if phase2_start.elapsed() >= phase2_ceiling {
+            return Err(RingError::Election(format!(
+                "ring membership kept changing for {phase2_ceiling:?} (flapping peer?) in namespace '{}'; last digest {digest}",
+                p.namespace
+            )));
         }
         if tokio::time::Instant::now() >= agree_deadline {
             let views: Vec<(String, Option<String>)> = members

--- a/crates/cascadia-cli/src/election.rs
+++ b/crates/cascadia-cli/src/election.rs
@@ -1,0 +1,161 @@
+//! Auto-ring election (#89): pure ring resolution + membership digest, and
+//! the two-phase mDNS barrier. See docs/superpowers/specs/2026-07-01-mdns-auto-ring-design.md.
+
+use cascadia_topology::NodeInfo;
+use cascadia_types::hash::fnv1a_hex;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RingError {
+    #[error("self ({0}) not in member set")]
+    SelfMissing(String),
+    #[error("empty member set")]
+    Empty,
+    #[error("auto-ring: {0}")]
+    Election(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RingAssignment {
+    pub rank: u32,
+    pub total: u32,
+    /// Next stage's advertised relay endpoint; None on the last rank.
+    pub next: Option<(String, u16)>,
+    /// The coordinator's (rank 0's) advertised host — for operator logs.
+    pub coordinator_host: String,
+}
+impl RingAssignment {
+    pub fn is_first(&self) -> bool {
+        self.rank == 0
+    }
+    pub fn is_last(&self) -> bool {
+        self.next.is_none()
+    }
+}
+
+/// Deterministic total order: (memory_mb DESC, node_id ASC). node_id is unique
+/// (topology key), so the order is total — no undetermined tie-break.
+fn sorted(members: &[NodeInfo]) -> Vec<&NodeInfo> {
+    let mut v: Vec<&NodeInfo> = members.iter().collect();
+    v.sort_by(|a, b| {
+        b.memory_mb
+            .cmp(&a.memory_mb)
+            .then_with(|| a.node_id.cmp(&b.node_id))
+    });
+    v
+}
+
+/// PURE. Digest of the RESOLVED ORDER (spec F1): FNV over the '\n'-joined
+/// "memory_mb:node_id" pairs in sort order. Digesting the order (not just the
+/// id set) certifies rank assignment: a restart-ghost advertising a different
+/// memory_mb yields a different digest, so agreement can never mis-wire ranks.
+pub fn member_digest(members: &[NodeInfo]) -> String {
+    let joined = sorted(members)
+        .iter()
+        .map(|n| format!("{}:{}", n.memory_mb, n.node_id))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fnv1a_hex(joined.as_bytes())
+}
+
+/// PURE. Locate self in the sorted order -> rank/next/total/coordinator.
+pub fn resolve_ring(members: &[NodeInfo], self_id: &str) -> Result<RingAssignment, RingError> {
+    if members.is_empty() {
+        return Err(RingError::Empty);
+    }
+    let order = sorted(members);
+    let idx = order
+        .iter()
+        .position(|n| n.node_id == self_id)
+        .ok_or_else(|| RingError::SelfMissing(self_id.to_string()))?;
+    Ok(RingAssignment {
+        rank: idx as u32,
+        total: order.len() as u32,
+        next: order.get(idx + 1).map(|n| (n.host.clone(), n.port)),
+        coordinator_host: order[0].host.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn node(id: &str, host: &str, mem: u64) -> NodeInfo {
+        let mut n = NodeInfo::new(id, host, 9100);
+        n.memory_mb = mem;
+        n
+    }
+
+    #[test]
+    fn rank0_is_max_memory_and_chain_is_correct() {
+        let m = vec![
+            node("c", "10.0.0.3", 16000),
+            node("a", "10.0.0.1", 32000),
+            node("b", "10.0.0.2", 16000),
+        ];
+        let a = resolve_ring(&m, "a").unwrap();
+        assert_eq!(
+            (a.rank, a.total, a.is_first(), a.is_last()),
+            (0, 3, true, false)
+        );
+        assert_eq!(a.next, Some(("10.0.0.2".into(), 9100))); // b: 16000, tie-break id
+        assert_eq!(a.coordinator_host, "10.0.0.1");
+        let last = resolve_ring(&m, "c").unwrap();
+        assert_eq!((last.rank, last.is_last()), (2, true));
+        assert_eq!(last.coordinator_host, "10.0.0.1");
+    }
+
+    #[test]
+    fn permutation_invariant() {
+        let base = vec![
+            node("a", "h1", 32000),
+            node("b", "h2", 16000),
+            node("c", "h3", 8000),
+        ];
+        let want = resolve_ring(&base, "b").unwrap();
+        let shuffled = vec![base[2].clone(), base[0].clone(), base[1].clone()];
+        assert_eq!(resolve_ring(&shuffled, "b").unwrap(), want);
+    }
+
+    #[test]
+    fn same_set_different_memory_yields_different_digest() {
+        let s1 = vec![node("a", "h1", 32000), node("b", "h2", 16000)];
+        let mut s2 = s1.clone();
+        s2[0].memory_mb = 8000; // ghost with changed memory
+        assert_ne!(
+            member_digest(&s1),
+            member_digest(&s2),
+            "digest must cover order (F1)"
+        );
+    }
+
+    #[test]
+    fn digest_is_independent_of_input_vec_order() {
+        let a = vec![node("a", "h1", 32000), node("b", "h2", 16000)];
+        let b = vec![a[1].clone(), a[0].clone()];
+        assert_eq!(member_digest(&a), member_digest(&b));
+    }
+
+    #[test]
+    fn self_absent_errors() {
+        assert!(matches!(
+            resolve_ring(&[node("a", "h", 1)], "zzz"),
+            Err(RingError::SelfMissing(_))
+        ));
+    }
+
+    #[test]
+    fn memory_zero_sorts_last() {
+        let m = vec![node("a", "h1", 0), node("b", "h2", 16000)];
+        assert_eq!(resolve_ring(&m, "b").unwrap().rank, 0);
+        assert_eq!(resolve_ring(&m, "a").unwrap().rank, 1);
+    }
+
+    #[test]
+    fn n1_degenerate_self_only_ring() {
+        let m = vec![node("solo", "10.0.0.7", 8000)];
+        let r = resolve_ring(&m, "solo").unwrap();
+        assert_eq!(
+            (r.rank, r.total, r.next.clone(), r.is_first(), r.is_last()),
+            (0, 1, None, true, true)
+        );
+    }
+}

--- a/crates/cascadia-cli/src/election.rs
+++ b/crates/cascadia-cli/src/election.rs
@@ -48,6 +48,8 @@ fn sorted(members: &[NodeInfo]) -> Vec<&NodeInfo> {
 /// "memory_mb:node_id" pairs in sort order. Digesting the order (not just the
 /// id set) certifies rank assignment: a restart-ghost advertising a different
 /// memory_mb yields a different digest, so agreement can never mis-wire ranks.
+/// Precondition: node_id must not contain ':' or '\n' (auto-ring ids are
+/// sanitized to [A-Za-z0-9-]; see auto_node_id), else pair joining is ambiguous.
 pub fn member_digest(members: &[NodeInfo]) -> String {
     let joined = sorted(members)
         .iter()
@@ -73,6 +75,191 @@ pub fn resolve_ring(members: &[NodeInfo], self_id: &str) -> Result<RingAssignmen
         next: order.get(idx + 1).map(|n| (n.host.clone(), n.port)),
         coordinator_host: order[0].host.clone(),
     })
+}
+
+pub struct ElectParams {
+    pub self_id: String,
+    pub namespace: String, // discovery already filters; kept for messages
+    pub model_hash: String,
+    pub engine: String,
+    pub cluster_size: u32,
+}
+
+/// Outcome of one evaluation of the current member snapshot.
+#[derive(Debug, PartialEq)]
+pub enum Step {
+    Wait,                 // < N participants; keep polling
+    Conflict(String),     // model/engine mismatch on a participant -> abort
+    Ready(Vec<String>),   // exactly N participants (node_ids)
+    TooMany(Vec<String>), // > N participants (transient ghost or real surplus)
+}
+
+/// PURE. Classify the current snapshot. Self-contained: filters to
+/// participants (cluster_size == mine) internally, so passing raw
+/// topo.nodes() is safe — manual/dashboard workers never affect the count.
+/// Conflict checks run BEFORE the count (spec: mismatch preemption).
+pub fn phase1_step(members: &[NodeInfo], p: &ElectParams) -> Step {
+    let participants: Vec<&NodeInfo> = members
+        .iter()
+        .filter(|m| m.cluster_size == Some(p.cluster_size))
+        .collect();
+    for m in &participants {
+        match &m.model_hash {
+            Some(h) if *h == p.model_hash => {}
+            _ => {
+                return Step::Conflict(format!(
+                    "peer {} model_hash {:?} != {} (version skew or wrong --model)",
+                    m.node_id, m.model_hash, p.model_hash
+                ))
+            }
+        }
+        if !m.engines.iter().any(|e| e == &p.engine) {
+            return Step::Conflict(format!("peer {} engine != {}", m.node_id, p.engine));
+        }
+    }
+    let n = p.cluster_size as usize;
+    let ids: Vec<String> = participants.iter().map(|m| m.node_id.clone()).collect();
+    match participants.len() {
+        len if len < n => Step::Wait,
+        len if len == n => Step::Ready(ids),
+        _ => Step::TooMany(ids),
+    }
+}
+
+/// PURE. Phase-2 commit predicate: exactly N members AND every member
+/// (including self) advertises my digest (spec F2 cardinality guard).
+pub fn agreed(members: &[NodeInfo], my_digest: &str, n: u32) -> bool {
+    members.len() == n as usize
+        && members
+            .iter()
+            .all(|m| m.ring_digest.as_deref() == Some(my_digest))
+}
+
+use cascadia_discovery::DiscoveryService;
+use cascadia_topology::Topology;
+use std::time::Duration;
+
+pub struct ElectTimeouts {
+    pub discover: Duration,
+    pub agree: Duration,
+    pub settle: Duration,
+}
+
+/// Member view = participants from the topology, with self's entry overlaid
+/// (spec F5: self is injected explicitly, never via mDNS self-reflection).
+fn current_members(topo: &Topology, me: &NodeInfo, p: &ElectParams) -> Vec<NodeInfo> {
+    let mut v: Vec<NodeInfo> = topo
+        .nodes()
+        .into_iter()
+        .filter(|n| n.cluster_size == Some(p.cluster_size))
+        .filter(|n| n.node_id != me.node_id)
+        .collect();
+    v.push(me.clone());
+    v
+}
+
+pub async fn elect(
+    topo: &Topology,
+    disco: &mut DiscoveryService,
+    self_node: &NodeInfo,
+    p: &ElectParams,
+    t: &ElectTimeouts,
+) -> Result<(RingAssignment, String), RingError> {
+    // ---- Phase 1: collect exactly N matched participants ----
+    let mut me = self_node.clone();
+    let discover_deadline = tokio::time::Instant::now() + t.discover;
+    let mut stable_since: Option<(String, tokio::time::Instant)> = None; // (digest, since)
+    let members = loop {
+        let members = current_members(topo, &me, p);
+        match phase1_step(&members, p) {
+            Step::Conflict(msg) => return Err(RingError::Election(msg)),
+            Step::Ready(_) => {
+                // Settle: the RESOLVED ORDER (member_digest — excludes
+                // last_seen churn) must hold for t.settle before Phase 2.
+                let d = member_digest(&members);
+                match &stable_since {
+                    Some((prev, since)) if *prev == d => {
+                        if since.elapsed() >= t.settle {
+                            break members;
+                        }
+                    }
+                    _ => stable_since = Some((d, tokio::time::Instant::now())),
+                }
+            }
+            Step::TooMany(ids) => {
+                // Transient ghosts get debounce-pruned; only a surplus that
+                // persists to the deadline is fatal.
+                tracing::warn!(
+                    ?ids,
+                    n = p.cluster_size,
+                    "more than N participants; waiting for prune"
+                );
+                stable_since = None;
+            }
+            Step::Wait => {
+                tracing::info!(
+                    have = members.len(),
+                    want = p.cluster_size,
+                    "waiting for peers"
+                );
+                stable_since = None;
+            }
+        }
+        if tokio::time::Instant::now() >= discover_deadline {
+            let ids: Vec<String> = members.iter().map(|m| m.node_id.clone()).collect();
+            return Err(RingError::Election(format!(
+                "discovered {} of {} participants in namespace '{}' after {:?}: {:?}",
+                members.len(),
+                p.cluster_size,
+                p.namespace,
+                t.discover,
+                ids
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    };
+
+    // ---- Phase 2: agree via digest ----
+    let mut digest = member_digest(&members);
+    me.ring_digest = Some(digest.clone());
+    // F5/livelock fix: our digest must be visible in the SAME view `agreed`
+    // reads. update_txt only informs peers; write the local topology too.
+    topo.add_node(me.clone());
+    disco
+        .update_txt(me.clone())
+        .map_err(|e| RingError::Election(format!("cannot advertise digest (mDNS daemon): {e}")))?;
+
+    let mut agree_deadline = tokio::time::Instant::now() + t.agree;
+    loop {
+        let members = current_members(topo, &me, p);
+        if agreed(&members, &digest, p.cluster_size) {
+            let ring = resolve_ring(&members, &p.self_id)?;
+            return Ok((ring, digest));
+        }
+        let now_digest = member_digest(&members);
+        if now_digest != digest && members.len() == p.cluster_size as usize {
+            // Set/order shifted while stable-sized: adopt + re-advertise.
+            // The commit predicate MUST track what we advertise.
+            digest = now_digest;
+            me.ring_digest = Some(digest.clone());
+            topo.add_node(me.clone());
+            if let Err(e) = disco.update_txt(me.clone()) {
+                tracing::warn!(error = %e, "digest re-advertise failed; peers may not converge");
+            }
+            agree_deadline = tokio::time::Instant::now() + t.agree; // restart window
+        }
+        if tokio::time::Instant::now() >= agree_deadline {
+            let views: Vec<(String, Option<String>)> = members
+                .iter()
+                .map(|m| (m.node_id.clone(), m.ring_digest.clone()))
+                .collect();
+            return Err(RingError::Election(format!(
+                "ring membership did not converge in namespace '{}'; my digest {} vs peer views {:?}",
+                p.namespace, digest, views
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 #[cfg(test)]
@@ -157,5 +344,150 @@ mod tests {
             (r.rank, r.total, r.next.clone(), r.is_first(), r.is_last()),
             (0, 1, None, true, true)
         );
+    }
+}
+
+#[cfg(test)]
+mod elect_tests {
+    use super::*;
+    fn part(id: &str, mem: u64, hash: &str, cs: u32) -> NodeInfo {
+        let mut n = NodeInfo::new(id, "h", 9100);
+        n.memory_mb = mem;
+        n.model_hash = Some(hash.into());
+        n.cluster_size = Some(cs);
+        n.engines = vec!["ov-runtime".into()];
+        n
+    }
+    fn params() -> ElectParams {
+        ElectParams {
+            self_id: "a".into(),
+            namespace: "default".into(),
+            model_hash: "h".into(),
+            engine: "ov-runtime".into(),
+            cluster_size: 3,
+        }
+    }
+    #[test]
+    fn under_n_waits() {
+        assert_eq!(
+            phase1_step(&[part("a", 1, "h", 3), part("b", 1, "h", 3)], &params()),
+            Step::Wait
+        );
+    }
+    #[test]
+    fn exactly_n_ready() {
+        let m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "h", 3),
+            part("c", 1, "h", 3),
+        ];
+        assert!(matches!(phase1_step(&m, &params()), Step::Ready(_)));
+    }
+    #[test]
+    fn over_n_toomany() {
+        let m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "h", 3),
+            part("c", 1, "h", 3),
+            part("d", 1, "h", 3),
+        ];
+        assert!(matches!(phase1_step(&m, &params()), Step::TooMany(_)));
+    }
+    #[test]
+    fn model_mismatch_conflicts_and_names_offender() {
+        let m = vec![
+            part("a", 1, "h", 3),
+            part("bad-peer", 1, "WRONG", 3),
+            part("c", 1, "h", 3),
+        ];
+        match phase1_step(&m, &params()) {
+            Step::Conflict(msg) => assert!(msg.contains("bad-peer"), "offender not named: {msg}"),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+    #[test]
+    fn engine_mismatch_conflicts() {
+        let mut m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "h", 3),
+            part("c", 1, "h", 3),
+        ];
+        m[1].engines = vec!["mock".into()];
+        assert!(matches!(phase1_step(&m, &params()), Step::Conflict(_)));
+    }
+    #[test]
+    fn conflict_preempts_count() {
+        // Both a mismatch AND >N present: mismatch must fire first (spec order).
+        let m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "WRONG", 3),
+            part("c", 1, "h", 3),
+            part("d", 1, "h", 3),
+        ];
+        assert!(matches!(phase1_step(&m, &params()), Step::Conflict(_)));
+    }
+    #[test]
+    fn non_participants_are_invisible_unfiltered() {
+        // A manual worker (no cluster_size, different model) passed RAW:
+        // neither counted nor a conflict.
+        let mut manual = NodeInfo::new("m", "h", 9100);
+        manual.model_hash = Some("other".into()); // no cluster_size
+        let m = vec![part("a", 1, "h", 3), part("b", 1, "h", 3), manual];
+        assert_eq!(phase1_step(&m, &params()), Step::Wait);
+    }
+    #[test]
+    fn n1_self_only_is_ready() {
+        let p = ElectParams {
+            cluster_size: 1,
+            ..params()
+        };
+        assert!(matches!(
+            phase1_step(&[part("a", 1, "h", 1)], &p),
+            Step::Ready(_)
+        ));
+    }
+    #[test]
+    fn agreement_requires_len_n_and_unanimous() {
+        let mut m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "h", 3),
+            part("c", 1, "h", 3),
+        ];
+        let d = member_digest(&m);
+        for x in &mut m {
+            x.ring_digest = Some(d.clone());
+        }
+        assert!(agreed(&m, &d, 3));
+        m.pop(); // now 2 -> cardinality guard fails
+        assert!(!agreed(&m, &d, 3));
+    }
+    #[test]
+    fn agreement_fails_on_one_disagreeing_digest() {
+        let mut m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "h", 3),
+            part("c", 1, "h", 3),
+        ];
+        let d = member_digest(&m);
+        m[0].ring_digest = Some(d.clone());
+        m[1].ring_digest = Some(d.clone());
+        m[2].ring_digest = Some("0000000000000000".into());
+        assert!(!agreed(&m, &d, 3));
+    }
+    #[test]
+    fn agreement_fails_when_self_digest_missing() {
+        // Regression for the self-write-back livelock: if self's entry lacks
+        // the digest, unanimity must be false (which is why elect MUST write
+        // its digest into the local topology, not only the mDNS TXT).
+        let mut m = vec![
+            part("a", 1, "h", 3),
+            part("b", 1, "h", 3),
+            part("c", 1, "h", 3),
+        ];
+        let d = member_digest(&m);
+        m[1].ring_digest = Some(d.clone());
+        m[2].ring_digest = Some(d.clone());
+        // m[0] (self) has ring_digest None
+        assert!(!agreed(&m, &d, 3));
     }
 }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1558,6 +1558,13 @@ async fn cmd_worker(mut args: WorkerArgs) -> Result<()> {
         // non-zero and systemd's `Restart=on-failure` rebuilds the stage,
         // rather than exit 0 (a "success" systemd won't restart) and leave
         // the pipeline a stage short. A clean SlotEmpty exit returns Ok.
+        //
+        // Auto-ring note (spec F4): a ring member that aborts post-commit exits
+        // its process; this rank then sees connect-failure or ConnectionReset ->
+        // ConnectionFatal -> non-zero exit -> systemd rebuild. Deliberately NO
+        // first-frame deadline: idle rings are legal (transport frame_idle_ceiling).
+        // Covered by cascadia-runner's relay_loop_exits_on_connection_fatal_step
+        // and recv-RST tests.
         match exit {
             Ok(cascadia_runner::RelayExit::ConnectionFatal) => {
                 return Err(anyhow!("relay loop exited: peer link dead; rebuild needed"));

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -256,6 +256,10 @@ mod worker_mode_tests {
     fn rank_without_total_errors() {
         assert!(resolve_worker_mode(Some(0), None, None).is_err());
     }
+    #[test]
+    fn total_without_rank_errors() {
+        assert!(resolve_worker_mode(None, Some(2), None).is_err());
+    }
 }
 
 /// Reject flag combinations that are incompatible with auto-ring
@@ -273,9 +277,7 @@ fn preflight_auto(args: &WorkerArgs, n: u32) -> Result<()> {
         bail!("--engine ov-dist-spec auto-ring requires --draft-model on every box (the elected rank 0 needs it; other ranks ignore it)");
     }
     if !args.advertise_engines.is_empty() {
-        // The election's engine cross-check compares the single running
-        // engine; a multi-entry advertised list would defeat it.
-        bail!("--advertise-engines is not valid with --cluster-size");
+        bail!("--advertise-engines is not valid with --cluster-size (the election cross-checks the single running engine)");
     }
     Ok(())
 }
@@ -1230,7 +1232,9 @@ async fn run_auto_election(args: &WorkerArgs, cluster_size: u32) -> Result<AutoR
     let topology = cascadia_topology::Topology::new();
     topology.add_node(self_node.clone());
     let mut discovery = cascadia_discovery::DiscoveryService::new(topology.clone(), ns.clone());
-    discovery.start(self_node.clone())?;
+    discovery
+        .start(self_node.clone())
+        .context("start mDNS discovery for auto-ring election")?;
 
     let p = election::ElectParams {
         self_id: node_id,

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -148,6 +148,48 @@ mod namespace_tests {
     }
 }
 
+/// Auto-ring node_id: "{hostname}-{ip}", every char outside [A-Za-z0-9-]
+/// mapped to '-', capped at 63 bytes (mDNS instance / DNS label limit).
+/// Rank-independent — rank is unknown before election. Manual path keeps
+/// "{hostname}-r{rank}".
+#[allow(dead_code)] // consumed by run_auto_election (next commit)
+fn auto_node_id(hostname: &str, ip: &str) -> String {
+    let mut s: String = format!("{hostname}-{ip}")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if s.len() > 63 {
+        s.truncate(63);
+    } // safe: output is pure ASCII
+    s
+}
+
+#[cfg(test)]
+mod node_id_tests {
+    use super::auto_node_id;
+    #[test]
+    fn dots_become_dashes() {
+        assert_eq!(auto_node_id("ws", "192.168.0.5"), "ws-192-168-0-5");
+    }
+    #[test]
+    fn illegal_chars_sanitized() {
+        assert!(auto_node_id("my box!", "10.0.0.1")
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-'));
+    }
+    #[test]
+    fn capped_at_63_bytes_even_with_non_ascii() {
+        let long = "héllo".repeat(30);
+        assert!(auto_node_id(&long, "10.0.0.1").len() <= 63);
+    }
+}
+
 /// Which worker mode the flags select. Pure — unit-tested without clap.
 #[derive(Debug, PartialEq)]
 enum WorkerMode {

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -25,6 +25,7 @@ use tracing_subscriber::EnvFilter;
 
 pub mod discover;
 pub mod doctor;
+pub mod election;
 pub mod placement;
 pub mod profile;
 pub mod profile_stage;

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1087,6 +1087,9 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         cpu_cores: specs.cpu_cores,
         os: specs.os,
         engines,
+        model_hash: None,
+        cluster_size: None,
+        ring_digest: None,
         last_seen: 0.0,
     };
     topology.add_node(self_node.clone());

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -290,6 +290,32 @@ fn preflight_ip(ip: std::net::IpAddr, n: u32) -> Result<()> {
     Ok(())
 }
 
+/// Reject `--listen :0` for auto-ring: port 0 means "let the OS pick a
+/// port," but auto-ring advertises `listen_port` over mDNS for peers to
+/// dial — a peer dialing port 0 would never connect. Split out so it's
+/// unit-testable without spinning up `run_auto_election`'s async election.
+fn preflight_listen_port(listen_port: u16) -> Result<()> {
+    if listen_port == 0 {
+        bail!("--listen must specify a nonzero port for auto-ring (got :0); peers dial the advertised relay port");
+    }
+    Ok(())
+}
+
+/// Reject `--settle >= --discover-timeout`: the settle barrier waits for
+/// the discovered peer set to stay stable for `settle` seconds, but that
+/// wait is bounded by `discover_timeout` — if settle is >= the timeout,
+/// the barrier can never resolve before discovery gives up. Split out so
+/// it's unit-testable without spinning up the async election.
+fn preflight_settle(settle: u64, discover_timeout: u64) -> Result<()> {
+    if settle >= discover_timeout {
+        bail!(
+            "--settle ({settle}s) must be less than --discover-timeout ({discover_timeout}s), \
+             else the barrier can never settle before discovery times out"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod preflight_tests {
     use super::*;
@@ -328,6 +354,17 @@ mod preflight_tests {
         assert!(preflight_ip("127.0.0.1".parse().unwrap(), 2).is_err());
         assert!(preflight_ip("127.0.0.1".parse().unwrap(), 1).is_ok());
         assert!(preflight_ip("192.168.0.5".parse().unwrap(), 3).is_ok());
+    }
+    #[test]
+    fn listen_port_zero_rejected() {
+        assert!(preflight_listen_port(0).is_err());
+        assert!(preflight_listen_port(9100).is_ok());
+    }
+    #[test]
+    fn settle_must_be_less_than_discover_timeout() {
+        assert!(preflight_settle(30, 120).is_ok());
+        assert!(preflight_settle(120, 120).is_err());
+        assert!(preflight_settle(121, 120).is_err());
     }
 }
 
@@ -1177,10 +1214,6 @@ struct AutoRing {
     topology: cascadia_topology::Topology,
     discovery: cascadia_discovery::DiscoveryService,
     self_node: cascadia_topology::NodeInfo,
-    /// Held through the election so a fast peer's dial finds a listener;
-    /// dropped just before runner.start_with_listen (the engine binds the
-    /// port itself — holding this would AddrInUse it).
-    prebound: Option<tokio::net::TcpListener>,
 }
 
 async fn run_auto_election(args: &WorkerArgs, cluster_size: u32) -> Result<AutoRing> {
@@ -1198,6 +1231,8 @@ async fn run_auto_election(args: &WorkerArgs, cluster_size: u32) -> Result<AutoR
     let ns = cluster_namespace();
     // Honor --listen: advertise the SAME relay port the engine will bind.
     let (_, listen_port) = parse_addr(&args.listen, "0.0.0.0")?;
+    preflight_listen_port(listen_port)?;
+    preflight_settle(args.settle, args.discover_timeout)?;
 
     let self_node = cascadia_topology::NodeInfo {
         node_id: node_id.clone(),
@@ -1220,15 +1255,15 @@ async fn run_auto_election(args: &WorkerArgs, cluster_size: u32) -> Result<AutoR
         last_seen: 0.0,
     };
 
-    // Pre-bind the relay port for the election window: an already-committed
-    // upstream's dial completes its TCP handshake while we finish Phase 2.
-    // Dropped by cmd_worker just before start_with_listen (see AutoRing doc).
-    let prebound = tokio::net::TcpListener::bind(("0.0.0.0", listen_port))
-        .await
-        .map_err(|e| {
-            anyhow!("pre-bind :{listen_port} failed (another worker on this host?): {e}")
-        })?;
-
+    // NOTE: we deliberately do NOT pre-bind the relay port here. An
+    // already-committed upstream's dial that races ahead of our own listener
+    // hits connection-refused (closed port) and self-heals via the
+    // transport dialer's connect-refused + 500ms retry loop in
+    // `connect_with_timeout`. A pre-bound listener would instead let that
+    // dial complete into the kernel accept-queue, only for us to drop it
+    // (and RST the already-ESTABLISHED connection) right before
+    // `start_with_listen` — turning a self-healing race into a connection-
+    // fatal one that kills the stage on its first send/recv. See PR review.
     let topology = cascadia_topology::Topology::new();
     topology.add_node(self_node.clone());
     let mut discovery = cascadia_discovery::DiscoveryService::new(topology.clone(), ns.clone());
@@ -1268,7 +1303,6 @@ async fn run_auto_election(args: &WorkerArgs, cluster_size: u32) -> Result<AutoR
         topology,
         discovery,
         self_node,
-        prebound: Some(prebound),
     })
 }
 
@@ -1347,12 +1381,11 @@ async fn cmd_worker(mut args: WorkerArgs) -> Result<()> {
     } else {
         None
     };
-    // Release the election-era relay listener so the engine can bind the
-    // port itself (holding it would AddrInUse every non-first stage). The
-    // dialer's 500ms connect retry absorbs the sub-second rebind gap.
-    if let Some(a) = auto.as_mut() {
-        a.prebound.take();
-    }
+    // No election-era listener to release here: run_auto_election does not
+    // pre-bind the relay port (see its comment). The engine binds it fresh
+    // via start_with_listen below; any upstream dial that raced ahead hits
+    // connection-refused and self-heals via connect_with_timeout's 500ms
+    // retry loop.
     runner.start_with_listen(peers, shard, listen).await?;
 
     // Probe listener: bind a TCP socket on listen_port so the
@@ -1461,7 +1494,11 @@ async fn cmd_worker(mut args: WorkerArgs) -> Result<()> {
     // Auto path: publish api_port now that rank 0 is known, PRESERVING the
     // committed ring_digest carried in self_node (props_from_node rewrites the
     // whole TXT record; blanking the digest would strand a straggler in Phase 2).
-    if api_port.is_some() && self_node.cluster_size.is_some() {
+    // Gated to rank == 0: if an operator passes --api on the identical command
+    // to every box, non-coordinator ranks would otherwise advertise an api_port
+    // they never serve (rank > 0 returns in the relay arm before the API block
+    // below), leaving the dashboard pointing at a dead address for every stage.
+    if api_port.is_some() && self_node.cluster_size.is_some() && rt.rank == 0 {
         let mut sn = self_node.clone();
         sn.api_port = api_port;
         topology.add_node(sn.clone());

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -129,6 +129,24 @@ fn gather_node_specs() -> NodeSpecs {
     }
 }
 
+/// Namespace for discovery/advertise: CASCADIA_NAMESPACE, else "default".
+pub(crate) fn cluster_namespace() -> String {
+    std::env::var("CASCADIA_NAMESPACE").unwrap_or_else(|_| "default".into())
+}
+
+#[cfg(test)]
+mod namespace_tests {
+    use super::cluster_namespace;
+    // NOTE: env is process-global; keep this the ONLY test in the crate that
+    // touches CASCADIA_NAMESPACE (a set_var sibling would race under the
+    // parallel test runner).
+    #[test]
+    fn defaults_to_default_when_unset() {
+        std::env::remove_var("CASCADIA_NAMESPACE");
+        assert_eq!(cluster_namespace(), "default");
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "cascadia",
@@ -1080,7 +1098,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         host: cascadia_discovery::local_ip().to_string(),
         port: listen_port,
         api_port,
-        namespace: "default".to_owned(),
+        namespace: cluster_namespace(),
         device,
         memory_mb: specs.memory_mb,
         cpu_model: specs.cpu_model,
@@ -1093,7 +1111,8 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         last_seen: 0.0,
     };
     topology.add_node(self_node.clone());
-    let mut discovery = cascadia_discovery::DiscoveryService::new(topology.clone(), "default");
+    let mut discovery =
+        cascadia_discovery::DiscoveryService::new(topology.clone(), cluster_namespace());
     if let Err(e) = discovery.start(self_node.clone()) {
         tracing::warn!(error = %e, "mDNS discovery failed to start; cluster topology may be incomplete");
     }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use cascadia_engine::Builder;
 use cascadia_engine_mock::MockBuilder;
 use cascadia_engine_openvino::{
@@ -147,6 +147,75 @@ mod namespace_tests {
     }
 }
 
+/// Which worker mode the flags select. Pure — unit-tested without clap.
+#[derive(Debug, PartialEq)]
+enum WorkerMode {
+    Manual { rank: u32, total: u32 },
+    Auto { cluster_size: u32 },
+}
+
+/// Rank/total after mode resolution (manual flags or auto election).
+/// The ONLY place Option<u32> rank/total get unwrapped.
+#[derive(Clone, Copy, Debug)]
+struct RankTotal {
+    rank: u32,
+    total: u32,
+}
+
+fn resolve_worker_mode(
+    rank: Option<u32>,
+    total: Option<u32>,
+    cluster_size: Option<u32>,
+) -> Result<WorkerMode> {
+    match (rank, total, cluster_size) {
+        (Some(_), _, Some(_)) | (_, Some(_), Some(_)) => Err(anyhow!(
+            "--cluster-size is mutually exclusive with --rank/--total"
+        )),
+        (Some(r), Some(t), None) => Ok(WorkerMode::Manual { rank: r, total: t }),
+        (None, None, Some(n)) if n >= 1 => Ok(WorkerMode::Auto { cluster_size: n }),
+        (None, None, Some(_)) => Err(anyhow!("--cluster-size must be >= 1")),
+        (None, None, None) => Err(anyhow!(
+            "pass --cluster-size N (auto-ring) or --rank/--total (manual)"
+        )),
+        _ => Err(anyhow!("--rank and --total must be given together")),
+    }
+}
+
+#[cfg(test)]
+mod worker_mode_tests {
+    use super::*;
+    #[test]
+    fn auto_when_cluster_size() {
+        assert_eq!(
+            resolve_worker_mode(None, None, Some(3)).unwrap(),
+            WorkerMode::Auto { cluster_size: 3 }
+        );
+    }
+    #[test]
+    fn manual_when_rank_total() {
+        assert_eq!(
+            resolve_worker_mode(Some(0), Some(2), None).unwrap(),
+            WorkerMode::Manual { rank: 0, total: 2 }
+        );
+    }
+    #[test]
+    fn cluster_size_plus_rank_errors() {
+        assert!(resolve_worker_mode(Some(0), None, Some(3)).is_err());
+    }
+    #[test]
+    fn neither_errors() {
+        assert!(resolve_worker_mode(None, None, None).is_err());
+    }
+    #[test]
+    fn cluster_size_zero_errors() {
+        assert!(resolve_worker_mode(None, None, Some(0)).is_err());
+    }
+    #[test]
+    fn rank_without_total_errors() {
+        assert!(resolve_worker_mode(Some(0), None, None).is_err());
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "cascadia",
@@ -231,13 +300,30 @@ pub enum EngineKind {
 
 #[derive(Parser, Debug, Clone)]
 pub struct WorkerArgs {
-    /// 0-based stage index.
+    /// 0-based stage index (manual path). Omit for auto-ring (--cluster-size).
     #[arg(long)]
-    pub rank: u32,
-
-    /// Total number of stages.
+    pub rank: Option<u32>,
+    /// Total stages (manual path). Omit for auto-ring (--cluster-size).
     #[arg(long)]
-    pub total: u32,
+    pub total: Option<u32>,
+    /// Auto-ring: form an N-stage ring from mDNS-discovered peers running the
+    /// identical command. Mutually exclusive with --rank/--total.
+    /// K8s/cloud note: mDNS multicast does not cross pods — use the explicit
+    /// --rank/--total/--next flags there (the escape hatch; RFC #28).
+    #[arg(long)]
+    pub cluster_size: Option<u32>,
+    /// Auto-ring: seconds to wait for N peers before giving up.
+    #[arg(long, default_value_t = 120, value_parser = clap::value_parser!(u64).range(1..))]
+    pub discover_timeout: u64,
+    /// Auto-ring: seconds to wait for membership-digest agreement. Keep this
+    /// at 2x the mDNS re-announce interval or more, so one lost digest update
+    /// does not spuriously abort (spec F8).
+    #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(1..))]
+    pub agree_timeout: u64,
+    /// Auto-ring: seconds the discovered set must stay stable before agreement.
+    /// Must exceed the discovery debounce window (750ms); minimum 1.
+    #[arg(long, default_value_t = 2, value_parser = clap::value_parser!(u64).range(1..))]
+    pub settle: u64,
 
     /// First transformer layer this stage holds (global, 0-based, inclusive).
     /// Together with --layer-end, pins an explicit asymmetric layer split
@@ -500,8 +586,12 @@ impl WorkerArgs {
     /// into `cmd_run`) means `run` and `worker` can't silently drift.
     fn single_node(model: String, device: String, engine: EngineKind, api: String) -> Self {
         WorkerArgs {
-            rank: 0,
-            total: 1,
+            rank: Some(0),
+            total: Some(1),
+            cluster_size: None,
+            discover_timeout: 120,
+            agree_timeout: 30,
+            settle: 2,
             layer_start: 0,
             layer_end: 0,
             model,
@@ -699,11 +789,11 @@ fn ovgenai_chat_template(model: &str) -> cascadia_api::ChatTemplateConfig {
     }
 }
 
-fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
+fn build_builder(args: &WorkerArgs, rt: RankTotal) -> Result<Box<dyn Builder>> {
     match args.engine {
         EngineKind::Mock => Ok(Box::new(MockBuilder::new())),
         EngineKind::OvGenai => {
-            if args.total != 1 {
+            if rt.total != 1 {
                 return Err(anyhow!("ov-genai is single-stage only; use --total 1"));
             }
             if args.draft_model.is_some() && args.prompt_lookup > 0 {
@@ -737,7 +827,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             Ok(Box::new(b))
         }
         EngineKind::OvRuntime => {
-            let mut b = OvRuntimeBuilder::new(&args.model, args.rank, args.total, &args.device);
+            let mut b = OvRuntimeBuilder::new(&args.model, rt.rank, rt.total, &args.device);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 b = b.with_cache_dir(&dir);
             }
@@ -750,7 +840,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             Ok(Box::new(b))
         }
         EngineKind::Gemma4 => {
-            let mut b = Gemma4Builder::new(&args.model, args.rank, args.total, &args.device);
+            let mut b = Gemma4Builder::new(&args.model, rt.rank, rt.total, &args.device);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 b = b.with_cache_dir(&dir);
             }
@@ -764,7 +854,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
         }
         EngineKind::OvDistSpec => {
             // Driver = rank 0 (needs --draft-model). Worker = rank > 0.
-            if args.rank == 0 {
+            if rt.rank == 0 {
                 let draft = args
                     .draft_model
                     .as_deref()
@@ -785,7 +875,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
                 Ok(Box::new(b))
             } else {
                 let mut b =
-                    OvDistSpecWorkerBuilder::new(&args.model, args.rank, args.total, &args.device);
+                    OvDistSpecWorkerBuilder::new(&args.model, rt.rank, rt.total, &args.device);
                 if let Some(dir) = &args.ov_cache_dir {
                     b = b.with_cache_dir(dir);
                 }
@@ -800,7 +890,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
         }
         EngineKind::SparseMoe => {
             let mut cfg = SparseMoEBuilderConfig::new(&args.model, &args.device)
-                .with_rank(args.rank, args.total)
+                .with_rank(rt.rank, rt.total)
                 .with_kv_prefix_cache_size(args.kv_prefix_cache_size);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 cfg.cache_dir = Some(dir);
@@ -841,7 +931,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             Ok(Box::new(SparseMoEBuilder::new(cfg)))
         }
         EngineKind::Qwen36Moe => Ok(Box::new(
-            Qwen36Builder::new(&args.model, &args.device).with_rank(args.rank, args.total),
+            Qwen36Builder::new(&args.model, &args.device).with_rank(rt.rank, rt.total),
         )),
     }
 }
@@ -964,20 +1054,25 @@ fn install_shutdown_signal_handler(
 }
 
 async fn cmd_worker(args: WorkerArgs) -> Result<()> {
-    if args.rank >= args.total {
-        return Err(anyhow!(
-            "--rank must be in [0, {}); got {}",
-            args.total,
-            args.rank
-        ));
-    }
-    let is_first = args.rank == 0;
-    let is_last = args.rank == args.total - 1;
+    let rt: RankTotal = match resolve_worker_mode(args.rank, args.total, args.cluster_size)? {
+        WorkerMode::Manual { rank, total } => {
+            if rank >= total {
+                bail!("--rank must be in [0, {total}); got {rank}");
+            }
+            RankTotal { rank, total }
+        }
+        WorkerMode::Auto { .. } => {
+            // Wired in a later task (auto-ring stays unreachable until then).
+            bail!("auto-ring not wired yet");
+        }
+    };
+    let is_first = rt.rank == 0;
+    let is_last = rt.rank == rt.total - 1;
 
     info!(
         engine = ?args.engine,
-        rank = args.rank,
-        total = args.total,
+        rank = rt.rank,
+        total = rt.total,
         device = %args.device,
         model = %args.model,
         "cascadia worker starting"
@@ -1017,7 +1112,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         tp_rank: 0,
     };
 
-    let builder = build_builder(&args)?;
+    let builder = build_builder(&args, rt)?;
     let runner = Arc::new(Runner::new(builder));
     let listen = if !is_first {
         Some((listen_host.as_str(), listen_port))
@@ -1094,7 +1189,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         .and_then(|a| parse_addr(a, "0.0.0.0").ok())
         .map(|(_, p)| p);
     let self_node = cascadia_topology::NodeInfo {
-        node_id: format!("{}-r{}", specs.hostname, args.rank),
+        node_id: format!("{}-r{}", specs.hostname, rt.rank),
         host: cascadia_discovery::local_ip().to_string(),
         port: listen_port,
         api_port,

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -152,7 +152,6 @@ mod namespace_tests {
 /// mapped to '-', capped at 63 bytes (mDNS instance / DNS label limit).
 /// Rank-independent — rank is unknown before election. Manual path keeps
 /// "{hostname}-r{rank}".
-#[allow(dead_code)] // consumed by run_auto_election (next commit)
 fn auto_node_id(hostname: &str, ip: &str) -> String {
     let mut s: String = format!("{hostname}-{ip}")
         .chars()
@@ -256,6 +255,77 @@ mod worker_mode_tests {
     #[test]
     fn rank_without_total_errors() {
         assert!(resolve_worker_mode(Some(0), None, None).is_err());
+    }
+}
+
+/// Reject flag combinations that are incompatible with auto-ring
+/// (`--cluster-size`). Called before `run_auto_election` so a bad
+/// combination fails fast instead of after paying the discover/agree
+/// timeouts.
+fn preflight_auto(args: &WorkerArgs, n: u32) -> Result<()> {
+    if matches!(args.engine, EngineKind::OvGenai) && n > 1 {
+        bail!("--engine ov-genai is single-stage only; auto-ring needs a multi-stage engine (ov-runtime, gemma4, ov-dist-spec, sparse-moe, qwen36-moe)");
+    }
+    if args.layer_start != 0 || args.layer_end != 0 {
+        bail!("--layer-start/--layer-end are not valid with --cluster-size (auto-ring uses an even split)");
+    }
+    if matches!(args.engine, EngineKind::OvDistSpec) && args.draft_model.is_none() {
+        bail!("--engine ov-dist-spec auto-ring requires --draft-model on every box (the elected rank 0 needs it; other ranks ignore it)");
+    }
+    if !args.advertise_engines.is_empty() {
+        // The election's engine cross-check compares the single running
+        // engine; a multi-entry advertised list would defeat it.
+        bail!("--advertise-engines is not valid with --cluster-size");
+    }
+    Ok(())
+}
+
+/// Split from cmd_worker so the loopback gate is unit-testable.
+fn preflight_ip(ip: std::net::IpAddr, n: u32) -> Result<()> {
+    if ip.is_loopback() && n > 1 {
+        bail!("no reachable LAN IP (local_ip() returned loopback); auto-ring needs a routable address on every box");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod preflight_tests {
+    use super::*;
+    fn base() -> WorkerArgs {
+        WorkerArgs::single_node(
+            "m".into(),
+            "CPU".into(),
+            EngineKind::OvRuntime,
+            ":8000".into(),
+        )
+    }
+    #[test]
+    fn ov_genai_multistage_rejected() {
+        let mut a = base();
+        a.engine = EngineKind::OvGenai;
+        assert!(preflight_auto(&a, 3).is_err());
+    }
+    #[test]
+    fn layer_flags_rejected() {
+        let mut a = base();
+        a.layer_start = 4;
+        assert!(preflight_auto(&a, 3).is_err());
+    }
+    #[test]
+    fn dist_spec_without_draft_rejected() {
+        let mut a = base();
+        a.engine = EngineKind::OvDistSpec;
+        assert!(preflight_auto(&a, 3).is_err());
+    }
+    #[test]
+    fn ov_runtime_ok() {
+        assert!(preflight_auto(&base(), 3).is_ok());
+    }
+    #[test]
+    fn loopback_multinode_rejected() {
+        assert!(preflight_ip("127.0.0.1".parse().unwrap(), 2).is_err());
+        assert!(preflight_ip("127.0.0.1".parse().unwrap(), 1).is_ok());
+        assert!(preflight_ip("192.168.0.5".parse().unwrap(), 3).is_ok());
     }
 }
 
@@ -1096,7 +1166,110 @@ fn install_shutdown_signal_handler(
     })
 }
 
-async fn cmd_worker(args: WorkerArgs) -> Result<()> {
+/// Everything cmd_worker needs from a completed election. `discovery` MUST
+/// stay alive for the whole serving run (its Drop unregisters mDNS).
+struct AutoRing {
+    rt: RankTotal,
+    next: Option<(String, u16)>,
+    coordinator_host: String,
+    topology: cascadia_topology::Topology,
+    discovery: cascadia_discovery::DiscoveryService,
+    self_node: cascadia_topology::NodeInfo,
+    /// Held through the election so a fast peer's dial finds a listener;
+    /// dropped just before runner.start_with_listen (the engine binds the
+    /// port itself — holding this would AddrInUse it).
+    prebound: Option<tokio::net::TcpListener>,
+}
+
+async fn run_auto_election(args: &WorkerArgs, cluster_size: u32) -> Result<AutoRing> {
+    let specs = tokio::task::spawn_blocking(gather_node_specs)
+        .await
+        .unwrap_or_default();
+    let ip = cascadia_discovery::local_ip();
+    preflight_ip(ip, cluster_size)?;
+    if cluster_namespace() == "default" {
+        tracing::warn!("auto-ring on the shared 'default' namespace; set CASCADIA_NAMESPACE to isolate this cluster");
+    }
+    let ip = ip.to_string();
+    let node_id = auto_node_id(&specs.hostname, &ip);
+    let model_hash = cascadia_types::hash::fnv1a_hex(args.model.as_bytes());
+    let ns = cluster_namespace();
+    // Honor --listen: advertise the SAME relay port the engine will bind.
+    let (_, listen_port) = parse_addr(&args.listen, "0.0.0.0")?;
+
+    let self_node = cascadia_topology::NodeInfo {
+        node_id: node_id.clone(),
+        host: ip,
+        port: listen_port,
+        api_port: None, // advertised only after rank 0 is elected
+        namespace: ns.clone(),
+        device: args
+            .advertise_device
+            .clone()
+            .unwrap_or_else(|| args.device.clone()),
+        memory_mb: specs.memory_mb,
+        cpu_model: specs.cpu_model,
+        cpu_cores: specs.cpu_cores,
+        os: specs.os,
+        engines: vec![engine_name(args.engine).to_owned()],
+        model_hash: Some(model_hash.clone()),
+        cluster_size: Some(cluster_size),
+        ring_digest: None,
+        last_seen: 0.0,
+    };
+
+    // Pre-bind the relay port for the election window: an already-committed
+    // upstream's dial completes its TCP handshake while we finish Phase 2.
+    // Dropped by cmd_worker just before start_with_listen (see AutoRing doc).
+    let prebound = tokio::net::TcpListener::bind(("0.0.0.0", listen_port))
+        .await
+        .map_err(|e| {
+            anyhow!("pre-bind :{listen_port} failed (another worker on this host?): {e}")
+        })?;
+
+    let topology = cascadia_topology::Topology::new();
+    topology.add_node(self_node.clone());
+    let mut discovery = cascadia_discovery::DiscoveryService::new(topology.clone(), ns.clone());
+    discovery.start(self_node.clone())?;
+
+    let p = election::ElectParams {
+        self_id: node_id,
+        namespace: ns,
+        model_hash,
+        engine: engine_name(args.engine).to_owned(),
+        cluster_size,
+    };
+    let t = election::ElectTimeouts {
+        discover: std::time::Duration::from_secs(args.discover_timeout),
+        agree: std::time::Duration::from_secs(args.agree_timeout),
+        settle: std::time::Duration::from_secs(args.settle),
+    };
+    let (ring, committed_digest) =
+        election::elect(&topology, &mut discovery, &self_node, &p, &t).await?;
+
+    // Keep self_node consistent with what elect advertised (F6: later
+    // api_port re-advertise must carry this digest, not blank it).
+    let mut self_node = self_node;
+    self_node.ring_digest = Some(committed_digest);
+
+    tracing::info!(rank = ring.rank, total = ring.total, next = ?ring.next,
+        coordinator = %ring.coordinator_host, "auto-ring elected");
+    Ok(AutoRing {
+        rt: RankTotal {
+            rank: ring.rank,
+            total: ring.total,
+        },
+        next: ring.next.clone(),
+        coordinator_host: ring.coordinator_host,
+        topology,
+        discovery,
+        self_node,
+        prebound: Some(prebound),
+    })
+}
+
+async fn cmd_worker(mut args: WorkerArgs) -> Result<()> {
+    let mut auto: Option<AutoRing> = None;
     let rt: RankTotal = match resolve_worker_mode(args.rank, args.total, args.cluster_size)? {
         WorkerMode::Manual { rank, total } => {
             if rank >= total {
@@ -1104,11 +1277,17 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
             }
             RankTotal { rank, total }
         }
-        WorkerMode::Auto { .. } => {
-            // Wired in a later task (auto-ring stays unreachable until then).
-            bail!("auto-ring not wired yet");
+        WorkerMode::Auto { cluster_size } => {
+            preflight_auto(&args, cluster_size)?;
+            let ring = run_auto_election(&args, cluster_size).await?;
+            let rt = ring.rt; // RankTotal is Copy — no partial move
+            auto = Some(ring);
+            rt
         }
     };
+    if auto.is_some() && rt.rank == 0 && args.api.is_none() {
+        args.api = Some(":8000".into());
+    }
     let is_first = rt.rank == 0;
     let is_last = rt.rank == rt.total - 1;
 
@@ -1130,6 +1309,8 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     };
     let downstream = if is_last {
         None
+    } else if let Some((host, port)) = auto.as_ref().and_then(|a| a.next.clone()) {
+        Some(PeerEndpoint::new(host, port))
     } else {
         let next = args
             .next
@@ -1162,6 +1343,12 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     } else {
         None
     };
+    // Release the election-era relay listener so the engine can bind the
+    // port itself (holding it would AddrInUse every non-first stage). The
+    // dialer's 500ms connect retry absorbs the sub-second rebind gap.
+    if let Some(a) = auto.as_mut() {
+        a.prebound.take();
+    }
     runner.start_with_listen(peers, shard, listen).await?;
 
     // Probe listener: bind a TCP socket on listen_port so the
@@ -1205,56 +1392,93 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     // coordinator's dashboard /api/topology can render the full cluster
     // and not just self. Best-effort: a host without a working multicast
     // path (CI sandbox, restricted LAN) still serves; the dashboard just
-    // shows fewer nodes. We bind `_discovery` for the rest of this
-    // function so its Drop unregisters the mDNS record cleanly on
-    // shutdown (relay loop or `serve_with_nodelay`).
-    let topology = cascadia_topology::Topology::new();
-    let engines = if !args.advertise_engines.is_empty() {
-        args.advertise_engines.clone()
-    } else {
-        vec![engine_name(args.engine).to_owned()]
-    };
-    let device = args
-        .advertise_device
-        .clone()
-        .unwrap_or_else(|| args.device.clone());
-    // sysinfo + hostname do blocking syscalls; gather them off the async
-    // runtime thread so they don't stall worker startup.
-    let specs = tokio::task::spawn_blocking(gather_node_specs)
-        .await
-        .unwrap_or_default();
+    // shows fewer nodes. The manual path advertises here; the auto path
+    // already advertised in run_auto_election — this join point makes
+    // sure only ONE DiscoveryService instance exists either way, so
+    // heartbeat/latency-probe/DashboardState all hang off the same
+    // topology + discovery daemon.
+    //
     // Advertise the API/dashboard port separately from the relay port so
     // the dashboard can show a node's reachable address (the relay `port`
-    // isn't an HTTP endpoint). None for relay-only stages.
+    // isn't an HTTP endpoint). None for relay-only stages. Hoisted above
+    // the join because it depends only on `args`, and the auto path needs
+    // it re-applied post-election (rank 0 is only known after elect()).
     let api_port = args
         .api
         .as_deref()
         .and_then(|a| parse_addr(a, "0.0.0.0").ok())
         .map(|(_, p)| p);
-    let self_node = cascadia_topology::NodeInfo {
-        node_id: format!("{}-r{}", specs.hostname, rt.rank),
-        host: cascadia_discovery::local_ip().to_string(),
-        port: listen_port,
-        api_port,
-        namespace: cluster_namespace(),
-        device,
-        memory_mb: specs.memory_mb,
-        cpu_model: specs.cpu_model,
-        cpu_cores: specs.cpu_cores,
-        os: specs.os,
-        engines,
-        model_hash: None,
-        cluster_size: None,
-        ring_digest: None,
-        last_seen: 0.0,
+    let coordinator_host = auto.as_ref().map(|a| a.coordinator_host.clone());
+
+    let (topology, mut discovery, self_node) = match auto.take() {
+        Some(a) => (a.topology, a.discovery, a.self_node),
+        None => {
+            let engines = if !args.advertise_engines.is_empty() {
+                args.advertise_engines.clone()
+            } else {
+                vec![engine_name(args.engine).to_owned()]
+            };
+            let device = args
+                .advertise_device
+                .clone()
+                .unwrap_or_else(|| args.device.clone());
+            // sysinfo + hostname do blocking syscalls; gather them off the
+            // async runtime thread so they don't stall worker startup.
+            let specs = tokio::task::spawn_blocking(gather_node_specs)
+                .await
+                .unwrap_or_default();
+            let self_node = cascadia_topology::NodeInfo {
+                node_id: format!("{}-r{}", specs.hostname, rt.rank),
+                host: cascadia_discovery::local_ip().to_string(),
+                port: listen_port,
+                api_port,
+                namespace: cluster_namespace(),
+                device,
+                memory_mb: specs.memory_mb,
+                cpu_model: specs.cpu_model,
+                cpu_cores: specs.cpu_cores,
+                os: specs.os,
+                engines,
+                model_hash: None,
+                cluster_size: None,
+                ring_digest: None,
+                last_seen: 0.0,
+            };
+            let topology = cascadia_topology::Topology::new();
+            topology.add_node(self_node.clone());
+            let mut discovery =
+                cascadia_discovery::DiscoveryService::new(topology.clone(), cluster_namespace());
+            if let Err(e) = discovery.start(self_node.clone()) {
+                tracing::warn!(error = %e, "mDNS discovery failed to start; cluster topology may be incomplete");
+            }
+            (topology, discovery, self_node)
+        }
     };
-    topology.add_node(self_node.clone());
-    let mut discovery =
-        cascadia_discovery::DiscoveryService::new(topology.clone(), cluster_namespace());
-    if let Err(e) = discovery.start(self_node.clone()) {
-        tracing::warn!(error = %e, "mDNS discovery failed to start; cluster topology may be incomplete");
+    // Auto path: publish api_port now that rank 0 is known, PRESERVING the
+    // committed ring_digest carried in self_node (props_from_node rewrites the
+    // whole TXT record; blanking the digest would strand a straggler in Phase 2).
+    if api_port.is_some() && self_node.cluster_size.is_some() {
+        let mut sn = self_node.clone();
+        sn.api_port = api_port;
+        topology.add_node(sn.clone());
+        if let Err(e) = discovery.update_txt(sn) {
+            tracing::warn!(error = %e, "api_port re-advertise failed; dashboard may show no API address");
+        }
     }
-    let _discovery = discovery;
+
+    if self_node.cluster_size.is_some() {
+        let port = api_port.unwrap_or(8000);
+        if rt.rank == 0 {
+            tracing::info!("auto-ring: serving API at http://{}:{port}", self_node.host);
+        } else {
+            tracing::info!(
+                rank = rt.rank,
+                total = rt.total,
+                "auto-ring: coordinator = {}:{port}",
+                coordinator_host.as_deref().unwrap_or("?")
+            );
+        }
+    }
 
     // Self-heartbeat: re-insert our own NodeInfo every 2 s so last_seen
     // stays current in the local topology even when no mDNS event has

--- a/crates/cascadia-dashboard/web/src/lib/api.ts
+++ b/crates/cascadia-dashboard/web/src/lib/api.ts
@@ -22,6 +22,9 @@ export type NodeInfo = {
   engines: string[];
   /** Unix seconds, fractional. Compared against Date.now()/1000 for freshness. */
   last_seen: number;
+  model_hash?: string;
+  cluster_size?: number;
+  ring_digest?: string;
 };
 
 export type Edge = {

--- a/crates/cascadia-discovery/src/lib.rs
+++ b/crates/cascadia-discovery/src/lib.rs
@@ -170,6 +170,20 @@ fn node_from_service(srv: &ServiceInfo, expected_namespace: &str) -> Option<Node
     };
 
     let node_id = get("node_id")?;
+    // member_digest (cascadia-cli/src/election.rs) joins `memory_mb:node_id`
+    // pairs with '\n'; that's only injective if node_id contains neither
+    // separator. Auto-ring node_ids are sanitized to [A-Za-z0-9-], but this
+    // function decodes a peer's node_id RAW from an mDNS TXT record with no
+    // charset guard — a hostile/malformed LAN peer could otherwise engineer
+    // two divergent member sets that hash to the same digest, so `agreed()`
+    // would pass while nodes wire different rings. Reject at the decode
+    // boundary, same as the namespace-mismatch rejection below. Do NOT widen
+    // this to a full charset allowlist: MANUAL-path node_ids are
+    // `{hostname}-r{rank}` and legitimately contain dots (FQDNs).
+    if node_id.contains(':') || node_id.contains('\n') {
+        debug!(%node_id, "rejecting peer: node_id contains reserved digest separator");
+        return None;
+    }
     let namespace = get("namespace").unwrap_or_else(|| "default".into());
     if namespace != expected_namespace {
         return None;
@@ -522,6 +536,79 @@ mod tests {
         .unwrap();
         let decoded = node_from_service(&info, "default").unwrap();
         assert_eq!(decoded.model_hash, None);
+    }
+
+    // CRITICAL: member_digest (cascadia-cli/src/election.rs) joins
+    // `memory_mb:node_id` pairs with '\n'. If a peer's raw node_id can
+    // contain ':' or '\n', two different member sets can be engineered to
+    // hash to the same digest, so agreed() would pass on divergent sets and
+    // nodes would silently wire different rings. node_from_service must
+    // reject such peers at the decode boundary.
+    #[test]
+    fn node_id_with_digest_separator_is_rejected() {
+        let node = NodeInfo::new("evil\n1:x", "127.0.0.1", 9100);
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            "evil-service", // instance name must be a valid mDNS label; the
+            // node_id lives in the TXT record props, not the service name.
+            "evil.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props_from_node(&node)),
+        )
+        .expect("build ServiceInfo");
+        assert!(node_from_service(&info, "default").is_none());
+
+        let node2 = NodeInfo::new("a:b", "127.0.0.1", 9100);
+        let info2 = ServiceInfo::new(
+            SERVICE_TYPE,
+            "evil-service-2",
+            "evil2.local.",
+            node2.host.as_str(),
+            node2.port,
+            Some(props_from_node(&node2)),
+        )
+        .expect("build ServiceInfo");
+        assert!(node_from_service(&info2, "default").is_none());
+    }
+
+    // Guard against over-rejection: MANUAL-path node_ids are
+    // `{hostname}-r{rank}` and legitimately contain dots (FQDNs). Only ':'
+    // and '\n' are reserved digest separators.
+    #[test]
+    fn dotted_hostname_node_id_still_accepted() {
+        let node = NodeInfo::new("host.lan-r0", "192.168.0.5", 9100);
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            "host.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props_from_node(&node)),
+        )
+        .expect("build ServiceInfo");
+        let decoded = node_from_service(&info, "default").expect("decode");
+        assert_eq!(decoded.node_id, "host.lan-r0");
+    }
+
+    // CASCADIA_NAMESPACE="" must not silently break matching: an empty
+    // namespace should round-trip through props_from_node / node_from_service
+    // just like any other value.
+    #[test]
+    fn empty_namespace_round_trips() {
+        let mut node = NodeInfo::new("h-empty-ns", "127.0.0.1", 9100);
+        node.namespace = "".into();
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            "h-empty-ns.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props_from_node(&node)),
+        )
+        .expect("build ServiceInfo");
+        let decoded = node_from_service(&info, "").expect("decode");
+        assert_eq!(decoded.namespace, "");
     }
 }
 

--- a/crates/cascadia-discovery/src/lib.rs
+++ b/crates/cascadia-discovery/src/lib.rs
@@ -17,6 +17,50 @@ use tracing::{debug, info, warn};
 
 pub const SERVICE_TYPE: &str = "_cascadia._tcp.local.";
 
+/// Debounce window for browse Removed/Resolved pairs. Must be shorter than
+/// the worker's --settle (>=1s) so a truly-dead peer clears before commit,
+/// and long enough to absorb a re-register's Removed->Resolved gap.
+const DEBOUNCE_WINDOW: Duration = Duration::from_millis(750);
+
+/// Debounce for browse Removed/Resolved: a Removed followed by a Resolved for
+/// the same id within the window is a TXT refresh (keep membership), not a leave.
+struct RemoveDebounce {
+    window: Duration,
+    pending: Mutex<HashMap<String, std::time::Instant>>,
+}
+
+impl RemoveDebounce {
+    fn new(window: Duration) -> Self {
+        Self {
+            window,
+            pending: Mutex::new(HashMap::new()),
+        }
+    }
+    fn on_removed(&self, id: &str, now: std::time::Instant) {
+        self.pending.lock().insert(id.to_string(), now);
+    }
+    /// Returns true if this Resolved cancelled a pending removal (refresh).
+    fn on_resolved(&self, id: &str, now: std::time::Instant) -> bool {
+        if let Some(t) = self.pending.lock().remove(id) {
+            return now.duration_since(t) <= self.window;
+        }
+        false
+    }
+    /// Ids whose Removed timer expired at `now` (=> truly remove).
+    fn expired(&self, now: std::time::Instant) -> Vec<String> {
+        let mut g = self.pending.lock();
+        let dead: Vec<String> = g
+            .iter()
+            .filter(|(_, t)| now.duration_since(**t) > self.window)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in &dead {
+            g.remove(id);
+        }
+        dead
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("mdns error: {0}")]
@@ -198,8 +242,9 @@ pub struct DiscoveryService {
     /// JoinHandle for the background browse-loop thread. Held so we
     /// don't lose the handle (preventing it from being silently
     /// orphaned on drop) and so close() can wait for the thread to
-    /// exit cleanly after the daemon shutdown causes its receiver
-    /// channel to close.
+    /// exit cleanly. The loop polls with `recv_timeout` and breaks as
+    /// soon as `receiver.is_disconnected()` is true, which happens
+    /// once the daemon shuts down and drops its sender.
     browse_thread: Option<std::thread::JoinHandle<()>>,
 }
 
@@ -235,15 +280,17 @@ impl DiscoveryService {
         let topology = self.topology.clone();
         let namespace = self.namespace.clone();
         let handle = std::thread::spawn(move || {
-            for event in receiver.iter() {
-                match event {
-                    ServiceEvent::ServiceResolved(srv) => {
+            let debounce = RemoveDebounce::new(DEBOUNCE_WINDOW);
+            loop {
+                match receiver.recv_timeout(Duration::from_millis(200)) {
+                    Ok(ServiceEvent::ServiceResolved(srv)) => {
                         if let Some(node) = node_from_service(&srv, &namespace) {
+                            debounce.on_resolved(&node.node_id, std::time::Instant::now());
                             debug!(node_id = %node.node_id, "discovered");
                             topology.add_node(node);
                         }
                     }
-                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                    Ok(ServiceEvent::ServiceRemoved(_, fullname)) => {
                         // The mDNS fullname is `<node_id>.<SERVICE_TYPE>`.
                         // Strip the service-type suffix rather than splitting
                         // on the first '.', so a node_id containing a dot
@@ -254,10 +301,20 @@ impl DiscoveryService {
                             .strip_suffix(SERVICE_TYPE)
                             .and_then(|s| s.strip_suffix('.'))
                             .unwrap_or(&fullname);
-                        debug!(%node_id, "peer removed");
-                        topology.remove_node(node_id);
+                        // Do NOT remove yet — debounce absorbs re-register flaps.
+                        debounce.on_removed(node_id, std::time::Instant::now());
                     }
-                    other => debug!(?other, "discovery event"),
+                    Ok(other) => debug!(?other, "discovery event"),
+                    // Daemon shut down -> channel closed -> exit so close()'s
+                    // join() returns (mdns-sd Receiver is flume; the concrete
+                    // error type isn't re-exported, so use is_disconnected()).
+                    Err(_) if receiver.is_disconnected() => break,
+                    Err(_) => {} // timeout tick
+                }
+                // Sweep on EVERY iteration, not only on timeout.
+                for id in debounce.expired(std::time::Instant::now()) {
+                    debug!(%id, "peer removed (debounce expired)");
+                    topology.remove_node(&id);
                 }
             }
         });
@@ -277,12 +334,35 @@ impl DiscoveryService {
             }
         }
         // Best-effort join of the browse loop. Once the daemon is
-        // shut down its sender drops and `receiver.iter()` returns
-        // None, which lets the thread exit. We don't fail close() on
-        // a panicked thread.
+        // shut down its sender drops, so the loop's next
+        // `recv_timeout` (at most 200ms out) observes
+        // `receiver.is_disconnected()` and breaks. We don't fail
+        // close() on a panicked thread.
         if let Some(handle) = self.browse_thread.take() {
             let _ = handle.join();
         }
+    }
+
+    /// Re-advertise this node's TXT (ring_digest / api_port changed) without a
+    /// membership gap: mdns-sd re-registers the same fullname in place
+    /// (HashMap replace + unsolicited announce). Peers that do see a
+    /// Removed/Resolved pair absorb it via the browse-loop debounce.
+    pub fn update_txt(&mut self, node: NodeInfo) -> Result<()> {
+        let daemon = self
+            .daemon
+            .as_ref()
+            .ok_or_else(|| Error::Mdns("discovery not started".into()))?;
+        let host_name = format!("{}.local.", node.node_id);
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            &host_name,
+            node.host.as_str(),
+            node.port,
+            Some(props_from_node(&node)),
+        )?;
+        daemon.register(info)?;
+        Ok(())
     }
 }
 
@@ -420,5 +500,29 @@ mod tests {
         let decoded = node_from_service(&info, "default").unwrap();
         assert_eq!(decoded.cluster_size, None);
         assert_eq!(decoded.model_hash, None);
+    }
+}
+
+#[cfg(test)]
+mod debounce_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+    #[test]
+    fn resolved_within_window_is_a_refresh() {
+        let d = RemoveDebounce::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.on_removed("n1", t0);
+        assert!(d.on_resolved("n1", t0 + Duration::from_millis(100)));
+        assert!(d.expired(t0 + Duration::from_secs(5)).is_empty());
+    }
+    #[test]
+    fn removed_without_resolve_expires_to_true_removal() {
+        let d = RemoveDebounce::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.on_removed("n2", t0);
+        assert_eq!(
+            d.expired(t0 + Duration::from_secs(1)),
+            vec!["n2".to_string()]
+        );
     }
 }

--- a/crates/cascadia-discovery/src/lib.rs
+++ b/crates/cascadia-discovery/src/lib.rs
@@ -282,6 +282,8 @@ impl DiscoveryService {
         let handle = std::thread::spawn(move || {
             let debounce = RemoveDebounce::new(DEBOUNCE_WINDOW);
             loop {
+                // 200ms tick = sweep granularity; 3-4 sweeps per DEBOUNCE_WINDOW
+                // (750ms) bounds extra removal latency at one tick.
                 match receiver.recv_timeout(Duration::from_millis(200)) {
                     Ok(ServiceEvent::ServiceResolved(srv)) => {
                         if let Some(node) = node_from_service(&srv, &namespace) {
@@ -308,6 +310,9 @@ impl DiscoveryService {
                     // Daemon shut down -> channel closed -> exit so close()'s
                     // join() returns (mdns-sd Receiver is flume; the concrete
                     // error type isn't re-exported, so use is_disconnected()).
+                    // Note: pending debounce entries are not flushed on
+                    // shutdown; the topology handle may briefly retain a
+                    // departing peer. Fine for process exit (the common path).
                     Err(_) if receiver.is_disconnected() => break,
                     Err(_) => {} // timeout tick
                 }
@@ -540,6 +545,21 @@ mod debounce_tests {
         assert_eq!(
             d.expired(t0 + Duration::from_secs(1)),
             vec!["n2".to_string()]
+        );
+    }
+    #[test]
+    fn window_boundary_is_refresh_inclusive_expire_exclusive() {
+        let d = RemoveDebounce::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.on_removed("n3", t0);
+        // exactly at the window edge: still a refresh...
+        assert!(d.on_resolved("n3", t0 + Duration::from_millis(500)));
+        d.on_removed("n4", t0);
+        // ...and exactly at the edge, not yet expired.
+        assert!(d.expired(t0 + Duration::from_millis(500)).is_empty());
+        assert_eq!(
+            d.expired(t0 + Duration::from_millis(501)),
+            vec!["n4".to_string()]
         );
     }
 }

--- a/crates/cascadia-discovery/src/lib.rs
+++ b/crates/cascadia-discovery/src/lib.rs
@@ -160,6 +160,9 @@ fn node_from_service(srv: &ServiceInfo, expected_namespace: &str) -> Option<Node
         cpu_cores,
         os,
         engines,
+        model_hash: None,
+        cluster_size: None,
+        ring_digest: None,
         last_seen: 0.0,
     })
 }

--- a/crates/cascadia-discovery/src/lib.rs
+++ b/crates/cascadia-discovery/src/lib.rs
@@ -486,8 +486,26 @@ mod tests {
         let node = NodeInfo::new("h", "127.0.0.1", 9100);
         let mut props = props_from_node(&node);
         props.insert("cluster_size".into(), "not-a-number".into());
-        // Non-16-hex model_hash (e.g. hostile/corrupt TXT) is treated as absent.
-        props.insert("model_hash".into(), "zz-not-hex".into());
+        // 16-char non-hex model_hash (right length, wrong character class) is
+        // treated as absent — exercises the hex16 guard's char-class branch,
+        // not just its length check.
+        props.insert("model_hash".into(), "gggggggggggggggg".into());
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            "h.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props.clone()),
+        )
+        .unwrap();
+        let decoded = node_from_service(&info, "default").unwrap();
+        assert_eq!(decoded.cluster_size, None);
+        assert_eq!(decoded.model_hash, None);
+
+        // 16-char uppercase hex is also rejected — hex16 requires lowercase
+        // (matches the encode side, which always emits lowercase digests).
+        props.insert("model_hash".into(), "AF63DC4C8601EC8C".into());
         let info = ServiceInfo::new(
             SERVICE_TYPE,
             &node.node_id,
@@ -498,7 +516,6 @@ mod tests {
         )
         .unwrap();
         let decoded = node_from_service(&info, "default").unwrap();
-        assert_eq!(decoded.cluster_size, None);
         assert_eq!(decoded.model_hash, None);
     }
 }

--- a/crates/cascadia-discovery/src/lib.rs
+++ b/crates/cascadia-discovery/src/lib.rs
@@ -104,6 +104,15 @@ fn props_from_node(info: &NodeInfo) -> HashMap<String, String> {
     if let Some(api_port) = info.api_port {
         p.insert("api_port".into(), api_port.to_string());
     }
+    if let Some(h) = &info.model_hash {
+        p.insert("model_hash".into(), h.clone());
+    }
+    if let Some(cs) = info.cluster_size {
+        p.insert("cluster_size".into(), cs.to_string());
+    }
+    if let Some(d) = &info.ring_digest {
+        p.insert("ring_digest".into(), d.clone());
+    }
     p
 }
 
@@ -140,6 +149,18 @@ fn node_from_service(srv: &ServiceInfo, expected_namespace: &str) -> Option<Node
         })
         .unwrap_or_default();
 
+    // Election fields. Guard hash shape (16 lowercase hex) so a corrupt or
+    // hostile TXT value degrades to "absent" instead of poisoning matching.
+    let hex16 = |s: String| -> Option<String> {
+        (s.len() == 16
+            && s.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()))
+        .then_some(s)
+    };
+    let model_hash = get("model_hash").and_then(hex16);
+    let cluster_size = get("cluster_size").and_then(|s| s.parse().ok());
+    let ring_digest = get("ring_digest").and_then(hex16);
+
     let host = srv
         .get_addresses()
         .iter()
@@ -160,9 +181,9 @@ fn node_from_service(srv: &ServiceInfo, expected_namespace: &str) -> Option<Node
         cpu_cores,
         os,
         engines,
-        model_hash: None,
-        cluster_size: None,
-        ring_digest: None,
+        model_hash,
+        cluster_size,
+        ring_digest,
         last_seen: 0.0,
     })
 }
@@ -338,5 +359,66 @@ mod tests {
             .and_then(|s| s.strip_suffix('.'))
             .unwrap_or(&fullname);
         assert_eq!(stripped, "host.lan-r0");
+    }
+
+    #[test]
+    fn election_fields_round_trip_when_present() {
+        let mut node = NodeInfo::new("host-192-168-0-5", "192.168.0.5", 9100);
+        node.model_hash = Some("af63dc4c8601ec8c".into());
+        node.cluster_size = Some(3);
+        node.ring_digest = Some("cbf29ce484222325".into());
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            "host.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props_from_node(&node)),
+        )
+        .expect("build ServiceInfo");
+        let decoded = node_from_service(&info, "default").expect("decode");
+        assert_eq!(decoded.model_hash, Some("af63dc4c8601ec8c".into()));
+        assert_eq!(decoded.cluster_size, Some(3));
+        assert_eq!(decoded.ring_digest, Some("cbf29ce484222325".into()));
+    }
+
+    #[test]
+    fn absent_election_fields_decode_to_none_not_empty() {
+        // A worker (old binary / manual path) advertises none of the 3 fields.
+        let node = NodeInfo::new("host-192-168-0-9", "192.168.0.9", 9100);
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            "host.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props_from_node(&node)),
+        )
+        .unwrap();
+        let decoded = node_from_service(&info, "default").unwrap();
+        assert_eq!(decoded.model_hash, None, "must be None, not Some(\"\")");
+        assert_eq!(decoded.cluster_size, None, "must be None, not Some(0)");
+        assert_eq!(decoded.ring_digest, None);
+    }
+
+    #[test]
+    fn malformed_election_values_decode_to_none() {
+        let node = NodeInfo::new("h", "127.0.0.1", 9100);
+        let mut props = props_from_node(&node);
+        props.insert("cluster_size".into(), "not-a-number".into());
+        // Non-16-hex model_hash (e.g. hostile/corrupt TXT) is treated as absent.
+        props.insert("model_hash".into(), "zz-not-hex".into());
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &node.node_id,
+            "h.local.",
+            node.host.as_str(),
+            node.port,
+            Some(props),
+        )
+        .unwrap();
+        let decoded = node_from_service(&info, "default").unwrap();
+        assert_eq!(decoded.cluster_size, None);
+        assert_eq!(decoded.model_hash, None);
     }
 }

--- a/crates/cascadia-topology/Cargo.toml
+++ b/crates/cascadia-topology/Cargo.toml
@@ -11,3 +11,6 @@ description = "Cluster topology graph: nodes + measured edges (latency, bandwidt
 serde = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/cascadia-topology/src/lib.rs
+++ b/crates/cascadia-topology/src/lib.rs
@@ -20,7 +20,10 @@ fn now_ts() -> f64 {
         .unwrap_or(0.0)
 }
 
-/// One node's advertised capacity. Populated by discovery + heartbeats.
+/// One node's advertised capacity **+ election advertisement**. Populated by
+/// discovery + heartbeats. The `model_hash`/`cluster_size`/`ring_digest` fields
+/// carry mDNS auto-ring (#89) negotiation state, not capacity — see
+/// docs/superpowers/specs/2026-07-01-mdns-auto-ring-design.md.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct NodeInfo {
     pub node_id: String,
@@ -52,6 +55,16 @@ pub struct NodeInfo {
     pub os: String,
     #[serde(default)]
     pub engines: Vec<String>,
+    /// FNV-1a hash of the worker's `--model` string (auto-ring model match).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_hash: Option<String>,
+    /// Operator's `--cluster-size` (auto-ring participant marker). `None` =
+    /// not an auto-ring participant (manual/dashboard-only worker).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster_size: Option<u32>,
+    /// Phase-2 agreement digest of this node's resolved member ordering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ring_digest: Option<String>,
     #[serde(default = "now_ts")]
     pub last_seen: f64,
 }
@@ -77,6 +90,9 @@ impl NodeInfo {
             cpu_cores: 0,
             os: String::new(),
             engines: Vec::new(),
+            model_hash: None,
+            cluster_size: None,
+            ring_digest: None,
             last_seen: now_ts(),
         }
     }
@@ -212,5 +228,29 @@ impl Topology {
             inner.edges.retain(|(s, d), _| s != id && d != id);
         }
         stale
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults_election_fields_to_none() {
+        let n = NodeInfo::new("n1", "127.0.0.1", 9100);
+        assert_eq!(n.model_hash, None);
+        assert_eq!(n.cluster_size, None);
+        assert_eq!(n.ring_digest, None);
+    }
+
+    #[test]
+    fn election_fields_omitted_from_json_when_none() {
+        let n = NodeInfo::new("n1", "127.0.0.1", 9100);
+        let j = serde_json::to_string(&n).unwrap();
+        assert!(
+            !j.contains("model_hash"),
+            "None fields must be skipped: {j}"
+        );
+        assert!(!j.contains("ring_digest"), "{j}");
     }
 }

--- a/crates/cascadia-topology/src/lib.rs
+++ b/crates/cascadia-topology/src/lib.rs
@@ -22,8 +22,8 @@ fn now_ts() -> f64 {
 
 /// One node's advertised capacity **+ election advertisement**. Populated by
 /// discovery + heartbeats. The `model_hash`/`cluster_size`/`ring_digest` fields
-/// carry mDNS auto-ring (#89) negotiation state, not capacity — see
-/// docs/superpowers/specs/2026-07-01-mdns-auto-ring-design.md.
+/// carry mDNS auto-ring (#89) negotiation state, not capacity. See issue #89
+/// for the auto-ring election design.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct NodeInfo {
     pub node_id: String,

--- a/crates/cascadia-types/src/hash.rs
+++ b/crates/cascadia-types/src/hash.rs
@@ -1,0 +1,47 @@
+//! Deterministic FNV-1a-64 rendered as fixed-width lowercase hex.
+//!
+//! Used for wire-stable identity hashes (mDNS TXT `model_hash`, ring
+//! membership digests). MUST NOT use `std::collections::hash_map::
+//! DefaultHasher` — its output is not stable across builds/hosts, which
+//! would make two nodes on different cascadia versions disagree.
+
+/// FNV-1a-64 over `bytes`, rendered as 16 lowercase zero-padded hex chars.
+/// Pure, endianness-independent, identical on every host and build.
+pub fn fnv1a_hex(bytes: &[u8]) -> String {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    let mut h = OFFSET;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    format!("{h:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_vectors_are_stable() {
+        // FNV-1a-64 reference vectors (canonical; hand-verified).
+        assert_eq!(fnv1a_hex(b""), "cbf29ce484222325");
+        assert_eq!(fnv1a_hex(b"a"), "af63dc4c8601ec8c");
+    }
+
+    #[test]
+    fn output_is_always_16_hex_chars() {
+        for s in ["", "a", "hello", "Qwen/Qwen3-1.7B", "\u{1f600}"] {
+            let h = fnv1a_hex(s.as_bytes());
+            assert_eq!(h.len(), 16, "hash of {s:?} not 16 chars: {h}");
+            assert!(h
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        }
+    }
+
+    #[test]
+    fn distinct_inputs_including_prefixes_differ() {
+        assert_ne!(fnv1a_hex(b"model"), fnv1a_hex(b"model-v2"));
+    }
+}

--- a/crates/cascadia-types/src/lib.rs
+++ b/crates/cascadia-types/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod chunk;
 pub mod error;
+pub mod hash;
 pub mod load;
 pub mod peer;
 pub mod shard;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ Topology graph with per-link latency and bandwidth measurements. This is where C
 
 ## `cascadia-discovery`
 
-mDNS peer discovery via the `mdns-sd` crate. Advertises `_cascadia._tcp.local.` and browses for siblings in the same namespace (a TXT-record field; peers in other namespaces are ignored). Zero-config: spin up workers on the same LAN and they find each other.
+mDNS peer discovery via the `mdns-sd` crate. Advertises `_cascadia._tcp.local.` and browses for siblings in the same `CASCADIA_NAMESPACE`, which is now honored by both `worker` and `discover`. Zero-config: spin up a worker and the coordinator finds it — `worker --cluster-size N` auto-forms the pipeline ring from the discovered peers.
 
 ## `cascadia-download`
 


### PR DESCRIPTION
## What

Adds zero-config multi-node worker startup. Running the **identical** command on N Intel boxes auto-forms a split-brain-safe pipeline ring over mDNS plus a leaderless membership-digest election:

```
cascadia worker --engine <e> --model <m> --cluster-size N
```

The elected rank 0 (biggest-RAM node) serves the OpenAI API; every other rank relays activations. Closes #89.

Purely additive: the existing manual `--rank/--total/--next` path is untouched and remains the fallback for environments where multicast does not cross the segment (Tailscale/WireGuard, K8s, routed subnets).

## Why

Bringing up a multi-node pipeline today means hand-assigning `--rank`, `--total`, and `--next host:port` per box and launching them in the right order — error-prone and demo-hostile. On a shared LAN the topology is discoverable, so the ring can form itself: same command everywhere, no per-node flags, no launch ordering.

## How it works

1. **Discovery** — mDNS on `_cascadia._tcp.local.`; TXT records now carry `model_hash`, `cluster_size`, and `ring_digest`.
2. **Phase 1 — exactly-N barrier** — wait for exactly N peers sharing `(namespace, model_hash, engine, cluster_size)`; the discovered set must hold stable for `--settle` seconds. Over-subscription (> N) is refused, not truncated.
3. **Phase 2 — membership-digest agreement** — each node computes an order-covering FNV-1a digest of the resolved ring's `(memory_mb, node_id)` pairs and re-advertises it; the ring commits only when all N advertise the identical digest (cardinality `len == N` **and** unanimity).

## Mode selection

Both paths are opt-in and mutually exclusive (`resolve_worker_mode`):

| Flags | Mode | Discovery |
|-------|------|-----------|
| `--rank R --total T --next host:port` | Manual (unchanged) | none — hardcoded wiring |
| `--cluster-size N` | Auto-ring | mDNS + election |
| both | error: `--cluster-size is mutually exclusive with --rank/--total` | — |
| neither | error: `pass --cluster-size N (auto-ring) or --rank/--total (manual)` | — |

Discovery starts only on `--cluster-size`. Without it, `cascadia-discovery` is never touched — zero behavior change to the manual path.

## Split-brain safety

- Digest covers the resolved **order**, not just the member set, and is immune to input vector order.
- Agreement guards both cardinality and unanimity; self is injected explicitly.
- Node identity is `hostname-ip`, sanitized; peer node_ids containing digest separators are rejected to preserve digest injectivity.

## Validation

`cargo test -p cascadia-types -p cascadia-discovery -p cascadia-cli` → **79 cli / 13 types / discovery codec all pass, 0 fail**. Coverage includes:

- `three_concurrent_elections_converge` — concurrent `elect()` convergence
- digest order-coverage / order-independence, cardinality + unanimity guards, over-N rejection, and the mDNS TXT encode/decode roundtrip

Workspace `cargo fmt` clean, clippy baseline unchanged, `cargo deny` passes.

Fleet validation scripts (`probe-discovery.sh` multicast preflight + `run-auto.sh` runner) live in the `cascadia-fleet-tests` harness.

## Not covered / draft status

Live multi-machine convergence needs a shared L2 segment — mDNS multicast does **not** traverse Tailscale/WireGuard or route across subnets (empirically confirmed on the fleet: 0/6 multicast vs 6/6 unicast over the tailnet). That is the documented limitation the manual path exists for.

Opening as **draft**: the election/correctness logic is fully unit-tested, but the live shared-L2 hardware pass is still pending.
