### PR TITLE
docs: clean up README.md and formatting improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ Cascadia is a Cargo workspace; one concern per crate. The `Engine` + `Builder` t
 
 ## Deploying
 
-Cascadia does not daemonize itself, so it needs to be ran under systemd / NSSM / launchd. See [`docs/deploy/`](docs/deploy/) for a systemd unit template and Windows / macOS recipes. Cascadia handles `SIGTERM` cleanly.
+Cascadia does not daemonize itself, so it needs to be run under systemd / NSSM / launchd. See [`docs/deploy/`](docs/deploy/) for a systemd unit template and Windows / macOS recipes. Cascadia handles `SIGTERM` cleanly.
 
 **Security**: the HTTP API and inter-stage TCP relay are plaintext and unauthenticated. Bind only to trusted networks (LAN, loopback) or terminate TLS + auth at a reverse proxy in front of `--api`. See [SECURITY.md](SECURITY.md) for the threat model and built-in hardening.
 
 ## Troubleshooting
 
-`config.json not in <model dir>`**: `ov-runtime` reads the HF model `config.json` from the shard's tokenizer dir to derive rotary parameters. Older shard exports may not bundle `config.json`; copy it from the source model's HF cache (`~/.cache/huggingface/hub/models--<repo>/snapshots/<sha>/config.json`) into the shards root. Shards produced by `cascadia shard` bundle it automatically.
+**`config.json not in <model dir>`**: `ov-runtime` reads the HF model `config.json` from the shard's tokenizer dir to derive rotary parameters. Older shard exports may not bundle `config.json`; copy it from the source model's HF cache (`~/.cache/huggingface/hub/models--<repo>/snapshots/<sha>/config.json`) into the shards root. Shards produced by `cascadia shard` bundle it automatically.
 
 **`could not connect to … within 30s`**: start the downstream worker first; check `--listen` on the downstream matches `--next` on the upstream and that the host's firewall allows the port.
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ There are follow-up steps for performing real inference in **[QUICKSTART.md](QUI
 **Prebuilt bundles** for Linux and Windows x86_64 are on the [Releases page](https://github.com/labscommunity/cascadia/releases): binary + OpenVINO runtime libraries, ready to run. Building from source instead has two modes:
 
 ```bash
-# Stub mode — Rust only. Good for dev / CI on macOS / Linux / Windows.
+# Stub mode. Rust only. Good for dev / CI on macOS / Linux / Windows.
 # Engines that need OpenVINO return a clean runtime error.
 cargo build --release -p cascadia
 
-# Real OpenVINO mode — links against openvino-genai 2026.2.0+. Required
+# Real OpenVINO mode. Links against openvino-genai 2026.2.0+. Required
 # for inference on real Intel hardware.
 INTEL_OPENVINO_DIR=/path/to/openvino_genai_<platform>_2026.2.0.0 \
   cargo build --release -p cascadia --features openvino
@@ -82,7 +82,7 @@ Prerequisites:
 ### Single machine
 
 ```bash
-# `run` is single-machine sugar — picks the ov-genai engine, GPU device,
+# `run` is single-machine sugar, picks the ov-genai engine, GPU device,
 # and an OpenAI API on :8000. The model is fetched from HuggingFace on
 # first use and cached under ~/.cache/cascadia/models/.
 cascadia run unsloth/Meta-Llama-3.1-8B-Instruct
@@ -110,7 +110,7 @@ cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
              --num-stages 2 --quantization int4
 ```
 
-Copy the output directory to each node (`scp -r` / `rsync`), or re-shard separately on each node — whichever is faster on your network. Then run one worker per node — **start the last stage first** so the first stage finds it (if it isn't up yet, the first stage prints a clear "waiting for downstream peer" line and retries):
+Copy the output directory to each node (`scp -r` / `rsync`), or re-shard separately on each node, whichever is faster on your network. Then run one worker per node: **start the last stage first** so the first stage finds it (if it isn't up yet, the first stage prints a clear "waiting for downstream peer" line and retries):
 
 ```bash
 # Node B (last stage, listens for activations):
@@ -141,33 +141,33 @@ $ cascadia engines
   qwen36-moe     Qwen3.6-35B-A3B staged chain (GatedDeltaNet + MoE); qwen3_5_moe IR-surgery shards
 ```
 
-`sparse-moe` consumes a `manifest.json` + per-expert artefact tree, not `cascadia shard` output — see [docs/architectures/minimax-m2.md](docs/architectures/minimax-m2.md) and [docs/architectures/moe.md](docs/architectures/moe.md). Tuning: [docs/perf/A3_TOPK_REDUCTION.md](docs/perf/A3_TOPK_REDUCTION.md), [docs/perf/CHESS_PER_CHANNEL.md](docs/perf/CHESS_PER_CHANNEL.md).
+`sparse-moe` consumes a `manifest.json` + per-expert artefact tree, not `cascadia shard` output, see [docs/architectures/minimax-m2.md](docs/architectures/minimax-m2.md) and [docs/architectures/moe.md](docs/architectures/moe.md). Tuning: [docs/perf/A3_TOPK_REDUCTION.md](docs/perf/A3_TOPK_REDUCTION.md), [docs/perf/CHESS_PER_CHANNEL.md](docs/perf/CHESS_PER_CHANNEL.md).
 
 ### Supported model families
 
 `cascadia shard` works today with Llama (1–3.3), Mistral (7B, NeMo, Small 3.x text), Qwen2 / Qwen2.5, Qwen3 dense, DeepSeek R1 Distills (Qwen and Llama variants), Phi-3, Phi-4 / Phi-4-mini (partial rotary), and Gemma 1 / Gemma 2 (logit softcapping + the 4-norm structure; sliding-window attention is treated as full-causal, so output is exact within the window). Gemma 4 (E2B / E4B / 31B) exports through a dedicated path (`tools/export_gemma4.py`, auto-dispatched by `cascadia shard`).
 
-Qwen3.5/3.6 hybrid MoE (`model_type: qwen3_5_moe`) is special-cased: `cascadia shard` dispatches it to a dedicated IR-surgery exporter and it serves through the `qwen36-moe` engine ([docs/architectures/qwen36-moe-support.md](docs/architectures/qwen36-moe-support.md)). Other mixture-of-experts and architecturally-incompatible families — Llama 4, Qwen3-MoE, Mixtral, gpt-oss, full DeepSeek-V2/V3, Gemma 3, the Gemma 4 26B-A4B MoE variant, and Mamba hybrids — are detected and rejected up front with a clear error. See [docs/SHARDING.md](docs/SHARDING.md) and [docs/architectures/](docs/architectures/) for the full per-family status table and deep-dives.
+Qwen3.5/3.6 hybrid MoE (`model_type: qwen3_5_moe`) is special-cased: `cascadia shard` dispatches it to a dedicated IR-surgery exporter and it serves through the `qwen36-moe` engine ([docs/architectures/qwen36-moe-support.md](docs/architectures/qwen36-moe-support.md)). Other mixture-of-experts and architecturally-incompatible families like Llama 4, Qwen3-MoE, Mixtral, gpt-oss, full DeepSeek-V2/V3, Gemma 3, the Gemma 4 26B-A4B MoE variant, and Mamba hybrids are detected and rejected up front with a clear error. See [docs/SHARDING.md](docs/SHARDING.md) and [docs/architectures/](docs/architectures/) for the full per-family status table and deep-dives.
 
 ## Architecture
 
 Cascadia is a Cargo workspace; one concern per crate. The `Engine` + `Builder` traits in `cascadia-engine` are the plugin seam. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for design rationale and per-crate responsibilities. Key crates:
 
-- `cascadia-api/` — OpenAI-compatible HTTP (axum)
-- `cascadia-runner/` — Per-stage runner; concurrent-safe chunk streaming
-- `cascadia-engine/` — `Engine` + `Builder` traits — the plugin seam
-- `cascadia-engine-openvino/` — Five OV engines (`ov-genai`, `ov-runtime`, `ov-dist-spec`, `gemma4`, `qwen36-moe`)
-- `cascadia-engine-sparse-moe/` — Sparse-MoE engine; routes only the top-k experts per token
-- `cascadia-int4-gemm/` — hand-rolled AVX-512 INT4 GEMM kernels for the MoE expert path
-- `cascadia-ov-genai-shim/` — C++ FFI shim wrapping `openvino-genai`
-- `cascadia-transport/` — TCP activation relay (length-prefixed tensor wire format)
-- `cascadia-topology/` — Per-link latency + bandwidth measurements
-- `cascadia-discovery/` — mDNS peer discovery on `_cascadia._tcp.local.`
+- `cascadia-api/`: OpenAI-compatible HTTP (axum)
+- `cascadia-runner/`: Per-stage runner; concurrent-safe chunk streaming
+- `cascadia-engine/`: `Engine` + `Builder` traits (the plugin seam)
+- `cascadia-engine-openvino/`: Five OV engines (`ov-genai`, `ov-runtime`, `ov-dist-spec`, `gemma4`, `qwen36-moe`)
+- `cascadia-engine-sparse-moe/`: Sparse-MoE engine; routes only the top-k experts per token
+- `cascadia-int4-gemm/`: hand-rolled AVX-512 INT4 GEMM kernels for the MoE expert path
+- `cascadia-ov-genai-shim/`: C++ FFI shim wrapping `openvino-genai`
+- `cascadia-transport/`: TCP activation relay (length-prefixed tensor wire format)
+- `cascadia-topology/`: Per-link latency + bandwidth measurements
+- `cascadia-discovery/`: mDNS peer discovery on `_cascadia._tcp.local.`
 
 ### Cluster status
 
-- **Placement is manual today.** Operators set `--rank` / `--total` / `--listen` / `--next host:port` on each worker. `cascadia discover` browses the LAN, but workers still need explicit ranks — full auto-ring formation is not yet wired into `cascadia worker` (tracked in [#89](https://github.com/labscommunity/cascadia/issues/89)).
-- **Device profiling.** `cascadia profile-devices --model <dir>` benchmarks each OV device (iGPU / NPU / CPU) on a host and writes `device_profile.json` — step 1 toward automatic placement. See [docs/perf/DEVICE_PROFILE.md](docs/perf/DEVICE_PROFILE.md).
+- **Placement is manual today.** Operators set `--rank` / `--total` / `--listen` / `--next host:port` on each worker. `cascadia discover` browses the LAN, but workers still need explicit ranks, full auto-ring formation is not yet wired into `cascadia worker` (tracked in [#89](https://github.com/labscommunity/cascadia/issues/89)).
+- **Device profiling.** `cascadia profile-devices --model <dir>` benchmarks each OV device (iGPU / NPU / CPU) on a host and writes `device_profile.json`, step 1 toward automatic placement. See [docs/perf/DEVICE_PROFILE.md](docs/perf/DEVICE_PROFILE.md).
 - **Tensor parallelism:** type-system plumbing only; no engine implements it yet. See [docs/TENSOR_PARALLELISM.md](docs/TENSOR_PARALLELISM.md).
 
 ## Deploying

--- a/README.md
+++ b/README.md
@@ -13,27 +13,28 @@
 
 ---
 
-Cascadia distributes LLM inference across Intel laptops, desktops, and AI PCs. Shard a model across the machines you already have and serve it through an OpenAI-compatible API — no cloud, no NVIDIA GPUs required.
+Cascadia distributes LLM inference across Intel laptops, desktops, and AI PCs. Shard a model across the machines you already have and serve it through an OpenAI-compatible API. No cloud or NVIDIA GPUs required.
 
 Frontier models don't fit on a single laptop. Cloud APIs are expensive, opaque, and require sending your data offsite. Cascadia lets you point a few Intel machines at each other and run models that none of them could handle alone.
 
 ## Features
 
-- **OpenAI-compatible API** — `/v1/chat/completions` with SSE streaming; point existing clients at it unchanged
-- **Pipeline parallelism** — shard a model into stages and run each stage on a different machine, activations relayed over TCP
-- **Built-in sharder** — `cascadia shard` cuts a HuggingFace model into INT4 per-stage shards; no external tooling
-- **Seven engines** — `mock`, `ov-genai`, `ov-runtime`, `ov-dist-spec` (distributed speculative decoding), `gemma4`, a CPU-targeted `sparse-moe` engine for large mixture-of-experts models like Kimi K2.6 and MiniMax-M2, and `qwen36-moe` for Qwen3.6's hybrid MoE
-- **Single static binary per node** — Rust only at runtime; no Python on workers
-- **Zero-config peer discovery** — `cascadia discover` finds LAN peers over mDNS
-- **`cascadia doctor`** — diagnoses the one failure everyone hits: OpenVINO silently not seeing your GPU
+- **OpenAI-compatible API**: `/v1/chat/completions` with SSE streaming; point existing clients at it unchanged
+- **Pipeline parallelism**: shard a model into stages and run each stage on a different machine, activations relayed over TCP
+- **Built-in sharder**: `cascadia shard` cuts a HuggingFace model into INT4 per-stage shards; no external tooling
+- **Seven engines**: `mock`, `ov-genai`, `ov-runtime`, `ov-dist-spec` (distributed speculative decoding), `gemma4`, a CPU-targeted `sparse-moe` engine for large mixture-of-experts models like Kimi K2.6 and MiniMax-M2, and `qwen36-moe` for Qwen3.6's hybrid MoE
+- **Single static binary per node**: Rust only at runtime; no Python on workers
+- **Zero-config peer discovery**: `cascadia discover` finds LAN peers over mDNS
+- **`cascadia doctor`**: diagnoses the one failure everyone hits: OpenVINO silently not seeing your GPU
 
-**Status: pre-alpha.** Working on Intel AI PCs (Lunar Lake / Arrow Lake / Panther Lake) and Arc B-series (Battlemage) discrete GPUs. Intel Arc A-series discrete GPUs and Xeon CPU-only servers are on the roadmap.
+> [!NOTE]
+> Cascadia is in **pre-alpha status**. It works on Intel AI PCs (Lunar Lake / Arrow Lake / Panther Lake) and Arc B-series (Battlemage) discrete GPUs. Intel Arc A-series discrete GPUs and Xeon CPU-only servers are on the roadmap.
 
 ## Quick start
 
-**On an Intel machine?** Grab a self-contained bundle from [Releases](https://github.com/labscommunity/cascadia/releases) — OpenVINO runtime included, no build, no SDK. Unzip and run `cascadia doctor`.
+**On an Intel machine?** Grab a self-contained bundle from [Releases](https://github.com/labscommunity/cascadia/releases): OpenVINO runtime included, no build, no SDK. Unzip and run `cascadia doctor`.
 
-Or the 5-minute source path — no OpenVINO, works on any machine with Rust:
+Or build from source. You must have Rust installed; OpenVINO isn't required, and Cascadia will mock responses:
 
 ```bash
 cargo build --release -p cascadia
@@ -48,11 +49,13 @@ curl http://localhost:8000/v1/chat/completions -d '{
 }'
 ```
 
-A JSON chat-completion back means the full path (API → engine → streaming) works. **[QUICKSTART.md](QUICKSTART.md)** walks this through, then real inference.
+If you receive a JSON chat-completion back, it means the full path (API → engine → streaming) works.
+
+There are follow-up steps for performing real inference in **[QUICKSTART.md](QUICKSTART.md)**.
 
 ## Installation
 
-**Prebuilt bundles** for Linux and Windows x86_64 are on the [Releases page](https://github.com/labscommunity/cascadia/releases) — binary + OpenVINO runtime libraries, ready to run. Building from source instead has two modes:
+**Prebuilt bundles** for Linux and Windows x86_64 are on the [Releases page](https://github.com/labscommunity/cascadia/releases): binary + OpenVINO runtime libraries, ready to run. Building from source instead has two modes:
 
 ```bash
 # Stub mode — Rust only. Good for dev / CI on macOS / Linux / Windows.
@@ -65,9 +68,14 @@ INTEL_OPENVINO_DIR=/path/to/openvino_genai_<platform>_2026.2.0.0 \
   cargo build --release -p cascadia --features openvino
 ```
 
-Prerequisites: Rust 1.85+; for `--features openvino`, a C++ toolchain (VS 2022 Build Tools on Windows, `g++` ≥ 12 on Linux) plus the OpenVINO GenAI SDK. **[INSTALL.md](INSTALL.md)** has download links, the Linux GPU-runtime steps (`./scripts/setup-openvino.sh` automates them), and the Docker image.
+Prerequisites: 
+- Rust 1.85+; for `--features openvino`
+- A C++ toolchain (VS 2022 Build Tools on Windows, `g++` ≥ 12 on Linux) and the OpenVINO GenAI SDK
 
-> After building, run **`cascadia doctor`**. On Intel AI PCs the GPU can be invisible to OpenVINO even with a working driver, and that failure is otherwise silent — you just get slow CPU inference. `doctor` makes it loud and tells you how to fix it.
+**[INSTALL.md](INSTALL.md)** has download links, the Linux GPU-runtime steps (`./scripts/setup-openvino.sh` automates them), and the Docker image.
+
+> [!IMPORTANT]
+> After building, run **`cascadia doctor`**. On Intel AI PCs, the GPU can be invisible to OpenVINO even with a working driver. That failure is otherwise silent (you would just get slow CPU inference). `doctor` detects the problem and tells you how to fix it.
 
 ## Usage
 
@@ -164,19 +172,19 @@ Cascadia is a Cargo workspace; one concern per crate. The `Engine` + `Builder` t
 
 ## Deploying
 
-Cascadia does not daemonize itself — run it under systemd / NSSM / launchd. See [`docs/deploy/`](docs/deploy/) for a systemd unit template and Windows / macOS recipes. Cascadia handles `SIGTERM` cleanly.
+Cascadia does not daemonize itself, so it needs to be ran under systemd / NSSM / launchd. See [`docs/deploy/`](docs/deploy/) for a systemd unit template and Windows / macOS recipes. Cascadia handles `SIGTERM` cleanly.
 
 **Security**: the HTTP API and inter-stage TCP relay are plaintext and unauthenticated. Bind only to trusted networks (LAN, loopback) or terminate TLS + auth at a reverse proxy in front of `--api`. See [SECURITY.md](SECURITY.md) for the threat model and built-in hardening.
 
 ## Troubleshooting
 
-**`config.json not in <model dir>`** — `ov-runtime` reads the HF model `config.json` from the shard's tokenizer dir to derive rotary parameters. Older shard exports may not bundle `config.json`; copy it from the source model's HF cache (`~/.cache/huggingface/hub/models--<repo>/snapshots/<sha>/config.json`) into the shards root. Shards produced by `cascadia shard` bundle it automatically.
+`config.json not in <model dir>`**: `ov-runtime` reads the HF model `config.json` from the shard's tokenizer dir to derive rotary parameters. Older shard exports may not bundle `config.json`; copy it from the source model's HF cache (`~/.cache/huggingface/hub/models--<repo>/snapshots/<sha>/config.json`) into the shards root. Shards produced by `cascadia shard` bundle it automatically.
 
-**`could not connect to … within 30s`** — Start the downstream worker first; check `--listen` on the downstream matches `--next` on the upstream and that the host's firewall allows the port.
+**`could not connect to … within 30s`**: start the downstream worker first; check `--listen` on the downstream matches `--next` on the upstream and that the host's firewall allows the port.
 
-**Worker dies silently when SSH session closes** — On Windows OpenSSH the child process is tied to the SSH parent. Run workers under systemd / NSSM / Task Scheduler in production.
+**Worker dies silently when SSH session closes**: on Windows OpenSSH the child process is tied to the SSH parent. Run workers under systemd / NSSM / Task Scheduler in production.
 
-`cascadia doctor` diagnoses most environment/hardware issues before they bite.
+`cascadia doctor` diagnoses most other environment/hardware issues.
 
 ## Documentation
 
@@ -193,8 +201,10 @@ Cascadia does not daemonize itself — run it under systemd / NSSM / launchd. Se
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the build/test gate, crate layout, and commit conventions. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the build/test gate, crate layout, and commit conventions.
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-Apache-2.0 — see [LICENSE](LICENSE). Third-party attributions are in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+Apache-2.0 (see [LICENSE](LICENSE)). Third-party attributions are in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).


### PR DESCRIPTION
## Summary

Cleans up some of the `README.md`: removes excessive em-dashes, clarifies a few points around installation, adds some GitHub alert formatting for callouts and important information.

## Checklist

- [ ] `just check` passes locally (see [CONTRIBUTING.md](https://github.com/labscommunity/cascadia/blob/main/CONTRIBUTING.md) for the by-hand equivalent)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …), one logical change per commit
- [ ] If this touches an OV engine: tested on real Intel hardware (say which, and which OpenVINO version) — CI only covers stub mode
