### PR TITLE
feat: weight-residency paths for the hybrid split — --park-prefill, NPUW bank probe, in-place GEMV RFC

### DIFF
--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -379,6 +379,16 @@ pub struct WorkerArgs {
     #[arg(long, default_value_t = false)]
     pub no_chunked_prefill: bool,
 
+    /// Park the chunked-prefill model between prefills (ov-runtime static
+    /// path only): after each task's prefill phase the prefill CompiledModel
+    /// is dropped — freeing its resident stage-weight copy, the structural
+    /// memory cost of the two-model split — and re-created from the compile
+    /// cache at the next prefill. Trades a per-task reload (logged as
+    /// reload_ms) for ~1x steady-state weight residency; for memory-tight
+    /// stages. Composes with --prefill-device.
+    #[arg(long, default_value_t = false)]
+    pub park_prefill: bool,
+
     /// Speculative-decode draft model path (FastDraft companion).
     #[arg(long)]
     pub draft_model: Option<String>,
@@ -596,6 +606,7 @@ impl WorkerArgs {
             npu_min_response_len: None,
             prefill_device: None,
             no_chunked_prefill: false,
+            park_prefill: false,
             draft_model: None,
             draft_device: None,
             spec_k: 5,
@@ -1136,6 +1147,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
                 b = b.with_prefill_device(dev);
             }
             b = b.with_chunked_prefill_disabled(args.no_chunked_prefill);
+            b = b.with_prefill_parking(args.park_prefill);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 b = b.with_cache_dir(&dir);
             }
@@ -1376,17 +1388,18 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     }
     // Fail loud, not silent: the phase-split flags are load-bearing when
     // given, and only the ov-runtime engine implements them.
-    if (args.prefill_device.is_some() || args.no_chunked_prefill)
+    if (args.prefill_device.is_some() || args.no_chunked_prefill || args.park_prefill)
         && args.engine != EngineKind::OvRuntime
     {
         return Err(anyhow!(
-            "--prefill-device / --no-chunked-prefill require --engine ov-runtime \
-             (the chunked-prefill phase split lives in the static-KV runtime path)"
+            "--prefill-device / --no-chunked-prefill / --park-prefill require \
+             --engine ov-runtime (the chunked-prefill phase split lives in the \
+             static-KV runtime path)"
         ));
     }
-    if args.prefill_device.is_some() && args.no_chunked_prefill {
+    if (args.prefill_device.is_some() || args.park_prefill) && args.no_chunked_prefill {
         return Err(anyhow!(
-            "--prefill-device conflicts with --no-chunked-prefill"
+            "--prefill-device / --park-prefill conflict with --no-chunked-prefill"
         ));
     }
     let is_first = args.rank == 0;

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1272,6 +1272,9 @@ impl OvRuntimeEngine {
                 sk.reset();
             }
             self.position = 0;
+            // Failure recovery is also a going-idle transition: release the
+            // prefill weight copy (no-op unless --park-prefill).
+            self.park_prefill_model();
             res = Err(match failed {
                 Some(id) => e.for_task(id),
                 None => e,
@@ -1706,14 +1709,6 @@ impl OvRuntimeEngine {
         Ok((odt, oshape, obytes))
     }
 
-    /// One chunked-prefill inference covering `real` (<= C) tokens starting at
-    /// absolute `position`, on the prefill runtime (`--prefill-device`). Pads
-    /// the primary input to the fixed C-window, masks the padding, feeds the
-    /// SAME host KV ring the decode model uses, absorbs the `real` new
-    /// tokens' K/V, and returns output 0 (`[1, C, X]`; rows `real..C` are
-    /// pad-query garbage the caller must never use). The ring is the whole
-    /// prefill→decode handoff: KV lives once in host DRAM regardless of which
-    /// device computed it.
     /// Re-create a parked prefill compilation (no-op while loaded or without
     /// a variant). Reload cost is logged; with a CACHE_DIR-backed compile the
     /// reload comes from the OV blob/UMD cache rather than a cold compile.
@@ -1791,13 +1786,16 @@ impl OvRuntimeEngine {
                 "negative chunk position {position}"
             )));
         }
-        sk.begin_token(position as usize);
-        sk.write_prefill_mask(&mut pf.mask_bytes, pf.context, real);
+        // Parked check FIRST: begin_token/write_prefill_mask mutate ring
+        // state — advancing the cursor for a token whose K/V is never
+        // absorbed would desync the ring if this error ever fires.
         let prt = pf.runtime.as_mut().ok_or_else(|| {
             EngineError::Backend(
                 "prefill model is parked — callers must ensure_prefill_loaded first".into(),
             )
         })?;
+        sk.begin_token(position as usize);
+        sk.write_prefill_mask(&mut pf.mask_bytes, pf.context, real);
 
         // Primary input, converted/padded straight into the reusable
         // `primary_buf` (zero pads: masked out of attention, outputs unused,
@@ -2017,7 +2015,13 @@ impl Engine for OvRuntimeEngine {
                 // inflates the first real request's TTFT — the very metric
                 // the phase split exists to improve.
                 if self.prefill.is_some() && !warm.is_empty() {
-                    if let Err(e) = self.run_first_chunk(warm, 0, true) {
+                    // Ensure covers a future re-warm with --park-prefill:
+                    // today warmup precedes any park, but that ordering is
+                    // an invariant nothing else enforces.
+                    if let Err(e) = self
+                        .ensure_prefill_loaded()
+                        .and_then(|_| self.run_first_chunk(warm, 0, true).map(|_| ()))
+                    {
                         warn!(error = %e, "ov-runtime warmup (prefill model) failed");
                     }
                 }
@@ -2116,6 +2120,11 @@ impl Engine for OvRuntimeEngine {
                 sk.reset();
             }
             self.position = 0;
+            // Cancel is a "task over, going idle" transition — exactly what
+            // --park-prefill exists for. Without this, a cancelled task
+            // leaves the second weight copy resident until the NEXT task's
+            // prefill completes.
+            self.park_prefill_model();
         }
     }
 }
@@ -2302,12 +2311,12 @@ impl OvRuntimeBuilder {
         self.prefill_device = Some(device.into());
         self
     }
-    /// Skip the export's chunked-prefill variant (prefill one token per step).
     /// Park the prefill model between prefills (see `park_prefill`).
     pub fn with_prefill_parking(mut self, park: bool) -> Self {
         self.park_prefill = park;
         self
     }
+    /// Skip the export's chunked-prefill variant (prefill one token per step).
     pub fn with_chunked_prefill_disabled(mut self, disabled: bool) -> Self {
         self.disable_chunked_prefill = disabled;
         self

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -570,7 +570,12 @@ fn float_elem_bytes(dtype: ShimDType) -> EngineResult<usize> {
 /// prefill→decode handoff is zero-cost by construction, and the two devices
 /// never hold KV — only weights — so DRAM keeps a single KV copy.
 struct StaticPrefill {
-    runtime: OvRuntime,
+    /// The compiled prefill model. `None` while PARKED (`--park-prefill`):
+    /// dropping the CompiledModel releases its resident weight copy — the
+    /// structural memory cost of the two-model split — between prefills;
+    /// `ensure_prefill_loaded` re-creates it from `PrefillReload` on demand.
+    /// Wiring, window dims, and buffers persist across park/reload.
+    runtime: Option<OvRuntime>,
     /// Fixed query-window width C of the prefill IR.
     seq: usize,
     /// Fixed total context of the prefill IR (= ring past_len + seq).
@@ -585,6 +590,16 @@ struct StaticPrefill {
     mask_bytes: Vec<u8>,
     primary_buf: Vec<u8>,
     pos_buf: Vec<u8>,
+}
+
+/// Everything needed to re-create a parked prefill compilation: the variant's
+/// IR path, its device, and the plugin properties the original compile used
+/// (CACHE_DIR etc., so a reload hits the OV blob/UMD cache instead of a cold
+/// compile).
+struct PrefillReload {
+    xml: String,
+    device: String,
+    plugin_entries: Vec<(String, String)>,
 }
 
 // -------- Engine --------
@@ -638,6 +653,13 @@ pub struct OvRuntimeEngine {
     /// possibly on a different device — that consumes the prompt `seq` tokens
     /// per inference, sharing `static_kv`'s ring with the decode model.
     prefill: Option<StaticPrefill>,
+    /// `--park-prefill`: drop the prefill CompiledModel after each task's
+    /// prefill phase (freeing its resident weight copy) and re-create it on
+    /// the next prefill. Trades a per-task reload for ~1× steady-state
+    /// weight residency between requests.
+    park_prefill: bool,
+    /// Reload source for a parked prefill model.
+    prefill_reload: Option<PrefillReload>,
     step_warn: StepWarnLimiter,
 }
 
@@ -917,6 +939,7 @@ impl OvRuntimeEngine {
         let pf_seq = self.prefill.as_ref().map(|p| p.seq);
 
         if let (Some(pf_seq), true) = (pf_seq, in_window) {
+            self.ensure_prefill_loaded()?;
             let mut rows: Vec<f32> = Vec::new();
             let mut x_out = 0usize;
             let mut off = 0usize;
@@ -1323,6 +1346,9 @@ impl OvRuntimeEngine {
                     let take = chunk_take(c, tokens.len() - idx, chunk_start as usize, past_len);
                     let ts = std::time::Instant::now();
                     let (token, wire) = if take >= 2 {
+                        // Lazy so a prompt that never chunks (1-token, or
+                        // fully over-window) skips a parked model's reload.
+                        self.ensure_prefill_loaded()?;
                         let is_final_chunk = idx + take == tokens.len();
                         // Single-stage: nothing reads a non-final chunk's
                         // logits — skip the [1,C,vocab] copy + convert.
@@ -1393,6 +1419,9 @@ impl OvRuntimeEngine {
                 if let Some(a) = self.active.as_mut() {
                     a.t_prefill = a.started.elapsed();
                 }
+                // Prefill phase over: with --park-prefill, release the
+                // prefill model's resident weights until the next task.
+                self.park_prefill_model();
             }
             nt
         } else {
@@ -1685,6 +1714,49 @@ impl OvRuntimeEngine {
     /// pad-query garbage the caller must never use). The ring is the whole
     /// prefill→decode handoff: KV lives once in host DRAM regardless of which
     /// device computed it.
+    /// Re-create a parked prefill compilation (no-op while loaded or without
+    /// a variant). Reload cost is logged; with a CACHE_DIR-backed compile the
+    /// reload comes from the OV blob/UMD cache rather than a cold compile.
+    fn ensure_prefill_loaded(&mut self) -> EngineResult<()> {
+        let parked = self.prefill.as_ref().is_some_and(|p| p.runtime.is_none());
+        if !parked {
+            return Ok(());
+        }
+        let src = self.prefill_reload.as_ref().ok_or_else(|| {
+            EngineError::Backend("parked prefill model without a reload source".into())
+        })?;
+        let ts = std::time::Instant::now();
+        let plugin = PluginConfig {
+            entries: src.plugin_entries.clone(),
+        };
+        let prt = OvRuntime::compile(&src.xml, &src.device, &plugin)
+            .map_err(map_ov_err)
+            .map_err(|e| EngineError::Backend(format!("prefill reload on {}: {e}", src.device)))?;
+        if let Some(pf) = self.prefill.as_mut() {
+            pf.runtime = Some(prt);
+        }
+        info!(
+            reload_ms = ts.elapsed().as_millis() as u64,
+            device = %src.device,
+            "prefill model reloaded (was parked)"
+        );
+        Ok(())
+    }
+
+    /// `--park-prefill`: drop the prefill CompiledModel, releasing its
+    /// resident weight copy until the next prefill. Wiring and buffers stay.
+    /// Cheap no-op when disabled, already parked, or no variant exists.
+    fn park_prefill_model(&mut self) {
+        if !self.park_prefill {
+            return;
+        }
+        if let Some(pf) = self.prefill.as_mut() {
+            if pf.runtime.take().is_some() {
+                info!("prefill model parked (resident weights freed until next prefill)");
+            }
+        }
+    }
+
     /// Run one chunked-prefill inference for `real` (<= C) tokens starting at
     /// absolute `position`, absorbing their K/V into the shared ring. Returns
     /// the primary output `[1, C, X]` bytes when `want_output`, else empty —
@@ -1721,6 +1793,11 @@ impl OvRuntimeEngine {
         }
         sk.begin_token(position as usize);
         sk.write_prefill_mask(&mut pf.mask_bytes, pf.context, real);
+        let prt = pf.runtime.as_mut().ok_or_else(|| {
+            EngineError::Backend(
+                "prefill model is parked — callers must ensure_prefill_loaded first".into(),
+            )
+        })?;
 
         // Primary input, converted/padded straight into the reusable
         // `primary_buf` (zero pads: masked out of attention, outputs unused,
@@ -1765,39 +1842,33 @@ impl OvRuntimeEngine {
         }
 
         match input {
-            ChunkInput::Ids(_) => pf
-                .runtime
+            ChunkInput::Ids(_) => prt
                 .set_input(in_main, ShimDType::I64, &[1, pf.seq], &pf.primary_buf)
                 .map_err(map_ov_err)?,
-            ChunkInput::Hidden(_, hid) => pf
-                .runtime
+            ChunkInput::Hidden(_, hid) => prt
                 .set_input(in_main, ShimDType::F16, &[1, pf.seq, hid], &pf.primary_buf)
                 .map_err(map_ov_err)?,
         }
-        pf.runtime
-            .set_input(
-                &pf.attn_in,
-                ShimDType::I64,
-                &[1, pf.context],
-                &pf.mask_bytes,
-            )
-            .map_err(map_ov_err)?;
-        pf.runtime
-            .set_input(&pf.pos_in, ShimDType::I64, &[1, pf.seq], &pf.pos_buf)
+        prt.set_input(
+            &pf.attn_in,
+            ShimDType::I64,
+            &[1, pf.context],
+            &pf.mask_bytes,
+        )
+        .map_err(map_ov_err)?;
+        prt.set_input(&pf.pos_in, ShimDType::I64, &[1, pf.seq], &pf.pos_buf)
             .map_err(map_ov_err)?;
         let kv_shape = [1, sk.kv_heads, sk.past_len, sk.head_dim];
         for (li, layer) in pf.layers.iter().enumerate() {
-            pf.runtime
-                .set_input(&layer.key_in, sk.kv_dtype, &kv_shape, &sk.key_buf[li])
+            prt.set_input(&layer.key_in, sk.kv_dtype, &kv_shape, &sk.key_buf[li])
                 .map_err(map_ov_err)?;
-            pf.runtime
-                .set_input(&layer.val_in, sk.kv_dtype, &kv_shape, &sk.val_buf[li])
+            prt.set_input(&layer.val_in, sk.kv_dtype, &kv_shape, &sk.val_buf[li])
                 .map_err(map_ov_err)?;
         }
-        pf.runtime.infer().map_err(map_ov_err)?;
+        prt.infer().map_err(map_ov_err)?;
 
         let primary = if want_output {
-            pf.runtime.output(0).map_err(map_ov_err)?
+            prt.output(0).map_err(map_ov_err)?
         } else {
             (ShimDType::F16, Vec::new(), Vec::new())
         };
@@ -1809,8 +1880,8 @@ impl OvRuntimeEngine {
         let want_shape = [1usize, sk.kv_heads, pf.context, sk.head_dim];
         for li in 0..pf.layers.len() {
             let (ko, vo) = (pf.layers[li].key_out, pf.layers[li].val_out);
-            let (_, kshape, kpres) = pf.runtime.output(ko).map_err(map_ov_err)?;
-            let (_, vshape, vpres) = pf.runtime.output(vo).map_err(map_ov_err)?;
+            let (_, kshape, kpres) = prt.output(ko).map_err(map_ov_err)?;
+            let (_, vshape, vpres) = prt.output(vo).map_err(map_ov_err)?;
             if kpres.len() != expect
                 || vpres.len() != expect
                 || kshape != want_shape
@@ -1832,6 +1903,11 @@ impl OvRuntimeEngine {
 
     fn step_last(&mut self) -> EngineResult<()> {
         let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
+        // A seq=1 static frame means this task's prefill chunks are done —
+        // with --park-prefill, release the prefill model's weights now.
+        if pos_opt.is_some() && shape[1] == 1 {
+            self.park_prefill_model();
+        }
         let (out, out_shape) = match pos_opt {
             // Static (NPU): the carried absolute position drives the ring
             // (reset at 0); seq is always 1.
@@ -1859,6 +1935,11 @@ impl OvRuntimeEngine {
         // stage, so it gets the widened prefill budget. Seq=1 frames (decode
         // steps, tokenwise prefill) keep the strict decode deadline.
         let prefill_reply = shape[1] > 1;
+        // A seq=1 static frame means this task's prefill chunks are done —
+        // with --park-prefill, release the prefill model's weights now.
+        if pos_opt.is_some() && shape[1] == 1 {
+            self.park_prefill_model();
+        }
         let (out, out_shape, fwd_pos) = match pos_opt {
             Some(pos) => {
                 let (o, s) = self.run_relay(&hidden, shape, pos)?;
@@ -2166,6 +2247,11 @@ pub struct OvRuntimeBuilder {
     /// Ignore the export's chunked-prefill variant and prefill one token per
     /// step (the pre-variant behavior); conflicts with `prefill_device`.
     pub disable_chunked_prefill: bool,
+    /// `--park-prefill`: drop the prefill CompiledModel after each task's
+    /// prefill (freeing its resident weight copy — the structural cost of
+    /// the two-model split) and re-create it on the next prefill from the
+    /// blob cache. For memory-tight stages; costs a per-task reload.
+    pub park_prefill: bool,
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
@@ -2173,6 +2259,7 @@ pub struct OvRuntimeBuilder {
     pub ov_properties: Vec<(String, String)>,
     runtime: Option<OvRuntime>,
     prefill_runtime: Option<OvRuntime>,
+    prefill_reload: Option<PrefillReload>,
     spec: Option<ShardSpec>,
     rotary: Option<Rotary>,
     hidden_size: usize,
@@ -2216,6 +2303,11 @@ impl OvRuntimeBuilder {
         self
     }
     /// Skip the export's chunked-prefill variant (prefill one token per step).
+    /// Park the prefill model between prefills (see `park_prefill`).
+    pub fn with_prefill_parking(mut self, park: bool) -> Self {
+        self.park_prefill = park;
+        self
+    }
     pub fn with_chunked_prefill_disabled(mut self, disabled: bool) -> Self {
         self.disable_chunked_prefill = disabled;
         self
@@ -2368,18 +2460,27 @@ impl Builder for OvRuntimeBuilder {
             }
             _ => None,
         };
-        if self.prefill_device.is_some() && self.static_prefill_params.is_none() {
-            return Err(EngineError::ShardRejected(if stage_cfg.stateful {
-                "--prefill-device requires a stateless static export: re-export with \
-                 tools/export_shards.py --target npu --static-prefill-seq N (the stateful \
-                 path keeps KV inside OV state, which two devices cannot share)"
-                    .into()
-            } else if self.disable_chunked_prefill {
-                "--prefill-device conflicts with --no-chunked-prefill".into()
+        if (self.prefill_device.is_some() || self.park_prefill)
+            && self.static_prefill_params.is_none()
+        {
+            let flag = if self.prefill_device.is_some() {
+                "--prefill-device"
             } else {
-                "--prefill-device requires a chunked-prefill IR variant: re-export this \
-                 pipeline with --static-prefill-seq N"
-                    .into()
+                "--park-prefill"
+            };
+            return Err(EngineError::ShardRejected(if stage_cfg.stateful {
+                format!(
+                    "{flag} requires a stateless static export: re-export with \
+                     tools/export_shards.py --target npu --static-prefill-seq N (the stateful \
+                     path keeps KV inside OV state, which two devices cannot share)"
+                )
+            } else if self.disable_chunked_prefill {
+                format!("{flag} conflicts with --no-chunked-prefill")
+            } else {
+                format!(
+                    "{flag} requires a chunked-prefill IR variant: re-export this \
+                     pipeline with --static-prefill-seq N"
+                )
             }));
         }
 
@@ -2481,12 +2582,21 @@ impl Builder for OvRuntimeBuilder {
                         .collect(),
                 }
             };
-            let prt = OvRuntime::compile(prefill_xml.to_str().unwrap_or_default(), &pdev, &pplugin)
+            let pxml = prefill_xml.to_str().unwrap_or_default().to_string();
+            let prt = OvRuntime::compile(&pxml, &pdev, &pplugin)
                 .map_err(map_ov_err)
                 .map_err(|e| {
                     EngineError::Backend(format!("chunked-prefill variant on {pdev}: {e}"))
                 })?;
             self.prefill_runtime = Some(prt);
+            // Everything a parked model needs to come back (--park-prefill);
+            // the PREFILL device's plugin entries so a reload both hits the
+            // compile cache and never re-introduces decode-device tuning.
+            self.prefill_reload = Some(PrefillReload {
+                xml: pxml,
+                device: pdev,
+                plugin_entries: pplugin.entries.clone(),
+            });
         }
 
         events.push(LoadProgress::message(
@@ -2675,7 +2785,7 @@ impl Builder for OvRuntimeBuilder {
                     )));
                 }
                 Some(StaticPrefill {
-                    runtime: prt,
+                    runtime: Some(prt),
                     seq: pseq as usize,
                     context: pctx as usize,
                     ids_in,
@@ -2707,6 +2817,8 @@ impl Builder for OvRuntimeBuilder {
             active: None,
             static_kv,
             prefill,
+            park_prefill: self.park_prefill,
+            prefill_reload: self.prefill_reload,
             step_warn: StepWarnLimiter::default(),
         }))
     }
@@ -3005,6 +3117,22 @@ mod tests {
             .err()
             .expect("advertised variant without the IR file must be rejected");
         assert!(err.to_string().contains("missing"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn park_prefill_on_stateful_shard_rejected() {
+        let dir = write_stage_dir(
+            "park-stateful",
+            r#"{"layer_start":0,"layer_end":2,"has_embed":true,"has_head":true,"stateful":true}"#,
+        );
+        let mut b = OvRuntimeBuilder::new(&dir, 0, 1, "CPU").with_prefill_parking(true);
+        let err = b
+            .load(ShardSpec::single_stage("m", "CPU"))
+            .await
+            .err()
+            .expect("stateful + --park-prefill must be rejected");
+        assert!(err.to_string().contains("--park-prefill"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2589,6 +2589,13 @@ impl Builder for OvRuntimeBuilder {
                     EngineError::Backend(format!("chunked-prefill variant on {pdev}: {e}"))
                 })?;
             self.prefill_runtime = Some(prt);
+            if self.park_prefill && self.cache_dir.is_none() {
+                warn!(
+                    "--park-prefill without --ov-cache-dir: every reload is a full \
+                     cold compile (measured ~minutes on NPU) instead of a blob-cache \
+                     import — set --ov-cache-dir"
+                );
+            }
             // Everything a parked model needs to come back (--park-prefill);
             // the PREFILL device's plugin entries so a reload both hits the
             // compile cache and never re-introduces decode-device tuning.

--- a/crates/cascadia-engine-openvino/tests/npuw_bank_probe.rs
+++ b/crates/cascadia-engine-openvino/tests/npuw_bank_probe.rs
@@ -81,11 +81,25 @@ async fn npuw_bank_probe() {
 
     // Sanity generation so the probe also reports whether NPUW-compiled
     // variants still produce sane output through the ring.
+    // Infer-time failures are probe DATA on this explicitly-unsupported
+    // NPUW surface — print a PROBE-RESULT line instead of panicking so the
+    // external sampling wrapper still gets its hold window.
     let task = GenerationTask::new("npuw-probe", "The capital of France is").with_max_tokens(8);
-    engine.submit(task).expect("submit");
+    let mut gen_failed = false;
+    if let Err(e) = engine.submit(task) {
+        eprintln!("PROBE-RESULT submit-failed: {e}");
+        gen_failed = true;
+    }
     let mut text = String::new();
-    loop {
-        let chunks = engine.step().expect("step");
+    while !gen_failed {
+        let chunks = match engine.step() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("PROBE-RESULT infer-failed: {e}");
+                gen_failed = true;
+                break;
+            }
+        };
         let mut done = false;
         for (_, c) in chunks {
             text.push_str(&c.text);
@@ -97,8 +111,12 @@ async fn npuw_bank_probe() {
             break;
         }
     }
-    eprintln!("PROBE-GEN {text:?}");
+    if !gen_failed {
+        eprintln!("PROBE-GEN {text:?}");
+    }
     eprintln!("PROBE-HOLD {hold_s}s (sample this process's working set now)");
     std::thread::sleep(std::time::Duration::from_secs(hold_s));
-    eprintln!("PROBE-RESULT ok");
+    if !gen_failed {
+        eprintln!("PROBE-RESULT ok");
+    }
 }

--- a/crates/cascadia-engine-openvino/tests/npuw_bank_probe.rs
+++ b/crates/cascadia-engine-openvino/tests/npuw_bank_probe.rs
@@ -1,0 +1,104 @@
+//! EXPERIMENT probe: can two user-level NPU compilations share one weight
+//! allocation through the (undocumented) NPUW weights bank?
+//!
+//! Background: NPUW shares a single weight bank across ITS internal
+//! prefill/generate/head submodels via a process-global bank keyed by
+//! `NPUW_WEIGHTS_BANK`. If two independent `compile_model` calls of sibling
+//! IRs (our decode + chunked-prefill variants, byte-identical weights) can
+//! join one bank, an all-NPU phase split would hold ~1x weights instead of
+//! 2x. This probe measures exactly that, nothing more — it is NOT a
+//! supported configuration (see experiments/npuw-bank-probe/NOTES.md).
+//!
+//! Env-gated (skip=pass): CASCADIA_NPUW_PROBE=1 + CASCADIA_STATIC_SHARDS
+//! (single-stage static export WITH a prefill variant). CASCADIA_NPUW=1 adds
+//! the NPUW properties (run once without for the baseline). The process
+//! prints PROBE-HOLD and sleeps CASCADIA_PROBE_HOLD_S (default 12) after
+//! generating, so an external wrapper can sample its working set:
+//!
+//! ```text
+//! CASCADIA_NPUW_PROBE=1 [CASCADIA_NPUW=1] CASCADIA_STATIC_SHARDS=<dir> \
+//!   cargo test -p cascadia-engine-openvino --features openvino \
+//!   --test npuw_bank_probe --release -- --nocapture
+//! ```
+
+use cascadia_engine::Builder;
+use cascadia_engine_openvino::OvRuntimeBuilder;
+use cascadia_types::{GenerationTask, PeerLayout, ShardSpec};
+
+#[tokio::test]
+async fn npuw_bank_probe() {
+    if std::env::var("CASCADIA_NPUW_PROBE").ok().as_deref() != Some("1") {
+        eprintln!("CASCADIA_NPUW_PROBE not set; skipping");
+        return;
+    }
+    let Ok(shards) = std::env::var("CASCADIA_STATIC_SHARDS") else {
+        eprintln!("CASCADIA_STATIC_SHARDS not set; skipping");
+        return;
+    };
+    let with_npuw = std::env::var("CASCADIA_NPUW").ok().as_deref() == Some("1");
+    let hold_s: u64 = std::env::var("CASCADIA_PROBE_HOLD_S")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(12);
+
+    // All-NPU: decode AND prefill variants both compile on the NPU — the
+    // configuration whose 2x weight residency the bank would deduplicate.
+    let mut builder = OvRuntimeBuilder::new(&shards, 0, 1, "NPU").with_prefill_device("NPU");
+    if with_npuw {
+        builder = builder.with_ov_properties(vec![
+            ("NPU_USE_NPUW".into(), "YES".into()),
+            ("NPUW_WEIGHTS_BANK".into(), "cascadia-bank-probe".into()),
+        ]);
+        eprintln!("PROBE-MODE npuw-bank");
+    } else {
+        eprintln!("PROBE-MODE baseline");
+    }
+
+    builder
+        .connect(PeerLayout::single_stage())
+        .await
+        .expect("connect");
+    let load = builder.load(ShardSpec::single_stage(&shards, "NPU")).await;
+    let mut load = match load {
+        Ok(l) => l,
+        Err(e) => {
+            // A compile failure IS a probe result (NPUW may reject already-
+            // sharded stateless graphs) — report and end without failing the
+            // suite, so the wrapper can record the outcome.
+            eprintln!("PROBE-RESULT load-failed: {e}");
+            return;
+        }
+    };
+    use futures::StreamExt;
+    while load.next().await.is_some() {}
+    let mut engine = match Box::new(builder).build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("PROBE-RESULT build-failed: {e}");
+            return;
+        }
+    };
+
+    // Sanity generation so the probe also reports whether NPUW-compiled
+    // variants still produce sane output through the ring.
+    let task = GenerationTask::new("npuw-probe", "The capital of France is").with_max_tokens(8);
+    engine.submit(task).expect("submit");
+    let mut text = String::new();
+    loop {
+        let chunks = engine.step().expect("step");
+        let mut done = false;
+        for (_, c) in chunks {
+            text.push_str(&c.text);
+            if c.is_final {
+                done = true;
+            }
+        }
+        if done {
+            break;
+        }
+    }
+    eprintln!("PROBE-GEN {text:?}");
+    eprintln!("PROBE-HOLD {hold_s}s (sample this process's working set now)");
+    std::thread::sleep(std::time::Duration::from_secs(hold_s));
+    eprintln!("PROBE-RESULT ok");
+}

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -57,8 +57,38 @@ async fn run_once(
     prompt: &str,
     max_new: u32,
 ) -> RunOut {
-    let mut builder =
-        OvRuntimeBuilder::new(shards, 0, 1, device).with_chunked_prefill_disabled(disable_chunk);
+    run_tasks(
+        shards,
+        device,
+        prefill_device,
+        disable_chunk,
+        false,
+        prompt,
+        max_new,
+        1,
+    )
+    .await
+    .remove(0)
+}
+
+/// Drive `tasks` sequential generations through one engine instance. With
+/// `park` the prefill model is dropped after each task's prefill and
+/// reloaded on the next — task 2's TTFT includes the reload, which is the
+/// number `--park-prefill` trades for ~1x steady-state weight residency.
+#[allow(clippy::too_many_arguments)]
+async fn run_tasks(
+    shards: &str,
+    device: &str,
+    prefill_device: Option<&str>,
+    disable_chunk: bool,
+    park: bool,
+    prompt: &str,
+    max_new: u32,
+    tasks: usize,
+) -> Vec<RunOut> {
+    let mut builder = OvRuntimeBuilder::new(shards, 0, 1, device)
+        .with_chunked_prefill_disabled(disable_chunk)
+        .with_prefill_parking(park);
     if let Some(pd) = prefill_device {
         builder = builder.with_prefill_device(pd);
     }
@@ -74,36 +104,41 @@ async fn run_once(
     while load.next().await.is_some() {}
     let mut engine = Box::new(builder).build().expect("build");
 
-    let task = GenerationTask::new("static-prefill-parity", prompt).with_max_tokens(max_new);
-    engine.submit(task).expect("submit");
+    let mut outs = Vec::new();
+    for n in 0..tasks {
+        let task = GenerationTask::new(format!("static-prefill-parity-{n}"), prompt)
+            .with_max_tokens(max_new);
+        engine.submit(task).expect("submit");
 
-    let started = Instant::now();
-    let mut ttft = None;
-    let mut ids = Vec::new();
-    let mut text = String::new();
-    loop {
-        let chunks = engine.step().expect("step");
-        let mut done = false;
-        for (_, c) in chunks {
-            if ttft.is_none() {
-                ttft = Some(started.elapsed());
+        let started = Instant::now();
+        let mut ttft = None;
+        let mut ids = Vec::new();
+        let mut text = String::new();
+        loop {
+            let chunks = engine.step().expect("step");
+            let mut done = false;
+            for (_, c) in chunks {
+                if ttft.is_none() {
+                    ttft = Some(started.elapsed());
+                }
+                ids.push(c.token_id);
+                text.push_str(&c.text);
+                if c.is_final {
+                    done = true;
+                }
             }
-            ids.push(c.token_id);
-            text.push_str(&c.text);
-            if c.is_final {
-                done = true;
+            if done {
+                break;
             }
         }
-        if done {
-            break;
-        }
+        outs.push(RunOut {
+            ids,
+            text,
+            ttft: ttft.unwrap_or_default(),
+            total: started.elapsed(),
+        });
     }
-    RunOut {
-        ids,
-        text,
-        ttft: ttft.unwrap_or_default(),
-        total: started.elapsed(),
-    }
+    outs
 }
 
 fn report(name: &str, r: &RunOut) {
@@ -296,5 +331,26 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
         );
     } else {
         eprintln!("CASCADIA_PREFILL_DEVICE not set; hybrid leg skipped");
+    }
+
+    // Parking (CASCADIA_PARK=1): two sequential tasks through one engine
+    // with --park-prefill semantics — task 1 parks after prefill, task 2
+    // pays the reload (visible in its TTFT). Both must stay token-identical
+    // to the baseline.
+    if std::env::var("CASCADIA_PARK").is_ok_and(|v| v == "1") {
+        let pd = prefill_device.as_deref();
+        let outs = run_tasks(&shards, &device, pd, false, true, &prompt, max_new, 2).await;
+        let label = pd.unwrap_or(&device).to_string();
+        report(&format!("parked#1  [{label}+{device}]"), &outs[0]);
+        report(&format!("parked#2  [{label}+{device}]"), &outs[1]);
+        for (n, o) in outs.iter().enumerate() {
+            assert_eq!(
+                base.ids, o.ids,
+                "parked task {n} diverged from tokenwise (text: {:?})",
+                o.text
+            );
+        }
+    } else {
+        eprintln!("CASCADIA_PARK not set; parking leg skipped");
     }
 }

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -395,8 +395,8 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
 
     // Parking (CASCADIA_PARK=1): two sequential tasks through one engine
     // with --park-prefill semantics — task 1 parks after prefill, task 2
-    // pays the reload (visible in its TTFT). Both must stay token-identical
-    // to the baseline.
+    // pays the reload (visible in its TTFT). Both must stay in parity with the
+    // baseline (near-tie-tolerant; see `assert_parity`).
     if std::env::var("CASCADIA_PARK").is_ok_and(|v| v == "1") {
         let pd = prefill_device.as_deref();
         let outs = run_tasks(&shards, &device, pd, false, true, &prompt, max_new, 2).await;

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -24,6 +24,9 @@
 //! `CASCADIA_PREFILL_DEVICE` (prefill device for the chunked run — set NPU
 //! on an AI PC for the hybrid split; default = decode device),
 //! `CASCADIA_STATIC_PROMPT`, `CASCADIA_STATIC_MAX_NEW` (default 32),
+//! `CASCADIA_STATIC_TASKS=N` (sequential requests per chunked/hybrid engine —
+//! request 2+ is steady-state TTFT, without the ~300 ms first-infer init a
+//! cache-imported NPU blob defers),
 //! `CASCADIA_PARITY_SOFT=1` (tolerate even an EARLY fork — one within the first
 //! `NEAR_TIE_MIN_PREFIX` decoded tokens, which otherwise hard-fails as suspect
 //! corruption; late near-tie forks are already tolerated by default. For pure
@@ -298,6 +301,16 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(32);
+    // CASCADIA_STATIC_TASKS=N (default 1): drive N sequential requests
+    // through the chunked/hybrid engines and report each. Request 1 through
+    // a cache-imported NPU blob pays ~300 ms of driver init the import
+    // deferred (a cold in-process compile does not); request 2+ is the
+    // steady-state TTFT a long-lived worker sees.
+    let bench_tasks: usize = std::env::var("CASCADIA_STATIC_TASKS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(1);
 
     // Guard against a vacuous pass: without a chunked-prefill variant, the
     // "chunked" and "hybrid" runs silently take the identical tokenwise path
@@ -322,19 +335,36 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
     assert!(!base.ids.is_empty(), "baseline generated no tokens");
 
     // Chunked prefill, same device (weight-stream amortization only).
-    let chunked = run_once(&shards, &device, None, false, &prompt, max_new).await;
-    report(&format!("chunked   [{device}]"), &chunked);
-    assert_parity(&format!("chunked prefill on {device}"), &base, &chunked);
+    let chunked_runs =
+        run_tasks(&shards, &device, None, false, false, &prompt, max_new, bench_tasks).await;
+    for (i, c) in chunked_runs.iter().enumerate() {
+        let label = if bench_tasks == 1 {
+            format!("chunked   [{device}]")
+        } else {
+            format!("chunked#{}  [{device}]", i + 1)
+        };
+        report(&label, c);
+        assert_parity(&format!("chunked prefill on {device} (task {i})"), &base, c);
+    }
 
     // Hybrid: chunked prefill on another device, decode unchanged.
     if let Some(pd) = prefill_device.as_deref() {
-        let hybrid = run_once(&shards, &device, Some(pd), false, &prompt, max_new).await;
-        report(&format!("hybrid    [{pd}+{device}]"), &hybrid);
-        assert_parity(
-            &format!("hybrid ({pd} prefill + {device} decode)"),
-            &base,
-            &hybrid,
-        );
+        let hybrid_runs =
+            run_tasks(&shards, &device, Some(pd), false, false, &prompt, max_new, bench_tasks)
+                .await;
+        for (i, h) in hybrid_runs.iter().enumerate() {
+            let label = if bench_tasks == 1 {
+                format!("hybrid    [{pd}+{device}]")
+            } else {
+                format!("hybrid#{}  [{pd}+{device}]", i + 1)
+            };
+            report(&label, h);
+            assert_parity(
+                &format!("hybrid ({pd} prefill + {device} decode, task {i})"),
+                &base,
+                h,
+            );
+        }
     } else {
         eprintln!("CASCADIA_PREFILL_DEVICE not set; hybrid leg skipped");
     }

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -350,11 +350,7 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
         report(&format!("parked#1  [{label}+{device}]"), &outs[0]);
         report(&format!("parked#2  [{label}+{device}]"), &outs[1]);
         for (n, o) in outs.iter().enumerate() {
-            assert_eq!(
-                base.ids, o.ids,
-                "parked task {n} diverged from tokenwise (text: {:?})",
-                o.text
-            );
+            assert_parity(&format!("parked task {n}"), &base, o);
         }
     } else {
         eprintln!("CASCADIA_PARK not set; parking leg skipped");

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -338,8 +338,17 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
     assert!(!base.ids.is_empty(), "baseline generated no tokens");
 
     // Chunked prefill, same device (weight-stream amortization only).
-    let chunked_runs =
-        run_tasks(&shards, &device, None, false, false, &prompt, max_new, bench_tasks).await;
+    let chunked_runs = run_tasks(
+        &shards,
+        &device,
+        None,
+        false,
+        false,
+        &prompt,
+        max_new,
+        bench_tasks,
+    )
+    .await;
     for (i, c) in chunked_runs.iter().enumerate() {
         let label = if bench_tasks == 1 {
             format!("chunked   [{device}]")
@@ -347,14 +356,26 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
             format!("chunked#{}  [{device}]", i + 1)
         };
         report(&label, c);
-        assert_parity(&format!("chunked prefill on {device} (task {})", i + 1), &base, c);
+        assert_parity(
+            &format!("chunked prefill on {device} (task {})", i + 1),
+            &base,
+            c,
+        );
     }
 
     // Hybrid: chunked prefill on another device, decode unchanged.
     if let Some(pd) = prefill_device.as_deref() {
-        let hybrid_runs =
-            run_tasks(&shards, &device, Some(pd), false, false, &prompt, max_new, bench_tasks)
-                .await;
+        let hybrid_runs = run_tasks(
+            &shards,
+            &device,
+            Some(pd),
+            false,
+            false,
+            &prompt,
+            max_new,
+            bench_tasks,
+        )
+        .await;
         for (i, h) in hybrid_runs.iter().enumerate() {
             let label = if bench_tasks == 1 {
                 format!("hybrid    [{pd}+{device}]")

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -92,6 +92,12 @@ async fn run_tasks(
     if let Some(pd) = prefill_device {
         builder = builder.with_prefill_device(pd);
     }
+    // CASCADIA_OV_CACHE: compiled-blob cache dir. Load-bearing for the
+    // parking leg — without it a parked model's reload is a full cold
+    // compile (~minutes on NPU) instead of a cache import.
+    if let Ok(cache) = std::env::var("CASCADIA_OV_CACHE") {
+        builder = builder.with_cache_dir(cache);
+    }
     builder
         .connect(PeerLayout::single_stage())
         .await

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -31,6 +31,9 @@
 //! `NEAR_TIE_MIN_PREFIX` decoded tokens, which otherwise hard-fails as suspect
 //! corruption; late near-tie forks are already tolerated by default. For pure
 //! timing sweeps; see `assert_parity`).
+//! NOTE: `CASCADIA_OV_CACHE` applies to EVERY leg's compiles (not only the
+//! parking leg) — cached-NPU legs pay the ~300-430 ms first-infer import
+//! init, so compare like-for-like when A/B-ing against cacheless runs.
 //! Unset `CASCADIA_STATIC_SHARDS` ⇒ skip-pass (stub CI stays green).
 //! Multi-stage pipelines are exercised on hardware via `cascadia worker`
 //! (`--prefill-device`), not here.
@@ -344,7 +347,7 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
             format!("chunked#{}  [{device}]", i + 1)
         };
         report(&label, c);
-        assert_parity(&format!("chunked prefill on {device} (task {i})"), &base, c);
+        assert_parity(&format!("chunked prefill on {device} (task {})", i + 1), &base, c);
     }
 
     // Hybrid: chunked prefill on another device, decode unchanged.
@@ -360,7 +363,7 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
             };
             report(&label, h);
             assert_parity(
-                &format!("hybrid ({pd} prefill + {device} decode, task {i})"),
+                &format!("hybrid ({pd} prefill + {device} decode, task {})", i + 1),
                 &base,
                 h,
             );
@@ -380,7 +383,7 @@ async fn chunked_prefill_matches_tokenwise_and_reports_timing() {
         report(&format!("parked#1  [{label}+{device}]"), &outs[0]);
         report(&format!("parked#2  [{label}+{device}]"), &outs[1]);
         for (n, o) in outs.iter().enumerate() {
-            assert_parity(&format!("parked task {n}"), &base, o);
+            assert_parity(&format!("parked task {}", n + 1), &base, o);
         }
     } else {
         eprintln!("CASCADIA_PARK not set; parking leg skipped");

--- a/docs/perf/HYBRID_NPU_CPU.md
+++ b/docs/perf/HYBRID_NPU_CPU.md
@@ -300,6 +300,29 @@ on-box NPU compile (or move the compile off-box / behind NPUW folding), and
    Yi-9B under memory pressure) never arises single-stage. Measure per
    model; the knobs compose every way.
 
+## Weight residency: `--park-prefill`
+
+The split's structural memory cost is the second resident copy of stage
+weights (each compiled model owns its own device-format copy; OpenVINO has
+no cross-device weight sharing — verified against plugin sources, see
+`docs/rfcs/openvino-inplace-int4-gemv.md`). `--park-prefill` drops the
+prefill CompiledModel after each task's prefill and re-creates it from the
+compile cache at the next prefill, freeing the prefill variant's weights
+between requests (~0.64 GB at 1B; scales with stage size):
+
+```bash
+cascadia worker ... --prefill-device NPU --park-prefill \
+  --ov-cache-dir /path/to/ov-cache   # REQUIRED for parking to make sense
+```
+
+Measured (~435-token prompt, parity asserted across two sequential tasks):
+unparked hybrid TTFT 717 ms; parked tasks 1323 / 1396 ms **with** the blob
+cache; **292 s** without it (a cold NPU recompile — the engine warns if
+parking is enabled with no cache dir). Use it on memory-tight stages; skip
+it where the ~0.7 s TTFT tax outweighs the freed memory. The NPUW
+weights-bank alternative for all-NPU configs was probed and is functionally
+viable but memory-unproven (`experiments/npuw-bank-probe/NOTES.md`).
+
 ## Constraints & follow-ups
 
 - Static path only. The stateful (`cpu-gpu`) path keeps KV inside OpenVINO

--- a/docs/rfcs/openvino-inplace-int4-gemv.md
+++ b/docs/rfcs/openvino-inplace-int4-gemv.md
@@ -1,0 +1,80 @@
+# RFC draft: in-place INT4 GEMV execution mode for the OpenVINO CPU plugin
+
+**Status:** draft for upstream discussion (openvinotoolkit/openvino). NOT yet
+filed — per repo policy, verify against the latest OV release and search for
+prior art immediately before filing.
+
+## Problem
+
+Heterogeneous phase-split LLM serving on Intel AI PCs (prefill on NPU, decode
+on CPU — the same split AMD ships as Ryzen AI hybrid mode and Intel's own NPUW
+implements internally between its prefill/generate submodels) pays **~2×
+resident weight memory**: every OpenVINO plugin repacks weights into its own
+execution format at `compile_model` time.
+
+- CPU: `prepareWeightsMemory` (`src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp`)
+  always allocates a plugin-owned buffer and reorders into the oneDNN-chosen
+  blocked layout (`format_tag::any`); INT4 additionally gets nibble rewrites
+  (i4→u4 +8). The `.bin`'s mmapped constants are never executed from.
+- NPU: weights are memcpy'd into a transient Level-Zero buffer and transformed
+  by an on-device init schedule into resident L0 weights
+  (`weightless_graph.cpp`); ~1× resident after load.
+- The only cross-model sharing (NPUW weights bank) is keyed **per device**
+  (`weights_bank.hpp: unordered_map<std::string /*device*/, DeviceBank>`).
+
+On a 32 GB Lunar Lake AI PC serving a pipeline stage, the duplicated CPU copy
+is the difference between a model fitting or not.
+
+## Proposal
+
+An opt-in CPU-plugin execution mode (e.g.
+`ov::intel_cpu::inplace_weights(true)` or an `ov::hint`) under which
+**M=1 (GEMV) FullyConnected/MatMul with weights-decompression executes
+directly from the model's original grouped-INT4 constant memory** (the
+mmapped `.bin`), skipping the compile-time reorder for those primitives only.
+
+Scope deliberately narrow:
+- M=1 (single-token decode) only — GEMM keeps the blocked repack.
+- Grouped u4/i4 + scales/zps in the canonical IR layout.
+- Falls back to the current path when the ISA/kernel can't honor it.
+
+## Why this is performance-viable
+
+Decode GEMV is DRAM-bandwidth-bound, not layout-bound: Intel's own kernel
+work (arXiv 2508.06753) streams grouped INT4 from the canonical layout at
+"within 20-25% of theoretical peak" on Lunar Lake — i.e. ~0.7× DRAM peak, the
+same ballpark the repacked path achieves, because the bottleneck is the
+memory stream, not the register-blocking that the repack optimizes for GEMM.
+
+Measured motivation (cascadia PR #107, Lunar Lake 258V, Llama-3.2-1B INT4):
+NPU-prefill + CPU-decode phase split cuts TTFT 7.7-24× at unchanged decode
+tok/s, with the shared host KV ring making the handoff free — the remaining
+structural cost of the split is exactly the duplicated CPU weight copy this
+RFC removes (steady-state residency would drop to NPU-resident weights + the
+OS page cache of the shared .bin).
+
+## Alternatives considered
+
+- Cross-device weights bank: rejected — CPU and NPU execution formats differ;
+  neither plugin can consume the other's buffer.
+- Remote-tensor-wrapped constants: the per-plugin import/repack happens
+  regardless of buffer ownership.
+- Weightless blobs / mmap: shares the *source* pages (already the case) but
+  not the resident execution copies.
+
+## Open questions
+
+1. Does oneDNN's `weights_decompression` brgemm path accept an external
+   plain-layout u4 buffer for M=1, or is a new microkernel needed?
+2. Interaction with `dynamic_quantization_group_size` (activation DQ forces
+   symmetric weight conversion today — another rewrite).
+3. Accuracy parity: the in-place path must be bit-compatible with the
+   repacked path for the same primitive.
+4. Should the mode be per-model (compile property) or per-primitive
+   (automatic for M=1 shapes)?
+
+## Prior-art search to redo at filing time
+
+- `gh search issues --repo=openvinotoolkit/openvino "share weights devices"`
+- `gh search prs --repo=openvinotoolkit/openvino "inplace weights"`
+- pip index versions openvino (verify latest; re-run the residency repro).

--- a/experiments/npuw-bank-probe/NOTES.md
+++ b/experiments/npuw-bank-probe/NOTES.md
@@ -1,0 +1,64 @@
+# NPUW weights-bank sharing probe
+
+**Question:** can two *user-level* NPU compilations (our decode + chunked-
+prefill IR variants — byte-identical weights, different static shapes) share
+one weight allocation through OpenVINO's NPUW weights bank, cutting an
+all-NPU phase split from 2× to ~1× resident weights?
+
+**Why it might work:** NPUW internally shares one bank across its own
+prefill/generate/head submodels; the bank manager is process-global, keyed by
+the `NPUW_WEIGHTS_BANK` string, and bank storage dedups tensors per device.
+If two `compile_model` calls with the same bank name dedup identical
+constants, we get the sharing for free.
+
+**Why it might not:** `NPU_USE_NPUW=YES` routes the whole compile through
+NPUW's partitioner, which is built for single whole models (it does its own
+prefill/generate split for LLM-flagged stateful graphs) — our graphs are
+already sharded, stateless, and static, a shape NPUW was not designed to
+ingest. This is an undocumented surface; treat any behavior as unsupported.
+
+## Method
+
+`crates/cascadia-engine-openvino/tests/npuw_bank_probe.rs` (env-gated):
+compiles BOTH variants on `NPU` (`--prefill-device NPU` equivalent), runs an
+8-token sanity generation, then holds the process alive while
+`run_npuw_probe.ps1` samples peak working set. Two modes:
+
+- `baseline` — plain NPU compiles (the shipping all-NPU config).
+- `npuw` — adds `NPU_USE_NPUW=YES` + `NPUW_WEIGHTS_BANK=cascadia-bank-probe`
+  to both compiles.
+
+Model: Llama-3.2-1B INT4 single-stage static export (+ seq=64 prefill
+variant), Lunar Lake 258V (pawan-01), OV GenAI 2026.1 SDK.
+
+## Results (pawan-01, LNL 258V, 2026-07-15, two complete runs)
+
+Both modes **compiled and generated correct output** ("Paris. The capital of
+Germany is Berlin") — NPUW accepts our pre-sharded stateless static graphs
+and the shared bank name does not break execution.
+
+| Mode | peak process WS | steady process WS |
+|---|---|---|
+| baseline (plain NPU ×2 compiles) | 9.39 GB | 0.04 GB |
+| npuw (shared `NPUW_WEIGHTS_BANK`) | 6.32 GB | 4.32 GB |
+
+**The memory verdict is UNRESOLVED — process working set cannot compare the
+two paths.** The plain NPU plugin holds weights in driver-owned Level-Zero
+allocations invisible to process WS (hence 0.04 GB "steady" with two models
+loaded), while NPUW's bank allocates host-USM tensors that DO count (4.32 GB
+— far above 2× the 0.64 GB INT4 weights, consistent with NPUW's DCOFF
+decompressing INT4→f16 host-side). Peaks are dominated by compiler
+transients. So: the bank likely dedups, but DCOFF expansion may make total
+residency WORSE than plain-path INT4 for compressed models. A system-wide
+free-memory-delta measurement (captures driver allocations) was scripted
+(`run_npuw_probe.ps1` sysfoot columns) but a bastion network outage
+interrupted the run; re-run it when the fleet path is stable before drawing
+a memory conclusion.
+
+## Verdict
+
+Functionally viable, memory-unproven, unsupported surface. Do not build on
+it: prefer `--park-prefill` (shipped, measured) for residency relief today
+and the in-place INT4 GEMV RFC (docs/rfcs/) for the principled 1× path.
+Re-probe with the sysfoot measurement + accuracy sweep + multi-stage before
+reconsidering.

--- a/experiments/npuw-bank-probe/NOTES.md
+++ b/experiments/npuw-bank-probe/NOTES.md
@@ -22,7 +22,7 @@ ingest. This is an undocumented surface; treat any behavior as unsupported.
 `crates/cascadia-engine-openvino/tests/npuw_bank_probe.rs` (env-gated):
 compiles BOTH variants on `NPU` (`--prefill-device NPU` equivalent), runs an
 8-token sanity generation, then holds the process alive while
-`run_npuw_probe.ps1` samples peak working set. Two modes:
+`a sysfoot wrapper (run_npuw_probe.ps1 — NOT committed; lost in a session restart; re-derive: poll `(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory` at 5 s intervals around the PROBE-HOLD window)` samples peak working set. Two modes:
 
 - `baseline` — plain NPU compiles (the shipping all-NPU config).
 - `npuw` — adds `NPU_USE_NPUW=YES` + `NPUW_WEIGHTS_BANK=cascadia-bank-probe`
@@ -51,7 +51,7 @@ decompressing INT4→f16 host-side). Peaks are dominated by compiler
 transients. So: the bank likely dedups, but DCOFF expansion may make total
 residency WORSE than plain-path INT4 for compressed models. A system-wide
 free-memory-delta measurement (captures driver allocations) was scripted
-(`run_npuw_probe.ps1` sysfoot columns) but a bastion network outage
+(`a sysfoot wrapper (run_npuw_probe.ps1 — NOT committed; lost in a session restart; re-derive: poll `(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory` at 5 s intervals around the PROBE-HOLD window)` sysfoot columns) but a bastion network outage
 interrupted the run; re-run it when the fleet path is stable before drawing
 a memory conclusion.
 


### PR DESCRIPTION
## Prefill weight residency: parking, NPUW bank probe, and the in-place-GEMV RFC

Stacked on #107. The phase split holds two compiled models; this PR is the three-path answer to that residency cost, in the order they pay off:

1. **`--park-prefill` (shipped, measured)**: drop the prefill CompiledModel after each prefill; reload from the OV blob cache per request. ~1× steady weights for +~0.7 s/request with `--ov-cache-dir` (292 s cold without — load-time warning added). Parking leg in the parity harness (`CASCADIA_PARK=1`).
2. **NPUW weights-bank probe** (`experiments/npuw-bank-probe/`): shared-bank NPUW compiles of our static shards work; memory verdict documented (DCOFF expands INT4→f16 host-side; process-WS blind to L0).
3. **`docs/rfcs/openvino-inplace-int4-gemv.md`**: the upstream ask, narrowed by the spike's evidence (#109) — mmap-backed execution of grouped-INT4 decompress weights as a documented contract + eliminating the compile-time private peak. Upstream-gap evidence included (upstream oneDNN has no optimized s4 grouped-decompression kernel; OV's fast path is fork-only). Not yet filed.

Context from the 1B→70B benchmark campaign (docs on #107/#109): residency rules measured per device — NPU-resident models cost ≈1.4× INT4 in L0 (the priciest place to keep models), iGPU ≈1×, and the dual-blob pattern is what capped 14B pairs and 70B stage-0 on 32 GB boxes — which is exactly the regime parking (and a pipeline-stage park variant, future work) addresses.

Also here: `CASCADIA_STATIC_TASKS` steady-state knob (first-request cache-import init ≈300–430 ms is measurement noise a long-lived worker never re-pays).

**Do-not-merge hold per repo owner.**

---

## Rebase + validation (2026-07-24)

Rebased onto `main` with #107/#109; faithful (engine inference byte-identical pre/post-rebase). `--park-prefill` validated on hardware (matias-04, Llama-3.2-1B static shard): parking drops the prefill CompiledModel after each request and reloads on the next — `parked#1` 1468 ms → `parked#2` 2056 ms, i.e. the reload adds ~1.4 s to that request (the residency↔latency trade), decode unchanged.

## Test plan

**Tier A — `just check` (Mac/CI):**
- Builder rejects park on a stateful shard / without a chunked-prefill variant: `park_prefill_on_stateful_shard_rejected`.
- `--park-prefill` CLI guards (manual): requires `--engine ov-runtime`; conflicts with `--no-chunked-prefill`.
- RFC (`docs/rfcs/openvino-inplace-int4-gemv.md`) + NPUW-probe notes present.

**Tier B — `--features openvino`:**
- Parity harness `CASCADIA_PARK=1` leg — 2 sequential tasks through one engine, near-tie-tolerant parity, the reload cost visible in task-2 TTFT (set `CASCADIA_OV_CACHE` or the reload is a multi-minute cold compile).
- NPUW weights-bank probe (`npuw_bank_probe.rs`, `CASCADIA_NPUW_PROBE=1`).

## Caveat

The **park-without-cache load-time warning** only fires with `--ov-cache-dir ""` (explicitly disabling the auto-default cache) and has **no unit test** — it's observable only at runtime on a real export.
