### PR TITLE
fix: build, CLI and docs bugs found by running every documented command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ touch the OpenVINO stack. For real inference, **[INSTALL.md](INSTALL.md)**
 covers the OpenVINO SDK + GPU runtime.
 
 ```bash
-cargo build --release -p cascadia    # stub mode
-cascadia doctor                       # sanity-check your environment
+cargo build --release -p cascadia     # stub mode
+./target/release/cascadia doctor      # sanity-check your environment
 ```
 
 ## Repo layout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "half",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokenizers",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [workspace.package]
 version = "0.1.1" # x-release-please-version
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.89"
 license = "Apache-2.0"
 repository = "https://github.com/labscommunity/cascadia"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,21 +75,27 @@ FROM ubuntu:24.04 AS openvino
 #
 # From Intel's repo, not the distro: Ubuntu ships Compute Runtime 23.43 and
 # Debian 22.43, both older than the hardware cascadia targets (Lunar Lake, Arc
-# B). Intel publishes that repo for Ubuntu only — hence the Ubuntu base.
+# B). Use the `unified` component — `client` is stuck on 24.39, older than
+# Battlemage support (24.48). Intel publishes for Ubuntu only: hence this base.
+ARG INTEL_KEY_FPR=E0258B57D9C442D5DB1855C271740E4DE392BFE3
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates gnupg wget \
+    # Verify the key's fingerprint before trusting it as an apt anchor.
     && wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
-         | gpg --yes --dearmor -o /usr/share/keyrings/intel-graphics.gpg \
+         | gpg --dearmor > /tmp/intel.gpg \
+    && gpg --show-keys --with-colons /tmp/intel.gpg | awk -F: '/^fpr:/{print $10}' \
+         | grep -qx "$INTEL_KEY_FPR" \
+    && install -m 0644 /tmp/intel.gpg /usr/share/keyrings/intel-graphics.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
-https://repositories.intel.com/gpu/ubuntu noble client" \
+https://repositories.intel.com/gpu/ubuntu noble unified" \
          > /etc/apt/sources.list.d/intel-gpu.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         ocl-icd-libopencl1 intel-opencl-icd libze-intel-gpu1 libze1 \
     # Don't leave Intel's repo (or the tools that added it) in the shipped image:
     # anything built FROM this would silently inherit it as a trusted apt source.
     && apt-get purge -y --auto-remove gnupg wget \
-    && rm -f /etc/apt/sources.list.d/intel-gpu.list \
+    && rm -f /etc/apt/sources.list.d/intel-gpu.list /usr/share/keyrings/intel-graphics.gpg /tmp/intel.gpg \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build-openvino /opt/intel/openvino/runtime/lib/intel64 /opt/intel/openvino/runtime/lib/intel64
 # TBB ships beside the runtime, not inside it — copy the SDK's own build rather

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,30 +3,40 @@
 # GPU) becomes `docker run` instead of a multi-package host install.
 #
 # This is a REFERENCE image, not a CI-tested artifact: GPU inference needs
-# the host's Intel GPU passed into the container (`--device /dev/dri`) and
-# a host driver new enough to match the in-image compute-runtime. CPU/stub
-# use works anywhere. Pin OPENVINO_URL to the GenAI archive you want.
+# the host's Intel GPU passed into the container and a host driver new enough
+# to match the in-image compute-runtime. CPU/stub use works anywhere.
+#
+# The `openvino` target is x86_64-only (the SDK archive and Intel's drivers are
+# amd64); `stub` builds on any arch. GPU passthrough is `--device /dev/dri` on
+# Linux; under WSL2 it is `--device /dev/dxg -v /usr/lib/wsl:/usr/lib/wsl`, and
+# the NPU is not exposed to containers at all.
 #
 # Build (stub, no OpenVINO):
 #   docker build --target stub -t cascadia:stub .
-# Build (real OpenVINO):
+# Build (real OpenVINO). Use the ubuntu22 archive: the builder below is Debian
+# bookworm (glibc 2.36) and the ubuntu24 build of OpenVINO imports GLIBC_2.38
+# symbols, so it cannot be linked here. The ubuntu22 libs run fine on the
+# Ubuntu 24.04 runtime image.
 #   docker build --target openvino \
-#     --build-arg OPENVINO_URL=https://storage.openvinotoolkit.org/.../openvino_genai_ubuntu24_2026.2.0.0_x86_64.tar.gz \
+#     --build-arg OPENVINO_URL=https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.2/linux/openvino_genai_ubuntu22_2026.2.0.0_x86_64.tar.gz \
 #     -t cascadia:ov .
-# Run (GPU):
-#   docker run --rm --device /dev/dri -p 8000:8000 cascadia:ov \
-#     run unsloth/Meta-Llama-3.1-8B-Instruct
+# Run (GPU). Mount a model directory — cascadia serves pre-exported models
+# from disk (an OpenVINO IR, or a `cascadia shard` tree); it does not download
+# or convert at run time:
+#   docker run --rm --device /dev/dri -p 8000:8000 -v ~/models:/models \
+#     cascadia:ov run /models/llama-3.1-8b-int4-ov
 
 # ── builder ──────────────────────────────────────────────────────────────
-FROM rust:1.82-bookworm AS builder
+FROM rust:1.89-bookworm AS builder
 WORKDIR /src
 
 # OpenVINO GenAI SDK archive URL. Override with --build-arg. Empty = stub.
 ARG OPENVINO_URL=""
 
-# C++ toolchain for the FFI shim.
+# C++ toolchain for the FFI shim. The OpenCL loader is needed at LINK time too:
+# libopenvino_genai.so imports OpenCL, so without it the final link fails.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        g++ cmake curl ca-certificates \
+        g++ curl ca-certificates ocl-icd-libopencl1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Fetch + unpack the OpenVINO GenAI SDK if a URL was given.
@@ -43,9 +53,13 @@ COPY . .
 FROM builder AS build-stub
 RUN cargo build --release -p cascadia
 
-# openvino target — links against the bundled SDK.
+# openvino target — links against the bundled SDK. TBB lives outside
+# runtime/lib/intel64 and libopenvino.so imports it, so it must be on the
+# linker's search path.
 FROM builder AS build-openvino
 RUN INTEL_OPENVINO_DIR=/opt/intel/openvino \
+    LIBRARY_PATH=/opt/intel/openvino/runtime/3rdparty/tbb/lib:/opt/intel/openvino/runtime/lib/intel64 \
+    LD_LIBRARY_PATH=/opt/intel/openvino/runtime/3rdparty/tbb/lib:/opt/intel/openvino/runtime/lib/intel64 \
         cargo build --release -p cascadia --features openvino
 
 # ── runtime: stub ─────────────────────────────────────────────────────────
@@ -55,15 +69,33 @@ ENTRYPOINT ["cascadia"]
 CMD ["doctor"]
 
 # ── runtime: openvino (GPU) ────────────────────────────────────────────────
-FROM debian:bookworm-slim AS openvino
-# Intel GPU runtime: OpenCL ICD + Level-Zero + Compute Runtime. Without
-# these the OpenVINO GPU plugin silently sees only the CPU.
+FROM ubuntu:24.04 AS openvino
+# Intel GPU runtime: OpenCL ICD + Compute Runtime (+ Level-Zero for NPU).
+# Without these the OpenVINO GPU plugin silently sees only the CPU.
+#
+# From Intel's repo, not the distro: Ubuntu ships Compute Runtime 23.43 and
+# Debian 22.43, both older than the hardware cascadia targets (Lunar Lake, Arc
+# B). Intel publishes that repo for Ubuntu only — hence the Ubuntu base.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ocl-icd-libopencl1 intel-opencl-icd intel-level-zero-gpu level-zero \
-        libtbb12 ca-certificates \
+        ca-certificates gnupg wget \
+    && wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
+         | gpg --yes --dearmor -o /usr/share/keyrings/intel-graphics.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+https://repositories.intel.com/gpu/ubuntu noble client" \
+         > /etc/apt/sources.list.d/intel-gpu.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        ocl-icd-libopencl1 intel-opencl-icd libze-intel-gpu1 libze1 \
+    # Don't leave Intel's repo (or the tools that added it) in the shipped image:
+    # anything built FROM this would silently inherit it as a trusted apt source.
+    && apt-get purge -y --auto-remove gnupg wget \
+    && rm -f /etc/apt/sources.list.d/intel-gpu.list \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build-openvino /opt/intel/openvino/runtime/lib/intel64 /opt/intel/openvino/runtime/lib/intel64
+# TBB ships beside the runtime, not inside it — copy the SDK's own build rather
+# than apt's libtbb12, which is a different oneTBB than OpenVINO was built with.
+COPY --from=build-openvino /opt/intel/openvino/runtime/3rdparty/tbb/lib /opt/intel/openvino/runtime/3rdparty/tbb/lib
 COPY --from=build-openvino /src/target/release/cascadia /usr/local/bin/cascadia
-ENV LD_LIBRARY_PATH=/opt/intel/openvino/runtime/lib/intel64
+ENV LD_LIBRARY_PATH=/opt/intel/openvino/runtime/lib/intel64:/opt/intel/openvino/runtime/3rdparty/tbb/lib
 ENTRYPOINT ["cascadia"]
 CMD ["doctor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,15 +77,18 @@ FROM ubuntu:24.04 AS openvino
 # Debian 22.43, both older than the hardware cascadia targets (Lunar Lake, Arc
 # B). Use the `unified` component — `client` is stuck on 24.39, older than
 # Battlemage support (24.48). Intel publishes for Ubuntu only: hence this base.
-ARG INTEL_KEY_FPR=E0258B57D9C442D5DB1855C271740E4DE392BFE3
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates gnupg wget \
-    # Verify the key's fingerprint before trusting it as an apt anchor.
     && wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
          | gpg --dearmor > /tmp/intel.gpg \
-    && gpg --show-keys --with-colons /tmp/intel.gpg | awk -F: '/^fpr:/{print $10}' \
-         | grep -qx "$INTEL_KEY_FPR" \
+    # Pin the exact SET of primary keys Intel ships (current + its 2024
+    # predecessor). Asking only whether the keyring CONTAINS a pinned key is not
+    # enough: a keyring is a concatenation, so whoever controls the URL could
+    # append their own key and apt would trust that one too.
+    && [ "$(gpg --show-keys --with-colons /tmp/intel.gpg \
+              | awk -F: '$1=="pub"{p=1;next} $1=="fpr"&&p{print $10;p=0}' | sort | tr '\n' ' ')" \
+         = "4E9EFCDEF82800256C1E7C64B02DB9BD8C321DCB E0258B57D9C442D5DB1855C271740E4DE392BFE3 " ] \
     && install -m 0644 /tmp/intel.gpg /usr/share/keyrings/intel-graphics.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
 https://repositories.intel.com/gpu/ubuntu noble unified" \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,9 +17,11 @@ After any install, run **`cascadia doctor`** — it checks your toolchain and te
 Each [GitHub Release](https://github.com/labscommunity/cascadia/releases) ships self-contained bundles with the OpenVINO runtime included — no SDK install, no `INTEL_OPENVINO_DIR`:
 
 - **Windows** — `cascadia-<ver>-windows-x86_64.zip`: unzip, run `cascadia.exe doctor`. Needs only a current Intel graphics driver (the OpenCL/GPU runtime ships inside it).
-- **Linux** — `cascadia-<ver>-linux-x86_64.tar.gz`: untar, run `./cascadia doctor`. Bundled libraries load from `lib/` beside the binary. Needs glibc 2.35+ (Ubuntu 22.04 or newer) and, for GPU inference, the Intel GPU runtime stack below (`./scripts/setup-openvino.sh`).
+- **Linux** — `cascadia-<ver>-linux-x86_64.tar.gz`: untar, run `./cascadia doctor`. Bundled libraries load from `lib/` beside the binary. Needs glibc 2.35+ (Ubuntu 22.04 or newer) and, for GPU inference, the Intel GPU runtime stack below (the bundle has no scripts — use the `apt-get` block, or `scripts/setup-openvino.sh` from a source checkout).
 
-Python is not needed to run anything — only `cascadia shard` uses it (see "Export-time Python" below).
+The binary is not installed on your PATH — run it as `./cascadia` from the unpacked directory, or add that directory to PATH.
+
+Python is not needed for inference. It is needed only for `cascadia shard` — which works from the prebuilt binary too: the Python exporters are compiled into it and extracted at run time (see "Export-time Python" below).
 
 ---
 
@@ -28,7 +30,7 @@ Python is not needed to run anything — only `cascadia shard` uses it (see "Exp
 The fast path. Builds on macOS / Linux / Windows with nothing but Rust. The OpenVINO-backed engines return a clean runtime error; the `mock` engine works, so you can exercise the full API, transport, and multi-stage plumbing.
 
 ```bash
-rustup default stable        # need 1.85+
+rustup default stable        # need 1.89+
 cargo build --release -p cascadia
 ./target/release/cascadia doctor
 ```
@@ -43,8 +45,14 @@ Three things have to be in place. `cascadia doctor` verifies all three.
 
 The FFI shim (`cascadia-ov-genai-shim`) compiles C++ against the OpenVINO GenAI headers.
 
-- **Linux:** `g++` ≥ 12 (`sudo apt install g++`)
+- **Linux:** `g++` ≥ 12 (`sudo apt install g++`) **and an OpenCL loader** (`sudo apt install ocl-icd-libopencl1`) — `libopenvino_genai.so` imports OpenCL, so the final link fails without it.
 - **Windows:** Visual Studio 2022 Build Tools; build from a *Developer Command Prompt for VS 2022*
+
+The SDK keeps TBB outside `runtime/lib/intel64`. If the link fails on `tbb::detail::…`, put it on the linker's search path:
+
+```bash
+export LIBRARY_PATH="$INTEL_OPENVINO_DIR/runtime/3rdparty/tbb/lib:$INTEL_OPENVINO_DIR/runtime/lib/intel64"
+```
 
 ### 2. OpenVINO GenAI SDK
 
@@ -65,20 +73,32 @@ export INTEL_OPENVINO_DIR=/opt/intel/openvino_genai_2026.2.0.0
 
 This is the step most people miss. OpenVINO GPU inference is **not** a single install — the GPU plugin needs the Intel Compute Runtime, OpenCL ICD, and Level-Zero loader, and your user must be in the `render` group. **Without these, OpenVINO silently sees only the CPU**, even with a working driver and a healthy `clinfo`.
 
-Run the helper (Ubuntu 22.04 / 24.04):
+From a source checkout, run the helper (Ubuntu 22.04 / 24.04):
 
 ```bash
 ./scripts/setup-openvino.sh
 ```
 
-…or do it by hand:
+It adds Intel's graphics repo and installs the current driver. Use the repo, not the distro packages: Ubuntu 24.04 ships Compute Runtime 23.43, which predates Lunar Lake and Arc B — on that hardware OpenVINO may see no GPU at all.
+
+From a release bundle (no `scripts/`), do the same by hand:
 
 ```bash
-sudo apt-get install -y ocl-icd-libopencl1 intel-opencl-icd intel-level-zero-gpu level-zero
+sudo apt-get install -y ca-certificates gnupg wget
+wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
+  | sudo gpg --yes --dearmor -o /usr/share/keyrings/intel-graphics.gpg
+. /etc/os-release   # noble on 24.04, jammy on 22.04
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+https://repositories.intel.com/gpu/ubuntu $UBUNTU_CODENAME client" \
+  | sudo tee /etc/apt/sources.list.d/intel-gpu.list
+sudo apt-get update
+sudo apt-get install -y ocl-icd-libopencl1 intel-opencl-icd libze-intel-gpu1 libze1
 sudo usermod -a -G render "$USER"   # then LOG OUT/IN — group changes don't apply to the current shell
 ```
 
-On **Windows** the OpenCL runtime ships inside the Intel graphics driver, so just install the latest driver and reboot. `scripts/setup-openvino.ps1` checks your driver, MSVC, and SDK env.
+Intel publishes that repo for Ubuntu only. On other distros install the equivalents by hand; older Compute Runtimes may not enumerate recent Intel GPUs.
+
+On **Windows** the OpenCL runtime ships inside the Intel graphics driver, so just install the latest driver and reboot. `scripts/setup-openvino.ps1` (source checkout) checks your driver, MSVC, and SDK env.
 
 On **macOS** there is no Intel GPU runtime — use stub mode for dev only.
 
@@ -91,7 +111,7 @@ INTEL_OPENVINO_DIR=/opt/intel/openvino_genai_2026.2.0.0 \
 ./target/release/cascadia doctor   # should list a GPU device, not just CPU
 ```
 
-The binary is statically linked apart from the OpenVINO dynamic libraries. To run it elsewhere, copy the binary plus `INTEL_OPENVINO_DIR/runtime/lib/intel64/` (Linux) or `runtime/bin/intel64/Release/` + `runtime/3rdparty/tbb/bin/` (Windows) onto the target's library path.
+The binary is statically linked apart from the OpenVINO dynamic libraries. To run it elsewhere, copy the binary plus `INTEL_OPENVINO_DIR/runtime/lib/intel64/` **and** `runtime/3rdparty/tbb/lib/` (Linux), or `runtime/bin/intel64/Release/` + `runtime/3rdparty/tbb/bin/` (Windows), onto the target's library path. TBB ships beside the runtime, not inside it, and `libopenvino` imports it.
 
 ---
 
@@ -100,10 +120,14 @@ The binary is statically linked apart from the OpenVINO dynamic libraries. To ru
 Sharding a HuggingFace model into per-stage IRs runs a bundled Python exporter. This is needed **only** when you run `cascadia shard` — not at inference time, and not on workers. Install once, anywhere with the RAM:
 
 ```bash
-pip install torch transformers openvino safetensors huggingface_hub nncf
+pip install -r tools/requirements.txt   # from a source checkout
 ```
 
-`nncf` is optional (INT4 quantization); without it, sharding falls back to FP16. `cascadia doctor` reports whether these are present.
+From a release bundle there is no `tools/` directory: run `cascadia doctor` (or `cascadia shard`) and it prints the exact pinned `pip install` line for the exporter compiled into that binary.
+
+`nncf` is optional (INT4 quantization); without it, sharding falls back to FP16 — `cascadia shard` warns when it is missing. `cascadia doctor` reports whether the core export packages (torch / openvino / transformers) are present.
+
+Exporting a **whole-model** IR for `--engine ov-genai` is a different job and uses Intel's exporter, not this one — `pip install "optimum-intel[openvino]"`, see [docs/engines/ov-genai.md](docs/engines/ov-genai.md).
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,7 @@ sudo apt-get install -y ocl-icd-libopencl1 intel-opencl-icd libze-intel-gpu1 lib
 sudo usermod -a -G render "$USER"   # then LOG OUT/IN — group changes don't apply to the current shell
 ```
 
-Intel publishes that repo for Ubuntu only. On other distros install the equivalents by hand; older Compute Runtimes may not enumerate recent Intel GPUs.
+The same package names work on 22.04 (jammy) and 24.04 (noble) from Intel's repo. Intel publishes it for Ubuntu only; on other distros install the equivalents by hand, and note that older Compute Runtimes may not enumerate recent Intel GPUs.
 
 On **Windows** the OpenCL runtime ships inside the Intel graphics driver, so just install the latest driver and reboot. `scripts/setup-openvino.ps1` (source checkout) checks your driver, MSVC, and SDK env.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,7 +89,7 @@ wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
   | sudo gpg --yes --dearmor -o /usr/share/keyrings/intel-graphics.gpg
 . /etc/os-release   # noble on 24.04, jammy on 22.04
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
-https://repositories.intel.com/gpu/ubuntu $UBUNTU_CODENAME client" \
+https://repositories.intel.com/gpu/ubuntu $UBUNTU_CODENAME unified" \
   | sudo tee /etc/apt/sources.list.d/intel-gpu.list
 sudo apt-get update
 sudo apt-get install -y ocl-icd-libopencl1 intel-opencl-icd libze-intel-gpu1 libze1

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -102,6 +102,7 @@ node. Use `cascadia discover` to find peers' addresses on your LAN.
 ## Where to go next
 
 - **[INSTALL.md](INSTALL.md)** — full setup, OpenVINO, Docker.
+- **[docs/CLI.md](docs/CLI.md)** — every command and flag.
 - **[docs/SHARDING.md](docs/SHARDING.md)** — supported models, picking stage counts.
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — building, testing, the crate layout.
 - `cascadia <command> --help` — every command is self-documenting.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,7 +1,15 @@
 # Quickstart
 
-Two paths: a 5-minute stub run that works on any machine, and the real
-thing on Intel hardware. If you just cloned the repo, start here.
+First, how you got `cascadia` decides what you need:
+
+| You have | To run real models you need | Start at |
+|---|---|---|
+| A **release bundle** ([Releases](https://github.com/labscommunity/cascadia/releases)) | nothing to build — the OpenVINO runtime is inside it (on Linux, GPU inference still needs the Intel GPU runtime stack: [INSTALL.md](INSTALL.md)) | [§2](#2-real-inference-on-one-intel-machine) (skip the build) |
+| A **clone of the repo** | Rust; plus the OpenVINO GenAI SDK + a C++ toolchain for real inference ([INSTALL.md](INSTALL.md)) | [§1](#1-five-minutes-no-openvino-works-anywhere) |
+
+From a bundle, run the binary from inside the unpacked directory (`./cascadia`,
+or `.\cascadia.exe` on Windows) — it is not on your PATH. Everything below is
+written as `cascadia …`.
 
 ---
 
@@ -25,7 +33,9 @@ cargo build --release -p cascadia
 In another terminal:
 
 ```bash
-curl http://localhost:8000/v1/chat/completions -d '{
+curl http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
   "model": "mock-model",
   "messages": [{"role": "user", "content": "Capital of France?"}]
 }'
@@ -38,23 +48,41 @@ request path working end to end. ✅
 
 ## 2. Real inference on one Intel machine
 
-First get OpenVINO set up — see **[INSTALL.md](INSTALL.md)** (C++ toolchain,
-the GenAI SDK, and on Linux the GPU runtime stack). Then:
+**From a release bundle?** Skip straight to `cascadia doctor` below — the
+OpenVINO runtime ships inside the bundle, so there is nothing to build and no
+SDK to install.
+
+**Building from source?** Get OpenVINO set up first — see
+**[INSTALL.md](INSTALL.md)** (C++ toolchain, the GenAI SDK, and on Linux the
+GPU runtime stack) — then build with the feature enabled:
 
 ```bash
 INTEL_OPENVINO_DIR=/path/to/openvino_genai_2026.2.0.0 \
   cargo build --release -p cascadia --features openvino
+```
 
+Either way, from here on it's the same:
+
+```bash
 # Confirm OpenVINO can see your GPU (not just CPU):
 cascadia doctor
 
-# Run a real model (auto-downloads from HuggingFace on first use,
-# cached under ~/.cache/cascadia/models/):
-cascadia run unsloth/Meta-Llama-3.1-8B-Instruct
+# Export a model to a 1-stage INT4 shard. Cascadia serves models from
+# disk — it does not download or convert at run time. `cascadia shard`
+# is what fetches from HuggingFace (needs the export deps, see INSTALL.md).
+cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
+             --output-dir ~/cascadia/llama-8b-1stage \
+             --num-stages 1 --quantization int4
+
+cascadia run ~/cascadia/llama-8b-1stage --engine ov-runtime --device GPU
 ```
 
-The model is fetched once and cached; subsequent runs are fast. Hit the
-same `:8000` endpoint as above.
+The export runs once; subsequent starts hit the OpenVINO kernel cache and
+are fast. Hit the same `:8000` endpoint as above.
+
+> Already have a whole-model OpenVINO IR (e.g. a pre-exported `*-int4-ov`
+> directory)? Point `cascadia run <dir>` at it and it serves through the
+> `ov-genai` engine — see [docs/engines/ov-genai.md](docs/engines/ov-genai.md).
 
 > `cascadia run` is single-machine sugar — it picks the `ov-genai` engine,
 > `GPU` device, and an API on `:8000`. For full control use `cascadia

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Prerequisites:
 
 ## Usage
 
+Every command and flag is catalogued in [docs/CLI.md](docs/CLI.md).
+
 ### Single machine
 
 Cascadia serves models from a local directory — it does not download or convert at run time. Only `cascadia shard` fetches from HuggingFace (caching under `~/.cache/cascadia/models/`). Export once, then serve:
@@ -221,6 +223,7 @@ Cascadia does not daemonize itself, so it needs to be run under systemd / NSSM /
 |---|---|
 | [QUICKSTART.md](QUICKSTART.md) | 5-minute stub run → real inference |
 | [INSTALL.md](INSTALL.md) | Full setup: OpenVINO SDK, GPU runtime, Docker |
+| [docs/CLI.md](docs/CLI.md) | Every command and flag |
 | [docs/SHARDING.md](docs/SHARDING.md) | Sharding flow + per-model-family support table |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Design decisions + crate responsibilities |
 | [docs/engines/](docs/engines/) | Per-engine deep dives |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Prerequisites:
 Cascadia serves models from a local directory — it does not download or convert at run time. Only `cascadia shard` fetches from HuggingFace (caching under `~/.cache/cascadia/models/`). Export once, then serve:
 
 ```bash
-# Export to a 1-stage INT4 shard (export deps: see Installation below).
+# Export to a 1-stage INT4 shard (export deps: see Installation above).
 cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
              --output-dir ~/cascadia/llama-8b-1stage \
              --num-stages 1 --quantization int4
@@ -155,7 +155,7 @@ cascadia worker --rank 0 --total 2 --engine ov-runtime --device GPU \
 
 Not sure of a node's address? `cascadia discover` lists Cascadia peers on the LAN and the `host:port` to pass to `--next`.
 
-Add `--engine ov-dist-spec --draft-model ~/models/llama-3.2-1b-int4-ov --spec-k 4` on rank 0 (the draft is a local OpenVINO IR directory, not an HF id) for distributed speculative decoding ([docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
+For distributed speculative decoding, run **every** rank with `--engine ov-dist-spec` (they share a wire protocol) and give rank 0 `--draft-model ~/models/llama-3.2-1b-int4-ov --spec-k 4` — the draft is a local OpenVINO IR directory, not an HF id. See ([docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
 
 ### Engines
 
@@ -209,7 +209,7 @@ Cascadia does not daemonize itself, so it needs to be run under systemd / NSSM /
 
 **`config.json not in <model dir>`**: `ov-runtime` reads the HF model `config.json` from the shard's tokenizer dir to derive rotary parameters. Older shard exports may not bundle `config.json`; copy it from the source model's HF cache (`~/.cache/huggingface/hub/models--<repo>/snapshots/<sha>/config.json`) into the shards root. Shards produced by `cascadia shard` bundle it automatically.
 
-**`could not connect to … within 30s`**: start the downstream worker first; check `--listen` on the downstream matches `--next` on the upstream and that the host's firewall allows the port.
+**`could not connect to downstream peer within timeout`** (engines wait 60 s): start the downstream worker first; check `--listen` on the downstream matches `--next` on the upstream and that the host's firewall allows the port.
 
 **Worker dies silently when SSH session closes**: on Windows OpenSSH the child process is tied to the SSH parent. Run workers under systemd / NSSM / Task Scheduler in production.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/labscommunity/cascadia/actions/workflows/ci.yml"><img src="https://github.com/labscommunity/cascadia/actions/workflows/ci.yml/badge.svg" alt="ci"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="license"></a>
-  <img src="https://img.shields.io/badge/rust-1.85%2B-orange.svg" alt="rust 1.85+">
+  <img src="https://img.shields.io/badge/rust-1.89%2B-orange.svg" alt="rust 1.89+">
   <img src="https://img.shields.io/badge/status-pre--alpha-red.svg" alt="pre-alpha">
 </p>
 
@@ -32,7 +32,22 @@ Frontier models don't fit on a single laptop. Cloud APIs are expensive, opaque, 
 
 ## Quick start
 
-**On an Intel machine?** Grab a self-contained bundle from [Releases](https://github.com/labscommunity/cascadia/releases): OpenVINO runtime included, no build, no SDK. Unzip and run `cascadia doctor`.
+**On an Intel machine?** Grab a self-contained bundle from [Releases](https://github.com/labscommunity/cascadia/releases): OpenVINO runtime included, no build, no SDK. Unpack it and run the binary from inside — it is not installed on your PATH:
+
+```bash
+# Linux
+tar -xzf cascadia-<ver>-linux-x86_64.tar.gz && cd cascadia-<ver>-linux-x86_64
+./cascadia doctor
+```
+
+```powershell
+# Windows
+Expand-Archive cascadia-<ver>-windows-x86_64.zip -DestinationPath .
+cd cascadia-<ver>-windows-x86_64
+.\cascadia.exe doctor
+```
+
+That's the whole install: no Rust, no OpenVINO SDK, no `INTEL_OPENVINO_DIR`. Commands below are written as `cascadia …`; from a bundle use `./cascadia` (`.\cascadia.exe` on Windows), or add the directory to your PATH.
 
 Or build from source. You must have Rust installed; OpenVINO isn't required, and Cascadia will mock responses:
 
@@ -43,7 +58,9 @@ cargo build --release -p cascadia
 ```
 
 ```bash
-curl http://localhost:8000/v1/chat/completions -d '{
+curl http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
   "model": "mock-model",
   "messages": [{"role": "user", "content": "Capital of France?"}]
 }'
@@ -69,10 +86,10 @@ INTEL_OPENVINO_DIR=/path/to/openvino_genai_<platform>_2026.2.0.0 \
 ```
 
 Prerequisites: 
-- Rust 1.85+; for `--features openvino`
+- Rust 1.89+; for `--features openvino`
 - A C++ toolchain (VS 2022 Build Tools on Windows, `g++` ≥ 12 on Linux) and the OpenVINO GenAI SDK
 
-**[INSTALL.md](INSTALL.md)** has download links, the Linux GPU-runtime steps (`./scripts/setup-openvino.sh` automates them), and the Docker image.
+**[INSTALL.md](INSTALL.md)** has download links, the Linux GPU-runtime steps (`scripts/setup-openvino.sh` automates them from a source checkout), and the Docker image.
 
 > [!IMPORTANT]
 > After building, run **`cascadia doctor`**. On Intel AI PCs, the GPU can be invisible to OpenVINO even with a working driver. That failure is otherwise silent (you would just get slow CPU inference). `doctor` detects the problem and tells you how to fix it.
@@ -81,18 +98,29 @@ Prerequisites:
 
 ### Single machine
 
+Cascadia serves models from a local directory — it does not download or convert at run time. Only `cascadia shard` fetches from HuggingFace (caching under `~/.cache/cascadia/models/`). Export once, then serve:
+
 ```bash
-# `run` is single-machine sugar, picks the ov-genai engine, GPU device,
-# and an OpenAI API on :8000. The model is fetched from HuggingFace on
-# first use and cached under ~/.cache/cascadia/models/.
-cascadia run unsloth/Meta-Llama-3.1-8B-Instruct
+# Export to a 1-stage INT4 shard (export deps: see Installation below).
+cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
+             --output-dir ~/cascadia/llama-8b-1stage \
+             --num-stages 1 --quantization int4
+
+# `run` is single-machine sugar: one stage, OpenAI API on :8000.
+cascadia run ~/cascadia/llama-8b-1stage --engine ov-runtime --device GPU
+```
+
+Or serve a whole-model **OpenVINO IR** through the `ov-genai` engine, which adds FastDraft speculative decode and prompt-lookup. That layout comes from Intel's exporter, not `cascadia shard` — download a pre-exported INT4 IR (Intel publishes many under the [OpenVINO](https://huggingface.co/OpenVINO) org) or build one with `optimum-cli`, see [docs/engines/ov-genai.md](docs/engines/ov-genai.md):
+
+```bash
+cascadia run ~/models/llama-3.1-8b-int4-ov   # defaults to --engine ov-genai --device GPU
 ```
 
 For full control over engine, device, ports, and the speculative / sparsity knobs, use `cascadia worker` (`cascadia worker --help`):
 
 ```bash
 cascadia worker --rank 0 --total 1 --engine ov-genai --device GPU \
-              --model unsloth/Meta-Llama-3.1-8B-Instruct \
+              --model ~/models/llama-3.1-8b-int4-ov \
               --api :8000
 ```
 
@@ -101,8 +129,9 @@ cascadia worker --rank 0 --total 1 --engine ov-genai --device GPU \
 Shard once, on whichever machine has the RAM and a Python install:
 
 ```bash
-# Export-time deps (~3 GB; not needed at runtime):
-pip install torch transformers openvino safetensors huggingface_hub nncf
+# Export-time deps (~3 GB; not needed at runtime). From a source checkout:
+pip install -r tools/requirements.txt
+# From a release bundle there is no tools/ — `cascadia doctor` prints the pinned line.
 
 # Shard a HuggingFace model into 2 stages with INT4 weights:
 cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
@@ -126,7 +155,7 @@ cascadia worker --rank 0 --total 2 --engine ov-runtime --device GPU \
 
 Not sure of a node's address? `cascadia discover` lists Cascadia peers on the LAN and the `host:port` to pass to `--next`.
 
-Add `--engine ov-dist-spec --draft-model unsloth/Llama-3.2-1B-Instruct --spec-k 4` on rank 0 for distributed speculative decoding ([docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
+Add `--engine ov-dist-spec --draft-model ~/models/llama-3.2-1b-int4-ov --spec-k 4` on rank 0 (the draft is a local OpenVINO IR directory, not an HF id) for distributed speculative decoding ([docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
 
 ### Engines
 
@@ -141,7 +170,7 @@ $ cascadia engines
   qwen36-moe     Qwen3.6-35B-A3B staged chain (GatedDeltaNet + MoE); qwen3_5_moe IR-surgery shards
 ```
 
-`sparse-moe` consumes a `manifest.json` + per-expert artefact tree, not `cascadia shard` output, see [docs/architectures/minimax-m2.md](docs/architectures/minimax-m2.md) and [docs/architectures/moe.md](docs/architectures/moe.md). Tuning: [docs/perf/A3_TOPK_REDUCTION.md](docs/perf/A3_TOPK_REDUCTION.md), [docs/perf/CHESS_PER_CHANNEL.md](docs/perf/CHESS_PER_CHANNEL.md).
+`sparse-moe` consumes a `manifest.json` + per-expert artefact tree, not `cascadia shard` output, see [docs/architectures/minimax-m2.md](docs/architectures/minimax-m2.md) and [docs/architectures/moe.md](docs/architectures/moe.md). MiniMax-M2 is the in-repo export path (`tools/export_minimax_m2.py`); the Kimi K2.6 artefacts come from an external pipeline that is not part of this repo. Tuning: [docs/perf/A3_TOPK_REDUCTION.md](docs/perf/A3_TOPK_REDUCTION.md), [docs/perf/CHESS_PER_CHANNEL.md](docs/perf/CHESS_PER_CHANNEL.md).
 
 ### Supported model families
 

--- a/crates/cascadia-api/Cargo.toml
+++ b/crates/cascadia-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-api"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "OpenAI-compatible HTTP server (axum). Wraps cascadia-runner with /health, /v1/models, /v1/chat/completions."

--- a/crates/cascadia-cli/Cargo.toml
+++ b/crates/cascadia-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-cli"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "cascadia CLI — worker, run, shard, doctor, discover, engines subcommands."

--- a/crates/cascadia-cli/src/doctor.rs
+++ b/crates/cascadia-cli/src/doctor.rs
@@ -94,8 +94,14 @@ fn check_rust(r: &mut Report) {
     match first_line_of("rustc", "--version") {
         Some(v) => r.line(Level::Ok, "Rust toolchain", &v),
         None => {
-            r.line(Level::Fail, "Rust toolchain", "rustc not found on PATH");
-            r.note("Install via https://rustup.rs then `rustup default stable` (need 1.75+).");
+            // Informational, not a warning: a release bundle runs with no Rust
+            // toolchain at all, and `--strict` must still pass on such a host.
+            r.line(
+                Level::Info,
+                "Rust toolchain",
+                "rustc not found on PATH (only needed to build from source)",
+            );
+            r.note("Install via https://rustup.rs then `rustup default stable` (need 1.89+).");
         }
     }
 }
@@ -121,8 +127,9 @@ fn check_cpp(r: &mut Report) {
             );
         }
         None => {
+            // Build-only, like rustc above: a release bundle needs no compiler.
             r.line(
-                Level::Warn,
+                Level::Info,
                 "C++ compiler",
                 "no g++/clang++ on PATH (needed only for --features openvino)",
             );
@@ -132,48 +139,45 @@ fn check_cpp(r: &mut Report) {
 }
 
 fn check_python(r: &mut Report) {
-    // Python is an EXPORT-time dependency (`cascadia shard`), not a
-    // runtime one. Surface it here so users discover it before they hit
-    // sharding, but a miss is only a warning.
-    let py = ["python3", "python"]
-        .into_iter()
-        .find_map(|p| first_line_of(p, "--version").map(|v| (p, v)));
-    match py {
-        Some((p, v)) => {
-            r.line(Level::Ok, "Python (export-time)", &v);
-            // Probe the export packages so the warning is specific.
-            let probe = Command::new(p)
-                .args([
-                    "-c",
-                    "import torch, openvino, transformers, safetensors, huggingface_hub",
-                ])
-                .output();
-            match probe {
-                Ok(o) if o.status.success() => {
-                    r.line(
-                        Level::Ok,
-                        "Export packages",
-                        "torch/openvino/transformers present",
-                    );
-                }
-                _ => {
+    // Python is an EXPORT-time dependency (`cascadia shard`), not a runtime one.
+    // Surface it here so users discover it before they hit sharding, but a miss
+    // is only a warning. Resolve the interpreter the same way `cascadia shard`
+    // does — one that can import the deps, not the first that answers --version.
+    // `resolve_python` already probed the imports; don't pay for that twice.
+    match crate::resolve_python(None, true) {
+        Ok(env) => {
+            let version = first_line_of(&env.path, "--version").unwrap_or_default();
+            r.line(
+                Level::Ok,
+                "Python (export-time)",
+                &format!("{version} ({})", env.path),
+            );
+            match env.deps {
+                Some(_) => r.line(
+                    Level::Ok,
+                    "Export packages",
+                    "torch/openvino/transformers present",
+                ),
+                None => {
                     r.line(
                         Level::Warn,
                         "Export packages",
                         "missing (only needed for `cascadia shard`)",
                     );
-                    r.note(
-                        "pip install torch transformers openvino safetensors huggingface_hub nncf",
-                    );
+                    r.note(&crate::export_pip_install_line(&env.path));
                 }
             }
         }
-        None => {
+        Err(_) => {
             r.line(
                 Level::Warn,
                 "Python (export-time)",
                 "no python3/python on PATH (only needed for `cascadia shard`)",
             );
+            // Print the pins anyway: a bundle user has no tools/requirements.txt
+            // to read, and this is the only place they can learn them.
+            r.note("Install Python 3.10+, then:");
+            r.note(&crate::export_pip_install_line("python"));
         }
     }
 }
@@ -254,7 +258,9 @@ fn check_ov_devices(r: &mut Report) {
                 r.note("    (then log out/in — group changes don't apply to the current shell)");
                 r.note("  • install the GPU runtime packages: intel-opencl-icd,");
                 r.note(
-                    "    intel-level-zero-gpu, level-zero  (see INSTALL.md / setup-openvino.sh)",
+                    "    libze-intel-gpu1, libze1  (Ubuntu 24.04+; on 22.04 these come from \
+                     Intel's apt repo as intel-level-zero-gpu / level-zero — \
+                     `scripts/setup-openvino.sh` in a source checkout does this for you)",
                 );
                 r.note("On Windows: install the latest Intel graphics driver, then reboot.");
             }
@@ -287,7 +293,7 @@ pub fn cmd_doctor(args: DoctorArgs) -> Result<()> {
     println!();
     match r.worst {
         Level::Ok | Level::Info => {
-            println!("All good. Try:  cascadia run <hf-model-id-or-path>");
+            println!("All good. Try:  cascadia run <model-dir>   (export one first: cascadia shard --help)");
         }
         Level::Warn => {
             println!("Mostly OK with warnings above — see the remediation notes.");

--- a/crates/cascadia-cli/src/doctor.rs
+++ b/crates/cascadia-cli/src/doctor.rs
@@ -159,8 +159,10 @@ fn check_python(r: &mut Report) {
                     "torch/openvino/transformers present",
                 ),
                 None => {
+                    // Export-only, like rustc/g++ above: a worker never needs
+                    // Python, so this must not fail `--strict` on a bundle host.
                     r.line(
-                        Level::Warn,
+                        Level::Info,
                         "Export packages",
                         "missing (only needed for `cascadia shard`)",
                     );
@@ -170,7 +172,7 @@ fn check_python(r: &mut Report) {
         }
         Err(_) => {
             r.line(
-                Level::Warn,
+                Level::Info,
                 "Python (export-time)",
                 "no python3/python on PATH (only needed for `cascadia shard`)",
             );
@@ -258,9 +260,9 @@ fn check_ov_devices(r: &mut Report) {
                 r.note("    (then log out/in — group changes don't apply to the current shell)");
                 r.note("  • install the GPU runtime packages: intel-opencl-icd,");
                 r.note(
-                    "    libze-intel-gpu1, libze1  (Ubuntu 24.04+; on 22.04 these come from \
-                     Intel's apt repo as intel-level-zero-gpu / level-zero — \
-                     `scripts/setup-openvino.sh` in a source checkout does this for you)",
+                    "    libze-intel-gpu1, libze1 + intel-opencl-icd, from Intel's graphics repo \
+                     (`scripts/setup-openvino.sh` in a source checkout does this for you; \
+                     the distro's own packages are too old for recent Intel GPUs)",
                 );
                 r.note("On Windows: install the latest Intel graphics driver, then reboot.");
             }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -20,7 +20,7 @@ use cascadia_types::{GenerationTask, PeerEndpoint, PeerLayout, ShardSpec};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use futures::StreamExt;
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 pub mod discover;
@@ -271,7 +271,7 @@ pub struct WorkerArgs {
     ///   BATCH:GPU                 auto-batch (throughput-favored)
     ///
     /// Run `cascadia doctor` to see which devices OpenVINO can see on this host.
-    #[arg(long, default_value = "CPU")]
+    #[arg(long, default_value = "CPU", verbatim_doc_comment)]
     pub device: String,
 
     /// Inference engine.
@@ -1334,6 +1334,12 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     }
     let is_first = args.rank == 0;
     let is_last = args.rank == args.total - 1;
+
+    // Only rank 0 reaches the API bind; every other rank returns from the
+    // relay loop first. Say so rather than dropping the flag silently.
+    if args.api.is_some() && !is_first {
+        warn!(rank = args.rank, "--api is ignored on ranks other than 0");
+    }
 
     info!(
         engine = ?args.engine,

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -157,8 +157,9 @@ pub enum Command {
     /// that otherwise shows up as mysterious slowness. See `cascadia
     /// doctor --help`.
     Doctor(DoctorArgs),
-    /// Run a model on a single machine (sugar for a one-stage worker
-    /// with an OpenAI API). See `cascadia run --help`.
+    /// Run a model on a single machine (sugar for a one-stage worker with an
+    /// OpenAI API). Takes a local model directory — a whole-model OpenVINO IR,
+    /// or a `cascadia shard` tree. See `cascadia run --help`.
     Run(RunArgs),
     /// Run a pipeline-stage worker.
     Worker(WorkerArgs),
@@ -240,7 +241,9 @@ pub struct WorkerArgs {
     #[arg(long, default_value_t = 0)]
     pub layer_end: u32,
 
-    /// HF model id or local model directory.
+    /// Local model directory: a whole-model OpenVINO IR for ov-genai, or a
+    /// `cascadia shard` tree for the staged engines. NOT an HF repo id — the
+    /// worker never downloads or converts models; only `cascadia shard` does.
     #[arg(long)]
     pub model: String,
 
@@ -503,8 +506,9 @@ pub struct WorkerArgs {
 /// parallelism, use `cascadia worker` directly.
 #[derive(Parser, Debug, Clone)]
 pub struct RunArgs {
-    /// HF model id (e.g. `unsloth/Meta-Llama-3.1-8B-Instruct`) or a
-    /// local model / shard directory.
+    /// Local model directory: a whole-model OpenVINO IR (`optimum-cli export
+    /// openvino`, or a pre-exported `*-int4-ov` download) or a `cascadia shard`
+    /// tree. Not an HF repo id — `run` does not download or convert models.
     pub model: String,
 
     /// Device hint: GPU / CPU / NPU. Defaults to GPU — run `cascadia
@@ -514,8 +518,8 @@ pub struct RunArgs {
     #[arg(long, default_value = "GPU")]
     pub device: String,
 
-    /// Inference engine. Defaults to `ov-genai` (single-stage, auto-
-    /// exports from an HF id).
+    /// Inference engine. Defaults to `ov-genai` (single-stage, whole-model
+    /// OpenVINO IR). Use `--engine ov-runtime` for a `cascadia shard` tree.
     #[arg(long, value_enum, default_value_t = EngineKind::OvGenai)]
     pub engine: EngineKind,
 
@@ -951,6 +955,82 @@ fn warn_ignored_ov_perf_flags(args: &WorkerArgs) {
     }
 }
 
+/// Last path/repo segment of a model id, for the example commands below.
+fn model_stem(model: &str) -> String {
+    model
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("model")
+        .to_string()
+}
+
+/// True when the string looks like a filesystem path the user meant literally
+/// (`./x`, `/x`, `C:\x`, `~/x`) rather than an HF repo id (`org/name`).
+fn looks_like_path(model: &str) -> bool {
+    let p = std::path::Path::new(model);
+    p.is_absolute()
+        || model.starts_with('.')
+        || model.starts_with('~')
+        || model.contains('\\')
+        || model.matches('/').count() != 1
+}
+
+/// Why a `--model` was rejected, and what to do instead. Engines load a
+/// pre-exported model from a directory; only `cascadia shard` downloads.
+fn missing_model_error(model: &str, engine: EngineKind) -> anyhow::Error {
+    if looks_like_path(model) {
+        return anyhow!("no model directory at {model} (path does not exist)");
+    }
+    // Looks like an HF repo id: the old docs told people to pass one, and it can
+    // never work, so say what to run instead.
+    let stem = model_stem(model);
+    let serve = match engine {
+        EngineKind::OvGenai => format!(
+            "  ov-genai serves a whole-model OpenVINO IR — export one with `optimum-cli export\n  \
+             openvino`, or download a pre-exported *-int4-ov directory, then:\n    \
+             cascadia run <ir-dir>"
+        ),
+        _ => format!(
+            "  cascadia shard --model {model} --output-dir ./{stem}-1stage --num-stages 1\n    \
+             cascadia run ./{stem}-1stage --engine ov-runtime"
+        ),
+    };
+    anyhow!(
+        "no model directory at {model}\n\
+         \n\
+         Engines load a pre-exported model from disk; the worker does not download\n\
+         or convert models. Export first:\n\
+         \n\
+         {serve}"
+    )
+}
+
+/// Reject a `--model` (or `--draft-model`) that names nothing on disk, with the
+/// command to run instead. Without this an HF repo id — which the old docs told
+/// people to pass — surfaces as a bare "model not found", which reads like a
+/// missing file rather than a missing export.
+fn preflight_model_path(args: &WorkerArgs) -> Result<()> {
+    if matches!(args.engine, EngineKind::Mock) {
+        return Ok(());
+    }
+    if !std::path::Path::new(&args.model).exists() {
+        return Err(missing_model_error(&args.model, args.engine));
+    }
+    // The draft model is a whole OpenVINO IR dir too, and ov::genai builds a
+    // tokenizer from it — an HF id there fails the same way.
+    if let Some(draft) = &args.draft_model {
+        if !std::path::Path::new(draft).exists() {
+            return Err(anyhow!(
+                "no draft-model directory at {draft}\n\
+                 --draft-model takes a local OpenVINO IR directory (e.g. a FastDraft\n\
+                 *-int8-ov download), not an HF repo id."
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
     warn_ignored_ov_perf_flags(args);
     match args.engine {
@@ -1276,6 +1356,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         tp_rank: 0,
     };
 
+    preflight_model_path(&args)?;
     let builder = build_builder(&args)?;
     let runner = Arc::new(Runner::new(builder));
     let listen = if !is_first {
@@ -1347,9 +1428,12 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     // Advertise the API/dashboard port separately from the relay port so
     // the dashboard can show a node's reachable address (the relay `port`
     // isn't an HTTP endpoint). None for relay-only stages.
-    let api_port = args
-        .api
-        .as_deref()
+    // Only rank 0 serves an API; relay ranks return before the API block, so a
+    // --api passed to them (one systemd template covers every rank) must not be
+    // advertised as an endpoint the dashboard can't reach.
+    let api_port = is_first
+        .then(|| args.api.as_deref())
+        .flatten()
         .and_then(|a| parse_addr(a, "0.0.0.0").ok())
         .map(|(_, p)| p);
     let self_node = cascadia_topology::NodeInfo {
@@ -1624,6 +1708,35 @@ const EXPORT_SCRIPT: &str = include_str!(concat!(
     "/../../tools/export_shards.py"
 ));
 
+/// The exporter's pinned deps, compiled in beside the exporter itself so the
+/// pins we print always match the exporter in *this* binary — a release bundle
+/// carries no requirements.txt to point at.
+const EXPORT_REQUIREMENTS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tools/requirements.txt"
+));
+
+/// `pip install` line for the exporter deps, rendered from EXPORT_REQUIREMENTS
+/// and aimed at `python`'s own pip — installing into whatever `pip` happens to
+/// be on PATH is how you end up with the deps in the wrong interpreter.
+///
+/// Every entry is double-quoted: `>=`/`<`/`[extras]` need quoting, and double
+/// quotes are the only form that survives sh, zsh, PowerShell and cmd.exe alike.
+pub(crate) fn export_pip_install_line(python: &str) -> String {
+    let pkgs: Vec<String> = EXPORT_REQUIREMENTS
+        .lines()
+        .map(|l| l.split('#').next().unwrap_or("").trim()) // drop comments
+        .filter(|l| !l.is_empty())
+        .map(|p| format!("\"{p}\""))
+        .collect();
+    let py = if python.contains(char::is_whitespace) {
+        format!("\"{python}\"")
+    } else {
+        python.to_string()
+    };
+    format!("{py} -m pip install {}", pkgs.join(" "))
+}
+
 /// Sibling modules the exporter imports at runtime: the dedicated Gemma-4
 /// exporter (dispatched for gemma4 models) and the short-alias registry.
 /// They must be written next to export_shards.py in the temp dir so its
@@ -1697,6 +1810,83 @@ fn shard_exporter_flags(args: &ShardArgs) -> Result<Vec<String>> {
     Ok(flags)
 }
 
+/// The imports the bundled exporter needs. Shared with `cascadia doctor` so the
+/// two can't disagree about what "export packages present" means.
+pub(crate) const EXPORT_IMPORTS: &str =
+    "import torch, openvino, transformers, safetensors, huggingface_hub";
+
+/// A Python interpreter and what it can do.
+#[derive(Debug)]
+pub(crate) struct PythonEnv {
+    pub path: String,
+    /// Version summary from the dependency probe; `None` if the imports failed
+    /// (or `check_deps` was false), so callers can skip probing a second time.
+    pub deps: Option<String>,
+}
+
+/// True only if the interpreter runs AND exits 0. Spawning is not enough: the
+/// Windows Store `python3.exe` alias spawns, prints "Python was not found" and
+/// exits 9009 — treating that as an interpreter is the very bug we're fixing.
+fn python_runs(p: &str) -> bool {
+    std::process::Command::new(p)
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Import the exporter's deps and report their versions. `None` if the imports
+/// fail — that interpreter can't run the exporter.
+fn probe_export_deps(p: &str) -> Option<String> {
+    let code = format!(
+        "{EXPORT_IMPORTS}; import sys; \
+         print('python', sys.version.split()[0]); \
+         print('torch', torch.__version__); \
+         print('openvino', openvino.__version__); \
+         print('transformers', transformers.__version__)"
+    );
+    let out = std::process::Command::new(p)
+        .args(["-c", &code])
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Resolve the interpreter to run the embedded exporter with: prefer one that
+/// can import the deps, since on Windows `python3` is often a stub with no
+/// packages while `python` is the real install. Falls back to any interpreter
+/// that runs, so the caller can still surface the real `ModuleNotFoundError`.
+pub(crate) fn resolve_python(explicit: Option<&str>, check_deps: bool) -> Result<PythonEnv> {
+    let candidates: Vec<String> = match explicit {
+        Some(p) => vec![p.to_string()],
+        None => vec!["python3".to_string(), "python".to_string()],
+    };
+    let mut runnable: Option<String> = None;
+    for p in &candidates {
+        if check_deps {
+            if let Some(deps) = probe_export_deps(p) {
+                return Ok(PythonEnv {
+                    path: p.clone(),
+                    deps: Some(deps),
+                });
+            }
+        }
+        if runnable.is_none() && python_runs(p) {
+            runnable = Some(p.clone());
+        }
+    }
+    match (runnable, explicit) {
+        (Some(path), _) => Ok(PythonEnv { path, deps: None }),
+        (None, Some(p)) => Err(anyhow!(
+            "cannot run the interpreter passed to --python: {p:?}"
+        )),
+        (None, None) => Err(anyhow!(
+            "no Python interpreter found on PATH. Install Python 3.10+ or pass --python <path>."
+        )),
+    }
+}
+
 async fn cmd_shard(args: ShardArgs) -> Result<()> {
     use std::process::{Command, Stdio};
 
@@ -1712,39 +1902,16 @@ async fn cmd_shard(args: ShardArgs) -> Result<()> {
         eprintln!("warning: --static-seq/--static-context are ignored without --target npu");
     }
 
-    let python = if let Some(p) = args.python.as_deref() {
-        p.to_string()
-    } else {
-        // Try `python3` then `python`. clap doesn't run them — we just pick one.
-        if Command::new("python3").arg("--version").output().is_ok() {
-            "python3".into()
-        } else if Command::new("python").arg("--version").output().is_ok() {
-            "python".into()
-        } else {
-            return Err(anyhow!(
-                "no Python interpreter found on PATH. Install Python 3.10+ or pass --python <path>."
-            ));
-        }
-    };
+    // `--skip-check` means exactly that: don't import the deps just to pick an
+    // interpreter (importing torch costs seconds).
+    let env = resolve_python(args.python.as_deref(), !args.skip_check)?;
+    let python = env.path.clone();
 
     if !args.skip_check {
         eprintln!("Checking Python environment for required packages...");
-        let probe = Command::new(&python)
-            .args([
-                "-c",
-                "import torch, openvino, transformers, safetensors, huggingface_hub; \
-                 print('python', __import__('sys').version.split()[0]); \
-                 print('torch', torch.__version__); \
-                 print('openvino', openvino.__version__); \
-                 print('transformers', transformers.__version__);",
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output();
-        match probe {
-            Ok(out) if out.status.success() => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                for line in stdout.lines() {
+        match env.deps {
+            Some(versions) => {
+                for line in versions.lines() {
                     eprintln!("  {line}");
                 }
                 // NNCF is optional but warn if missing for INT4 quant.
@@ -1765,17 +1932,24 @@ async fn cmd_shard(args: ShardArgs) -> Result<()> {
                     }
                 }
             }
-            Ok(out) => {
-                let stderr = String::from_utf8_lossy(&out.stderr);
+            // The chosen interpreter runs but can't import the deps: re-run the
+            // import so the user sees the real ModuleNotFoundError.
+            None => {
+                let out = Command::new(&python)
+                    .args(["-c", EXPORT_IMPORTS])
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .output();
+                let stderr = out
+                    .map(|o| String::from_utf8_lossy(&o.stderr).into_owned())
+                    .unwrap_or_default();
                 return Err(anyhow!(
-                    "python environment check failed:\n{}\n\
-                     Install: pip install torch openvino transformers safetensors \
-                     huggingface_hub nncf",
-                    stderr.trim()
+                    "python environment check failed for interpreter {python:?}:\n{}\n\
+                     Install: {}\n\
+                     (or point at another interpreter with --python <path>)",
+                    stderr.trim(),
+                    export_pip_install_line(&python)
                 ));
-            }
-            Err(e) => {
-                return Err(anyhow!("couldn't run python interpreter {python:?}: {e}"));
             }
         }
     }
@@ -1835,6 +2009,13 @@ async fn cmd_shard(args: ShardArgs) -> Result<()> {
              --engine qwen36-moe --device CPU --api :8000",
             args.output_dir, args.output_dir
         );
+    } else if args.num_stages == 1 {
+        // Single stage: rank 0 is also the last stage, so there is no --next.
+        eprintln!(
+            "\nShard tree written to {}. Run with:\n  cascadia run {} \
+             --engine ov-runtime --device GPU",
+            args.output_dir, args.output_dir
+        );
     } else {
         eprintln!(
             "\nShard tree written to {}. Run with:\n  cascadia worker --rank 0 --total {} \
@@ -1844,6 +2025,97 @@ async fn cmd_shard(args: ShardArgs) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod python_tests {
+    use super::*;
+
+    fn worker(model: &str, engine: EngineKind) -> WorkerArgs {
+        let mut a = WorkerArgs::single_node(model.into(), "GPU".into(), engine, ":8000".into());
+        a.engine = engine;
+        a
+    }
+
+    #[test]
+    fn explicit_interpreter_that_cannot_run_names_the_path() {
+        // Must not tell the user to "pass --python" — they just did.
+        let err = resolve_python(Some("cascadia-no-such-python"), false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("cascadia-no-such-python"), "{err}");
+        assert!(!err.contains("on PATH"), "{err}");
+    }
+
+    #[test]
+    fn pip_line_quotes_every_specifier_and_targets_the_interpreter() {
+        let line = export_pip_install_line("python3");
+        assert!(line.starts_with("python3 -m pip install "), "{line}");
+        // Double quotes: the only form valid in sh, zsh, PowerShell and cmd.exe.
+        assert!(line.contains("\"transformers>=5.2,<5.5\""), "{line}");
+        assert!(line.contains("\"safetensors\""), "{line}");
+        // Comments and blank lines from requirements.txt never leak through.
+        assert!(!line.contains('#'), "{line}");
+        // An interpreter path with spaces stays one argument.
+        let q = export_pip_install_line("C:\\Program Files\\Python\\python.exe");
+        assert!(
+            q.starts_with("\"C:\\Program Files\\Python\\python.exe\" -m pip"),
+            "{q}"
+        );
+    }
+
+    #[test]
+    fn model_stem_handles_paths_and_repo_ids() {
+        assert_eq!(model_stem("unsloth/Meta-Llama-3.1-8B"), "Meta-Llama-3.1-8B");
+        assert_eq!(model_stem("C:\\models\\foo"), "foo");
+        assert_eq!(model_stem("foo/"), "model");
+        assert_eq!(model_stem(""), "model");
+    }
+
+    #[test]
+    fn preflight_rejects_an_hf_id_with_the_command_to_run() {
+        let err = preflight_model_path(&worker(
+            "unsloth/Meta-Llama-3.1-8B-Instruct",
+            EngineKind::OvRuntime,
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("cascadia shard"), "{err}");
+        // ov-genai cannot be fed a shard tree, so it gets different advice.
+        let genai = preflight_model_path(&worker("org/name", EngineKind::OvGenai))
+            .unwrap_err()
+            .to_string();
+        assert!(genai.contains("optimum-cli"), "{genai}");
+    }
+
+    #[test]
+    fn preflight_says_path_not_found_for_a_path_like_model() {
+        let err = preflight_model_path(&worker("./no-such-dir", EngineKind::OvRuntime))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("path does not exist"), "{err}");
+        assert!(
+            !err.contains("cascadia shard --model ./no-such-dir"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn preflight_accepts_an_existing_dir_and_the_mock_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().into_owned();
+        assert!(preflight_model_path(&worker(&path, EngineKind::OvRuntime)).is_ok());
+        assert!(preflight_model_path(&worker("mock-model", EngineKind::Mock)).is_ok());
+    }
+
+    #[test]
+    fn preflight_rejects_a_draft_model_that_is_not_a_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut args = worker(&dir.path().to_string_lossy(), EngineKind::OvGenai);
+        args.draft_model = Some("unsloth/Llama-3.2-1B-Instruct".into());
+        let err = preflight_model_path(&args).unwrap_err().to_string();
+        assert!(err.contains("draft-model"), "{err}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -591,8 +591,9 @@ const DEFAULT_STATIC_CONTEXT: u32 = 1024;
 
 #[derive(Parser, Debug, Clone)]
 pub struct ShardArgs {
-    /// HuggingFace repo id (e.g. unsloth/Meta-Llama-3.1-8B-Instruct)
-    /// or path to a local directory containing safetensors + config.json.
+    /// HuggingFace repo id (e.g. unsloth/Meta-Llama-3.1-8B-Instruct), a local
+    /// directory with safetensors + config.json, or — for the Gemma-4 / Qwen3.6
+    /// surgery paths — an already-exported OpenVINO IR directory.
     #[arg(long)]
     pub model: String,
 
@@ -965,51 +966,64 @@ fn model_stem(model: &str) -> String {
         .to_string()
 }
 
-/// True when the string looks like a filesystem path the user meant literally
-/// (`./x`, `/x`, `C:\x`, `~/x`) rather than an HF repo id (`org/name`).
-fn looks_like_path(model: &str) -> bool {
-    let p = std::path::Path::new(model);
-    p.is_absolute()
-        || model.starts_with('.')
-        || model.starts_with('~')
-        || model.contains('\\')
-        || model.matches('/').count() != 1
-}
-
-/// Why a `--model` was rejected, and what to do instead. Engines load a
-/// pre-exported model from a directory; only `cascadia shard` downloads.
-fn missing_model_error(model: &str, engine: EngineKind) -> anyhow::Error {
-    if looks_like_path(model) {
-        return anyhow!("no model directory at {model} (path does not exist)");
-    }
-    // Looks like an HF repo id: the old docs told people to pass one, and it can
-    // never work, so say what to run instead.
+/// How to produce a model this engine can serve.
+fn export_hint(model: &str, engine: EngineKind) -> String {
     let stem = model_stem(model);
-    let serve = match engine {
-        EngineKind::OvGenai => format!(
-            "  ov-genai serves a whole-model OpenVINO IR — export one with `optimum-cli export\n  \
-             openvino`, or download a pre-exported *-int4-ov directory, then:\n    \
+    match engine {
+        // Whole-model IR from Intel's exporter; `cascadia shard` can't make one.
+        EngineKind::OvGenai => "  download a pre-exported *-int4-ov directory, or export one with\n  \
+             `optimum-cli export openvino` (see docs/engines/ov-genai.md), then:\n    \
              cascadia run <ir-dir>"
+            .to_string(),
+        // Staged engines read a `cascadia shard` tree; the exporter picks the
+        // per-family path, so name the engine that matches this tree.
+        EngineKind::Gemma4 => format!(
+            "  cascadia shard --model {model} --output-dir ./{stem}-2stage --num-stages 2\n    \
+             cascadia worker --engine gemma4 --model ./{stem}-2stage ..."
+        ),
+        EngineKind::Qwen36Moe => format!(
+            "  cascadia shard --model <qwen3.6 int4-ov dir> --output-dir ./{stem}-2stage --num-stages 2\n    \
+             cascadia run ./{stem}-2stage --engine qwen36-moe"
+        ),
+        // sparse-moe consumes a manifest.json expert tree, not a shard tree.
+        EngineKind::SparseMoe => {
+            "  sparse-moe needs a manifest.json + per-expert tree — see\n  \
+             docs/architectures/moe.md (e.g. tools/export_minimax_m2.py)."
+                .to_string()
+        }
+        EngineKind::OvDistSpec => format!(
+            "  cascadia shard --model {model} --output-dir ./{stem}-2stage --num-stages 2\n    \
+             cascadia worker --engine ov-dist-spec --model ./{stem}-2stage --draft-model <ir-dir> ..."
         ),
         _ => format!(
             "  cascadia shard --model {model} --output-dir ./{stem}-1stage --num-stages 1\n    \
              cascadia run ./{stem}-1stage --engine ov-runtime"
         ),
-    };
+    }
+}
+
+/// Why a `--model` was rejected, and what to do instead. Engines load a
+/// pre-exported model from a directory; only `cascadia shard` downloads.
+///
+/// `org/name` is ambiguous — it is a valid HF repo id *and* a valid relative
+/// path — so don't guess: say both, and give the export command either way.
+fn missing_model_error(model: &str, engine: EngineKind) -> anyhow::Error {
+    let hint = export_hint(model, engine);
     anyhow!(
         "no model directory at {model}\n\
          \n\
-         Engines load a pre-exported model from disk; the worker does not download\n\
-         or convert models. Export first:\n\
+         If that is a path, it does not exist. If it is a HuggingFace repo id:\n\
+         engines load a pre-exported model from disk and never download or convert\n\
+         one. Export first:\n\
          \n\
-         {serve}"
+         {hint}"
     )
 }
 
-/// Reject a `--model` (or `--draft-model`) that names nothing on disk, with the
-/// command to run instead. Without this an HF repo id — which the old docs told
-/// people to pass — surfaces as a bare "model not found", which reads like a
-/// missing file rather than a missing export.
+/// Reject a `--model` (or, where the engine uses it, a `--draft-model`) that
+/// names nothing on disk, with the command to run instead. Without this an HF
+/// repo id — which the old docs told people to pass — surfaces as a bare "model
+/// not found", which reads like a missing file rather than a missing export.
 fn preflight_model_path(args: &WorkerArgs) -> Result<()> {
     if matches!(args.engine, EngineKind::Mock) {
         return Ok(());
@@ -1017,15 +1031,23 @@ fn preflight_model_path(args: &WorkerArgs) -> Result<()> {
     if !std::path::Path::new(&args.model).exists() {
         return Err(missing_model_error(&args.model, args.engine));
     }
-    // The draft model is a whole OpenVINO IR dir too, and ov::genai builds a
-    // tokenizer from it — an HF id there fails the same way.
-    if let Some(draft) = &args.draft_model {
-        if !std::path::Path::new(draft).exists() {
-            return Err(anyhow!(
-                "no draft-model directory at {draft}\n\
-                 --draft-model takes a local OpenVINO IR directory (e.g. a FastDraft\n\
-                 *-int8-ov download), not an HF repo id."
-            ));
+    // Only these read --draft-model, and ov-dist-spec only on the driver (rank 0)
+    // — a relay rank launched from the same argv must not be rejected for a draft
+    // IR it never opens.
+    let uses_draft = match args.engine {
+        EngineKind::OvGenai => true,
+        EngineKind::OvDistSpec => args.rank == 0,
+        _ => false,
+    };
+    if uses_draft {
+        if let Some(draft) = &args.draft_model {
+            if !std::path::Path::new(draft).exists() {
+                return Err(anyhow!(
+                    "no draft-model directory at {draft}\n\
+                     --draft-model takes a local OpenVINO IR directory (e.g. a FastDraft\n\
+                     *-int8-ov download), not an HF repo id."
+                ));
+            }
         }
     }
     Ok(())
@@ -1432,7 +1454,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     // --api passed to them (one systemd template covers every rank) must not be
     // advertised as an endpoint the dashboard can't reach.
     let api_port = is_first
-        .then(|| args.api.as_deref())
+        .then_some(args.api.as_deref())
         .flatten()
         .and_then(|a| parse_addr(a, "0.0.0.0").ok())
         .map(|(_, p)| p);
@@ -1729,10 +1751,12 @@ pub(crate) fn export_pip_install_line(python: &str) -> String {
         .filter(|l| !l.is_empty())
         .map(|p| format!("\"{p}\""))
         .collect();
-    let py = if python.contains(char::is_whitespace) {
-        format!("\"{python}\"")
-    } else {
-        python.to_string()
+    // A quoted path at the start of a PowerShell line is a string expression, not
+    // a command — it needs the call operator. Elsewhere (and unquoted) it's fine.
+    let py = match (python.contains(char::is_whitespace), cfg!(windows)) {
+        (true, true) => format!("& \"{python}\""),
+        (true, false) => format!("\"{python}\""),
+        (false, _) => python.to_string(),
     };
     format!("{py} -m pip install {}", pkgs.join(" "))
 }
@@ -2056,12 +2080,17 @@ mod python_tests {
         assert!(line.contains("\"safetensors\""), "{line}");
         // Comments and blank lines from requirements.txt never leak through.
         assert!(!line.contains('#'), "{line}");
-        // An interpreter path with spaces stays one argument.
+        // An interpreter path with spaces stays one argument — and on Windows it
+        // gets PowerShell's call operator, since a quoted string alone is not a
+        // command there.
         let q = export_pip_install_line("C:\\Program Files\\Python\\python.exe");
         assert!(
-            q.starts_with("\"C:\\Program Files\\Python\\python.exe\" -m pip"),
+            q.contains("\"C:\\Program Files\\Python\\python.exe\" -m pip"),
             "{q}"
         );
+        if cfg!(windows) {
+            assert!(q.starts_with("& \""), "{q}");
+        }
     }
 
     #[test]
@@ -2089,15 +2118,53 @@ mod python_tests {
     }
 
     #[test]
-    fn preflight_says_path_not_found_for_a_path_like_model() {
-        let err = preflight_model_path(&worker("./no-such-dir", EngineKind::OvRuntime))
+    fn preflight_covers_both_a_missing_path_and_an_hf_id() {
+        // `out/llama-1stage` is a valid relative path AND shaped like a repo id,
+        // so the message must not guess — it says both.
+        let err = preflight_model_path(&worker("out/llama-1stage", EngineKind::OvRuntime))
             .unwrap_err()
             .to_string();
-        assert!(err.contains("path does not exist"), "{err}");
         assert!(
-            !err.contains("cascadia shard --model ./no-such-dir"),
+            err.contains("If that is a path, it does not exist"),
             "{err}"
         );
+        assert!(err.contains("HuggingFace repo id"), "{err}");
+    }
+
+    #[test]
+    fn preflight_advice_matches_the_engine() {
+        // Each engine reads a different tree; don't send them all to ov-runtime.
+        for (engine, needle) in [
+            (EngineKind::Gemma4, "--engine gemma4"),
+            (EngineKind::Qwen36Moe, "--engine qwen36-moe"),
+            (EngineKind::SparseMoe, "manifest.json"),
+            (EngineKind::OvGenai, "optimum-cli"),
+            (EngineKind::OvRuntime, "--engine ov-runtime"),
+        ] {
+            let err = preflight_model_path(&worker("org/name", engine))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains(needle), "{engine:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn preflight_ignores_a_draft_model_the_engine_never_reads() {
+        // A relay rank launched from the same argv must not be rejected for a
+        // draft IR it never opens.
+        let dir = tempfile::tempdir().unwrap();
+        let mut args = worker(&dir.path().to_string_lossy(), EngineKind::OvRuntime);
+        args.draft_model = Some("unsloth/Llama-3.2-1B-Instruct".into());
+        assert!(preflight_model_path(&args).is_ok());
+
+        let mut relay = worker(&dir.path().to_string_lossy(), EngineKind::OvDistSpec);
+        relay.draft_model = Some("unsloth/Llama-3.2-1B-Instruct".into());
+        relay.rank = 1;
+        relay.total = 2;
+        assert!(preflight_model_path(&relay).is_ok());
+        // …but the driver (rank 0) does read it.
+        relay.rank = 0;
+        assert!(preflight_model_path(&relay).is_err());
     }
 
     #[test]

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -334,20 +334,23 @@ pub struct WorkerArgs {
     pub ov_execution_mode: Option<OvExecutionMode>,
 
     /// NPU LLM prefill chunk size (NPUW_LLM_PREFILL_CHUNK_SIZE, OV 2025.3+).
-    /// Applied only with --engine ov-genai on an NPU device; silently dropped
-    /// otherwise (only ov-genai routes it through an ov::genai LLMPipeline).
+    /// Applied only with --engine ov-genai on an NPU device; dropped with a
+    /// warning otherwise (only ov-genai routes it through an ov::genai
+    /// LLMPipeline).
     #[arg(long, value_name = "TOKS")]
     pub npu_prefill_chunk_size: Option<u32>,
 
     /// NPU max prompt length (MAX_PROMPT_LEN, static-shape constraint).
-    /// Applied only with --engine ov-genai on an NPU device; silently dropped
-    /// otherwise (only ov-genai routes it through an ov::genai LLMPipeline).
+    /// Applied only with --engine ov-genai on an NPU device; dropped with a
+    /// warning otherwise (only ov-genai routes it through an ov::genai
+    /// LLMPipeline).
     #[arg(long, value_name = "TOKS")]
     pub npu_max_prompt_len: Option<u32>,
 
     /// NPU min response length (MIN_RESPONSE_LEN, static-shape constraint).
-    /// Applied only with --engine ov-genai on an NPU device; silently dropped
-    /// otherwise (only ov-genai routes it through an ov::genai LLMPipeline).
+    /// Applied only with --engine ov-genai on an NPU device; dropped with a
+    /// warning otherwise (only ov-genai routes it through an ov::genai
+    /// LLMPipeline).
     #[arg(long, value_name = "TOKS")]
     pub npu_min_response_len: Option<u32>,
 
@@ -1757,12 +1760,14 @@ pub(crate) fn export_pip_install_line(python: &str) -> String {
         .filter(|l| !l.is_empty())
         .map(|p| format!("\"{p}\""))
         .collect();
-    // A quoted path at the start of a PowerShell line is a string expression, not
-    // a command — it needs the call operator. Elsewhere (and unquoted) it's fine.
-    let py = match (python.contains(char::is_whitespace), cfg!(windows)) {
-        (true, true) => format!("& \"{python}\""),
-        (true, false) => format!("\"{python}\""),
-        (false, _) => python.to_string(),
+    // Quote the interpreter only when it needs it. No PowerShell `&` call
+    // operator: `cfg!(windows)` is the build target, not the shell the user is
+    // in, and `&` is a syntax error in cmd.exe and Git Bash. PowerShell users
+    // with a spaced path add their own `&`; every other shell takes this as-is.
+    let py = if python.contains(char::is_whitespace) {
+        format!("\"{python}\"")
+    } else {
+        python.to_string()
     };
     format!("{py} -m pip install {}", pkgs.join(" "))
 }
@@ -2083,20 +2088,18 @@ mod python_tests {
         assert!(line.starts_with("python3 -m pip install "), "{line}");
         // Double quotes: the only form valid in sh, zsh, PowerShell and cmd.exe.
         assert!(line.contains("\"transformers>=5.2,<5.5\""), "{line}");
-        assert!(line.contains("\"safetensors\""), "{line}");
+        assert!(line.contains("\"safetensors>=0.4\""), "{line}");
         // Comments and blank lines from requirements.txt never leak through.
         assert!(!line.contains('#'), "{line}");
-        // An interpreter path with spaces stays one argument — and on Windows it
-        // gets PowerShell's call operator, since a quoted string alone is not a
-        // command there.
+        // An interpreter path with spaces stays one argument, and the line starts
+        // with the path itself: a leading `&` would be PowerShell-only and a
+        // syntax error in cmd.exe and Git Bash, which are the same target.
         let q = export_pip_install_line("C:\\Program Files\\Python\\python.exe");
         assert!(
-            q.contains("\"C:\\Program Files\\Python\\python.exe\" -m pip"),
+            q.starts_with("\"C:\\Program Files\\Python\\python.exe\" -m pip"),
             "{q}"
         );
-        if cfg!(windows) {
-            assert!(q.starts_with("& \""), "{q}");
-        }
+        assert!(!q.starts_with('&'), "{q}");
     }
 
     #[test]

--- a/crates/cascadia-cli/src/placement.rs
+++ b/crates/cascadia-cli/src/placement.rs
@@ -47,7 +47,7 @@ pub struct StageCost {
     pub lat_ms: BTreeMap<String, f64>,
 }
 
-/// The solver input — written by `profile-devices --per-stage`.
+/// The solver input — written by `cascadia profile-stages`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlacementProfile {
     pub model: String,
@@ -292,7 +292,7 @@ impl Placement {
 #[derive(Args, Debug)]
 pub struct PlaceArgs {
     /// Path to the `placement_profile.json` produced by
-    /// `profile-devices --per-stage`.
+    /// `cascadia profile-stages`.
     #[arg(long)]
     pub profile: PathBuf,
 

--- a/crates/cascadia-cli/src/placement.rs
+++ b/crates/cascadia-cli/src/placement.rs
@@ -1,7 +1,7 @@
 //! Three-tier {iGPU, NPU, CPU} placement solver — step 2 of issue #41.
 //!
 //! Takes a per-(stage, device) cost profile (latency + memory + op-support,
-//! produced by `profile-devices --per-stage`) and assigns each pipeline stage
+//! produced by `profile-stages`) and assigns each pipeline stage
 //! to exactly one device so as to **minimise total forward latency subject to
 //! each device's memory budget**. This is the offline ILP of PowerInfer §6.3
 //! adapted to Intel UMA — see `docs/perf/THREE_TIER_PLACEMENT.md`.

--- a/crates/cascadia-cli/src/profile_stage.rs
+++ b/crates/cascadia-cli/src/profile_stage.rs
@@ -1,4 +1,4 @@
-//! `profile-devices --per-stage` — build the per-(stage, device) cost table
+//! `cascadia profile-stages` — build the per-(stage, device) cost table
 //! the #41 placement ILP consumes (step 1.5, between `profile-devices` and
 //! `cascadia place`).
 //!
@@ -184,7 +184,7 @@ pub fn cmd_profile_per_stage(args: PerStageArgs) -> Result<()> {
     {
         let _ = args;
         bail!(
-            "`profile-devices --per-stage` needs a real OpenVINO runtime; this \
+            "`cascadia profile-stages` needs a real OpenVINO runtime; this \
              binary was built without the `openvino` feature (stub). Rebuild \
              with `--features openvino` on an Intel host."
         );

--- a/crates/cascadia-dashboard/Cargo.toml
+++ b/crates/cascadia-dashboard/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-dashboard"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Dashboard HTTP routes (topology, stats, SSE events) and embedded SPA for visualizing a Cascadia cluster."

--- a/crates/cascadia-discovery/Cargo.toml
+++ b/crates/cascadia-discovery/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-discovery"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Zero-config mDNS peer discovery for cascadia; populates a cascadia_topology::Topology."

--- a/crates/cascadia-download/Cargo.toml
+++ b/crates/cascadia-download/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-download"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Local model registry + HuggingFace snapshot downloader for cascadia."

--- a/crates/cascadia-engine-mock/Cargo.toml
+++ b/crates/cascadia-engine-mock/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-engine-mock"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Mock engine for tests — deterministic per-token output without real model weights."

--- a/crates/cascadia-engine-openvino/Cargo.toml
+++ b/crates/cascadia-engine-openvino/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-engine-openvino"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "OpenVINO-backed engines for cascadia — wraps cascadia-ov-genai-shim into the Engine + Builder traits."

--- a/crates/cascadia-engine-openvino/Cargo.toml
+++ b/crates/cascadia-engine-openvino/Cargo.toml
@@ -30,3 +30,4 @@ half = "2"
 
 [dev-dependencies]
 tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -133,12 +133,26 @@ fn check_tokenizer_irs(dir: &str) -> EngineResult<()> {
         return Ok(());
     }
     // A `cascadia shard` tree is a common mistake here: it has no tokenizer IRs
-    // because the staged engines tokenize in Rust. Say so rather than telling
-    // the user to re-export a model they already exported.
-    if d.join("pipeline_config.json").exists() {
+    // because the staged engines tokenize in Rust. Say so — and name the engine
+    // that matches this tree — rather than telling the user to re-export a model
+    // they already exported.
+    let pipeline_cfg = d.join("pipeline_config.json");
+    if pipeline_cfg.exists() {
+        let export_version = std::fs::read_to_string(&pipeline_cfg)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|v| v["export_version"].as_str().map(str::to_owned))
+            .unwrap_or_default();
+        let engine = if export_version.starts_with("gemma4") {
+            "gemma4"
+        } else if export_version.contains("qwen3_5") {
+            "qwen36-moe"
+        } else {
+            "ov-runtime"
+        };
         return Err(EngineError::InvalidConfig(format!(
             "{dir} is a `cascadia shard` tree, which ov-genai cannot serve. \
-             Use --engine ov-runtime."
+             Use --engine {engine}."
         )));
     }
     Err(EngineError::InvalidConfig(format!(
@@ -544,5 +558,43 @@ mod tests {
         let b = Box::new(OvGenaiBuilder::new("/x", "CPU"));
         let res = b.build();
         assert!(matches!(res, Err(EngineError::NotLoaded)));
+    }
+
+    #[test]
+    fn tokenizer_irs_are_required() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("openvino_model.xml"), "").unwrap();
+        // Model IR present, tokenizer IRs absent: this used to serve empty strings.
+        let err = check_tokenizer_irs(&dir.path().to_string_lossy())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("openvino_tokenizer.xml"), "{err}");
+        assert!(err.contains("openvino_detokenizer.xml"), "{err}");
+
+        for f in ["openvino_tokenizer.xml", "openvino_detokenizer.xml"] {
+            std::fs::write(dir.path().join(f), "").unwrap();
+        }
+        assert!(check_tokenizer_irs(&dir.path().to_string_lossy()).is_ok());
+    }
+
+    #[test]
+    fn a_shard_tree_names_the_engine_that_can_serve_it() {
+        for (export_version, engine) in [
+            ("v5_canonical_inputs", "ov-runtime"),
+            ("gemma4_cached_v1", "gemma4"),
+            ("qwen3_5_moe_surgery", "qwen36-moe"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("pipeline_config.json"),
+                format!("{{\"export_version\": \"{export_version}\"}}"),
+            )
+            .unwrap();
+            let err = check_tokenizer_irs(&dir.path().to_string_lossy())
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("shard` tree"), "{err}");
+            assert!(err.contains(&format!("--engine {engine}")), "{err}");
+        }
     }
 }

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -132,27 +132,30 @@ fn check_tokenizer_irs(dir: &str) -> EngineResult<()> {
     if missing.is_empty() {
         return Ok(());
     }
-    // A `cascadia shard` tree is a common mistake here: it has no tokenizer IRs
-    // because the staged engines tokenize in Rust. Say so — and name the engine
-    // that matches this tree — rather than telling the user to re-export a model
-    // they already exported.
-    let pipeline_cfg = d.join("pipeline_config.json");
-    if pipeline_cfg.exists() {
-        let export_version = std::fs::read_to_string(&pipeline_cfg)
+    // A staged tree is a common mistake here: it has no tokenizer IRs because the
+    // staged engines tokenize in Rust. Say so — and name the engine that matches
+    // this tree — rather than telling the user to re-export a model they already
+    // exported. Two tree shapes exist: export_shards.py / the gemma4 exporters
+    // write pipeline_config.json, while the surgery exporters write manifest.json.
+    let read_key = |file: &str, key: &str| -> Option<String> {
+        std::fs::read_to_string(d.join(file))
             .ok()
             .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-            .and_then(|v| v["export_version"].as_str().map(str::to_owned))
-            .unwrap_or_default();
-        let engine = if export_version.starts_with("gemma4") {
-            "gemma4"
-        } else if export_version.contains("qwen3_5") {
-            "qwen36-moe"
-        } else {
-            "ov-runtime"
-        };
+            .and_then(|v| v[key].as_str().map(str::to_owned))
+    };
+    let engine = match (
+        read_key("pipeline_config.json", "export_version"),
+        read_key("manifest.json", "arch"),
+    ) {
+        (Some(v), _) if v.starts_with("gemma4") => Some("gemma4"),
+        (Some(_), _) => Some("ov-runtime"),
+        (_, Some(a)) if a == "qwen3_5_moe" => Some("qwen36-moe"),
+        (_, Some(_)) => Some("sparse-moe"),
+        _ => None,
+    };
+    if let Some(engine) = engine {
         return Err(EngineError::InvalidConfig(format!(
-            "{dir} is a `cascadia shard` tree, which ov-genai cannot serve. \
-             Use --engine {engine}."
+            "{dir} is a staged tree, which ov-genai cannot serve. Use --engine {engine}."
         )));
     }
     Err(EngineError::InvalidConfig(format!(
@@ -578,22 +581,32 @@ mod tests {
     }
 
     #[test]
-    fn a_shard_tree_names_the_engine_that_can_serve_it() {
-        for (export_version, engine) in [
-            ("v5_canonical_inputs", "ov-runtime"),
-            ("gemma4_cached_v1", "gemma4"),
-            ("qwen3_5_moe_surgery", "qwen36-moe"),
+    fn a_staged_tree_names_the_engine_that_can_serve_it() {
+        // The (file, key, value) triples each exporter actually writes — not a
+        // fabricated combination. export_shards.py and the gemma4 exporters write
+        // pipeline_config.json; the surgery exporters write manifest.json only.
+        for (file, key, value, engine) in [
+            (
+                "pipeline_config.json",
+                "export_version",
+                "v5_canonical_inputs",
+                "ov-runtime",
+            ),
+            (
+                "pipeline_config.json",
+                "export_version",
+                "gemma4_cached_v1",
+                "gemma4",
+            ),
+            ("manifest.json", "arch", "qwen3_5_moe", "qwen36-moe"),
+            ("manifest.json", "arch", "minimax_m2", "sparse-moe"),
         ] {
             let dir = tempfile::tempdir().unwrap();
-            std::fs::write(
-                dir.path().join("pipeline_config.json"),
-                format!("{{\"export_version\": \"{export_version}\"}}"),
-            )
-            .unwrap();
+            std::fs::write(dir.path().join(file), format!("{{\"{key}\": \"{value}\"}}")).unwrap();
             let err = check_tokenizer_irs(&dir.path().to_string_lossy())
                 .unwrap_err()
                 .to_string();
-            assert!(err.contains("shard` tree"), "{err}");
+            assert!(err.contains("staged tree"), "{err}");
             assert!(err.contains(&format!("--engine {engine}")), "{err}");
         }
     }

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -120,6 +120,36 @@ impl OvGenaiBuilder {
     }
 }
 
+/// ov::genai builds its tokenizer from OpenVINO IRs in the model dir. Without
+/// them the pipeline still constructs, then every request returns an empty
+/// string with no error — reject the directory instead of serving silence.
+fn check_tokenizer_irs(dir: &str) -> EngineResult<()> {
+    let d = PathBuf::from(dir);
+    let missing: Vec<&str> = ["openvino_tokenizer.xml", "openvino_detokenizer.xml"]
+        .into_iter()
+        .filter(|f| !d.join(f).exists())
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    // A `cascadia shard` tree is a common mistake here: it has no tokenizer IRs
+    // because the staged engines tokenize in Rust. Say so rather than telling
+    // the user to re-export a model they already exported.
+    if d.join("pipeline_config.json").exists() {
+        return Err(EngineError::InvalidConfig(format!(
+            "{dir} is a `cascadia shard` tree, which ov-genai cannot serve. \
+             Use --engine ov-runtime."
+        )));
+    }
+    Err(EngineError::InvalidConfig(format!(
+        "{} missing from {dir}. ov-genai needs the tokenizer IRs beside the model IR; \
+         an export without them generates empty output. Re-export with \
+         `pip install \"optimum-intel[openvino]\"` + `optimum-cli export openvino`, \
+         or download a pre-exported IR.",
+        missing.join(" + "),
+    )))
+}
+
 #[async_trait]
 impl Builder for OvGenaiBuilder {
     async fn connect(&mut self, peers: PeerLayout) -> EngineResult<()> {
@@ -152,6 +182,11 @@ impl Builder for OvGenaiBuilder {
             if !PathBuf::from(dpath).exists() {
                 return Err(EngineError::ModelNotFound(dpath.clone()));
             }
+        }
+
+        check_tokenizer_irs(&self.model_path)?;
+        if let Some(draft) = &self.draft_model_path {
+            check_tokenizer_irs(draft)?;
         }
 
         let mut progress = vec![LoadProgress::message(format!(

--- a/crates/cascadia-engine-sparse-moe/Cargo.toml
+++ b/crates/cascadia-engine-sparse-moe/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-engine-sparse-moe"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Sparse-MoE engine for Kimi K2.6 style models. Runs per-layer shells (Rust by default, OV IR optional) and dispatches only the top-k experts the router selects, instead of running all 384 every step."

--- a/crates/cascadia-engine/Cargo.toml
+++ b/crates/cascadia-engine/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-engine"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Engine + Builder traits — the plugin interface every inference engine implements."

--- a/crates/cascadia-int4-gemm/Cargo.toml
+++ b/crates/cascadia-int4-gemm/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-int4-gemm"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Hand-rolled int4 GEMM for the K2.6 expert path — group-32 symmetric quantization with bf16 scales, matching compressed-tensors' on-disk format."

--- a/crates/cascadia-ov-genai-shim/Cargo.toml
+++ b/crates/cascadia-ov-genai-shim/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-ov-genai-shim"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "C++ FFI shim around openvino-genai for the missing pieces (draft_model, Tokenizer, prompt_lookup property)."

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -216,7 +216,7 @@ int32_t cascadia_runtime_output_dtype(
 
 /// Input-tensor introspection (rank / shape / dtype), mirroring the output
 /// getters. Reports the compiled model's concrete input dims — used by
-/// `profile-devices --per-stage` to size the zeroed inputs it feeds when
+/// `cascadia profile-stages` to size the zeroed inputs it feeds when
 /// timing a stage. Expects a static model; on a dynamic-shape port get_shape()
 /// errors (returns non-zero), which the caller surfaces as an error.
 int32_t cascadia_runtime_input_rank(

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -835,7 +835,7 @@ impl Runtime {
     }
 
     /// Input tensor `idx`'s shape — concrete dims for a static (NPU-export)
-    /// model. Used by `profile-devices --per-stage` to size the zeroed
+    /// model. Used by `cascadia profile-stages` to size the zeroed
     /// inputs it feeds when timing a stage.
     pub fn input_shape(&self, idx: usize) -> Result<Vec<usize>> {
         #[cfg(not(feature = "openvino"))]

--- a/crates/cascadia-runner/Cargo.toml
+++ b/crates/cascadia-runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-runner"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Per-stage Runner — owns Builder/Engine, drives the generate loop and relay loop."

--- a/crates/cascadia-topology/Cargo.toml
+++ b/crates/cascadia-topology/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-topology"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cluster topology graph: nodes + measured edges (latency, bandwidth)."

--- a/crates/cascadia-transport/Cargo.toml
+++ b/crates/cascadia-transport/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-transport"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "TCP activation tensor relay between pipeline stages — length-prefixed tensor wire format."

--- a/crates/cascadia-types/Cargo.toml
+++ b/crates/cascadia-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia-types"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Engine-agnostic core types: generation tasks, chunks, shards, peer layout."

--- a/crates/cascadia/Cargo.toml
+++ b/crates/cascadia/Cargo.toml
@@ -3,6 +3,7 @@ name = "cascadia"
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "cascadia binary — distributed LLM inference for Intel hardware."

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,8 +72,8 @@ mDNS peer discovery via the `mdns-sd` crate. Advertises `_cascadia._tcp.local.` 
 
 ## `cascadia-download`
 
-Model registry plus on-demand HuggingFace pull. Registry lives at `~/.cache/cascadia/registry.json`; writes are atomic (`.tmp` + `fsync` + rename). Symlinks at the registry path are rejected to prevent path-substitution attacks.
+Model registry plus on-demand HuggingFace pull. **Not wired into the CLI** — no crate depends on it; workers never download (only `cascadia shard` fetches). Registry lives at `~/.cache/cascadia/registry.json`; writes are atomic (`.tmp` + `fsync` + rename). Symlinks at the registry path are rejected to prevent path-substitution attacks.
 
 ## `cascadia-cli` + `cascadia`
 
-`cascadia worker --rank N --total M --engine <name> --model <path|hf_id> ...` is the core serving subcommand; `run` is its single-machine sugar. Other subcommands: `shard` (bundled exporter), `doctor` (environment checks), `discover` (mDNS browse), `engines`, `completions` (shell completions), `profile-devices` / `profile-stages` / `place` / `run-placement` (placement tooling). The `cascadia` crate is the binary entry point and depends on `cascadia-cli`.
+`cascadia worker --rank N --total M --engine <name> --model <dir> ...` is the core serving subcommand; `run` is its single-machine sugar. Other subcommands: `shard` (bundled exporter), `doctor` (environment checks), `discover` (mDNS browse), `engines`, `completions` (shell completions), `profile-devices` / `profile-stages` / `place` / `run-placement` (placement tooling). The `cascadia` crate is the binary entry point and depends on `cascadia-cli`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,8 +7,8 @@ which is always authoritative — run it if this page and the binary disagree.
 cascadia [--log-level <LEVEL>] <COMMAND>
 ```
 
-`--log-level` is global (default `info`, overrides `RUST_LOG`). `--version` and
-`--help` work everywhere.
+`--log-level` is global (default `info`, overrides `RUST_LOG`) and `--help` works
+on every subcommand. `--version` is only accepted on the top-level command.
 
 > **Security.** The HTTP API and the inter-stage TCP relay are plaintext and
 > unauthenticated. Bind them to trusted networks only, or put TLS + auth on a
@@ -133,11 +133,15 @@ a few each. MiniMax-M2 `sparse-moe` only.
 | `--ov-allow-auto-batching` | off | Allow GPU-plugin internal auto-batching. |
 | `--ov-execution-mode <MODE>` | — | `ACCURACY` / `PERFORMANCE`. |
 
-**`--ov-cache-dir` is on by default and matters.** Unset, it defaults to
+**`--ov-cache-dir` is on by default and matters.** For `ov-genai`, `ov-runtime`,
+`gemma4` and `sparse-moe`, leaving it unset defaults to
 `<user-cache>/cascadia/ov-cache` (`~/.cache` on Linux, `~/Library/Caches` on
 macOS, `%LOCALAPPDATA%` on Windows). This turns a ~20 s cold GPU compile into a
 ~1 s warm load on every later run — the single biggest latency win on the
 `ov-genai` path. Pass `--ov-cache-dir ""` to disable.
+
+Two engines don't get that default: `ov-dist-spec` uses the flag verbatim (so it
+is off unless you pass a path), and `qwen36-moe` ignores it entirely.
 
 On **Xe2 / Battlemage** GPUs, set `--ov-inference-precision f16` explicitly: f16
 and bf16 share XMX throughput, but the default can silently fall back to f32.
@@ -150,9 +154,9 @@ and bf16 share XMX throughput, but the default can silently fall back to f32.
 | `--npu-max-prompt-len <TOKS>` | `MAX_PROMPT_LEN` — static-shape constraint. |
 | `--npu-min-response-len <TOKS>` | `MIN_RESPONSE_LEN` — static-shape constraint. |
 
-All three apply **only** with `--engine ov-genai` on an NPU device, and are
-silently dropped otherwise — only `ov-genai` routes them through an
-`ov::genai::LLMPipeline`.
+All three apply **only** with `--engine ov-genai` on an NPU device — only that
+engine routes them through an `ov::genai::LLMPipeline`. Anywhere else they are
+dropped, with a warning in the log.
 
 ### Speculative decode
 
@@ -260,8 +264,10 @@ Discovery is informational: workers still need explicit `--rank` / `--total` /
 ## Heterogeneous placement
 
 A four-step pipeline that measures your hardware, then solves which device each
-stage should run on. Steps 1–3 need a real OpenVINO build; a stub binary will
-refuse. Background: [perf/THREE_TIER_PLACEMENT.md](perf/THREE_TIER_PLACEMENT.md).
+stage should run on. Only the measuring steps (`profile-stages`, `profile-devices`)
+need a real OpenVINO build — a stub binary refuses them. `place` is a pure solver
+and `run-placement --dry-run` only prints commands, so both run anywhere.
+Background: [perf/THREE_TIER_PLACEMENT.md](perf/THREE_TIER_PLACEMENT.md).
 
 ```
 shard --target npu  →  profile-stages  →  place  →  run-placement
@@ -397,7 +403,7 @@ OpenVINO GPU plugin can see.
 | `ov-runtime` | `cascadia shard` tree | The staged pipeline engine. |
 | `ov-dist-spec` | `cascadia shard` tree | Distributed speculative decode. Every rank must use it. |
 | `gemma4` | `gemma4_cached_v1` shards | Per-layer-type asymmetric attention, KV-sharing, baked softcap. |
-| `sparse-moe` | `manifest.json` + expert tree | Top-k expert routing through an AVX-512 int4 GEMM. Single-stage, CPU. |
+| `sparse-moe` | `manifest.json` + expert tree | Top-k expert routing through an AVX-512 int4 GEMM. CPU-targeted; single-stage or pipeline-parallel (`--total >= 2`). |
 | `qwen36-moe` | Qwen3.6 surgery output | Greedy-only, batch=1. CPU-targeted decode. |
 
 Per-engine deep dives: [engines/](engines/). Per-family export notes:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,404 @@
+# CLI reference
+
+Every command and flag `cascadia` accepts. This mirrors `cascadia <command> --help`,
+which is always authoritative — run it if this page and the binary disagree.
+
+```
+cascadia [--log-level <LEVEL>] <COMMAND>
+```
+
+`--log-level` is global (default `info`, overrides `RUST_LOG`). `--version` and
+`--help` work everywhere.
+
+> **Security.** The HTTP API and the inter-stage TCP relay are plaintext and
+> unauthenticated. Bind them to trusted networks only, or put TLS + auth on a
+> reverse proxy in front of `--api`. See [SECURITY.md](../SECURITY.md).
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| [`doctor`](#cascadia-doctor) | Check environment + hardware. **Run this first.** |
+| [`run`](#cascadia-run) | Serve a model on one machine (OpenAI API). |
+| [`worker`](#cascadia-worker) | Run one stage of a distributed pipeline. |
+| [`shard`](#cascadia-shard) | Export a model into per-stage OpenVINO IRs. |
+| [`engines`](#cascadia-engines) | List registered inference engines. |
+| [`discover`](#cascadia-discover) | List Cascadia peers on the LAN. |
+| [`profile-devices`](#cascadia-profile-devices) | Benchmark each OV device against one model. |
+| [`profile-stages`](#cascadia-profile-stages) | Cost table: each shard stage on each device. |
+| [`place`](#cascadia-place) | Solve device placement from that cost table. |
+| [`run-placement`](#cascadia-run-placement) | Launch a pipeline from a solved placement. |
+| [`completions`](#cascadia-completions) | Generate a shell completion script. |
+
+**Models are never downloaded at run time.** `run` and `worker` take a *local
+directory* — either a whole-model OpenVINO IR or a `cascadia shard` tree. Only
+`cascadia shard` fetches from HuggingFace. Passing an HF repo id to `run` or
+`worker` is an error.
+
+---
+
+## `cascadia doctor`
+
+Environment + hardware self-check. Catches the silent OpenVINO CPU-only
+fallback, which otherwise shows up much later as unexplained slowness.
+
+```
+cascadia doctor [--strict]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--strict` | off | Exit non-zero if any check is WARN or FAIL. For CI / provisioning gates. |
+
+Build-only checks (Rust, C++, export-time Python) report as informational, so
+`--strict` still passes on a release bundle, which ships no toolchain.
+
+---
+
+## `cascadia run`
+
+Single-machine serving. Sugar for a one-stage `worker` with the OpenAI API on.
+
+```
+cascadia run [OPTIONS] <MODEL>
+```
+
+`<MODEL>` — a local model directory. Either a whole-model OpenVINO IR (from
+`optimum-cli export openvino`, or a pre-exported `*-int4-ov` download) or a
+`cascadia shard` tree. **Not** an HF repo id.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--device <DEVICE>` | `GPU` | `GPU` / `CPU` / `NPU`. Also the indexed and compound OpenVINO forms — see [`--device` forms](#device-forms). |
+| `--engine <ENGINE>` | `ov-genai` | Inference engine. Use `ov-runtime` for a `cascadia shard` tree. |
+| `--api <API>` | `:8000` | API bind address. `127.0.0.1:8000` binds loopback only. |
+
+Note the defaults differ from `worker` (`GPU`/`ov-genai` here, `CPU`/`mock`
+there): `run` assumes you want real inference on the accelerator.
+
+```bash
+cascadia run ~/models/qwen3-1.7b-int4-ov --device GPU
+```
+
+---
+
+## `cascadia worker`
+
+One stage of a pipeline. Multi-stage inference is several `worker` processes
+chained by `--listen` / `--next`.
+
+```
+cascadia worker --rank <N> --total <N> --model <DIR> [OPTIONS]
+```
+
+### Topology
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--rank <RANK>` | *required* | 0-based stage index. |
+| `--total <TOTAL>` | *required* | Total number of stages. |
+| `--model <MODEL>` | *required* | Local model directory. Not an HF repo id. |
+| `--listen <LISTEN>` | `:9100` | Bind address for the upstream-receiving socket. |
+| `--next <NEXT>` | — | Downstream peer `host:port`. Required for every stage but the last. |
+| `--api <API>` | — | API bind address. **Rank 0 only** — other ranks enter the relay loop and never bind it. Passing it there logs a warning and is otherwise ignored. |
+| `--engine <ENGINE>` | `mock` | Inference engine. `mock` runs without OpenVINO. |
+| `--device <DEVICE>` | `CPU` | OpenVINO device target — see [below](#device-forms). |
+
+Rank 0 serves the API and holds the first layers; the last rank produces tokens
+and returns them up the chain. Start the *downstream* worker first — engines
+wait 60 s for a downstream peer, then give up.
+
+### Layer split
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--layer-start <N>` | `0` | First transformer layer this stage holds (inclusive). |
+| `--layer-end <N>` | `0` | One-past-last layer (exclusive). `0` = unset. |
+
+Both at `0` means an even split across ranks. Setting them pins an asymmetric
+split — e.g. a high-RAM CPU node holding most layers while small iGPU nodes hold
+a few each. MiniMax-M2 `sparse-moe` only.
+
+### OpenVINO tuning
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--ov-cache-dir <DIR>` | platform cache | Compiled-blob cache (plugin `CACHE_DIR`). See note below. |
+| `--ov-kv-precision <P>` | optimal | GPU KV-cache precision (`u8` / `f16`). |
+| `--ov-dyn-quant-group <N>` | — | GPU dynamic-quantization group size. |
+| `--ov-performance-mode <MODE>` | — | `LATENCY` / `THROUGHPUT` / `CUMULATIVE_THROUGHPUT`. |
+| `--ov-inference-precision <PREC>` | — | `f16` / `bf16` / `f32`. |
+| `--ov-num-streams <N>` | — | Parallel inference streams (`NUM_STREAMS`). |
+| `--ov-num-threads <N>` | — | Host CPU thread cap (`INFERENCE_NUM_THREADS`). CPU plugin only. |
+| `--ov-allow-auto-batching` | off | Allow GPU-plugin internal auto-batching. |
+| `--ov-execution-mode <MODE>` | — | `ACCURACY` / `PERFORMANCE`. |
+
+**`--ov-cache-dir` is on by default and matters.** Unset, it defaults to
+`<user-cache>/cascadia/ov-cache` (`~/.cache` on Linux, `~/Library/Caches` on
+macOS, `%LOCALAPPDATA%` on Windows). This turns a ~20 s cold GPU compile into a
+~1 s warm load on every later run — the single biggest latency win on the
+`ov-genai` path. Pass `--ov-cache-dir ""` to disable.
+
+On **Xe2 / Battlemage** GPUs, set `--ov-inference-precision f16` explicitly: f16
+and bf16 share XMX throughput, but the default can silently fall back to f32.
+
+### NPU
+
+| Flag | Meaning |
+|---|---|
+| `--npu-prefill-chunk-size <TOKS>` | `NPUW_LLM_PREFILL_CHUNK_SIZE` (OV 2025.3+). |
+| `--npu-max-prompt-len <TOKS>` | `MAX_PROMPT_LEN` — static-shape constraint. |
+| `--npu-min-response-len <TOKS>` | `MIN_RESPONSE_LEN` — static-shape constraint. |
+
+All three apply **only** with `--engine ov-genai` on an NPU device, and are
+silently dropped otherwise — only `ov-genai` routes them through an
+`ov::genai::LLMPipeline`.
+
+### Speculative decode
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--draft-model <DIR>` | — | Draft model path (FastDraft companion). A local IR dir, not an HF id. |
+| `--draft-device <DEVICE>` | same as `--device` | Device for the draft model. |
+| `--spec-k <K>` | `5` | Draft length per round. |
+| `--prompt-lookup <N>` | `0` | Prompt Lookup decoding with n-gram size N. Mutually exclusive with `--draft-model`. |
+
+For distributed speculative decode, every rank needs `--engine ov-dist-spec` —
+they share a wire protocol. See [engines/ov-dist-spec.md](engines/ov-dist-spec.md).
+
+### Sparse-MoE tuning
+
+`sparse-moe` engine only. Deep-dives: [perf/A3_TOPK_REDUCTION.md](perf/A3_TOPK_REDUCTION.md),
+[perf/CHESS_PER_CHANNEL.md](perf/CHESS_PER_CHANNEL.md).
+
+| Flag | Default | Env var | Meaning |
+|---|---|---|---|
+| `--top-k-override <K>` | manifest | — | Dispatch only the first K experts per token. K2.6 default is 8; K=4 gives +146% tok/s at matched quality. |
+| `--routing-threshold <T>` | `0.0` | — | Skip experts whose router weight is below T. Applied after `--top-k-override`. |
+| `--kv-prefix-cache-size <N>` | `0` | — | Cache post-prefill KV per prompt prefix. Single-stage only. ~150 MiB per snapshot, so practical caps are 1–8. |
+| `--max-cached-experts <N>` | `0` (unbounded) | `CASCADIA_MAX_EXPERTS_CACHED` | LRU bound on resident experts. ~25 MiB each (int4_bin) or ~75 MiB (ov_ir). |
+| `--ffn-sparsity-threshold <T>` | `0.0` (dense) | `CASCADIA_FFN_SPARSITY_THRESHOLD` | Skip FFN lanes below `T · max|silu(gate)|`. Useful range 0.05–0.15. |
+| `--ffn-axpy-down` | off | `CASCADIA_FFN_AXPY_DOWN` | AXPY-form down kernel. Only meaningful with `--ffn-sparsity-threshold > 0`. |
+| `--ffn-axpy-prebuild` | off | `CASCADIA_FFN_AXPY_PREBUILD` | Prebuild the AXPY cache for every (layer, expert). ~20 s once; ~190 GiB disk at K2.6. |
+| `--ffn-sparsity-thresholds-file <F>` | — | `CASCADIA_FFN_SPARSITY_THRESHOLDS_FILE` | Per-channel thresholds (CHESS). Takes precedence over the scalar. |
+| `--ffn-sparsity-capture-dir <D>` | — | `CASCADIA_FFN_SPARSITY_CAPTURE_DIR` | Dump `silu(gate)` histograms for calibration. Needs `--ffn-axpy-down`. |
+
+Raising sparsity trades quality for speed. Validate against dense before you
+deploy.
+
+### Other
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--max-tokens <N>` | `64` | Max new tokens in stdin mode. |
+| `--advertise-engines <LIST>` | from `--engine` | Override the engines list in the mDNS record. Cosmetic — dashboard only. |
+| `--advertise-device <LABEL>` | from `--device` | Override the device label in the mDNS record. Cosmetic. |
+
+---
+
+## `cascadia shard`
+
+Export a HuggingFace causal-LM into per-stage OpenVINO IRs. **The only command
+that downloads from HuggingFace.** Needs export-time Python deps (~3 GB); run
+`cascadia doctor` to see the exact pinned `pip install` line for your host.
+
+```
+cascadia shard --model <MODEL> -o <DIR> --num-stages <N> [OPTIONS]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--model <MODEL>` | *required* | HF repo id, a local dir with safetensors + `config.json`, or — for the Gemma-4 / Qwen3.6 surgery paths — an already-exported OpenVINO IR dir. |
+| `-o, --output-dir <DIR>` | *required* | Output shard tree (created for you). |
+| `--num-stages <N>` | *required* | Pipeline stages to split into. |
+| `--quantization <Q>` | `int4` | `fp16` / `int4` / `int4-asym` / `int8`. INT4 is the typical choice on Intel; FP16 if NNCF is unavailable or you want max quality. |
+| `--target <T>` | `cpu-gpu` | `npu` emits a stateless static-shape shard the NPU compiler accepts; `cpu-gpu` emits the stateful dynamic-shape shard. |
+| `--layer-split <LIST>` | even | Explicit per-stage boundaries. `--num-stages 3 --layer-split 16,24` on 32 layers → `[0,16) [16,24) [24,32)`. |
+| `--default-dtype <D>` | `fp16` | torch dtype during export. FP16 is **required** for `--target npu`. |
+| `--static-seq <N>` | `1` | NPU only: fixed query-window length. Must be 1. |
+| `--static-context <N>` | `1024` | NPU only: fixed total context length. |
+| `--stage <N>` | all | Export only this stage (debug) — re-export one stage without redoing the rest. |
+| `--python <PATH>` | auto | Override the interpreter running the bundled exporter. |
+| `--skip-check` | off | Skip interpreter/dependency detection. Faster start if you know the env is good. |
+
+```bash
+cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
+  -o ~/shards/llama-3.1-8b --num-stages 2 --quantization int4
+```
+
+Model-family dispatch happens inside the exporter. A Gemma-4 OpenVINO IR dir
+(with `openvino_language_model.xml`) routes to the text-surgery path; Gemma-4
+safetensors still use the torch exporter. Unsupported families are rejected up
+front — see [SHARDING.md](SHARDING.md) for the support table.
+
+---
+
+## `cascadia engines`
+
+Lists the registered inference engines. No flags.
+
+---
+
+## `cascadia discover`
+
+Browse mDNS for Cascadia peers on the LAN.
+
+```
+cascadia discover [--namespace <NS>] [--timeout <SECS>]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--namespace <NS>` | `default` | Discovery namespace. Peers in another namespace are ignored. |
+| `--timeout <SECS>` | `5` | How long to listen. Announces land in ~2.5 s in practice. |
+
+Discovery is informational: workers still need explicit `--rank` / `--total` /
+`--next`. Auto-ring formation is not wired up yet ([#89](https://github.com/labscommunity/cascadia/issues/89)).
+
+---
+
+## Heterogeneous placement
+
+A four-step pipeline that measures your hardware, then solves which device each
+stage should run on. Steps 1–3 need a real OpenVINO build; a stub binary will
+refuse. Background: [perf/THREE_TIER_PLACEMENT.md](perf/THREE_TIER_PLACEMENT.md).
+
+```
+shard --target npu  →  profile-stages  →  place  →  run-placement
+                       placement_profile.json      placement.json
+```
+
+`profile-devices` is a separate, simpler tool: it benchmarks *whole* models per
+device and is not part of this chain.
+
+### `cascadia profile-devices`
+
+Benchmark each OV device on this host against one whole model. Writes
+`device_profile.json`. See [perf/DEVICE_PROFILE.md](perf/DEVICE_PROFILE.md).
+
+```
+cascadia profile-devices --model <DIR> [OPTIONS]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--model <DIR>` | *required* | Exported OV-GenAI model dir. Same path you'd give `worker --engine ov-genai`. |
+| `--output <FILE>` | `device_profile.json` | Where to write the profile. |
+| `--devices <LIST>` | `auto` | `auto` enumerates every plugin OV sees. A comma list pins the set (`CPU,GPU` to skip a flaky NPU). `HETERO:` strings pass through verbatim. |
+| `--prompt <TEXT>` | `"Explain Intel Lunar Lake in three sentences."` | Measurement prompt. Keep it short — the bench measures decode. |
+| `--max-tokens <N>` | `32` | Tokens generated per run. |
+| `--runs <N>` | `3` | Measured runs per device; best is reported as tok/s. |
+| `--warmup <N>` | `1` | Warmup runs, not counted. Bump to 2 on large first-vs-second-run variance. |
+| `--include-hetero-permutations` | off | Also profile every `HETERO:` priority order. Count grows factorially — 6 extra runs on a 3-device host. |
+| `--ov-cache-dir <DIR>` | off | Off by default so cold-compile time is measured honestly. |
+| `--no-summary` | off | Suppress the stdout table. JSON is still written. |
+
+### `cascadia profile-stages`
+
+Cost table: every shard stage measured on every device (latency + memory +
+op-support). Writes the `placement_profile.json` that `place` consumes.
+
+```
+cascadia profile-stages --shard <DIR> [OPTIONS]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--shard <DIR>` | *required* | Multi-stage shard dir (`stage_0/`, `stage_1/`, …). **Must be a static export** — `cascadia shard --target npu`. |
+| `--output <FILE>` | `placement_profile.json` | The input to `cascadia place`. |
+| `--devices <LIST>` | `auto` | `auto`, or a comma list like `GPU,NPU,CPU`. |
+| `--runs <N>` | `5` | Timed forward passes per (stage, device); the min is recorded. |
+| `--warmup <N>` | `2` | Warmup passes, not counted. |
+| `--mem-headroom <F>` | `0.9` | Fraction of each device's memory treated as usable — leaves room for KV cache and activations. |
+| `--pool-gb <N>` | — | Usable shared UMA pool in GiB. Sets the solver's global memory gate *and* the CPU tier's budget. Omit to skip the global gate. |
+| `--force` | off | Re-measure even when a cached profile with a matching fingerprint exists. |
+
+Results are cached by fingerprint (shard, devices, pool) — NPU compiles are slow,
+so a matching profile is reused unless you pass `--force`.
+
+### `cascadia place`
+
+Solve the three-tier {iGPU, NPU, CPU} placement ILP. Writes `placement.json`.
+
+```
+cascadia place --profile <FILE> [OPTIONS]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--profile <FILE>` | *required* | The `placement_profile.json` from `profile-stages`. |
+| `--output <FILE>` | `placement.json` | Solved placement. |
+| `--worker-overhead-gb <N>` | `1` | Resident overhead *per worker process* in GiB, beyond its weights. Used only to warn when the total footprint would exhaust the pool and swap. ~1 GiB/worker measured for a 12-stage fp16 run on Lunar Lake. |
+
+### `cascadia run-placement`
+
+Launch the solved pipeline: one worker per stage, each pinned to its device.
+
+```
+cascadia run-placement --shard <DIR> --placement <FILE> [OPTIONS]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--shard <DIR>` | *required* | The same shard dir you profiled. |
+| `--placement <FILE>` | *required* | `placement.json` from `cascadia place`. |
+| `--api <API>` | `127.0.0.1:8000` | API bind address for the pipeline head (rank 0). |
+| `--relay-host <HOST>` | `127.0.0.1` | Host the relay sockets bind/dial. |
+| `--relay-base <PORT>` | `9100` | Base relay port. Stage `r` (r≥1) listens on `relay_base + r`. Concurrent runs on one host must not overlap. |
+| `--ov-cache-dir <DIR>` | — | Forwarded to every worker. |
+| `--dry-run` | off | Print the worker command lines and exit without spawning. |
+
+This launcher spawns all stages as **local** child processes. To span machines,
+run `cascadia worker` per box by hand.
+
+---
+
+## `cascadia completions`
+
+```
+cascadia completions <SHELL>
+```
+
+`<SHELL>` is one of `bash`, `zsh`, `fish`, `elvish`, `powershell`. The script
+goes to stdout.
+
+```bash
+cascadia completions zsh  > ~/.zfunc/_cascadia
+cascadia completions bash > /etc/bash_completion.d/cascadia
+```
+
+---
+
+## Device forms
+
+`--device` is forwarded verbatim to `ov::Core::compile_model`, so it accepts
+every form OpenVINO does:
+
+| Form | Meaning |
+|---|---|
+| `CPU` | Host CPU. |
+| `GPU`, `GPU.0`, `GPU.1`, … | A specific GPU. The iGPU is `.0` by convention. |
+| `NPU`, `NPU.0`, … | Neural Processing Unit (Lunar Lake and later). |
+| `AUTO` | Let OpenVINO pick. |
+| `MULTI:GPU.1,GPU.0,CPU` | Round-robin across devices. |
+| `HETERO:GPU.1,CPU` | Split the graph by op affinity. |
+| `BATCH:GPU` | Auto-batch (throughput-favored). |
+
+Run `cascadia doctor` to see which devices OpenVINO can actually reach on this
+host. A device that `clinfo` reports healthy is **not** necessarily one the
+OpenVINO GPU plugin can see.
+
+## Engines
+
+| Engine | Input layout | Notes |
+|---|---|---|
+| `mock` | none | No OpenVINO needed. Dev / discovery testing. |
+| `ov-genai` | whole-model OpenVINO IR | Default for `run`. Adds FastDraft speculative decode + prompt lookup. |
+| `ov-runtime` | `cascadia shard` tree | The staged pipeline engine. |
+| `ov-dist-spec` | `cascadia shard` tree | Distributed speculative decode. Every rank must use it. |
+| `gemma4` | `gemma4_cached_v1` shards | Per-layer-type asymmetric attention, KV-sharing, baked softcap. |
+| `sparse-moe` | `manifest.json` + expert tree | Top-k expert routing through an AVX-512 int4 GEMM. Single-stage, CPU. |
+| `qwen36-moe` | Qwen3.6 surgery output | Greedy-only, batch=1. CPU-targeted decode. |
+
+Per-engine deep dives: [engines/](engines/). Per-family export notes:
+[architectures/](architectures/).

--- a/docs/NPU_SHARDING.md
+++ b/docs/NPU_SHARDING.md
@@ -23,9 +23,9 @@ the host at runtime.
 
 ## Half 1 — Export: static, stateless, per-stage IRs
 
-`tools/export_shards.py --target npu` emits one IR per stage. The Rust
-`cascadia shard` CLI does **not** expose `--target`, so NPU exports run the
-Python exporter directly (needs `torch`, `transformers`, `nncf`, `safetensors`,
+`cascadia shard --target npu` emits one IR per stage (the CLI forwards
+`--target` / `--static-seq` / `--static-context` to the bundled exporter, which
+needs `torch`, `transformers`, `nncf`, `safetensors`,
 `openvino`). Per stage (`export_shards.py` sections 5-10, ~lines 1348-1538):
 
 - **Layer split.** Stage 0 owns the embedding + first layer slice
@@ -125,8 +125,8 @@ issue #41):
 ## Reproduce
 
 ```bash
-# 1. Export a 2-stage static NPU shard (run the Python exporter directly):
-python tools/export_shards.py \
+# 1. Export a 2-stage static NPU shard:
+cascadia shard \
   --model unsloth/Llama-3.2-1B-Instruct \
   --output-dir ./llama1b-npu-2stage \
   --num-stages 2 --quantization int4 \
@@ -137,7 +137,7 @@ cascadia profile-stages --shard ./llama1b-npu-2stage --devices NPU,GPU,CPU
 
 # 3. (optional) Solve + launch a heterogeneous pipeline:
 cascadia place --profile placement_profile.json --output placement.json
-cascadia run-placement --placement placement.json
+cascadia run-placement --shard ./llama1b-npu-2stage --placement placement.json
 ```
 
 A 2-stage Llama-3.2-1B NPU shard has been run end-to-end on a Meteor Lake AI PC

--- a/docs/SHARDING.md
+++ b/docs/SHARDING.md
@@ -12,7 +12,7 @@ the embedding + (on the last stage) the final norm + lm_head.
 
 ```bash
 # One-time pip install (export-time only, not needed at runtime):
-pip install torch transformers openvino safetensors huggingface_hub nncf
+pip install -r tools/requirements.txt
 
 # Two-stage shard from HF:
 cascadia shard --model unsloth/Meta-Llama-3.1-8B-Instruct \
@@ -51,7 +51,10 @@ network).
 | `--quantization` | `int4` (default — typical), `int4_asym`, `int8`, or `fp16`. INT4 needs nncf installed. |
 | `--layer-split a,b,...` | Override the uniform split. With `--num-stages 3 --layer-split 16,24` on a 32-layer model: stage 0 = layers 0..15, stage 1 = 16..23, stage 2 = 24..31. Useful for asymmetric hardware (e.g. give the bigger node more layers). |
 | `--stage N` | Re-export only stage N (debugging). |
-| `--python /path/to/python` | Override Python interpreter. Defaults to `python3` then `python`. |
+| `--target cpu-gpu\|npu` | Deployment target. `npu` emits a stateless static-shape shard — see [NPU_SHARDING.md](NPU_SHARDING.md). |
+| `--static-seq N` / `--static-context N` | NPU only: fixed query window (must be 1) and total context (default 1024). |
+| `--default-dtype fp16\|fp32` | torch dtype during export. `fp16` (default) is required for `--target npu`. |
+| `--python /path/to/python` | Override Python interpreter. By default cascadia tries `python3` then `python` and picks the first that can import the export deps — so a bare `python3` stub (common on Windows) doesn't shadow the real install. |
 | `--skip-check` | Skip the dependency probe — pass if you know your env is already set up. |
 
 ## Supported architectures
@@ -86,7 +89,8 @@ family, **Status** is one of:
 | **Qwen3 dense** | ✅ tested | Dispatches to `Qwen3DecoderLayer`; `q_norm` / `k_norm` (RMSNorm on Q/K before RoPE) are detected and applied automatically. `head_dim` is read from `config.head_dim` (Qwen3 decouples it from `hidden_size / num_heads`). |
 | **DeepSeek R1 Distills** (Qwen / Llama 7B–70B) | ✅ supported | Distills inherit their base config (`model_type: "qwen2"` or `"llama"`), so they ride the existing paths with no special handling. Short aliases (`r1-distill-qwen-7b`, …) resolve via `tools/model_aliases.py` (#49). |
 | **DeepSeek-V2-Lite** | ⚠️ best-effort / MoE | Standard attention + RoPE on the Llama path, BUT V2-Lite is itself MoE (`n_routed_experts`), so `is_moe_config` now rejects it (#60). Use the dense R1-Distills instead. |
-| **Phi-3** (Mini 4B, Medium 14B, Small 3.8B) | ✅ supported | `Phi3DecoderLayer` loads; fused `qkv_proj` is split (#58). **Partial rotary** (`partial_rotary_factor < 1.0`) is honoured (#69) — only the leading `factor·head_dim` dims rotate, the rest pass through. |
+| **Phi-3** (Mini 3.8B, Medium 14B) | ✅ supported | `Phi3DecoderLayer` loads; fused `qkv_proj` is split (#58). **Partial rotary** (`partial_rotary_factor < 1.0`) is honoured (#69) — only the leading `factor·head_dim` dims rotate, the rest pass through. |
+| **Phi-3-Small** (7B) | 🚧 rejected | A distinct **blocksparse** architecture (`Phi3SmallForCausalLM`, tiktoken tokenizer, `trust_remote_code`) — not the `Phi3DecoderLayer` path. Unrunnable on any OpenVINO stack today: no prebuilt int4-ov IR exists, `cascadia shard` fails at config-parse, and `optimum-cli export openvino` rejects `phi3small` as a custom architecture. |
 | **Phi-4** (14B, Phi-4-mini, Phi-4-reasoning) | ✅ supported (short context) | Reports `model_type: "phi3"`. **Phi-4-mini** has `partial_rotary_factor=0.75` (honoured, #69) and **LongRoPE** scaling (not modeled — soft-warned). Exact within the original context window; long-context degrades. |
 | **Gemma 1 / Gemma 2** | ✅ supported (short context) | Gemma 1 (2-norm) and Gemma 2 (4-norm + attention/final **logit softcapping** + sqrt(hidden) embed scaling) are applied (#61). Sliding-window attention (Gemma 2) is treated as full-causal — exact within the window. |
 | **Gemma 3** (1B / 4B / 12B / 27B) | 🚧 rejected | Interleaved local/global sliding-window, QK-norm, and per-layer-type RoPE bases are not modeled; `detect_architecture` rejects it up front (#69) rather than mis-exporting through the `gemma` path. |
@@ -102,8 +106,9 @@ family, **Status** is one of:
 
 For unknown architectures the script falls back to `LlamaDecoderLayer`
 and warns on stderr. If the resulting shard's outputs match the HF
-reference (you can spot-check with `cascadia worker --engine ov-genai`
-single-stage on the same model), it's good. If they diverge, file an
+reference, it's good. (To compare against a reference, serve an
+`optimum-cli`-exported IR of the same model through `--engine ov-genai`;
+ov-genai cannot read a HuggingFace checkout or a shard tree.) If they diverge, file an
 issue with the model's `model_type` and `architectures` from `config.json`.
 
 ### Architecture quirks — handled, dropped, or rejected
@@ -187,7 +192,7 @@ identical.
 ## Troubleshooting
 
 **"NNCF not installed" warning on INT4 export**: the script falls back to
-FP16 weights silently. Install nncf (`pip install nncf>=2.13`) and re-run.
+FP16 weights silently. Install nncf (`pip install "nncf>=2.18"`) and re-run.
 
 **"tied embeddings" log line on Llama 3.2 1B/3B**: not an error. Llama
 3.2 small models share `lm_head.weight` with `embed_tokens.weight`. The
@@ -202,8 +207,8 @@ int8` which doesn't hit the same path.
 **"unknown model_type, falling back to Llama" warning**: the model
 isn't in the explicit support list. The export will produce a working
 IR for any model whose layer interface matches Llama's, but you should
-verify the outputs (run `cascadia worker --engine ov-genai` against the
-same source model and compare the first 10 generated tokens).
+verify the outputs (serve an `optimum-cli`-exported IR of the same model
+through `--engine ov-genai` and compare the first 10 generated tokens).
 
 **OOM during INT4 quantization**: NNCF holds the full FP16 model in
 RAM during compression. For 70B+ models, run on a machine with ≥ 64 GB

--- a/docs/SHARDING.md
+++ b/docs/SHARDING.md
@@ -49,7 +49,7 @@ network).
 | `--model` | HF repo id (`unsloth/Meta-Llama-3.1-8B-Instruct`), a local dir with `config.json` + `*.safetensors`, or (Gemma-4 / Qwen3.6 only) an exported OpenVINO IR dir. HF repos auto-download into `~/.cache/cascadia/models/`. |
 | `-o`, `--output-dir` | Where to write the shard tree. |
 | `--num-stages N` | Pipeline stages to split into. 2 is the common case for 2-machine setups; use 3+ for larger clusters. |
-| `--quantization` | `int4` (default — typical), `int4_asym`, `int8`, or `fp16`. INT4 needs nncf installed. |
+| `--quantization` | `int4` (default — typical), `int4-asym`, `int8`, or `fp16`. INT4 needs nncf installed. |
 | `--layer-split a,b,...` | Override the uniform split. With `--num-stages 3 --layer-split 16,24` on a 32-layer model: stage 0 = layers 0..15, stage 1 = 16..23, stage 2 = 24..31. Useful for asymmetric hardware (e.g. give the bigger node more layers). |
 | `--stage N` | Re-export only stage N (debugging). |
 | `--target cpu-gpu\|npu` | Deployment target. `npu` emits a stateless static-shape shard — see [NPU_SHARDING.md](NPU_SHARDING.md). |
@@ -170,7 +170,7 @@ There's a per-stage overhead (network round-trip + OV plugin init), so
 | Mode | Weight bits | Quality loss | Speed | Recommended for |
 |------|------------:|--------------|-------|-----------------|
 | `int4` | 4 (sym, group=128) | ~1-2% on standard benchmarks | fastest | **Default.** Almost always the right choice. |
-| `int4_asym` | 4 (asym, group=128) | similar to int4 | similar | When INT4 sym shows numerical issues on a specific model. |
+| `int4-asym` | 4 (asym, group=128) | similar to int4 | similar | When INT4 sym shows numerical issues on a specific model. |
 | `int8` | 8 (asym, per-channel) | ~0.5% | slower than int4 | When int4 quality is unacceptable. |
 | `fp16` | 16 | none | slowest, biggest | Debugging or when nncf isn't installed. |
 

--- a/docs/SHARDING.md
+++ b/docs/SHARDING.md
@@ -11,7 +11,8 @@ the embedding + (on the last stage) the final norm + lm_head.
 ## Quick start
 
 ```bash
-# One-time pip install (export-time only, not needed at runtime):
+# One-time pip install (export-time only, not needed at runtime). From a source
+# checkout; from a release bundle run `cascadia doctor`, which prints the pins:
 pip install -r tools/requirements.txt
 
 # Two-stage shard from HF:
@@ -45,7 +46,7 @@ network).
 
 | Flag | Meaning |
 |------|---------|
-| `--model` | HF repo id (`unsloth/Meta-Llama-3.1-8B-Instruct`) OR local path to a directory with `config.json` + `*.safetensors`. HF repos auto-download into `~/.cache/cascadia/models/`. |
+| `--model` | HF repo id (`unsloth/Meta-Llama-3.1-8B-Instruct`), a local dir with `config.json` + `*.safetensors`, or (Gemma-4 / Qwen3.6 only) an exported OpenVINO IR dir. HF repos auto-download into `~/.cache/cascadia/models/`. |
 | `-o`, `--output-dir` | Where to write the shard tree. |
 | `--num-stages N` | Pipeline stages to split into. 2 is the common case for 2-machine setups; use 3+ for larger clusters. |
 | `--quantization` | `int4` (default — typical), `int4_asym`, `int8`, or `fp16`. INT4 needs nncf installed. |

--- a/docs/architectures/gemma4-support.md
+++ b/docs/architectures/gemma4-support.md
@@ -53,7 +53,7 @@ GEMMA 4 EXPORT COMPLETE  Total: 9596 MB
 
 Each stage compiles to an OpenVINO IR that runs through
 `openvino.Core().compile_model()` and returns logits of correct shape
-on prefill + decode. The pre-existing `--quantization {int4,int4_asym,
+on prefill + decode. The pre-existing `--quantization {int4,int4-asym,
 int8}` knobs are wired through (nncf compress_weights), though INT4
 on the per-layer-scalar buffers sometimes fails — start with `fp16`
 and try INT4 once you've confirmed parity.

--- a/docs/architectures/minimax-m2.md
+++ b/docs/architectures/minimax-m2.md
@@ -73,7 +73,7 @@ Needs a Python env with `torch`, `transformers>=4.57` (for `MiniMaxM2`),
 ## Run
 
 ```bash
-cascadia worker --engine sparse-moe --model /path/to/m2_export --device CPU
+cascadia worker --rank 0 --total 1 --engine sparse-moe --model /path/to/m2_export --device CPU --api :8000
 ```
 
 The builder reads `manifest.json`; `shell_backend: "ov_ir"` automatically

--- a/docs/architectures/mistral.md
+++ b/docs/architectures/mistral.md
@@ -78,7 +78,7 @@ all dropped sliding window.
 Same shape as the [R1-Distill recipe](./r1-distill.md). Substitute:
 
 ```bash
-ssh <export-host> "python ~/cascadia/tools/export_shards.py \
+ssh <export-host> "cascadia shard \
   --model mistral-nemo-12b \
   --output-dir /tmp/mistral_nemo_int4 \
   --num-stages 2 --quantization int4"

--- a/docs/architectures/qwen3.6.md
+++ b/docs/architectures/qwen3.6.md
@@ -35,7 +35,7 @@ layout and uses `VLMPipeline` (text-only) via the shim's
 ```bash
 # Pre-exported IR (preferred):
 #   https://huggingface.co/OpenVINO/Qwen3.6-35B-A3B-int4-ov
-cascadia run --engine ov-genai --model /path/to/Qwen3.6-35B-A3B-int4-ov --device GPU
+cascadia run /path/to/Qwen3.6-35B-A3B-int4-ov --engine ov-genai --device GPU
 ```
 
 Or export yourself with Optimum-Intel on the 2026.2 toolchain

--- a/docs/architectures/qwen36-moe-support.md
+++ b/docs/architectures/qwen36-moe-support.md
@@ -242,7 +242,7 @@ XML. Proven step by step:
   `proto_m3_decode.py` is the decode-loop reference for the Rust
   engine.
 - **Engine E2E: 5/5 API suite green**
-  (`cascadia run <shards> --engine qwen36-moe --device CPU --api`):
+  (`cascadia run <shards> --engine qwen36-moe --device CPU --api :8000`):
   /v1/models, two sequential chats (state-reset invariant), greedy
   determinism (identical 13-token outputs), 96-token generation at
   4.7-8.8 tok/s decode (matches the chain envelope). An earlier 2/5

--- a/docs/architectures/r1-distill.md
+++ b/docs/architectures/r1-distill.md
@@ -55,7 +55,7 @@ and the `192.168.1.10` / `192.168.1.20` addresses below are
 placeholders — node A is .10, node B is .20.)
 
 ```console
-$ curl http://192.168.1.10:8000/v1/chat/completions -d '{
+$ curl http://192.168.1.10:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
     "model": "r1-distill-qwen-1.5b",
     "messages": [{"role": "user", "content": "What is 17 * 23? Think step by step."}],
     "max_tokens": 96
@@ -141,7 +141,7 @@ Steps to reproduce the pipeline-parallel run:
 5. From a third terminal:
 
    ```bash
-   curl http://node-a.local:8000/v1/chat/completions -d '{
+   curl http://node-a.local:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
      "model": "r1-distill-qwen-1.5b",
      "messages": [{"role": "user", "content": "What is 17 * 23?"}],
      "max_tokens": 64

--- a/docs/architectures/r1-distill.md
+++ b/docs/architectures/r1-distill.md
@@ -97,7 +97,7 @@ Steps to reproduce the pipeline-parallel run:
 
    ```bash
    ssh <export-host> "source ~/.venv/export/bin/activate && \
-     python ~/cascadia/tools/export_shards.py \
+     cascadia shard \
        --model r1-distill-qwen-1.5b \
        --output-dir /tmp/r1_int4 \
        --num-stages 2 --quantization int4"

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -2,16 +2,21 @@
 
 Cascadia is a long-running CLI process; it does not daemonize itself. Run it under whatever supervisor your platform already uses — systemd on Linux, NSSM or Task Scheduler on Windows, launchd on macOS.
 
+Deploy a **release bundle**: the OpenVINO libraries sit beside the binary, so a service finds them with no extra environment. A **source-built** binary links against the SDK, and a service does not inherit your shell's `PATH` — point it at the runtime libs — **including TBB, which lives beside the runtime, not inside it**: `nssm set <svc> AppEnvironmentExtra PATH=<sdk>\runtime\bin\intel64\Release;<sdk>\runtime\3rdparty\tbb\bin;…` on Windows, `Environment=LD_LIBRARY_PATH=<sdk>/runtime/lib/intel64:<sdk>/runtime/3rdparty/tbb/lib` on Linux. Otherwise the worker exits immediately on a missing `libtbb`/`tbb12`.
+
 ## Linux (systemd)
 
 A template unit lives at [`cascadia-worker.service`](cascadia-worker.service). It expects a `cascadia` user, the `cascadia` binary on `PATH` (or adjust `ExecStart`), and shards under `/opt/cascadia/shards/`.
+
+`CASCADIA_API` is what keeps rank 0 alive: a worker started without `--api` reads stdin, gets EOF under systemd, and exits 0 — which `Restart=on-failure` will *not* restart. Relay ranks (rank > 0) ignore `--api` and stay up on the relay loop, so one template serves every rank.
 
 ```bash
 # Adjust the Environment= lines in the unit file, then:
 sudo cp docs/deploy/cascadia-worker.service /etc/systemd/system/cascadia-worker@.service
 sudo systemctl daemon-reload
 
-# Start the worker for stage 0 and stage 1:
+# Start the worker for stage 0 and stage 1 (one per HOST — two instances on the
+# same host would both bind CASCADIA_LISTEN):
 sudo systemctl enable --now cascadia-worker@0.service
 sudo systemctl enable --now cascadia-worker@1.service
 
@@ -22,7 +27,7 @@ sudo journalctl -u cascadia-worker@0.service -f
 
 The unit is `Type=simple`, so systemd tracks the worker process directly — no PID file needed. It restarts the worker on failure (`Restart=on-failure`, capped at 3 starts/min).
 
-`KillSignal=SIGTERM` works with the worker's SIGTERM handler — the worker calls `runner.close()` (drops sockets, releases GPU contexts) before exiting 0.
+`KillSignal=SIGTERM` works with rank 0's SIGTERM handler — it calls `runner.close()` (drops sockets, releases GPU contexts) before exiting 0. Relay ranks (rank > 0) sit in the activation-relay loop and do not install a handler, so they are terminated by the signal without a graceful close; nothing is persisted there, but expect no shutdown log line from them.
 
 ## Windows (NSSM)
 
@@ -31,12 +36,14 @@ The unit is `Type=simple`, so systemd tracks the worker process directly — no 
 nssm install cascadia-worker-0 "C:\cascadia\cascadia.exe" `
     "worker --rank 0 --total 2 --engine ov-runtime --device GPU " `
     "--model C:\cascadia\shards --next 10.0.0.2:9100 --listen :9100 " `
-    "--log-level info"
+    "--api :8000 --log-level info"
 nssm set cascadia-worker-0 AppStdout C:\ProgramData\cascadia\worker-0.log
 nssm set cascadia-worker-0 AppStderr C:\ProgramData\cascadia\worker-0.log
 nssm set cascadia-worker-0 AppExit Default Restart
 nssm start cascadia-worker-0
 ```
+
+`--api` is required on rank 0 for the same reason as under systemd: without it the worker reads stdin, gets EOF as a service, and exits 0 — which `AppExit Default Restart` turns into a restart loop. Relay ranks (rank > 0) don't need it.
 
 NSSM's graceful-stop sequence (console event, then `WM_CLOSE`, then `TerminateProcess`) gives the worker a chance to shut down cleanly.
 

--- a/docs/deploy/cascadia-worker.service
+++ b/docs/deploy/cascadia-worker.service
@@ -22,6 +22,10 @@ Environment=CASCADIA_LISTEN=:9100
 Environment=CASCADIA_DEVICE=GPU
 Environment=CASCADIA_ENGINE=ov-runtime
 
+# Rank 0 serves the API. Without --api the worker reads stdin, gets EOF under
+# systemd and exits 0 — inactive, and Restart=on-failure won't fire.
+Environment=CASCADIA_API=:8000
+
 # %i is the instance suffix (use `cascadia-worker@0.service`, `@1.service`, ...).
 ExecStart=/usr/bin/env cascadia worker \
     --rank %i --total ${CASCADIA_TOTAL} \
@@ -29,6 +33,7 @@ ExecStart=/usr/bin/env cascadia worker \
     --model ${CASCADIA_SHARDS} \
     --listen ${CASCADIA_LISTEN} \
     --next ${CASCADIA_NEXT} \
+    --api ${CASCADIA_API} \
     --log-level info
 
 # Cascadia handles SIGTERM cleanly: runner.close() then exit 0.

--- a/docs/engines/ov-dist-spec.md
+++ b/docs/engines/ov-dist-spec.md
@@ -64,7 +64,7 @@ cascadia worker --rank 1 --total 2 --engine ov-dist-spec --device GPU \
 cascadia worker --rank 0 --total 2 --engine ov-dist-spec --device GPU \
               --model /shards/shards_2stage_v5_beam \
               --next 10.10.10.2:9100 --api :8000 \
-              --draft-model unsloth/Llama-3.2-1B-Instruct \
+              --draft-model /models/llama-3.2-1b-int4-ov \
               --spec-k 4
 ```
 

--- a/docs/engines/ov-genai.md
+++ b/docs/engines/ov-genai.md
@@ -10,9 +10,15 @@ Wraps Intel's `openvino_genai.LLMPipeline` to expose **FastDraft speculative dec
 
 ## Shard format
 
-A single-directory OpenVINO IR exported by `optimum-cli`:
+A single-directory OpenVINO IR: the model graph (`openvino_model.xml`/`.bin`, or `openvino_language_model.xml` for the VLM-style exports of Qwen3.5/3.6 and Gemma 4) **plus** `openvino_tokenizer.xml` and `openvino_detokenizer.xml`. `ov::genai::LLMPipeline` loads the tokenizer as an OpenVINO model, so an IR missing those two starts and then generates empty strings (`completion_tokens: 0`) rather than failing loudly.
+
+`cascadia shard` does not produce this layout — it emits per-stage IRs for `ov-runtime`. Either download a pre-exported IR (Intel publishes INT4 IRs for many models under the [OpenVINO](https://huggingface.co/OpenVINO) org) or build one with Intel's exporter:
 
 ```bash
+# The [openvino] extra pulls openvino, nncf, AND openvino-tokenizers — without
+# openvino-tokenizers the export silently omits the two tokenizer IRs.
+pip install "optimum-intel[openvino]"
+
 optimum-cli export openvino \
     --model unsloth/Meta-Llama-3.1-8B-Instruct \
     --weight-format int4 \

--- a/docs/perf/A3_TOPK_REDUCTION.md
+++ b/docs/perf/A3_TOPK_REDUCTION.md
@@ -8,7 +8,7 @@ negligible quality cost.
 ## Usage
 
 ```bash
-cascadia worker --engine sparse-moe --top-k-override 4 ...
+cascadia worker --rank 0 --total 1 --engine sparse-moe --model <manifest-tree> --api :8000 --top-k-override 4
 ```
 
 Default is `None` (no behavior change — uses manifest's top_k, which
@@ -20,7 +20,7 @@ weights/ids; we just skip dispatching the tail.
 There's also a complementary flag:
 
 ```bash
-cascadia worker --engine sparse-moe --routing-threshold 0.1 ...
+cascadia worker --rank 0 --total 1 --engine sparse-moe --model <manifest-tree> --api :8000 --routing-threshold 0.1
 ```
 
 which skips experts whose router weight is below the threshold. The

--- a/docs/perf/CHESS_PER_CHANNEL.md
+++ b/docs/perf/CHESS_PER_CHANNEL.md
@@ -86,7 +86,7 @@ Capture requires `--ffn-axpy-down` (the only path that surfaces `silu(gate)`
 to the runner; the bf16-boundary path doesn't).
 
 ```bash
-cascadia worker \
+cascadia worker --rank 0 --total 1 --engine sparse-moe --api :8000 \
   --model /path/to/k26 \
   --device CPU \
   --ffn-axpy-down \
@@ -119,7 +119,7 @@ the threshold JSON file. Wall time: seconds.
 ### Phase 3 — serve
 
 ```bash
-cascadia worker \
+cascadia worker --rank 0 --total 1 --engine sparse-moe --api :8000 \
   --model /path/to/k26 \
   --device CPU \
   --ffn-axpy-down \

--- a/scripts/setup-openvino.sh
+++ b/scripts/setup-openvino.sh
@@ -39,10 +39,12 @@ UBUNTU_SUITE="${UBUNTU_CODENAME:-}"
 if [[ "${ID:-}" != "ubuntu" && "${ID_LIKE:-}" != *ubuntu* ]]; then UBUNTU_SUITE=""; fi
 
 INTEL_LIST=/etc/apt/sources.list.d/intel-gpu.list
-# Intel's graphics signing keys (production, and the 2024 predecessor). Pinning
-# the fingerprint means a hijacked key/URL cannot become an apt trust anchor.
-INTEL_KEY_FPR="E0258B57D9C442D5DB1855C271740E4DE392BFE3"
-INTEL_KEY_FPR_OLD="4E9EFCDEF82800256C1E7C64B02DB9BD8C321DCB"
+# The exact set of primary keys Intel ships (current signing key + its 2024
+# predecessor), sorted. Checking only that the keyring CONTAINS one of these is
+# not enough: a keyring is a concatenation, so whoever controls the key URL
+# could append their own and apt would trust that one too.
+INTEL_KEY_FPRS="4E9EFCDEF82800256C1E7C64B02DB9BD8C321DCB
+E0258B57D9C442D5DB1855C271740E4DE392BFE3"
 
 echo "==> Installing Intel GPU runtime packages (OpenCL + Level-Zero + Compute Runtime)"
 $SUDO apt-get update
@@ -64,9 +66,11 @@ if [[ -n "$UBUNTU_SUITE" ]]; then
     echo "ERROR: could not fetch Intel's graphics key. Nothing was changed."
     exit 1
   fi
-  if ! gpg --show-keys --with-colons "$KEY_TMP" | awk -F: '/^fpr:/{print $10}' \
-       | grep -qx -e "$INTEL_KEY_FPR" -e "$INTEL_KEY_FPR_OLD"; then
-    echo "ERROR: Intel's graphics key does not match a known fingerprint. Refusing to trust it."
+  KEY_PRIMARIES="$(gpg --show-keys --with-colons "$KEY_TMP" \
+    | awk -F: '$1=="pub"{p=1;next} $1=="fpr"&&p{print $10;p=0}' | sort)"
+  if [[ "$KEY_PRIMARIES" != "$(printf '%s\n' "$INTEL_KEY_FPRS" | sort)" ]]; then
+    echo "ERROR: Intel's graphics key is not the expected set of keys. Refusing to trust it."
+    echo "       Nothing was changed."
     exit 1
   fi
   $SUDO install -m 0644 "$KEY_TMP" /usr/share/keyrings/intel-graphics.gpg

--- a/scripts/setup-openvino.sh
+++ b/scripts/setup-openvino.sh
@@ -21,29 +21,82 @@ fi
 
 if ! command -v apt-get >/dev/null 2>&1; then
   echo "This script uses apt-get (Ubuntu/Debian). For other distros, install the"
-  echo "equivalents of: intel-opencl-icd intel-level-zero-gpu level-zero ocl-icd-libopencl1"
-  echo "and add your user to the 'render' group. See INSTALL.md."
+  echo "equivalents of: intel-opencl-icd, ocl-icd-libopencl1, and the Level-Zero"
+  echo "driver + loader (Ubuntu 24.04: libze-intel-gpu1 + libze1)."
+  echo "Then add your user to the 'render' group. See INSTALL.md."
   exit 1
 fi
 
 SUDO=""
 if [[ "$(id -u)" -ne 0 ]]; then SUDO="sudo"; fi
 
+# shellcheck disable=SC1091
+. /etc/os-release
+# Intel publishes its graphics repo for Ubuntu only; the suite is the *Ubuntu*
+# codename, which on derivatives (Mint, Pop!_OS) is UBUNTU_CODENAME, not
+# VERSION_CODENAME.
+UBUNTU_SUITE="${UBUNTU_CODENAME:-}"
+if [[ "${ID:-}" != "ubuntu" && "${ID_LIKE:-}" != *ubuntu* ]]; then UBUNTU_SUITE=""; fi
+
+INTEL_LIST=/etc/apt/sources.list.d/intel-gpu.list
+
 echo "==> Installing Intel GPU runtime packages (OpenCL + Level-Zero + Compute Runtime)"
 $SUDO apt-get update
+
+if [[ -n "$UBUNTU_SUITE" ]]; then
+  # Prefer Intel's repo, not the distro's: Ubuntu 24.04 ships Compute Runtime
+  # 23.43, which predates Lunar Lake and Arc B — the hardware cascadia targets.
+  echo "==> Adding Intel's graphics repo (${UBUNTU_SUITE})"
+  $SUDO apt-get install -y --no-install-recommends ca-certificates gnupg wget
+  wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
+    | $SUDO gpg --yes --dearmor -o /usr/share/keyrings/intel-graphics.gpg
+  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${UBUNTU_SUITE} client" \
+    | $SUDO tee "$INTEL_LIST" >/dev/null
+  # If the suite doesn't exist, remove the source again rather than leaving a
+  # broken entry that fails every future `apt-get update` on this machine.
+  if ! $SUDO apt-get update; then
+    $SUDO rm -f "$INTEL_LIST"
+    echo "ERROR: Intel's repo has no '${UBUNTU_SUITE}' suite — removed $INTEL_LIST."
+    echo "Install the GPU runtime by hand; see INSTALL.md."
+    exit 1
+  fi
+  LEVEL_ZERO_PKGS=(libze-intel-gpu1 libze1)
+elif apt-cache show libze-intel-gpu1 >/dev/null 2>&1; then
+  # Non-Ubuntu with the packages in its own repos: use them, but say what you get.
+  echo "==> Not Ubuntu; using distro packages (older Compute Runtime — new Intel"
+  echo "    GPUs may not be detected). See INSTALL.md."
+  LEVEL_ZERO_PKGS=(libze-intel-gpu1 libze1)
+else
+  echo "ERROR: no Level-Zero GPU driver available for ${PRETTY_NAME:-this distro}."
+  echo "Intel publishes its graphics repo for Ubuntu only. See INSTALL.md."
+  exit 1
+fi
+
 $SUDO apt-get install -y \
   ocl-icd-libopencl1 \
   intel-opencl-icd \
-  intel-level-zero-gpu \
-  level-zero
+  "${LEVEL_ZERO_PKGS[@]}"
 
-echo "==> Adding $USER to the 'render' group (needed for GPU device access)"
-if id -nG "$USER" | tr ' ' '\n' | grep -qx render; then
-  echo "    already in 'render' group."
+# Under `sudo`, $USER is root — adding *root* to the render group leaves the
+# actual human without GPU access, which is the failure this script exists to
+# prevent. Prefer the invoking user.
+TARGET_USER="${SUDO_USER:-${USER:-$(id -un)}}"
+if ! getent group render >/dev/null 2>&1; then
+  # No render group means no /dev/dri — a container, or a host with no Intel GPU.
+  # The packages are installed; don't fail the run over a group that can't exist.
+  echo "==> No 'render' group on this host (no /dev/dri?); skipping that step."
+elif [[ "$TARGET_USER" == "root" ]]; then
+  echo "==> Running as root with no SUDO_USER; skipping the 'render' group step."
+  echo "    Add your own account by hand:  sudo usermod -a -G render <you>"
 else
-  $SUDO usermod -a -G render "$USER"
-  echo "    added. LOG OUT AND BACK IN (or reboot) — group changes don't apply"
-  echo "    to the current shell session."
+  echo "==> Adding $TARGET_USER to the 'render' group (needed for GPU device access)"
+  if id -nG "$TARGET_USER" | tr ' ' '\n' | grep -qx render; then
+    echo "    already in 'render' group."
+  else
+    $SUDO usermod -a -G render "$TARGET_USER"
+    echo "    added. LOG OUT AND BACK IN (or reboot) — group changes don't apply"
+    echo "    to the current shell session."
+  fi
 fi
 
 echo

--- a/scripts/setup-openvino.sh
+++ b/scripts/setup-openvino.sh
@@ -22,7 +22,7 @@ fi
 if ! command -v apt-get >/dev/null 2>&1; then
   echo "This script uses apt-get (Ubuntu/Debian). For other distros, install the"
   echo "equivalents of: intel-opencl-icd, ocl-icd-libopencl1, and the Level-Zero"
-  echo "driver + loader (Ubuntu 24.04: libze-intel-gpu1 + libze1)."
+  echo "driver + loader (Intel's Ubuntu repo names them libze-intel-gpu1 + libze1)."
   echo "Then add your user to the 'render' group. See INSTALL.md."
   exit 1
 fi
@@ -39,6 +39,10 @@ UBUNTU_SUITE="${UBUNTU_CODENAME:-}"
 if [[ "${ID:-}" != "ubuntu" && "${ID_LIKE:-}" != *ubuntu* ]]; then UBUNTU_SUITE=""; fi
 
 INTEL_LIST=/etc/apt/sources.list.d/intel-gpu.list
+# Intel's graphics signing keys (production, and the 2024 predecessor). Pinning
+# the fingerprint means a hijacked key/URL cannot become an apt trust anchor.
+INTEL_KEY_FPR="E0258B57D9C442D5DB1855C271740E4DE392BFE3"
+INTEL_KEY_FPR_OLD="4E9EFCDEF82800256C1E7C64B02DB9BD8C321DCB"
 
 echo "==> Installing Intel GPU runtime packages (OpenCL + Level-Zero + Compute Runtime)"
 $SUDO apt-get update
@@ -46,11 +50,28 @@ $SUDO apt-get update
 if [[ -n "$UBUNTU_SUITE" ]]; then
   # Prefer Intel's repo, not the distro's: Ubuntu 24.04 ships Compute Runtime
   # 23.43, which predates Lunar Lake and Arc B — the hardware cascadia targets.
+  # `unified` carries 25.18; `client` is stuck on 24.39, which is older than
+  # Battlemage support (24.48).
   echo "==> Adding Intel's graphics repo (${UBUNTU_SUITE})"
   $SUDO apt-get install -y --no-install-recommends ca-certificates gnupg wget
-  wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
-    | $SUDO gpg --yes --dearmor -o /usr/share/keyrings/intel-graphics.gpg
-  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${UBUNTU_SUITE} client" \
+
+  # Dearmor to a temp file and check the fingerprint before installing it: a
+  # failed fetch must not truncate an existing keyring (gpg -o opens for write
+  # before it reads), which would leave apt unable to verify the repo.
+  KEY_TMP="$(mktemp)"
+  trap 'rm -f "$KEY_TMP"' EXIT
+  if ! wget -qO- https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor > "$KEY_TMP"; then
+    echo "ERROR: could not fetch Intel's graphics key. Nothing was changed."
+    exit 1
+  fi
+  if ! gpg --show-keys --with-colons "$KEY_TMP" | awk -F: '/^fpr:/{print $10}' \
+       | grep -qx -e "$INTEL_KEY_FPR" -e "$INTEL_KEY_FPR_OLD"; then
+    echo "ERROR: Intel's graphics key does not match a known fingerprint. Refusing to trust it."
+    exit 1
+  fi
+  $SUDO install -m 0644 "$KEY_TMP" /usr/share/keyrings/intel-graphics.gpg
+
+  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${UBUNTU_SUITE} unified" \
     | $SUDO tee "$INTEL_LIST" >/dev/null
   # If the suite doesn't exist, remove the source again rather than leaving a
   # broken entry that fails every future `apt-get update` on this machine.

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cascadia-tests-e2e"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 repository.workspace = true

--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -42,7 +42,8 @@ pub fn binary_path() -> PathBuf {
         } else {
             "release"
         })
-        .join("cascadia")
+        // EXE_SUFFIX or the path misses `cascadia.exe` on Windows.
+        .join(format!("cascadia{}", std::env::consts::EXE_SUFFIX))
 }
 
 pub struct CascadiaProc {

--- a/tools/export_shards.py
+++ b/tools/export_shards.py
@@ -1915,7 +1915,7 @@ def main():
     if torch is None:
         parser.error(
             "torch is required for this model's export path. "
-            "Install: pip install torch transformers safetensors nncf"
+            "Install: pip install -r tools/requirements.txt  (or run `cascadia doctor`, which prints the pins)"
         )
     from transformers import AutoConfig
 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -15,6 +15,7 @@ optimum-intel>=1.27
 nncf>=2.18
 torch>=2.6
 # Imported directly by export_shards.py and by the `cascadia shard` dependency
-# probe; today they only arrive transitively via transformers.
-safetensors
-huggingface_hub
+# probe; today they only arrive transitively via transformers. Floors match what
+# transformers>=5.2 already resolves to, so they pin without constraining it.
+safetensors>=0.4
+huggingface_hub>=0.30

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -14,3 +14,7 @@ openvino>=2026.2
 optimum-intel>=1.27
 nncf>=2.18
 torch>=2.6
+# Imported directly by export_shards.py and by the `cascadia shard` dependency
+# probe; today they only arrive transitively via transformers.
+safetensors
+huggingface_hub


### PR DESCRIPTION
## Summary

Every command in the docs was run as written, on real Intel hardware and on Linux. This fixes the ones that didn't work, and the code bugs behind them.

The headline: **the Docker image had never built** (builder was `rust:1.82`; `cascadia-int4-gemm` needs AVX-512 intrinsics stabilised in 1.89), and **MSRV was enforced by nothing** (`rust-version` was set in the workspace root and inherited by zero crates).

## What was broken

| Area | Bug |
|---|---|
| Build | Dockerfile builder `rust:1.82` < MSRV 1.89 → image never built, both targets |
| Build | `rust-version` inherited by no crate → MSRV unenforced |
| Scripts | `setup-openvino.sh` added an `ubuntu <codename>` apt source on Debian → 403 → left the entry behind, **bricking apt** |
| Scripts | Installed package names that exist on neither Debian nor Ubuntu (`intel-level-zero-gpu`, `level-zero`) |
| Engine | `ov-genai` accepted an IR with no tokenizer IRs → loaded fine, **generated empty strings**, no error |
| CLI | `cascadia shard` picked the first interpreter answering `--version`, including the Windows Store stub (exits 9009) |
| CLI | `--api` on rank ≥ 1 was silently dropped — ranks ≥ 1 return from the relay loop before the API binds |
| CLI | `place --help` pointed at `profile-devices --per-stage`, a flag that never existed |
| Docs | `cascadia run <hf-id>` documented as working — engines never download; only `cascadia shard` does |
| Docs | `--quantization int4_asym` — clap rejects it (`int4-asym`) |
| Docs | `r1-distill` curl examples had no `Content-Type` → **HTTP 415** |
| Tests | `tests-e2e` omitted `EXE_SUFFIX` → e2e could **never pass on Windows** (391/3 fail → **394/0**) |
| Bundle | `doctor` marked a missing `rustc` as a hard **FAIL** on a release bundle (which ships no toolchain) and advised a stale `1.75+`; the pip hint was unpinned |

## Changes

- **`docs/CLI.md`** — new CLI reference. All 11 subcommands and ~60 flags lived only in `--help`; `completions` was undocumented entirely.
- **Dockerfile runtime base `debian:bookworm-slim` → `ubuntu:24.04`.** Not a preference: Debian packages no Level-Zero GPU driver at all (neither bookworm nor trixie), so Ubuntu is the only base where the Intel GPU stack exists. Intel's apt key is pinned by the exact set of primary keys, and the repo/keyring/`wget`/`gnupg` are scrubbed from the shipped image.
- **~250 lines of production Rust across 5 files**, backed by ~230 lines of tests. The other 18 "Rust" files are one-line `rust-version.workspace = true` additions.

## Testing

Every fix was executed, not reasoned about.

**Intel AI PCs** (Core Ultra 7 258V · Arc 140V · NPU) — `ov-genai` inference on iGPU and NPU; `cascadia shard` from HuggingFace; 2-stage `ov-runtime` pipeline; 2-machine distributed inference (output identical to single-machine); full placement chain (`profile-stages` → `place` → `run-placement`, profiling CPU/GPU/NPU); `cargo +1.88` correctly rejected by MSRV; `ov-dist-spec` relay-rank preflight; curl without `Content-Type` → 415, with → 200. **Full suite: 394 passed, 0 failed on Windows.**

**Linux** — both Docker targets build; Intel drivers land at CR 25.18 (past the 24.48 Battlemage floor); real inference inside the container; image ships no apt source or keyring. Key pin verified in both directions: Intel's real key accepted, a real-plus-appended-attacker keyring rejected. `setup-openvino.sh` on Ubuntu 22.04/24.04 → CR 25.18; on Debian → clean refusal with apt left healthy.

**Release bundle** — a bundle built from this branch (same `release.yml` steps) runs on a toolchain-free host via RPATH, prints the pinned pip line, refuses an HF repo id, and serves real inference. The published v0.1.1 bundle reproduces the `doctor` bugs above.

> **Not verified:** Docker GPU passthrough (`--device /dev/dri`). Needs a Linux host with an Intel GPU; the fleet has none (the Linux box has an NVIDIA card, the AI PCs are Windows). This is the one claim resting on reasoning rather than execution.

## How to verify

Most of this is checkable without Intel hardware.

```bash
# gate
cargo fmt --all -- --check && cargo clippy --workspace --all-targets && cargo test --workspace --all-targets

# MSRV is now actually enforced (was inherited by no crate)
rustup toolchain install 1.88.0 --profile minimal
cargo +1.88.0 check -p cascadia-int4-gemm     # expect: "requires rustc 1.89"

# the docs match the binary — no phantom flags, no missing ones
cargo build -p cascadia
./target/debug/cascadia place --help          # names `cascadia profile-stages`, not the flag that never existed
./target/debug/cascadia worker --help         # --device table renders as a table, not one run-on line
./target/debug/cascadia run some/hf-repo-id   # refuses; engines never download
./target/debug/cascadia shard --model x -o y --num-stages 1 --quantization int4_asym   # rejected: it's int4-asym
```

x86_64 Linux + Docker:

```bash
# the image that never built
docker build --target openvino \
  --build-arg OPENVINO_URL=https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.2/linux/openvino_genai_ubuntu22_2026.2.0.0_x86_64.tar.gz \
  -t cascadia:ov .
docker run --rm cascadia:ov doctor            # enumerates CPU; no apt source or keyring left in the image

# the setup script, on a throwaway container (it used to brick apt on Debian)
docker run --rm -v "$PWD/scripts/setup-openvino.sh:/s.sh:ro" ubuntu:24.04 \
  bash -c 'apt-get update -qq && apt-get install -y -qq ca-certificates && bash /s.sh && apt-get update -qq && echo APT-OK'
docker run --rm -v "$PWD/scripts/setup-openvino.sh:/s.sh:ro" debian:bookworm-slim \
  bash -c 'apt-get update -qq && apt-get install -y -qq ca-certificates; bash /s.sh; apt-get update -qq && echo APT-STILL-HEALTHY'
```

The GPG pin is the one worth reviewing closely: it now requires the fetched keyring's **primary key set** to equal Intel's two keys exactly. A `grep -qx <fpr>` only proves the keyring *contains* the pinned key — an attacker controlling the key URL could append their own and apt would trust it too.

## Follow-ups (not in this PR)

- **No CI job tests MSRV or builds the Dockerfile.** Zero mentions of `1.89`/`rust-version`/`docker` in `.github/workflows/`. This PR fixes the bugs; it does not stop them recurring.
- The OpenVINO SDK tarball is fetched with **no checksum** (Dockerfile:45). The GPG pin protects the drivers; the archive itself is unverified.
- **`crates/cascadia-download` is dead code** (zero dependents) and is the sole reason for a RUSTSEC exception: `number_prefix` ← `indicatif` ← `hf-hub` ← `cascadia-download`. Deleting it removes the exception.
- Docker image can drop ~18 MB (unused ONNX/TF/PyTorch/Paddle frontends — cascadia reads only OpenVINO IR); ~128 MB more if NPU support is made optional, which needs a machine that can test NPU passthrough first.
