### PR TITLE
spike: CascadiaInt4Gemv extension op — decode GEMV from the IR mmap (route 1)

### DIFF
--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1390,14 +1390,10 @@ fn install_shutdown_signal_handler(
     })
 }
 
-async fn cmd_worker(args: WorkerArgs) -> Result<()> {
-    if args.rank >= args.total {
-        return Err(anyhow!(
-            "--rank must be in [0, {}); got {}",
-            args.total,
-            args.rank
-        ));
-    }
+/// Reject phase-split flag combinations before a worker binds any socket. Pure
+/// function of the args so it is unit-testable (the guards were inline in the
+/// async `cmd_worker`, reachable only by running a full worker).
+fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
     // Fail loud, not silent: the phase-split flags are load-bearing when
     // given, and only the ov-runtime engine implements them.
     if (args.prefill_device.is_some()
@@ -1417,6 +1413,18 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
             "--prefill-device / --park-prefill conflict with --no-chunked-prefill"
         ));
     }
+    Ok(())
+}
+
+async fn cmd_worker(args: WorkerArgs) -> Result<()> {
+    if args.rank >= args.total {
+        return Err(anyhow!(
+            "--rank must be in [0, {}); got {}",
+            args.total,
+            args.rank
+        ));
+    }
+    validate_worker_runtime_flags(&args)?;
     let is_first = args.rank == 0;
     let is_last = args.rank == args.total - 1;
 
@@ -2197,6 +2205,36 @@ mod python_tests {
         let mut a = WorkerArgs::single_node(model.into(), "GPU".into(), engine, ":8000".into());
         a.engine = engine;
         a
+    }
+
+    /// The phase-split flags only exist in the ov-runtime static path; using
+    /// one on another engine is rejected loudly (here: --gemv-offload on
+    /// ov-genai), not silently ignored.
+    #[test]
+    fn worker_flags_reject_phase_split_without_ov_runtime() {
+        let mut a = worker("m", EngineKind::OvGenai);
+        a.gemv_offload = true;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("ov-runtime"), "{err}");
+    }
+
+    /// A prefill device (or parking) is meaningless with chunked prefill
+    /// disabled — the two are mutually exclusive.
+    #[test]
+    fn worker_flags_reject_prefill_device_conflict_with_no_chunked() {
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.prefill_device = Some("NPU".into());
+        a.no_chunked_prefill = true;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("conflict"), "{err}");
+    }
+
+    /// A valid phase split (ov-runtime + prefill device, chunked enabled) passes.
+    #[test]
+    fn worker_flags_accept_valid_phase_split() {
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.prefill_device = Some("NPU".into());
+        assert!(validate_worker_runtime_flags(&a).is_ok());
     }
 
     #[test]

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -2550,6 +2550,96 @@ mod tests {
         assert!(!flags.iter().any(|f| f == "--static-context"));
     }
 
+    /// `--static-prefill-seq` needs `--target npu` (chunked prefill is a
+    /// static-KV-path feature); the default cpu-gpu target rejects it.
+    #[test]
+    fn shard_flags_static_prefill_seq_requires_npu() {
+        let args = parse_shard(&[
+            "cascadia",
+            "shard",
+            "--model",
+            "m",
+            "--output-dir",
+            "o",
+            "--num-stages",
+            "1",
+            "--static-prefill-seq",
+            "4",
+        ]);
+        let err = shard_exporter_flags(&args).unwrap_err().to_string();
+        assert!(err.contains("--target npu"), "{err}");
+    }
+
+    /// `--static-prefill-seq 1` is nonsense (a 1-wide chunk is the seq=1 decode
+    /// path); only 0 (off) or >= 2 is valid.
+    #[test]
+    fn shard_flags_static_prefill_seq_one_rejected() {
+        let args = parse_shard(&[
+            "cascadia",
+            "shard",
+            "--model",
+            "m",
+            "--output-dir",
+            "o",
+            "--num-stages",
+            "1",
+            "--target",
+            "npu",
+            "--static-prefill-seq",
+            "1",
+        ]);
+        let err = shard_exporter_flags(&args).unwrap_err().to_string();
+        assert!(err.contains(">= 2"), "{err}");
+    }
+
+    /// A chunk wider than the KV window would evict its own tokens mid-chunk:
+    /// `--static-prefill-seq` must be <= `--static-context - 1`.
+    #[test]
+    fn shard_flags_static_prefill_seq_exceeds_context_rejected() {
+        let args = parse_shard(&[
+            "cascadia",
+            "shard",
+            "--model",
+            "m",
+            "--output-dir",
+            "o",
+            "--num-stages",
+            "1",
+            "--target",
+            "npu",
+            "--static-context",
+            "8",
+            "--static-prefill-seq",
+            "8",
+        ]);
+        let err = shard_exporter_flags(&args).unwrap_err().to_string();
+        assert!(err.contains("evict"), "{err}");
+    }
+
+    /// A valid `--static-prefill-seq` is forwarded to the exporter verbatim
+    /// (a dropped/defaulted value would silently export a wrong-shape variant).
+    #[test]
+    fn shard_flags_static_prefill_seq_forwarded() {
+        let args = parse_shard(&[
+            "cascadia",
+            "shard",
+            "--model",
+            "m",
+            "--output-dir",
+            "o",
+            "--num-stages",
+            "1",
+            "--target",
+            "npu",
+            "--static-context",
+            "1024",
+            "--static-prefill-seq",
+            "64",
+        ]);
+        let flags = shard_exporter_flags(&args).expect("valid prefill-seq flags");
+        assert!(has_pair(&flags, "--static-prefill-seq", "64"), "{flags:?}");
+    }
+
     /// Golden vector: pins VALUES (not just flag presence), `--quantization`
     /// forwarding, and flag/value adjacency for the whole NPU argv — a bug
     /// that pushes a default instead of the user's value passes every

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -389,6 +389,16 @@ pub struct WorkerArgs {
     #[arg(long, default_value_t = false)]
     pub park_prefill: bool,
 
+    /// SPIKE: execute the decode model's sym-INT4 weight matmuls through the
+    /// CascadiaInt4Gemv extension op straight from the mmapped IR .bin — the
+    /// CPU plugin never makes its own resident repacked weight copy, so a
+    /// hybrid stage's decode side costs ~0 extra weight RAM. ov-runtime,
+    /// stateless static exports, --device CPU only. Numeric note: the op's
+    /// accumulation order differs from oneDNN's, so output parity vs the
+    /// stock kernel is validated empirically, not guaranteed bit-for-bit.
+    #[arg(long, default_value_t = false)]
+    pub gemv_offload: bool,
+
     /// Speculative-decode draft model path (FastDraft companion).
     #[arg(long)]
     pub draft_model: Option<String>,
@@ -607,6 +617,7 @@ impl WorkerArgs {
             prefill_device: None,
             no_chunked_prefill: false,
             park_prefill: false,
+            gemv_offload: false,
             draft_model: None,
             draft_device: None,
             spec_k: 5,
@@ -1148,6 +1159,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             }
             b = b.with_chunked_prefill_disabled(args.no_chunked_prefill);
             b = b.with_prefill_parking(args.park_prefill);
+            b = b.with_gemv_offload(args.gemv_offload);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
                 b = b.with_cache_dir(&dir);
             }
@@ -1388,12 +1400,15 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     }
     // Fail loud, not silent: the phase-split flags are load-bearing when
     // given, and only the ov-runtime engine implements them.
-    if (args.prefill_device.is_some() || args.no_chunked_prefill || args.park_prefill)
+    if (args.prefill_device.is_some()
+        || args.no_chunked_prefill
+        || args.park_prefill
+        || args.gemv_offload)
         && args.engine != EngineKind::OvRuntime
     {
         return Err(anyhow!(
-            "--prefill-device / --no-chunked-prefill / --park-prefill require \
-             --engine ov-runtime (the chunked-prefill phase split lives in the \
+            "--prefill-device / --no-chunked-prefill / --park-prefill / --gemv-offload \
+             require --engine ov-runtime (the chunked-prefill phase split lives in the \
              static-KV runtime path)"
         ));
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2798,9 +2798,7 @@ impl Builder for OvRuntimeBuilder {
                     &import_plugin(&pplugin),
                 )
                 .map_err(map_ov_err)
-                .map_err(|e| {
-                    EngineError::Backend(format!("prefill blob import on {pdev}: {e}"))
-                })?
+                .map_err(|e| EngineError::Backend(format!("prefill blob import on {pdev}: {e}")))?
             } else {
                 OvRuntime::compile(&pxml, &pdev, &pplugin)
                     .map_err(map_ov_err)

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -43,7 +43,7 @@ use cascadia_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec,
 use futures::stream;
 use serde::Deserialize;
 use tokenizers::Tokenizer;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::rotary::{load_model_config, Rotary};
 use crate::warn_limit::{StepWarn, StepWarnLimiter};
@@ -1057,8 +1057,10 @@ impl OvRuntimeEngine {
         want_output: bool,
     ) -> EngineResult<(Vec<f32>, Vec<usize>)> {
         let take = chunk.len();
+        debug!(take, position, "first-stage chunk: infer start");
         let (dtype, shape, bytes) =
             self.static_infer_chunk(ChunkInput::Ids(chunk), take, position, want_output)?;
+        debug!(take, position, "first-stage chunk: infer+absorb done");
         if !want_output {
             return Ok((Vec::new(), Vec::new()));
         }
@@ -1092,6 +1094,7 @@ impl OvRuntimeEngine {
         shape: [usize; 3],
         position: i64,
     ) -> EngineResult<()> {
+        debug!(?shape, position, "downstream send: start");
         let downstream = self
             .downstream
             .clone()
@@ -1120,6 +1123,7 @@ impl OvRuntimeEngine {
             guard.send(&hid).await
         })
         .map_err(|e| EngineError::Backend(e.to_string()))?;
+        debug!(position, "downstream send: done");
         Ok(())
     }
 

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -622,11 +622,11 @@ fn npu_aot_blob(xml_path: &std::path::Path, device: &str) -> Option<std::path::P
     // Refuse a blob older than its IR: silently serving a stale compile's
     // weights is the worst failure mode. The fallthrough recompiles (slow,
     // and on small-RAM boxes possibly OOM) — but loudly and correctly.
-    if let (Ok(bm), Ok(xm)) = (
+    match (
         blob.metadata().and_then(|m| m.modified()),
         xml_path.metadata().and_then(|m| m.modified()),
     ) {
-        if bm < xm {
+        (Ok(bm), Ok(xm)) if bm < xm => {
             tracing::error!(
                 blob = %blob.display(),
                 "AOT blob is OLDER than its IR — ignoring it (re-export or delete \
@@ -634,6 +634,17 @@ fn npu_aot_blob(xml_path: &std::path::Path, device: &str) -> Option<std::path::P
             );
             return None;
         }
+        (Ok(_), Ok(_)) => {}
+        // Could not read both mtimes (unsupported FS, a TOCTOU delete after the
+        // exists() check, permissions): the freshness guard cannot run. Import
+        // the blob rather than force a needless recompile, but do NOT do it
+        // silently — an unverified stale blob imports and infers wrong tokens
+        // at a clean 200 OK, exactly the failure mode the guard exists to catch.
+        _ => tracing::warn!(
+            blob = %blob.display(),
+            "AOT blob freshness could not be verified (IR/blob mtime unavailable); \
+             importing it unchecked — validate the blob with a real inference at deploy"
+        ),
     }
     Some(blob)
 }
@@ -3277,6 +3288,31 @@ mod tests {
         // Non-NPU devices always compile.
         assert_eq!(npu_aot_blob(&xml, "CPU"), None);
         assert_eq!(npu_aot_blob(&xml, "GPU"), None);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A blob older than its IR is refused (fall back to a fresh compile):
+    /// serving a stale compile's weights is the "worst failure mode" the guard
+    /// exists to prevent. The happy-path test above never makes the blob older,
+    /// so this pins the `bm < xm` branch specifically.
+    #[test]
+    fn npu_aot_blob_rejects_blob_older_than_ir() {
+        use std::time::{Duration, SystemTime};
+        let dir = std::env::temp_dir().join(format!("aot-blob-stale-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let xml = dir.join("openvino_model.xml");
+        let blob = dir.join("openvino_model.blob");
+        std::fs::write(&xml, "x").unwrap();
+        std::fs::write(&blob, "b").unwrap();
+        // Backdate the blob 60 s behind the IR it claims to be a compile of.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&blob)
+            .unwrap()
+            .set_modified(SystemTime::now() - Duration::from_secs(60))
+            .unwrap();
+        assert_eq!(npu_aot_blob(&xml, "NPU"), None);
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -3317,6 +3317,29 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// A blob import must drop CACHE_DIR (an import never writes the compile
+    /// cache, and a core-level cache property on `import_model` risks an
+    /// unsupported-property error that breaks AOT blob import outright) while
+    /// leaving every other plugin property intact.
+    #[test]
+    fn import_plugin_strips_cache_dir_keeps_rest() {
+        let p = PluginConfig::new()
+            .with("CACHE_DIR", "/tmp/x")
+            .with("PERFORMANCE_HINT", "LATENCY")
+            .with("NPU_USE_NPUW", "YES");
+        let out = import_plugin(&p);
+        assert!(!out.entries.iter().any(|(k, _)| k == "CACHE_DIR"));
+        assert!(out
+            .entries
+            .iter()
+            .any(|(k, v)| k == "PERFORMANCE_HINT" && v == "LATENCY"));
+        assert!(out
+            .entries
+            .iter()
+            .any(|(k, v)| k == "NPU_USE_NPUW" && v == "YES"));
+        assert_eq!(out.entries.len(), 2);
+    }
+
     #[test]
     fn argmax_row_selects_requested_row() {
         // 3 rows of vocab 4; best of row 1 is index 2; row 2 (pad garbage)

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -595,11 +595,37 @@ struct StaticPrefill {
 /// Everything needed to re-create a parked prefill compilation: the variant's
 /// IR path, its device, and the plugin properties the original compile used
 /// (CACHE_DIR etc., so a reload hits the OV blob/UMD cache instead of a cold
-/// compile).
+/// compile). `blob` short-circuits the reload to an AOT blob import.
 struct PrefillReload {
     xml: String,
     device: String,
     plugin_entries: Vec<(String, String)>,
+    blob: Option<String>,
+}
+
+/// Path of a precompiled AOT blob to IMPORT instead of compiling, when the
+/// target device is the NPU and a `.blob` sibling of the IR exists (same
+/// basename: `openvino_model.xml` → `openvino_model.blob`). Blobs come from
+/// `ov::CompiledModel::export_model` — typically cross-compiled on a big-RAM
+/// host with `NPU_PLATFORM` set — and importing skips the NPU compiler's
+/// ~6–9×-INT4-bytes host-RAM transient entirely (measured ~7 s / no visible
+/// RAM movement for an 8B variant, vs a >23 GB on-box compile). NPU only:
+/// blobs are device- and driver-specific, and CPU/GPU compiles are cheap.
+fn npu_aot_blob(xml_path: &std::path::Path, device: &str) -> Option<std::path::PathBuf> {
+    if !device.trim().to_ascii_uppercase().starts_with("NPU") {
+        return None;
+    }
+    let blob = xml_path.with_extension("blob");
+    blob.exists().then_some(blob)
+}
+
+/// Plugin config for a blob import: the compile-time properties minus
+/// CACHE_DIR (an import never writes the compile cache, and core-level cache
+/// properties on `import_model` risk an unsupported-property error).
+fn import_plugin(plugin: &PluginConfig) -> PluginConfig {
+    let mut p = plugin.clone();
+    p.entries.retain(|(k, _)| k != "CACHE_DIR");
+    p
 }
 
 // -------- Engine --------
@@ -1727,9 +1753,19 @@ impl OvRuntimeEngine {
         let plugin = PluginConfig {
             entries: src.plugin_entries.clone(),
         };
-        let prt = OvRuntime::compile(&src.xml, &src.device, &plugin)
-            .map_err(map_ov_err)
-            .map_err(|e| EngineError::Backend(format!("prefill reload on {}: {e}", src.device)))?;
+        let prt = if let Some(blob) = &src.blob {
+            OvRuntime::import_blob(blob, &src.device, &import_plugin(&plugin))
+                .map_err(map_ov_err)
+                .map_err(|e| {
+                    EngineError::Backend(format!("prefill blob re-import on {}: {e}", src.device))
+                })?
+        } else {
+            OvRuntime::compile(&src.xml, &src.device, &plugin)
+                .map_err(map_ov_err)
+                .map_err(|e| {
+                    EngineError::Backend(format!("prefill reload on {}: {e}", src.device))
+                })?
+        };
         if let Some(pf) = self.prefill.as_mut() {
             pf.runtime = Some(prt);
         }
@@ -2671,6 +2707,17 @@ impl Builder for OvRuntimeBuilder {
                 );
             }
             rt
+        } else if let Some(blob) = npu_aot_blob(&xml_path, &self.device) {
+            events.push(LoadProgress::message(format!(
+                "importing precompiled NPU blob (AOT, no on-box compile): {}",
+                blob.display()
+            )));
+            OvRuntime::import_blob(
+                blob.to_str().unwrap_or_default(),
+                &self.device,
+                &import_plugin(&plugin),
+            )
+            .map_err(map_ov_err)?
         } else {
             OvRuntime::compile(xml_path.to_str().unwrap_or_default(), &self.device, &plugin)
                 .map_err(map_ov_err)?
@@ -2712,11 +2759,28 @@ impl Builder for OvRuntimeBuilder {
                 }
             };
             let pxml = prefill_xml.to_str().unwrap_or_default().to_string();
-            let prt = OvRuntime::compile(&pxml, &pdev, &pplugin)
+            let pblob = npu_aot_blob(&prefill_xml, &pdev);
+            let prt = if let Some(blob) = &pblob {
+                events.push(LoadProgress::message(format!(
+                    "importing precompiled NPU prefill blob (AOT): {}",
+                    blob.display()
+                )));
+                OvRuntime::import_blob(
+                    blob.to_str().unwrap_or_default(),
+                    &pdev,
+                    &import_plugin(&pplugin),
+                )
                 .map_err(map_ov_err)
                 .map_err(|e| {
-                    EngineError::Backend(format!("chunked-prefill variant on {pdev}: {e}"))
-                })?;
+                    EngineError::Backend(format!("prefill blob import on {pdev}: {e}"))
+                })?
+            } else {
+                OvRuntime::compile(&pxml, &pdev, &pplugin)
+                    .map_err(map_ov_err)
+                    .map_err(|e| {
+                        EngineError::Backend(format!("chunked-prefill variant on {pdev}: {e}"))
+                    })?
+            };
             self.prefill_runtime = Some(prt);
             if self.park_prefill && self.cache_dir.is_none() {
                 warn!(
@@ -2732,6 +2796,7 @@ impl Builder for OvRuntimeBuilder {
                 xml: pxml,
                 device: pdev,
                 plugin_entries: pplugin.entries.clone(),
+                blob: pblob.map(|b| b.to_string_lossy().into_owned()),
             });
         }
 
@@ -3164,6 +3229,31 @@ mod tests {
         // Past the boundary: no chunk rows — caller steps tokenwise.
         assert_eq!(chunk_take(4, 100, 9, past_len), 0);
         assert_eq!(chunk_take(4, 100, 1000, past_len), 0);
+    }
+
+    /// AOT blob import triggers ONLY for the NPU device and only when a
+    /// `.blob` sibling of the IR exists — CPU/GPU always compile (blobs are
+    /// device-specific), and an absent blob falls back to the compiler.
+    #[test]
+    fn npu_aot_blob_selects_only_npu_with_blob_present() {
+        let dir = std::env::temp_dir().join(format!("aot-blob-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let xml = dir.join("openvino_model.xml");
+        std::fs::write(&xml, "x").unwrap();
+
+        // No blob on disk: never selected.
+        assert_eq!(npu_aot_blob(&xml, "NPU"), None);
+
+        let blob = dir.join("openvino_model.blob");
+        std::fs::write(&blob, "b").unwrap();
+        // Blob present: NPU (any casing/config suffix) imports it.
+        assert_eq!(npu_aot_blob(&xml, "NPU"), Some(blob.clone()));
+        assert_eq!(npu_aot_blob(&xml, " npu "), Some(blob.clone()));
+        // Non-NPU devices always compile.
+        assert_eq!(npu_aot_blob(&xml, "CPU"), None);
+        assert_eq!(npu_aot_blob(&xml, "GPU"), None);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2261,6 +2261,12 @@ pub struct OvRuntimeBuilder {
     /// the two-model split) and re-create it on the next prefill from the
     /// blob cache. For memory-tight stages; costs a per-task reload.
     pub park_prefill: bool,
+    /// `--gemv-offload` (SPIKE): compile the decode model with the
+    /// CascadiaInt4Gemv extension pass — sym-INT4 weight matmuls execute
+    /// straight from the mmapped .bin through a custom op instead of a
+    /// plugin-repacked resident copy (~1x steady-state decode weights).
+    /// Stateless static exports on a CPU device only.
+    pub gemv_offload: bool,
     pub cache_dir: Option<String>,
     pub kv_cache_precision: Option<String>,
     pub dyn_quant_group: Option<String>,
@@ -2314,6 +2320,11 @@ impl OvRuntimeBuilder {
     /// Park the prefill model between prefills (see `park_prefill`).
     pub fn with_prefill_parking(mut self, park: bool) -> Self {
         self.park_prefill = park;
+        self
+    }
+    /// Decode-side INT4 GEMV offload (see `gemv_offload`).
+    pub fn with_gemv_offload(mut self, offload: bool) -> Self {
+        self.gemv_offload = offload;
         self
     }
     /// Skip the export's chunked-prefill variant (prefill one token per step).
@@ -2469,6 +2480,26 @@ impl Builder for OvRuntimeBuilder {
             }
             _ => None,
         };
+        // --gemv-offload (spike): the offloaded matmuls run on the CPU
+        // plugin's evaluate() fallback, and the rewrite targets the stateless
+        // static IR's sym-INT4 pattern — gate both up front.
+        if self.gemv_offload {
+            if stage_cfg.stateful {
+                return Err(EngineError::ShardRejected(
+                    "--gemv-offload requires a stateless static export \
+                     (tools/export_shards.py --target npu)"
+                        .into(),
+                ));
+            }
+            if !self.device.trim().to_ascii_uppercase().starts_with("CPU") {
+                return Err(EngineError::ShardRejected(format!(
+                    "--gemv-offload executes offloaded matmuls on the CPU evaluate() \
+                     fallback — --device must be CPU (got {})",
+                    self.device
+                )));
+            }
+        }
+
         if (self.prefill_device.is_some() || self.park_prefill)
             && self.static_prefill_params.is_none()
         {
@@ -2552,9 +2583,39 @@ impl Builder for OvRuntimeBuilder {
         )));
         let plugin = self.plugin();
         let xml_path = stage_dir.join("openvino_model.xml");
-        let runtime =
+        let runtime = if self.gemv_offload {
+            // The custom op's member tensors don't survive blob
+            // serialization — strip CACHE_DIR for THIS compile only (the
+            // prefill compile below still caches; CPU compiles are fast).
+            let mut p = self.plugin();
+            if self.cache_dir.is_some() {
+                p.entries.retain(|(k, _)| k != "CACHE_DIR");
+                warn!(
+                    "--gemv-offload: decode compile skips CACHE_DIR (custom-op weights \
+                     don't survive blob serialization); the prefill compile still caches"
+                );
+            }
+            let (rt, offloaded) = OvRuntime::compile_gemv_offload(
+                xml_path.to_str().unwrap_or_default(),
+                &self.device,
+                &p,
+            )
+            .map_err(map_ov_err)?;
+            events.push(LoadProgress::message(format!(
+                "gemv-offload: {offloaded} sym-INT4 matmuls execute from the .bin mmap \
+                 (no plugin-resident weight copy)"
+            )));
+            if offloaded == 0 {
+                warn!(
+                    "--gemv-offload matched 0 matmuls — the IR does not carry the \
+                     expected NNCF sym-INT4 pattern; decode runs fully stock"
+                );
+            }
+            rt
+        } else {
             OvRuntime::compile(xml_path.to_str().unwrap_or_default(), &self.device, &plugin)
-                .map_err(map_ov_err)?;
+                .map_err(map_ov_err)?
+        };
         self.input_names = runtime.input_names().map_err(map_ov_err)?;
         self.runtime = Some(runtime);
 
@@ -3133,6 +3194,40 @@ mod tests {
             .err()
             .expect("advertised variant without the IR file must be rejected");
         assert!(err.to_string().contains("missing"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn gemv_offload_on_stateful_shard_rejected() {
+        let dir = write_stage_dir(
+            "gemv-stateful",
+            r#"{"layer_start":0,"layer_end":2,"has_embed":true,"has_head":true,"stateful":true}"#,
+        );
+        let mut b = OvRuntimeBuilder::new(&dir, 0, 1, "CPU").with_gemv_offload(true);
+        let err = b
+            .load(ShardSpec::single_stage("m", "CPU"))
+            .await
+            .err()
+            .expect("stateful + --gemv-offload must be rejected");
+        assert!(err.to_string().contains("--gemv-offload"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn gemv_offload_on_non_cpu_device_rejected() {
+        let dir = write_stage_dir(
+            "gemv-npu",
+            r#"{"layer_start":0,"layer_end":2,"has_embed":true,"has_head":true,
+                "stateful":false,"static_seq":1,"static_context":8,
+                "num_kv_heads":2,"head_dim":4}"#,
+        );
+        let mut b = OvRuntimeBuilder::new(&dir, 0, 1, "NPU").with_gemv_offload(true);
+        let err = b
+            .load(ShardSpec::single_stage("m", "NPU"))
+            .await
+            .err()
+            .expect("non-CPU device + --gemv-offload must be rejected");
+        assert!(err.to_string().contains("CPU"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1177,6 +1177,7 @@ impl OvRuntimeEngine {
         // hidden activation (see send_hidden_downstream). Each frame's payload
         // must match its shape*dtype, so we recv two separate tensors here.
         let want_pos = self.static_kv.is_some();
+        debug!(want_pos, "upstream recv: waiting");
         let (pos_tensor, tensor) = self
             .block_on(async move {
                 let mut guard = upstream.lock().await;
@@ -1189,6 +1190,7 @@ impl OvRuntimeEngine {
                 // can't wedge the stage (see `recv_tensor_reply`).
                 let (pos_tensor, t) = if want_pos {
                     let pos = guard.recv().await?.0;
+                    tracing::debug!("upstream recv: position frame arrived");
                     let (t, _) = guard.recv_reply().await?;
                     (Some(pos), t)
                 } else {
@@ -1198,6 +1200,7 @@ impl OvRuntimeEngine {
                 Ok::<_, cascadia_transport::TransportError>((pos_tensor, t))
             })
             .map_err(|e| EngineError::Backend(e.to_string()))?;
+        debug!("upstream recv: frames arrived");
         // Decode + strictly validate the position frame outside the transport
         // closure (so a bad frame yields a clear EngineError, not a desync).
         let position = match pos_tensor {

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1597,6 +1597,9 @@ impl OvRuntimeEngine {
                 other_ms,
                 "ov-runtime task done"
             );
+            if std::env::var("CASCADIA_PERF_DUMP").is_ok_and(|v| v == "1") {
+                dump_decode_profile(&self.runtime);
+            }
             self.active = None;
         }
 
@@ -2126,6 +2129,62 @@ impl Engine for OvRuntimeEngine {
             // prefill completes.
             self.park_prefill_model();
         }
+    }
+}
+
+/// CASCADIA_PERF_DUMP=1 (spike diagnostics): after a task finishes, print an
+/// aggregated per-node profile of the decode model's LAST inference — one
+/// representative decode token. Needs the model compiled with PERF_COUNT=YES
+/// (pass it via the plugin properties). Times inflate under profiling; use
+/// for ATTRIBUTION between node kinds, not absolute tok/s math.
+fn dump_decode_profile(runtime: &OvRuntime) {
+    let raw = match runtime.profiling() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("perf-dump unavailable: {e} (compile with PERF_COUNT=YES)");
+            return;
+        }
+    };
+    let mut by_type: std::collections::HashMap<String, (u64, u64, u32)> =
+        std::collections::HashMap::new();
+    let mut nodes: Vec<(String, String, u64)> = Vec::new();
+    let mut total_us = 0u64;
+    for line in raw.lines() {
+        let mut it = line.split('\t');
+        let (name, ntype, etype, real) = (
+            it.next().unwrap_or(""),
+            it.next().unwrap_or(""),
+            it.next().unwrap_or(""),
+            it.next().and_then(|v| v.parse::<u64>().ok()).unwrap_or(0),
+        );
+        let cpu = it.next().and_then(|v| v.parse::<u64>().ok()).unwrap_or(0);
+        total_us += real;
+        let e = by_type.entry(ntype.to_string()).or_default();
+        e.0 += real;
+        e.1 += cpu;
+        e.2 += 1;
+        if real > 0 {
+            nodes.push((name.to_string(), format!("{ntype}/{etype}"), real));
+        }
+    }
+    let mut rows: Vec<_> = by_type.into_iter().collect();
+    rows.sort_by_key(|(_, (real, _, _))| std::cmp::Reverse(*real));
+    eprintln!("perf-dump: decode-infer total {total_us} us by node type:");
+    for (ntype, (real, cpu, count)) in rows.iter().take(14) {
+        eprintln!("  {ntype:<28} real {real:>8} us  cpu {cpu:>8} us  x{count}");
+    }
+    nodes.sort_by_key(|(_, _, real)| std::cmp::Reverse(*real));
+    eprintln!("perf-dump: top nodes:");
+    for (name, kind, real) in nodes.iter().take(10) {
+        let short: String = name
+            .chars()
+            .rev()
+            .take(48)
+            .collect::<Vec<_>>()
+            .iter()
+            .rev()
+            .collect();
+        eprintln!("  {real:>8} us  {kind:<28} ...{short}");
     }
 }
 

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -616,7 +616,26 @@ fn npu_aot_blob(xml_path: &std::path::Path, device: &str) -> Option<std::path::P
         return None;
     }
     let blob = xml_path.with_extension("blob");
-    blob.exists().then_some(blob)
+    if !blob.exists() {
+        return None;
+    }
+    // Refuse a blob older than its IR: silently serving a stale compile's
+    // weights is the worst failure mode. The fallthrough recompiles (slow,
+    // and on small-RAM boxes possibly OOM) — but loudly and correctly.
+    if let (Ok(bm), Ok(xm)) = (
+        blob.metadata().and_then(|m| m.modified()),
+        xml_path.metadata().and_then(|m| m.modified()),
+    ) {
+        if bm < xm {
+            tracing::error!(
+                blob = %blob.display(),
+                "AOT blob is OLDER than its IR — ignoring it (re-export or delete \
+                 the stale blob); falling back to on-box compile"
+            );
+            return None;
+        }
+    }
+    Some(blob)
 }
 
 /// Plugin config for a blob import: the compile-time properties minus
@@ -2690,7 +2709,8 @@ impl Builder for OvRuntimeBuilder {
             // serialization — strip CACHE_DIR for THIS compile only (the
             // prefill compile below still caches; CPU compiles are fast).
             let mut p = self.plugin();
-            if self.cache_dir.is_some() {
+            let had_cache = p.entries.iter().any(|(k, _)| k == "CACHE_DIR");
+            if had_cache {
                 p.entries.retain(|(k, _)| k != "CACHE_DIR");
                 warn!(
                     "--gemv-offload: decode compile skips CACHE_DIR (custom-op weights \

--- a/crates/cascadia-engine-openvino/tests/blob_import_probe.rs
+++ b/crates/cascadia-engine-openvino/tests/blob_import_probe.rs
@@ -1,0 +1,42 @@
+//! AOT blob-import probe (hardware-gated; skip-pass without env).
+//!
+//! Validates the escape hatch for the NPU compile-memory spike: a blob
+//! produced by `ov::CompiledModel::export_model` on a big-RAM host (offline
+//! cross-compile via `NPU_PLATFORM`) is imported here WITHOUT running the
+//! compiler — the ~5.5×-INT4-bytes host transient never happens on this box.
+//! Success = the driver accepted the blob (metadata/platform handshake) and
+//! graph init + device weight load completed (the shim creates the infer
+//! request eagerly).
+//!
+//! ```text
+//! CASCADIA_BLOB_IMPORT=C:\path\to\model.blob [CASCADIA_BLOB_DEVICE=NPU] \
+//!   cargo test -p cascadia-engine-openvino --features openvino \
+//!   --test blob_import_probe -- --nocapture
+//! ```
+
+use std::time::Instant;
+
+use cascadia_ov_genai_shim::{PluginConfig, Runtime};
+
+#[test]
+fn imports_aot_blob_without_compiling() {
+    let Ok(blob) = std::env::var("CASCADIA_BLOB_IMPORT") else {
+        eprintln!("CASCADIA_BLOB_IMPORT not set; skipping");
+        return;
+    };
+    let device = std::env::var("CASCADIA_BLOB_DEVICE").unwrap_or_else(|_| "NPU".into());
+    let plugin = PluginConfig::default();
+
+    let t0 = Instant::now();
+    match Runtime::import_blob(&blob, &device, &plugin) {
+        Ok(rt) => {
+            let secs = t0.elapsed().as_secs_f64();
+            let inputs = rt.input_names().map(|n| n.len()).unwrap_or(0);
+            eprintln!(
+                "BLOB-IMPORT OK [{device}] {blob}: {secs:.1}s, {inputs} inputs \
+                 (graph initialized; no compiler ran on this host)"
+            );
+        }
+        Err(e) => panic!("BLOB-IMPORT FAILED [{device}] {blob}: {e}"),
+    }
+}

--- a/crates/cascadia-engine-openvino/tests/compile_warm_probe.rs
+++ b/crates/cascadia-engine-openvino/tests/compile_warm_probe.rs
@@ -29,16 +29,35 @@ fn warms_blob_cache_sequentially() {
         plugin.entries.push(("CACHE_DIR".into(), cache));
     }
 
+    // CASCADIA_WARM_INFER=1: after each compile, run ONE inference with the
+    // request's default (zeroed) input tensors and time it — isolates
+    // graph-specific first-inference pathologies (observed: a 70B
+    // embed-carrying stage hangs its first infer on iGPU/NPU while smaller
+    // stages run fine) without any pipeline machinery around them.
+    let do_infer = std::env::var("CASCADIA_WARM_INFER").is_ok_and(|v| v == "1");
+
     for xml in xmls.split(';').filter(|s| !s.trim().is_empty()) {
         let t0 = Instant::now();
         match Runtime::compile(xml, &device, &plugin) {
-            Ok(_rt) => eprintln!(
-                "WARM OK [{device}] {xml}: {:.0}s (blob cached; runtime dropped)",
-                t0.elapsed().as_secs_f64()
-            ),
+            Ok(mut rt) => {
+                eprintln!(
+                    "WARM OK [{device}] {xml}: {:.0}s",
+                    t0.elapsed().as_secs_f64()
+                );
+                if do_infer {
+                    let ti = Instant::now();
+                    match rt.infer() {
+                        Ok(()) => eprintln!(
+                            "INFER OK [{device}] {xml}: {:.1}s",
+                            ti.elapsed().as_secs_f64()
+                        ),
+                        Err(e) => eprintln!("INFER FAILED [{device}] {xml}: {e}"),
+                    }
+                }
+            }
             Err(e) => panic!("WARM FAILED [{device}] {xml}: {e}"),
         }
-        // _rt drops here — the transient and the compiled model are gone
+        // rt drops here — the transient and the compiled model are gone
         // before the next compile starts.
     }
 }

--- a/crates/cascadia-engine-openvino/tests/compile_warm_probe.rs
+++ b/crates/cascadia-engine-openvino/tests/compile_warm_probe.rs
@@ -1,0 +1,44 @@
+//! Cache-warming probe (hardware-gated; skip-pass without env).
+//!
+//! Compiles the given IR(s) one at a time in this single process, populating
+//! the OV blob cache (`CASCADIA_OV_CACHE`). Ops tool for multi-model /
+//! multi-stage NPU deployments on small-RAM boxes: the NPU compiler's host
+//! transient (~5.5× a model's INT4 bytes) is paid strictly SEQUENTIALLY here,
+//! so a later pipeline bring-up that starts all stages concurrently only
+//! ever imports cached blobs (~blob-size peak, no transient overlap).
+//!
+//! ```text
+//! CASCADIA_WARM_XML="a.xml;b.xml" CASCADIA_WARM_DEVICE=NPU \
+//! CASCADIA_OV_CACHE=C:\cache cargo test -p cascadia-engine-openvino \
+//!   --features openvino --test compile_warm_probe -- --nocapture
+//! ```
+
+use std::time::Instant;
+
+use cascadia_ov_genai_shim::{PluginConfig, Runtime};
+
+#[test]
+fn warms_blob_cache_sequentially() {
+    let Ok(xmls) = std::env::var("CASCADIA_WARM_XML") else {
+        eprintln!("CASCADIA_WARM_XML not set; skipping");
+        return;
+    };
+    let device = std::env::var("CASCADIA_WARM_DEVICE").unwrap_or_else(|_| "NPU".into());
+    let mut plugin = PluginConfig::default();
+    if let Ok(cache) = std::env::var("CASCADIA_OV_CACHE") {
+        plugin.entries.push(("CACHE_DIR".into(), cache));
+    }
+
+    for xml in xmls.split(';').filter(|s| !s.trim().is_empty()) {
+        let t0 = Instant::now();
+        match Runtime::compile(xml, &device, &plugin) {
+            Ok(_rt) => eprintln!(
+                "WARM OK [{device}] {xml}: {:.0}s (blob cached; runtime dropped)",
+                t0.elapsed().as_secs_f64()
+            ),
+            Err(e) => panic!("WARM FAILED [{device}] {xml}: {e}"),
+        }
+        // _rt drops here — the transient and the compiled model are gone
+        // before the next compile starts.
+    }
+}

--- a/crates/cascadia-engine-openvino/tests/gemv_residency_probe.rs
+++ b/crates/cascadia-engine-openvino/tests/gemv_residency_probe.rs
@@ -1,0 +1,74 @@
+//! EXPERIMENT probe: resident-memory delta of the CascadiaInt4Gemv decode
+//! offload. Loads ONLY the decode model (chunked prefill disabled) on CPU,
+//! generates a few tokens, then holds so an external wrapper can sample the
+//! process — the metric is PRIVATE bytes: the stock path's repacked weight
+//! copy is private commit, the offloaded path's weights are shareable
+//! mmapped file pages of the IR .bin.
+//!
+//! Env-gated (skip=pass): CASCADIA_GEMV_PROBE=1 + CASCADIA_STATIC_SHARDS;
+//! CASCADIA_GEMV=1 enables the offload (run once without for baseline);
+//! CASCADIA_PROBE_HOLD_S (default 12).
+
+use cascadia_engine::Builder;
+use cascadia_engine_openvino::OvRuntimeBuilder;
+use cascadia_types::{GenerationTask, PeerLayout, ShardSpec};
+
+#[tokio::test]
+async fn gemv_residency_probe() {
+    if std::env::var("CASCADIA_GEMV_PROBE").ok().as_deref() != Some("1") {
+        eprintln!("CASCADIA_GEMV_PROBE not set; skipping");
+        return;
+    }
+    let Ok(shards) = std::env::var("CASCADIA_STATIC_SHARDS") else {
+        eprintln!("CASCADIA_STATIC_SHARDS not set; skipping");
+        return;
+    };
+    let offload = std::env::var("CASCADIA_GEMV").ok().as_deref() == Some("1");
+    let hold_s: u64 = std::env::var("CASCADIA_PROBE_HOLD_S")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(12);
+    eprintln!(
+        "PROBE-MODE {}",
+        if offload { "gemv-offload" } else { "stock" }
+    );
+
+    // Both modes disable the chunked-prefill variant so exactly ONE compiled
+    // model (decode) is resident — the delta between modes is the decode
+    // weight copy alone.
+    let mut builder = OvRuntimeBuilder::new(&shards, 0, 1, "CPU")
+        .with_chunked_prefill_disabled(true)
+        .with_gemv_offload(offload);
+    builder
+        .connect(PeerLayout::single_stage())
+        .await
+        .expect("connect");
+    let mut load = builder
+        .load(ShardSpec::single_stage(&shards, "CPU"))
+        .await
+        .expect("load");
+    use futures::StreamExt;
+    while load.next().await.is_some() {}
+    let mut engine = Box::new(builder).build().expect("build");
+
+    let task = GenerationTask::new("gemv-probe", "The capital of France is").with_max_tokens(8);
+    engine.submit(task).expect("submit");
+    let mut text = String::new();
+    loop {
+        let chunks = engine.step().expect("step");
+        let mut done = false;
+        for (_, c) in chunks {
+            text.push_str(&c.text);
+            if c.is_final {
+                done = true;
+            }
+        }
+        if done {
+            break;
+        }
+    }
+    eprintln!("PROBE-GEN {text:?}");
+    eprintln!("PROBE-HOLD {hold_s}s (sample private bytes + WS now)");
+    std::thread::sleep(std::time::Duration::from_secs(hold_s));
+    eprintln!("PROBE-RESULT ok");
+}

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -123,7 +123,16 @@ async fn run_tasks(
         .await
         .expect("load");
     use futures::StreamExt;
-    while load.next().await.is_some() {}
+    // Surface load progress when the gemv-offload leg runs: the offloaded
+    // MatMul count printed here is the proof the extension pass actually
+    // fired (0 matches silently degrades to stock and would make the parity
+    // assertion vacuous for the offload).
+    let show_load = std::env::var("CASCADIA_GEMV_OFFLOAD").is_ok_and(|v| v == "1");
+    while let Some(ev) = load.next().await {
+        if show_load {
+            eprintln!("load: {ev:?}");
+        }
+    }
     let mut engine = Box::new(builder).build().expect("build");
 
     let mut outs = Vec::new();

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -114,6 +114,19 @@ async fn run_tasks(
     if std::env::var("CASCADIA_GEMV_OFFLOAD").is_ok_and(|v| v == "1") && !disable_chunk {
         builder = builder.with_gemv_offload(true);
     }
+    // CASCADIA_OV_PROPS="K=V,K=V": raw plugin properties for perf probing
+    // (e.g. INFERENCE_NUM_THREADS=8 — the LATENCY hint pins LNL to its 4
+    // P-cores, halving the custom op's row parallelism).
+    if let Ok(props) = std::env::var("CASCADIA_OV_PROPS") {
+        let kv: Vec<(String, String)> = props
+            .split(',')
+            .filter_map(|p| {
+                p.split_once('=')
+                    .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+            })
+            .collect();
+        builder = builder.with_ov_properties(kv);
+    }
     builder
         .connect(PeerLayout::single_stage())
         .await

--- a/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
+++ b/crates/cascadia-engine-openvino/tests/static_prefill_parity.rs
@@ -104,6 +104,16 @@ async fn run_tasks(
     if let Ok(cache) = std::env::var("CASCADIA_OV_CACHE") {
         builder = builder.with_cache_dir(cache);
     }
+    // CASCADIA_GEMV_OFFLOAD=1: run the NON-baseline legs' decode through the
+    // CascadiaInt4Gemv extension op (weights from the .bin mmap). The
+    // tokenwise baseline (disable_chunk) stays on the stock kernel, so the
+    // parity asserts become the cross-kernel check: offloaded decode vs
+    // oneDNN decode. Accumulation order differs, so a greedy divergence here
+    // is DATA about kernel rounding, not necessarily a bug — investigate
+    // before loosening.
+    if std::env::var("CASCADIA_GEMV_OFFLOAD").is_ok_and(|v| v == "1") && !disable_chunk {
+        builder = builder.with_gemv_offload(true);
+    }
     builder
         .connect(PeerLayout::single_stage())
         .await

--- a/crates/cascadia-ov-genai-shim/build.rs
+++ b/crates/cascadia-ov-genai-shim/build.rs
@@ -70,7 +70,15 @@ fn main() {
     let mut build = cc::Build::new();
     build
         .cpp(true)
-        .std("c++17")
+        .std("c++17");
+    // gemv_offload.cpp uses AVX2/FMA + AVX-VNNI intrinsics behind a runtime
+    // guard; GCC/Clang additionally need the target flags at COMPILE time
+    // (MSVC compiles intrinsics without arch flags). GCC >= 11 for -mavxvnni.
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("x86_64") && !target.contains("msvc") {
+        build.flag("-mavx2").flag("-mfma").flag("-mavxvnni");
+    }
+    build
         .file("cpp/shim.cpp")
         .file("cpp/gemv_offload.cpp")
         .include(&runtime_include)
@@ -91,7 +99,13 @@ fn main() {
     println!("cargo:rustc-link-search=native={ov_root}/runtime/3rdparty/tbb/lib/intel64");
     println!("cargo:rustc-link-lib=dylib=openvino_genai");
     println!("cargo:rustc-link-lib=dylib=openvino");
-    println!("cargo:rustc-link-lib=dylib=tbb12");
+    // Windows SDKs ship tbb12.lib; Linux OV archives ship libtbb.so.12
+    // (linker name `tbb`).
+    if std::env::var("TARGET").unwrap_or_default().contains("windows") {
+        println!("cargo:rustc-link-lib=dylib=tbb12");
+    } else {
+        println!("cargo:rustc-link-lib=dylib=tbb");
+    }
     if let Some(d) = &dnnl_dir {
         println!("cargo:rustc-link-search=native={d}/lib");
         println!("cargo:rustc-link-lib=dylib=dnnl");

--- a/crates/cascadia-ov-genai-shim/build.rs
+++ b/crates/cascadia-ov-genai-shim/build.rs
@@ -68,9 +68,7 @@ fn main() {
         .filter(|v| !v.trim().is_empty());
 
     let mut build = cc::Build::new();
-    build
-        .cpp(true)
-        .std("c++17");
+    build.cpp(true).std("c++17");
     // gemv_offload.cpp uses AVX2/FMA + AVX-VNNI intrinsics behind a runtime
     // guard; GCC/Clang additionally need the target flags at COMPILE time
     // (MSVC compiles intrinsics without arch flags). GCC >= 11 for -mavxvnni.
@@ -101,7 +99,10 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=openvino");
     // Windows SDKs ship tbb12.lib; Linux OV archives ship libtbb.so.12
     // (linker name `tbb`).
-    if std::env::var("TARGET").unwrap_or_default().contains("windows") {
+    if std::env::var("TARGET")
+        .unwrap_or_default()
+        .contains("windows")
+    {
         println!("cargo:rustc-link-lib=dylib=tbb12");
     } else {
         println!("cargo:rustc-link-lib=dylib=tbb");

--- a/crates/cascadia-ov-genai-shim/build.rs
+++ b/crates/cascadia-ov-genai-shim/build.rs
@@ -59,6 +59,7 @@ fn main() {
         .cpp(true)
         .std("c++17")
         .file("cpp/shim.cpp")
+        .file("cpp/gemv_offload.cpp")
         .include(&runtime_include)
         .include(&genai_include)
         .compile("cascadia_ov_genai_shim");
@@ -69,5 +70,7 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=openvino");
     println!("cargo:rerun-if-changed=cpp/shim.cpp");
     println!("cargo:rerun-if-changed=cpp/shim.h");
+    println!("cargo:rerun-if-changed=cpp/gemv_offload.cpp");
+    println!("cargo:rerun-if-changed=cpp/gemv_offload.hpp");
     println!("cargo:rerun-if-env-changed=INTEL_OPENVINO_DIR");
 }

--- a/crates/cascadia-ov-genai-shim/build.rs
+++ b/crates/cascadia-ov-genai-shim/build.rs
@@ -49,6 +49,9 @@ fn main() {
 
     let runtime_include = format!("{ov_root}/runtime/include");
     let genai_include = format!("{ov_root}/runtime/include/openvino/genai");
+    // openvino/core/parallel.hpp (used by the gemv-offload extension op)
+    // includes TBB headers; the SDK ships them under runtime/3rdparty.
+    let tbb_include = format!("{ov_root}/runtime/3rdparty/tbb/include");
     // OpenVINO 2026.x Windows ships .lib files under lib/intel64/Release
     // (and lib/intel64/Debug); Linux ships them directly under
     // lib/intel64. Add both paths; the linker picks whichever resolves.
@@ -62,12 +65,19 @@ fn main() {
         .file("cpp/gemv_offload.cpp")
         .include(&runtime_include)
         .include(&genai_include)
+        .include(&tbb_include)
         .compile("cascadia_ov_genai_shim");
 
     println!("cargo:rustc-link-search=native={runtime_lib_release}");
     println!("cargo:rustc-link-search=native={runtime_lib_root}");
+    // ov::parallel_for (gemv-offload extension) inlines TBB calls; the SDK
+    // ships the import libs under runtime/3rdparty/tbb/lib (Windows) and the
+    // shared objects under .../tbb/lib/intel64 (Linux archives).
+    println!("cargo:rustc-link-search=native={ov_root}/runtime/3rdparty/tbb/lib");
+    println!("cargo:rustc-link-search=native={ov_root}/runtime/3rdparty/tbb/lib/intel64");
     println!("cargo:rustc-link-lib=dylib=openvino_genai");
     println!("cargo:rustc-link-lib=dylib=openvino");
+    println!("cargo:rustc-link-lib=dylib=tbb12");
     println!("cargo:rerun-if-changed=cpp/shim.cpp");
     println!("cargo:rerun-if-changed=cpp/shim.h");
     println!("cargo:rerun-if-changed=cpp/gemv_offload.cpp");

--- a/crates/cascadia-ov-genai-shim/build.rs
+++ b/crates/cascadia-ov-genai-shim/build.rs
@@ -58,15 +58,29 @@ fn main() {
     let runtime_lib_root = format!("{ov_root}/runtime/lib/intel64");
     let runtime_lib_release = format!("{ov_root}/runtime/lib/intel64/Release");
 
-    cc::Build::new()
+    // Optional oneDNN embedding for the gemv-offload op (the spike's
+    // parity-throughput endgame): point DNNL_DIR at an extracted oneDNN
+    // install (include/ + lib/dnnl.lib + bin/dnnl.dll — use a TBB-runtime
+    // build so dnnl threads share the OV plugin's tbb12). Absent = the op
+    // keeps its own kernels only.
+    let dnnl_dir = std::env::var("DNNL_DIR")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+
+    let mut build = cc::Build::new();
+    build
         .cpp(true)
         .std("c++17")
         .file("cpp/shim.cpp")
         .file("cpp/gemv_offload.cpp")
         .include(&runtime_include)
         .include(&genai_include)
-        .include(&tbb_include)
-        .compile("cascadia_ov_genai_shim");
+        .include(&tbb_include);
+    if let Some(d) = &dnnl_dir {
+        build.include(format!("{d}/include"));
+        build.define("CASCADIA_HAVE_DNNL", None);
+    }
+    build.compile("cascadia_ov_genai_shim");
 
     println!("cargo:rustc-link-search=native={runtime_lib_release}");
     println!("cargo:rustc-link-search=native={runtime_lib_root}");
@@ -78,6 +92,11 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=openvino_genai");
     println!("cargo:rustc-link-lib=dylib=openvino");
     println!("cargo:rustc-link-lib=dylib=tbb12");
+    if let Some(d) = &dnnl_dir {
+        println!("cargo:rustc-link-search=native={d}/lib");
+        println!("cargo:rustc-link-lib=dylib=dnnl");
+    }
+    println!("cargo:rerun-if-env-changed=DNNL_DIR");
     println!("cargo:rerun-if-changed=cpp/shim.cpp");
     println!("cargo:rerun-if-changed=cpp/shim.h");
     println!("cargo:rerun-if-changed=cpp/gemv_offload.cpp");

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -10,11 +10,16 @@
 #include "gemv_offload.hpp"
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <set>
+#include <thread>
 #include <vector>
 
 #if defined(_MSC_VER) || defined(__x86_64__) || defined(_M_X64)
@@ -42,6 +47,35 @@ namespace {
 
 using ov::op::v0::Constant;
 
+// CASCADIA_GEMV_STATS=1: accumulate evaluate() wall time across all op
+// instances and print a summary at process exit — splits kernel time from
+// framework overhead when chasing the throughput gap. Spike-only.
+struct GemvStats {
+    std::atomic<uint64_t> calls{0};
+    std::atomic<uint64_t> ns{0};
+    std::atomic<uint64_t> weight_bytes{0};
+    bool enabled = false;
+    GemvStats() {
+        const char* v = std::getenv("CASCADIA_GEMV_STATS");
+        enabled = v && *v == '1';
+        if (enabled) std::atexit(&GemvStats::print);
+    }
+    static GemvStats& get() {
+        static GemvStats s;
+        return s;
+    }
+    static void print() {
+        auto& s = get();
+        const uint64_t c = s.calls.load(), n = s.ns.load(), b = s.weight_bytes.load();
+        if (c == 0) return;
+        fprintf(stderr,
+                "gemv-stats: calls=%llu total_ms=%.1f avg_us=%.1f weight_GB=%.2f "
+                "eff_GBps=%.1f\n",
+                static_cast<unsigned long long>(c), n / 1e6, n / 1e3 / c, b / 1e9,
+                b / (n / 1e9) / 1e9);
+    }
+};
+
 #ifdef CASCADIA_GEMV_X86
 bool cpu_has_avx2_fma() {
     static const bool ok = [] {
@@ -61,33 +95,106 @@ bool cpu_has_avx2_fma() {
     return ok;
 }
 
-// AVX2 grouped sym-INT4 dot: 16 packed bytes = 32 weights per iteration.
-// Nibble decode via (x ^ 8) - 8 sign trick; _mm_unpacklo/hi_epi8(lo, hi)
-// restores the low-nibble-first element order for free.
-float dot_group_avx2(const uint8_t* gw, const float* ga, size_t gsize) {
-    __m256 acc = _mm256_setzero_ps();
+bool cpu_has_avx_vnni() {
+    static const bool ok = [] {
+        if (!cpu_has_avx2_fma()) return false;
+#if defined(_MSC_VER)
+        int r[4] = {0};
+        __cpuidex(r, 7, 1);  // leaf 7 subleaf 1: EAX bit 4 = AVX-VNNI
+        return (r[0] & (1 << 4)) != 0;
+#else
+        return __builtin_cpu_supports("avxvnni");
+#endif
+    }();
+    return ok;
+}
+
+// AVX-VNNI grouped dot with dynamically-quantized int8 activations.
+// Weights become unsigned in ONE op (w_i4 + 8 == nibble ^ 8, since
+// (x^8)-8 is the sign decode); dpbusd(u8 = w+8, s8 = act_q) accumulates
+// Σ(w+8)·q exactly in i32 (4 products per lane, no i16 saturation stage),
+// and the +8 bias is removed once per group via the precomputed Σq:
+// Σw·q = acc − 8·Σq. Caller dequantizes with act_scale × weight_scale.
+int32_t dot_group_vnni(const uint8_t* gw, const int8_t* qa, size_t gsize) {
+    __m256i acc0 = _mm256_setzero_si256();
+    __m256i acc1 = _mm256_setzero_si256();
+    const __m128i xor8 = _mm_set1_epi8(8);
     const __m128i mask4 = _mm_set1_epi8(0x0F);
-    const __m128i bias = _mm_set1_epi8(8);
     size_t j = 0;
     for (; j + 16 <= gsize / 2; j += 16) {
         const __m128i raw = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
         const __m128i lo = _mm_and_si128(raw, mask4);
         const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), mask4);
-        // interleave -> element order e0,e1,e2,... then sign-extend 4->8 bit
-        __m128i a = _mm_unpacklo_epi8(lo, hi);
-        __m128i b = _mm_unpackhi_epi8(lo, hi);
-        a = _mm_sub_epi8(_mm_xor_si128(a, bias), bias);
-        b = _mm_sub_epi8(_mm_xor_si128(b, bias), bias);
-        const float* base = ga + 2 * j;
-        const __m256i w0 = _mm256_cvtepi8_epi32(a);
-        const __m256i w1 = _mm256_cvtepi8_epi32(_mm_srli_si128(a, 8));
-        const __m256i w2 = _mm256_cvtepi8_epi32(b);
-        const __m256i w3 = _mm256_cvtepi8_epi32(_mm_srli_si128(b, 8));
-        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w0), _mm256_loadu_ps(base + 0), acc);
-        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w1), _mm256_loadu_ps(base + 8), acc);
-        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w2), _mm256_loadu_ps(base + 16), acc);
-        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w3), _mm256_loadu_ps(base + 24), acc);
+        const __m128i a = _mm_xor_si128(_mm_unpacklo_epi8(lo, hi), xor8);
+        const __m128i b = _mm_xor_si128(_mm_unpackhi_epi8(lo, hi), xor8);
+        const __m256i w = _mm256_set_m128i(b, a);  // 32 u8 weights, in order
+        const __m256i q =
+            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(qa + 2 * j));
+        if ((j / 16) & 1) {
+            acc1 = _mm256_dpbusd_avx_epi32(acc1, w, q);
+        } else {
+            acc0 = _mm256_dpbusd_avx_epi32(acc0, w, q);
+        }
     }
+    __m256i acc = _mm256_add_epi32(acc0, acc1);
+    __m128i s = _mm_add_epi32(_mm256_castsi256_si128(acc), _mm256_extracti128_si256(acc, 1));
+    s = _mm_hadd_epi32(s, s);
+    s = _mm_hadd_epi32(s, s);
+    int32_t dot = _mm_cvtsi128_si32(s);
+    for (; j < gsize / 2; ++j) {
+        const uint8_t v = gw[j];
+        const int lo = (v & 0xF) ^ 8;  // w + 8, matching the SIMD lanes
+        const int hi = ((v >> 4) & 0xF) ^ 8;
+        dot += lo * qa[2 * j] + hi * qa[2 * j + 1];
+    }
+    return dot;
+}
+
+// AVX2 grouped sym-INT4 dot. Nibble decode via (x ^ 8) - 8 sign trick;
+// _mm_unpacklo/hi_epi8(lo, hi) restores the low-nibble-first element order
+// for free. FOUR independent accumulator chains: a single accumulator
+// serializes on FMA latency (~4-5 cycles) and was the dominant kernel stall;
+// with group_size=128 (64 packed bytes) a group is exactly one unrolled
+// iteration.
+static inline __m256 dot16_lo(const __m128i raw, const __m128i mask4, const __m128i bias,
+                              const float* base, __m256 acc, __m256 acc2, __m256* acc2_out) {
+    const __m128i lo = _mm_and_si128(raw, mask4);
+    const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), mask4);
+    __m128i a = _mm_unpacklo_epi8(lo, hi);
+    __m128i b = _mm_unpackhi_epi8(lo, hi);
+    a = _mm_sub_epi8(_mm_xor_si128(a, bias), bias);
+    b = _mm_sub_epi8(_mm_xor_si128(b, bias), bias);
+    acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(a)),
+                          _mm256_loadu_ps(base + 0), acc);
+    acc2 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(a, 8))),
+                           _mm256_loadu_ps(base + 8), acc2);
+    acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(b)),
+                          _mm256_loadu_ps(base + 16), acc);
+    acc2 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(b, 8))),
+                           _mm256_loadu_ps(base + 24), acc2);
+    *acc2_out = acc2;
+    return acc;
+}
+
+float dot_group_avx2(const uint8_t* gw, const float* ga, size_t gsize) {
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    __m256 acc2 = _mm256_setzero_ps();
+    __m256 acc3 = _mm256_setzero_ps();
+    const __m128i mask4 = _mm_set1_epi8(0x0F);
+    const __m128i bias = _mm_set1_epi8(8);
+    size_t j = 0;
+    for (; j + 32 <= gsize / 2; j += 32) {
+        const __m128i r0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
+        const __m128i r1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j + 16));
+        acc0 = dot16_lo(r0, mask4, bias, ga + 2 * j, acc0, acc1, &acc1);
+        acc2 = dot16_lo(r1, mask4, bias, ga + 2 * j + 32, acc2, acc3, &acc3);
+    }
+    for (; j + 16 <= gsize / 2; j += 16) {
+        const __m128i r0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
+        acc0 = dot16_lo(r0, mask4, bias, ga + 2 * j, acc0, acc1, &acc1);
+    }
+    const __m256 acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
     __m128 s = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
     s = _mm_hadd_ps(s, s);
     s = _mm_hadd_ps(s, s);
@@ -168,6 +275,9 @@ public:
 
     bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override {
         if (!m_w || !m_s) return false;
+        auto& stats = GemvStats::get();
+        const auto t0 = stats.enabled ? std::chrono::steady_clock::now()
+                                      : std::chrono::steady_clock::time_point{};
         const auto& act = inputs[0];
         auto& out = outputs[0];
         const size_t k = static_cast<size_t>(m_k);
@@ -193,55 +303,129 @@ public:
         const auto* wbytes = static_cast<const uint8_t*>(m_w->get_data_ptr());
         const auto* sc16 = static_cast<const ov::float16*>(m_s->get_data_ptr());
 
-        // f32 scratch of the activation row: read once, reused across N.
-        // Deliberately a per-call LOCAL, not thread_local: ov::parallel_for
+        // Scratch (per-call LOCALS, not thread_local: ov::parallel_for
         // blocks this thread and TBB work-steals other ready tasks onto it —
         // including another instance's evaluate(), which would clobber a
-        // shared thread_local while our row lambdas still read it.
+        // shared thread_local while our row lambdas still read it):
+        // f32 activation row, and — on the VNNI path — its per-group int8
+        // quantization + (scale, Σq) pairs, all computed ONCE per row and
+        // reused across all N outputs.
         std::vector<float> act_f32;
+        std::vector<int8_t> act_q;
+        std::vector<float> q_scale;
+        std::vector<int32_t> q_sum;
+#ifdef CASCADIA_GEMV_X86
+        const bool use_avx2 = cpu_has_avx2_fma();
+        // CASCADIA_GEMV_VNNI=1: dynamically-quantized int8 activations via
+        // AVX-VNNI dpbusd (~3x per-core over the f32-convert chain). This is
+        // dynamic quantization — output parity vs the stock f16/f32 kernel
+        // must be re-validated whenever it's enabled. Spike knob.
+        static const bool want_vnni = [] {
+            const char* v = std::getenv("CASCADIA_GEMV_VNNI");
+            return v && *v == '1';
+        }();
+        const bool use_vnni = want_vnni && cpu_has_avx_vnni();
+#else
+        const bool use_avx2 = false;
+        const bool use_vnni = false;
+#endif
+        // CASCADIA_GEMV_SEQ=1: single-thread A/B knob (spike-only).
+        static const bool sequential = [] {
+            const char* v = std::getenv("CASCADIA_GEMV_SEQ");
+            return v && *v == '1';
+        }();
         for (size_t r = 0; r < rows; ++r) {
             act_f32.resize(k);
             for (size_t i = 0; i < k; ++i) {
                 act_f32[i] = in_f16 ? static_cast<float>(act16[r * k + i]) : act32[r * k + i];
             }
             const float* a = act_f32.data();
-#ifdef CASCADIA_GEMV_X86
-            const bool use_avx2 = cpu_has_avx2_fma();
-#else
-            const bool use_avx2 = false;
-#endif
-            ov::parallel_for(n, [&](size_t row) {
-                const uint8_t* wrow = wbytes + row * (k / 2);
-                const ov::float16* srow = sc16 + row * groups;
-                float acc = 0.f;
+            if (use_vnni) {
+                act_q.resize(k);
+                q_scale.resize(groups);
+                q_sum.resize(groups);
                 for (size_t gi = 0; gi < groups; ++gi) {
-                    const uint8_t* gw = wrow + gi * (gsize / 2);
                     const float* ga = a + gi * gsize;
-                    float dot;
-#ifdef CASCADIA_GEMV_X86
-                    if (use_avx2) {
-                        dot = dot_group_avx2(gw, ga, gsize);
-                    } else
-#endif
-                    {
-                        dot = 0.f;
-                        for (size_t j = 0; j < gsize / 2; ++j) {
-                            const uint8_t b = gw[j];
-                            const int lo =
-                                static_cast<int8_t>(static_cast<uint8_t>(b << 4)) >> 4;
-                            const int hi = static_cast<int8_t>(b) >> 4;
-                            dot += static_cast<float>(lo) * ga[2 * j];
-                            dot += static_cast<float>(hi) * ga[2 * j + 1];
-                        }
+                    float amax = 0.f;
+                    for (size_t i = 0; i < gsize; ++i) {
+                        const float v = ga[i] < 0 ? -ga[i] : ga[i];
+                        if (v > amax) amax = v;
                     }
-                    acc += static_cast<float>(srow[gi]) * dot;
+                    const float s = amax > 0.f ? amax / 127.f : 1.f;
+                    const float inv = 1.f / s;
+                    int32_t sum = 0;
+                    for (size_t i = 0; i < gsize; ++i) {
+                        int q = static_cast<int>(ga[i] * inv + (ga[i] >= 0 ? 0.5f : -0.5f));
+                        if (q > 127) q = 127;
+                        if (q < -127) q = -127;
+                        act_q[gi * gsize + i] = static_cast<int8_t>(q);
+                        sum += q;
+                    }
+                    q_scale[gi] = s;
+                    q_sum[gi] = sum;
                 }
-                if (out_f16) {
-                    out16[r * n + row] = ov::float16(acc);
-                } else {
-                    out32[r * n + row] = acc;
+            }
+            const std::function<void(size_t, size_t)> rows_fn = [&](size_t rb, size_t re) {
+                for (size_t row = rb; row < re; ++row) {
+                    const uint8_t* wrow = wbytes + row * (k / 2);
+                    const ov::float16* srow = sc16 + row * groups;
+                    float acc = 0.f;
+                    for (size_t gi = 0; gi < groups; ++gi) {
+                        const uint8_t* gw = wrow + gi * (gsize / 2);
+                        float dot;
+#ifdef CASCADIA_GEMV_X86
+                        if (use_vnni) {
+                            const int32_t dq =
+                                dot_group_vnni(gw, act_q.data() + gi * gsize, gsize);
+                            dot = q_scale[gi] * static_cast<float>(dq - 8 * q_sum[gi]);
+                        } else if (use_avx2) {
+                            dot = dot_group_avx2(gw, a + gi * gsize, gsize);
+                        } else
+#endif
+                        {
+                            const float* ga = a + gi * gsize;
+                            dot = 0.f;
+                            for (size_t j = 0; j < gsize / 2; ++j) {
+                                const uint8_t b = gw[j];
+                                const int lo =
+                                    static_cast<int8_t>(static_cast<uint8_t>(b << 4)) >> 4;
+                                const int hi = static_cast<int8_t>(b) >> 4;
+                                dot += static_cast<float>(lo) * ga[2 * j];
+                                dot += static_cast<float>(hi) * ga[2 * j + 1];
+                            }
+                        }
+                        acc += static_cast<float>(srow[gi]) * dot;
+                    }
+                    if (out_f16) {
+                        out16[r * n + row] = ov::float16(acc);
+                    } else {
+                        out32[r * n + row] = acc;
+                    }
                 }
-            });
+            };
+            if (sequential) {
+                rows_fn(0, n);
+            } else {
+                // Blocked ov::parallel_for: fewer, larger tasks than
+                // per-row dispatch (measured better than both per-row and a
+                // private TBB-independent pool, which loses to wake latency
+                // + oversubscription against the plugin's own threads).
+                const size_t block = 32;
+                const size_t nblocks = (n + block - 1) / block;
+                ov::parallel_for(nblocks, [&](size_t bi) {
+                    const size_t b = bi * block;
+                    const size_t e = b + block < n ? b + block : n;
+                    rows_fn(b, e);
+                });
+            }
+        }
+        if (stats.enabled) {
+            stats.calls.fetch_add(1, std::memory_order_relaxed);
+            stats.ns.fetch_add(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                   std::chrono::steady_clock::now() - t0)
+                                   .count(),
+                               std::memory_order_relaxed);
+            stats.weight_bytes.fetch_add(rows * n * (k / 2), std::memory_order_relaxed);
         }
         return true;
     }

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -16,7 +16,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <map>
 #include <memory>
+#include <numeric>
 #include <mutex>
 #include <set>
 #include <thread>
@@ -38,6 +40,7 @@
 #include <openvino/op/multiply.hpp>
 #include <openvino/op/op.hpp>
 #include <openvino/op/reshape.hpp>
+#include <openvino/op/variadic_split.hpp>
 #include <openvino/pass/graph_rewrite.hpp>
 #include <openvino/pass/manager.hpp>
 #include <openvino/pass/pattern/op/wrap_type.hpp>
@@ -220,21 +223,34 @@ public:
 
     CascadiaInt4Gemv() = default;
 
-    CascadiaInt4Gemv(const ov::Output<ov::Node>& act,
-                     std::shared_ptr<Constant> weights_i4,
-                     std::shared_ptr<Constant> scales_f16,
-                     int64_t n, int64_t k, int64_t groups, int64_t group_size,
-                     std::string tag)
+    /// One fused GEMV over `segments` weight/scale pairs sharing the same
+    /// activation and K/groups/group_size — output rows are the segments
+    /// concatenated in order (a VariadicSplit downstream routes them back to
+    /// the original consumers). A single-projection op is the 1-segment case.
+    struct Segment {
+        std::shared_ptr<Constant> w;
+        std::shared_ptr<Constant> s;
+        int64_t n = 0;
+    };
+
+    CascadiaInt4Gemv(const ov::Output<ov::Node>& act, std::vector<Segment> segments,
+                     int64_t k, int64_t groups, int64_t group_size, std::string tag)
         : ov::op::Op({act}),
-          m_w(std::move(weights_i4)),
-          m_s(std::move(scales_f16)),
-          m_n(n),
+          m_segs(std::move(segments)),
           m_k(k),
           m_groups(groups),
           m_gsize(group_size),
           m_tag(std::move(tag)) {
+        m_n = 0;
+        for (const auto& seg : m_segs) m_n += seg.n;
         constructor_validate_and_infer_types();
     }
+
+    const std::vector<Segment>& segments() const { return m_segs; }
+    int64_t k() const { return m_k; }
+    int64_t groups() const { return m_groups; }
+    int64_t group_size() const { return m_gsize; }
+    const std::string& tag() const { return m_tag; }
 
     void validate_and_infer_types() override {
         auto shape = get_input_partial_shape(0);
@@ -253,8 +269,8 @@ public:
     }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& args) const override {
-        return std::make_shared<CascadiaInt4Gemv>(args.at(0), m_w, m_s, m_n, m_k, m_groups,
-                                                  m_gsize, m_tag);
+        return std::make_shared<CascadiaInt4Gemv>(args.at(0), m_segs, m_k, m_groups, m_gsize,
+                                                  m_tag);
     }
 
     bool visit_attributes(ov::AttributeVisitor& visitor) override {
@@ -274,7 +290,10 @@ public:
     bool has_evaluate() const override { return true; }
 
     bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override {
-        if (!m_w || !m_s) return false;
+        if (m_segs.empty()) return false;
+        for (const auto& seg : m_segs) {
+            if (!seg.w || !seg.s) return false;
+        }
         auto& stats = GemvStats::get();
         const auto t0 = stats.enabled ? std::chrono::steady_clock::now()
                                       : std::chrono::steady_clock::time_point{};
@@ -299,9 +318,28 @@ public:
         auto* out32 = out_f16 ? nullptr : out.data<float>();
 
         // i4 packed two-per-byte, element 0 in the LOW nibble; row-major
-        // [N, G, g] => per-output-row stride k/2 bytes.
-        const auto* wbytes = static_cast<const uint8_t*>(m_w->get_data_ptr());
-        const auto* sc16 = static_cast<const ov::float16*>(m_s->get_data_ptr());
+        // [N, G, g] => per-output-row stride k/2 bytes. Global output row ->
+        // (segment base, local row) via the prefix table below; blocks scan
+        // it linearly (<= a handful of segments).
+        struct SegPtrs {
+            const uint8_t* w;
+            const ov::float16* s;
+            size_t start, end;
+        };
+        std::vector<SegPtrs> segp;
+        segp.reserve(m_segs.size());
+        {
+            size_t off = 0;
+            for (const auto& seg : m_segs) {
+                SegPtrs sp;
+                sp.w = static_cast<const uint8_t*>(seg.w->get_data_ptr());
+                sp.s = static_cast<const ov::float16*>(seg.s->get_data_ptr());
+                sp.start = off;
+                off += static_cast<size_t>(seg.n);
+                sp.end = off;
+                segp.push_back(sp);
+            }
+        }
 
         // Scratch (per-call LOCALS, not thread_local: ov::parallel_for
         // blocks this thread and TBB work-steals other ready tasks onto it —
@@ -366,9 +404,13 @@ public:
                 }
             }
             const std::function<void(size_t, size_t)> rows_fn = [&](size_t rb, size_t re) {
+                size_t si = 0;
+                while (segp[si].end <= rb) ++si;
                 for (size_t row = rb; row < re; ++row) {
-                    const uint8_t* wrow = wbytes + row * (k / 2);
-                    const ov::float16* srow = sc16 + row * groups;
+                    while (segp[si].end <= row) ++si;
+                    const size_t local = row - segp[si].start;
+                    const uint8_t* wrow = segp[si].w + local * (k / 2);
+                    const ov::float16* srow = segp[si].s + local * groups;
                     float acc = 0.f;
                     for (size_t gi = 0; gi < groups; ++gi) {
                         const uint8_t* gw = wrow + gi * (gsize / 2);
@@ -431,8 +473,7 @@ public:
     }
 
 private:
-    std::shared_ptr<Constant> m_w;
-    std::shared_ptr<Constant> m_s;
+    std::vector<Segment> m_segs;
     int64_t m_n = 0, m_k = 0, m_groups = 0, m_gsize = 0;
     std::string m_tag;
 };
@@ -502,9 +543,10 @@ public:
             const auto& act_out = matmul->input_value(0);
             if (act_out.get_element_type() != ov::element::f16) return false;
 
-            auto gemv = std::make_shared<CascadiaInt4Gemv>(act_out, wconst, sconst, n, k,
-                                                           groups, gsize,
-                                                           matmul->get_friendly_name());
+            std::vector<CascadiaInt4Gemv::Segment> segs;
+            segs.push_back({wconst, sconst, n});
+            auto gemv = std::make_shared<CascadiaInt4Gemv>(act_out, std::move(segs), k, groups,
+                                                           gsize, matmul->get_friendly_name());
             gemv->set_friendly_name(matmul->get_friendly_name());
             ov::copy_runtime_info(matmul, gemv);
             ov::replace_node(matmul, gemv);
@@ -529,12 +571,86 @@ public:
 
 }  // namespace
 
+// Stage 2: fuse sibling GEMVs. Ops sharing the SAME activation output and
+// (K, groups, gsize, seq-shape) — a layer's q/k/v, or gate/up — become ONE
+// op whose output rows are the segments concatenated, plus a VariadicSplit
+// routing each slice back to the original consumers. Halves the per-token
+// node count (113 -> ~65 on Llama-1B) and doubles the mean GEMV size, which
+// is what amortizes the measured per-node fork-join floor.
+uint32_t fuse_sibling_gemvs(const std::shared_ptr<ov::Model>& model) {
+    // Group in deterministic topological order.
+    struct Group {
+        std::vector<std::shared_ptr<CascadiaInt4Gemv>> ops;
+    };
+    std::map<std::string, Group> groups;
+    std::vector<std::string> order;
+    for (const auto& node : model->get_ordered_ops()) {
+        auto gemv = ov::as_type_ptr<CascadiaInt4Gemv>(node);
+        if (!gemv || gemv->get_output_target_inputs(0).empty()) continue;
+        const auto& in = gemv->input_value(0);
+        char key[256];
+        snprintf(key, sizeof(key), "%p:%zu:%lld:%lld:%lld", // NOLINT
+                 static_cast<void*>(in.get_node()), in.get_index(),
+                 static_cast<long long>(gemv->k()), static_cast<long long>(gemv->groups()),
+                 static_cast<long long>(gemv->group_size()));
+        auto it = groups.find(key);
+        if (it == groups.end()) order.push_back(key);
+        groups[key].ops.push_back(gemv);
+    }
+
+    uint32_t fused = 0;
+    for (const auto& key : order) {
+        auto& grp = groups[key].ops;
+        if (grp.size() < 2) continue;
+        std::vector<CascadiaInt4Gemv::Segment> segs;
+        std::vector<int64_t> lengths;
+        std::string tag;
+        for (const auto& op : grp) {
+            for (const auto& seg : op->segments()) {
+                segs.push_back(seg);
+                lengths.push_back(seg.n);
+            }
+            if (!tag.empty()) tag += "+";
+            tag += op->tag();
+        }
+        auto fused_op = std::make_shared<CascadiaInt4Gemv>(
+            grp[0]->input_value(0), std::move(segs), grp[0]->k(), grp[0]->groups(),
+            grp[0]->group_size(), tag);
+        fused_op->set_friendly_name(grp[0]->get_friendly_name() + "_fused");
+        auto axis = Constant::create(ov::element::i64, ov::Shape{}, {-1});
+        auto lens = Constant::create(ov::element::i64, ov::Shape{lengths.size()}, lengths);
+        auto split = std::make_shared<ov::op::v1::VariadicSplit>(fused_op, axis, lens);
+        split->set_friendly_name(fused_op->get_friendly_name() + "_split");
+        for (size_t i = 0; i < grp.size(); ++i) {
+            ov::copy_runtime_info(grp[i], {fused_op, split});
+            grp[i]->output(0).replace(split->output(i));
+        }
+        ++fused;
+        fprintf(stderr, "gemv-fuse: %zu siblings -> %s (N=%lld)\n", grp.size(),
+                fused_op->get_friendly_name().c_str(),
+                static_cast<long long>(
+                    std::accumulate(lengths.begin(), lengths.end(), int64_t{0})));
+    }
+    return fused;
+}
+
 uint32_t offload_int4_gemv(ov::Core& core, const std::shared_ptr<ov::Model>& model) {
     core.add_extension(std::make_shared<ov::OpExtension<CascadiaInt4Gemv>>());
     auto counter = std::make_shared<std::atomic<uint32_t>>(0);
     ov::pass::Manager manager;
     manager.register_pass<OffloadInt4GemvPass>(counter);
     manager.run_passes(model);
+    // CASCADIA_GEMV_NOFUSE=1: A/B knob for the sibling fusion (spike-only).
+    static const bool nofuse = [] {
+        const char* v = std::getenv("CASCADIA_GEMV_NOFUSE");
+        return v && *v == '1';
+    }();
+    if (!nofuse && counter->load(std::memory_order_relaxed) > 0) {
+        const uint32_t fused = fuse_sibling_gemvs(model);
+        if (fused > 0) {
+            model->validate_nodes_and_infer_types();
+        }
+    }
     return counter->load(std::memory_order_relaxed);
 }
 

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -70,6 +70,12 @@ struct DnnlSegExec {
     size_t n = 0;
     std::vector<uint16_t> scales_gn;  // f16 bits, [G, N]
 };
+// NOTE (review finding, accepted): evaluate() mutates the shared DnnlState
+// (set_data_handle on shared memory objects) without per-call locking — safe
+// under the engine's single-infer-request usage, UNSAFE if the same node
+// instance ever executes from two infer requests concurrently. The dnnl path
+// is a default-off probe (CASCADIA_GEMV_DNNL); lock or clone per-call before
+// any multi-request use.
 struct DnnlState {
     bool ok = false;
     dnnl::engine eng;
@@ -811,6 +817,19 @@ public:
             const int64_t gsize = static_cast<int64_t>(ws[2]);
             if (gsize % 2 != 0) return false;
             const int64_t k = groups * gsize;
+            // The Reshape between decompress and MatMul must be the plain
+            // [N,G,g] -> [N,K] flatten. A chain that re-factorizes dims
+            // would otherwise be rewritten into a shape-inconsistent op and
+            // fail the WHOLE model validation, instead of staying on the
+            // stock path as the "anything deviant is left alone" contract
+            // promises.
+            const auto rsh_node = map.at(rsh).get_node_shared_ptr();
+            const auto& rshape = rsh_node->get_output_partial_shape(0);
+            if (rshape.rank().is_dynamic() || rshape.rank().get_length() != 2 ||
+                rshape[0].is_dynamic() || rshape[1].is_dynamic() ||
+                rshape[0].get_length() != n || rshape[1].get_length() != k) {
+                return false;
+            }
             const auto& act_out = matmul->input_value(0);
             if (act_out.get_element_type() != ov::element::f16) return false;
 
@@ -858,6 +877,11 @@ uint32_t fuse_sibling_gemvs(const std::shared_ptr<ov::Model>& model) {
     for (const auto& node : model->get_ordered_ops()) {
         auto gemv = ov::as_type_ptr<CascadiaInt4Gemv>(node);
         if (!gemv || gemv->get_output_target_inputs(0).empty()) continue;
+        // Only single-segment ops fuse: downstream rewiring maps split
+        // output i to grp[i]'s single consumer — an already-fused op
+        // (multi-segment) in the group would misalign lengths vs outputs
+        // and route one projection's rows into another's consumer.
+        if (gemv->segments().size() != 1) continue;
         const auto& in = gemv->input_value(0);
         char key[256];
         snprintf(key, sizeof(key), "%p:%zu:%lld:%lld:%lld", // NOLINT

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -124,20 +124,35 @@ int32_t dot_group_vnni(const uint8_t* gw, const int8_t* qa, size_t gsize) {
     const __m128i xor8 = _mm_set1_epi8(8);
     const __m128i mask4 = _mm_set1_epi8(0x0F);
     size_t j = 0;
+    for (; j + 32 <= gsize / 2; j += 32) {
+        _mm_prefetch(reinterpret_cast<const char*>(gw + j + 128), _MM_HINT_T0);
+        const __m128i raw0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
+        const __m128i raw1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j + 16));
+        const __m128i lo0 = _mm_and_si128(raw0, mask4);
+        const __m128i hi0 = _mm_and_si128(_mm_srli_epi16(raw0, 4), mask4);
+        const __m128i lo1 = _mm_and_si128(raw1, mask4);
+        const __m128i hi1 = _mm_and_si128(_mm_srli_epi16(raw1, 4), mask4);
+        const __m256i w0 = _mm256_set_m128i(
+            _mm_xor_si128(_mm_unpackhi_epi8(lo0, hi0), xor8),
+            _mm_xor_si128(_mm_unpacklo_epi8(lo0, hi0), xor8));
+        const __m256i w1 = _mm256_set_m128i(
+            _mm_xor_si128(_mm_unpackhi_epi8(lo1, hi1), xor8),
+            _mm_xor_si128(_mm_unpacklo_epi8(lo1, hi1), xor8));
+        acc0 = _mm256_dpbusd_avx_epi32(
+            acc0, w0, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(qa + 2 * j)));
+        acc1 = _mm256_dpbusd_avx_epi32(
+            acc1, w1,
+            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(qa + 2 * j + 32)));
+    }
     for (; j + 16 <= gsize / 2; j += 16) {
         const __m128i raw = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
         const __m128i lo = _mm_and_si128(raw, mask4);
         const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), mask4);
-        const __m128i a = _mm_xor_si128(_mm_unpacklo_epi8(lo, hi), xor8);
-        const __m128i b = _mm_xor_si128(_mm_unpackhi_epi8(lo, hi), xor8);
-        const __m256i w = _mm256_set_m128i(b, a);  // 32 u8 weights, in order
-        const __m256i q =
-            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(qa + 2 * j));
-        if ((j / 16) & 1) {
-            acc1 = _mm256_dpbusd_avx_epi32(acc1, w, q);
-        } else {
-            acc0 = _mm256_dpbusd_avx_epi32(acc0, w, q);
-        }
+        const __m256i w = _mm256_set_m128i(
+            _mm_xor_si128(_mm_unpackhi_epi8(lo, hi), xor8),
+            _mm_xor_si128(_mm_unpacklo_epi8(lo, hi), xor8));
+        acc0 = _mm256_dpbusd_avx_epi32(
+            acc0, w, _mm256_loadu_si256(reinterpret_cast<const __m256i*>(qa + 2 * j)));
     }
     __m256i acc = _mm256_add_epi32(acc0, acc1);
     __m128i s = _mm_add_epi32(_mm256_castsi256_si128(acc), _mm256_extracti128_si256(acc, 1));
@@ -153,30 +168,23 @@ int32_t dot_group_vnni(const uint8_t* gw, const int8_t* qa, size_t gsize) {
     return dot;
 }
 
-// AVX2 grouped sym-INT4 dot. Nibble decode via (x ^ 8) - 8 sign trick;
-// _mm_unpacklo/hi_epi8(lo, hi) restores the low-nibble-first element order
-// for free. FOUR independent accumulator chains: a single accumulator
-// serializes on FMA latency (~4-5 cycles) and was the dominant kernel stall;
-// with group_size=128 (64 packed bytes) a group is exactly one unrolled
-// iteration.
-static inline __m256 dot16_lo(const __m128i raw, const __m128i mask4, const __m128i bias,
-                              const float* base, __m256 acc, __m256 acc2, __m256* acc2_out) {
-    const __m128i lo = _mm_and_si128(raw, mask4);
-    const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), mask4);
-    __m128i a = _mm_unpacklo_epi8(lo, hi);
-    __m128i b = _mm_unpackhi_epi8(lo, hi);
-    a = _mm_sub_epi8(_mm_xor_si128(a, bias), bias);
-    b = _mm_sub_epi8(_mm_xor_si128(b, bias), bias);
-    acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(a)),
-                          _mm256_loadu_ps(base + 0), acc);
-    acc2 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(a, 8))),
-                           _mm256_loadu_ps(base + 8), acc2);
-    acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(b)),
-                          _mm256_loadu_ps(base + 16), acc);
-    acc2 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(b, 8))),
-                           _mm256_loadu_ps(base + 24), acc2);
-    *acc2_out = acc2;
-    return acc;
+// AVX2 grouped sym-INT4 dots — FLAT loops, no helper calls: MSVC refuses
+// to inline SIMD helpers taking/returning __m256 by value and spills vector
+// registers to stack per 16-byte step, capping a core at ~5.7 GB/s (the
+// measured wall that VNNI, fusion, and 2-row blocking all failed to move).
+// Nibble decode via (x ^ 8) - 8; unpacklo/hi restores low-first order.
+
+#if defined(_MSC_VER)
+#define CASCADIA_INLINE __forceinline
+#else
+#define CASCADIA_INLINE inline __attribute__((always_inline))
+#endif
+
+CASCADIA_INLINE float hsum8(__m256 v) {
+    __m128 s = _mm_add_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    s = _mm_hadd_ps(s, s);
+    s = _mm_hadd_ps(s, s);
+    return _mm_cvtss_f32(s);
 }
 
 float dot_group_avx2(const uint8_t* gw, const float* ga, size_t gsize) {
@@ -187,21 +195,28 @@ float dot_group_avx2(const uint8_t* gw, const float* ga, size_t gsize) {
     const __m128i mask4 = _mm_set1_epi8(0x0F);
     const __m128i bias = _mm_set1_epi8(8);
     size_t j = 0;
-    for (; j + 32 <= gsize / 2; j += 32) {
-        const __m128i r0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
-        const __m128i r1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j + 16));
-        acc0 = dot16_lo(r0, mask4, bias, ga + 2 * j, acc0, acc1, &acc1);
-        acc2 = dot16_lo(r1, mask4, bias, ga + 2 * j + 32, acc2, acc3, &acc3);
-    }
     for (; j + 16 <= gsize / 2; j += 16) {
-        const __m128i r0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
-        acc0 = dot16_lo(r0, mask4, bias, ga + 2 * j, acc0, acc1, &acc1);
+        _mm_prefetch(reinterpret_cast<const char*>(gw + j + 128), _MM_HINT_T0);
+        const __m128i raw = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
+        const __m128i lo = _mm_and_si128(raw, mask4);
+        const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), mask4);
+        __m128i a = _mm_unpacklo_epi8(lo, hi);
+        __m128i b = _mm_unpackhi_epi8(lo, hi);
+        a = _mm_sub_epi8(_mm_xor_si128(a, bias), bias);
+        b = _mm_sub_epi8(_mm_xor_si128(b, bias), bias);
+        const float* base = ga + 2 * j;
+        acc0 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(a)),
+                               _mm256_loadu_ps(base + 0), acc0);
+        acc1 = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(a, 8))),
+            _mm256_loadu_ps(base + 8), acc1);
+        acc2 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(b)),
+                               _mm256_loadu_ps(base + 16), acc2);
+        acc3 = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(b, 8))),
+            _mm256_loadu_ps(base + 24), acc3);
     }
-    const __m256 acc = _mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3));
-    __m128 s = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
-    s = _mm_hadd_ps(s, s);
-    s = _mm_hadd_ps(s, s);
-    float dot = _mm_cvtss_f32(s);
+    float dot = hsum8(_mm256_add_ps(_mm256_add_ps(acc0, acc1), _mm256_add_ps(acc2, acc3)));
     for (; j < gsize / 2; ++j) {
         const uint8_t v = gw[j];
         const int lo = static_cast<int8_t>(static_cast<uint8_t>(v << 4)) >> 4;
@@ -210,6 +225,62 @@ float dot_group_avx2(const uint8_t* gw, const float* ga, size_t gsize) {
         dot += static_cast<float>(hi) * ga[2 * j + 1];
     }
     return dot;
+}
+
+// Two rows per pass against one activation read; fully flat.
+void dot_group_avx2_x2(const uint8_t* gw0, const uint8_t* gw1, const float* ga, size_t gsize,
+                       float* d0, float* d1) {
+    __m256 r0a = _mm256_setzero_ps(), r0b = _mm256_setzero_ps();
+    __m256 r1a = _mm256_setzero_ps(), r1b = _mm256_setzero_ps();
+    const __m128i mask4 = _mm_set1_epi8(0x0F);
+    const __m128i bias = _mm_set1_epi8(8);
+    size_t j = 0;
+    for (; j + 16 <= gsize / 2; j += 16) {
+        _mm_prefetch(reinterpret_cast<const char*>(gw0 + j + 128), _MM_HINT_T0);
+        _mm_prefetch(reinterpret_cast<const char*>(gw1 + j + 128), _MM_HINT_T0);
+        const float* base = ga + 2 * j;
+        const __m256 v0 = _mm256_loadu_ps(base + 0);
+        const __m256 v1 = _mm256_loadu_ps(base + 8);
+        const __m256 v2 = _mm256_loadu_ps(base + 16);
+        const __m256 v3 = _mm256_loadu_ps(base + 24);
+
+        const __m128i q0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw0 + j));
+        __m128i l0 = _mm_and_si128(q0, mask4);
+        __m128i h0 = _mm_and_si128(_mm_srli_epi16(q0, 4), mask4);
+        __m128i a0 = _mm_sub_epi8(_mm_xor_si128(_mm_unpacklo_epi8(l0, h0), bias), bias);
+        __m128i b0 = _mm_sub_epi8(_mm_xor_si128(_mm_unpackhi_epi8(l0, h0), bias), bias);
+        r0a = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(a0)), v0, r0a);
+        r0b = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(a0, 8))), v1, r0b);
+        r0a = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(b0)), v2, r0a);
+        r0b = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(b0, 8))), v3, r0b);
+
+        const __m128i q1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw1 + j));
+        __m128i l1 = _mm_and_si128(q1, mask4);
+        __m128i h1 = _mm_and_si128(_mm_srli_epi16(q1, 4), mask4);
+        __m128i a1 = _mm_sub_epi8(_mm_xor_si128(_mm_unpacklo_epi8(l1, h1), bias), bias);
+        __m128i b1 = _mm_sub_epi8(_mm_xor_si128(_mm_unpackhi_epi8(l1, h1), bias), bias);
+        r1a = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(a1)), v0, r1a);
+        r1b = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(a1, 8))), v1, r1b);
+        r1a = _mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(b1)), v2, r1a);
+        r1b = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(b1, 8))), v3, r1b);
+    }
+    float f0 = hsum8(_mm256_add_ps(r0a, r0b));
+    float f1 = hsum8(_mm256_add_ps(r1a, r1b));
+    for (; j < gsize / 2; ++j) {
+        const uint8_t v0 = gw0[j], v1 = gw1[j];
+        f0 += static_cast<float>(static_cast<int8_t>(static_cast<uint8_t>(v0 << 4)) >> 4) *
+                  ga[2 * j] +
+              static_cast<float>(static_cast<int8_t>(v0) >> 4) * ga[2 * j + 1];
+        f1 += static_cast<float>(static_cast<int8_t>(static_cast<uint8_t>(v1 << 4)) >> 4) *
+                  ga[2 * j] +
+              static_cast<float>(static_cast<int8_t>(v1) >> 4) * ga[2 * j + 1];
+    }
+    *d0 = f0;
+    *d1 = f1;
 }
 #endif  // CASCADIA_GEMV_X86
 
@@ -403,11 +474,43 @@ public:
                     q_sum[gi] = sum;
                 }
             }
+            const auto emit = [&](size_t row, float acc) {
+                if (out_f16) {
+                    out16[r * n + row] = ov::float16(acc);
+                } else {
+                    out32[r * n + row] = acc;
+                }
+            };
             const std::function<void(size_t, size_t)> rows_fn = [&](size_t rb, size_t re) {
                 size_t si = 0;
                 while (segp[si].end <= rb) ++si;
-                for (size_t row = rb; row < re; ++row) {
+                size_t row = rb;
+                while (row < re) {
                     while (segp[si].end <= row) ++si;
+#ifdef CASCADIA_GEMV_X86
+                    // Fast path: TWO rows of the same segment per pass — one
+                    // activation read feeds both weight streams (see
+                    // dot_group_avx2_x2). f32 path only; VNNI keeps 1-row.
+                    if (use_avx2 && !use_vnni && row + 1 < re && row + 1 < segp[si].end) {
+                        const size_t local = row - segp[si].start;
+                        const uint8_t* w0 = segp[si].w + local * (k / 2);
+                        const uint8_t* w1 = w0 + (k / 2);
+                        const ov::float16* s0 = segp[si].s + local * groups;
+                        const ov::float16* s1 = s0 + groups;
+                        float acc0 = 0.f, acc1 = 0.f;
+                        for (size_t gi = 0; gi < groups; ++gi) {
+                            float d0, d1;
+                            dot_group_avx2_x2(w0 + gi * (gsize / 2), w1 + gi * (gsize / 2),
+                                              a + gi * gsize, gsize, &d0, &d1);
+                            acc0 += static_cast<float>(s0[gi]) * d0;
+                            acc1 += static_cast<float>(s1[gi]) * d1;
+                        }
+                        emit(row, acc0);
+                        emit(row + 1, acc1);
+                        row += 2;
+                        continue;
+                    }
+#endif
                     const size_t local = row - segp[si].start;
                     const uint8_t* wrow = segp[si].w + local * (k / 2);
                     const ov::float16* srow = segp[si].s + local * groups;
@@ -438,11 +541,8 @@ public:
                         }
                         acc += static_cast<float>(srow[gi]) * dot;
                     }
-                    if (out_f16) {
-                        out16[r * n + row] = ov::float16(acc);
-                    } else {
-                        out32[r * n + row] = acc;
-                    }
+                    emit(row, acc);
+                    ++row;
                 }
             };
             if (sequential) {

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -32,6 +32,10 @@
 #endif
 #endif
 
+#ifdef CASCADIA_HAVE_DNNL
+#include <oneapi/dnnl/dnnl.hpp>
+#endif
+
 #include <openvino/core/parallel.hpp>
 #include <openvino/openvino.hpp>
 #include <openvino/op/constant.hpp>
@@ -49,6 +53,30 @@ namespace cascadia_gemv {
 namespace {
 
 using ov::op::v0::Constant;
+
+#ifdef CASCADIA_HAVE_DNNL
+// The endgame path: a dnnl matmul primitive with INT4 weights-decompression
+// executing DIRECTLY over the op's mmapped weight bytes. Our packed-i4
+// [N, K] rows are exactly dnnl's plain `ba` layout for weights dims [K, N]
+// (zero weight copy); only the scales transpose into a small resident
+// [G, N] f16 buffer (~4 MB across a 1B model). fpmath_mode(f16, apply_to_
+// int=true) selects the same weights-decompression brgemm family the OV CPU
+// plugin uses (measured ~51 GB/s vs our loop's ~22). TBB-runtime dnnl build
+// shares the plugin's tbb12, so its threads come from the existing pool.
+struct DnnlSegExec {
+    dnnl::matmul prim;
+    dnnl::memory w_mem, sc_mem, src_mem, dst_mem;
+    size_t out_off = 0;
+    size_t n = 0;
+    std::vector<uint16_t> scales_gn;  // f16 bits, [G, N]
+};
+struct DnnlState {
+    bool ok = false;
+    dnnl::engine eng;
+    dnnl::stream strm;
+    std::vector<DnnlSegExec> segs;
+};
+#endif
 
 // CASCADIA_GEMV_STATS=1: accumulate evaluate() wall time across all op
 // instances and print a summary at process exit — splits kernel time from
@@ -423,6 +451,9 @@ public:
         std::vector<int8_t> act_q;
         std::vector<float> q_scale;
         std::vector<int32_t> q_sum;
+#ifdef CASCADIA_HAVE_DNNL
+        std::vector<float> dnnl_dst;
+#endif
 #ifdef CASCADIA_GEMV_X86
         const bool use_avx2 = cpu_has_avx2_fma();
         // CASCADIA_GEMV_VNNI=1: dynamically-quantized int8 activations via
@@ -449,6 +480,52 @@ public:
                 act_f32[i] = in_f16 ? static_cast<float>(act16[r * k + i]) : act32[r * k + i];
             }
             const float* a = act_f32.data();
+#ifdef CASCADIA_HAVE_DNNL
+            // CASCADIA_GEMV_DNNL=1: run this row through dnnl int4-
+            // decompression matmuls over the SAME mmapped weights. Falls
+            // back permanently to the built-in kernels on any failure.
+            static const bool want_dnnl = [] {
+                const char* v = std::getenv("CASCADIA_GEMV_DNNL");
+                return v && (*v == '1' || *v == '2');
+            }();
+            if (want_dnnl) {
+                auto st = dnnl_state();
+                if (st->ok) {
+                    bool done = true;
+                    try {
+                        if (out_f16) dnnl_dst.resize(n);
+                        for (auto& ex : st->segs) {
+                            ex.src_mem.set_data_handle(
+                                const_cast<float*>(a));
+                            float* dst_ptr = out_f16
+                                                 ? dnnl_dst.data() + ex.out_off
+                                                 : out32 + r * n + ex.out_off;
+                            ex.dst_mem.set_data_handle(dst_ptr);
+                            ex.prim.execute(
+                                st->strm,
+                                {{DNNL_ARG_SRC, ex.src_mem},
+                                 {DNNL_ARG_WEIGHTS, ex.w_mem},
+                                 {DNNL_ARG_DST, ex.dst_mem},
+                                 {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
+                                  ex.sc_mem}});
+                        }
+                        st->strm.wait();
+                        if (out_f16) {
+                            for (size_t i = 0; i < n; ++i) {
+                                out16[r * n + i] = ov::float16(dnnl_dst[i]);
+                            }
+                        }
+                    } catch (const std::exception& e) {
+                        fprintf(stderr,
+                                "gemv-dnnl: execute failed (%s) — disabling\n",
+                                e.what());
+                        st->ok = false;
+                        done = false;
+                    }
+                    if (done) continue;
+                }
+            }
+#endif
             if (use_vnni) {
                 act_q.resize(k);
                 q_scale.resize(groups);
@@ -573,6 +650,100 @@ public:
     }
 
 private:
+#ifdef CASCADIA_HAVE_DNNL
+    // Lazily-built per executing instance (clones start empty). ok=false
+    // after any failure -> permanent fallback to the built-in kernels.
+    std::shared_ptr<DnnlState> dnnl_state() const {
+        std::lock_guard<std::mutex> lk(m_dnnl_mu);
+        if (m_dnnl) return m_dnnl;
+        auto st = std::make_shared<DnnlState>();
+        try {
+            st->eng = dnnl::engine(dnnl::engine::kind::cpu, 0);
+            st->strm = dnnl::stream(st->eng);
+            const int64_t k = m_k, groups = m_groups, gsize = m_gsize;
+            size_t off = 0;
+            for (const auto& seg : m_segs) {
+                DnnlSegExec ex;
+                ex.n = static_cast<size_t>(seg.n);
+                ex.out_off = off;
+                off += ex.n;
+                // scales [N, G] f16 -> [G, N] (dnnl expects K-groups major)
+                const auto* sc =
+                    static_cast<const uint16_t*>(seg.s->get_data_ptr());
+                ex.scales_gn.resize(static_cast<size_t>(groups) * ex.n);
+                for (size_t n_i = 0; n_i < ex.n; ++n_i) {
+                    for (int64_t g = 0; g < groups; ++g) {
+                        ex.scales_gn[static_cast<size_t>(g) * ex.n + n_i] =
+                            sc[n_i * static_cast<size_t>(groups) +
+                               static_cast<size_t>(g)];
+                    }
+                }
+                using dt = dnnl::memory::data_type;
+                using tag = dnnl::memory::format_tag;
+                // Mode 1 (CASCADIA_GEMV_DNNL=1): weights in OUR plain
+                // ba layout, zero-copy from the mmap. Mode 2 (=2): let dnnl
+                // pick its preferred layout (format_tag::any) and reorder
+                // ONCE into a resident repacked buffer — measures upstream
+                // brgemm's ceiling at the cost of the residency goal.
+                static const bool pick_any = [] {
+                    const char* v = std::getenv("CASCADIA_GEMV_DNNL");
+                    return v && *v == '2';
+                }();
+                dnnl::memory::desc src_md({1, k}, dt::f32, tag::ab);
+                dnnl::memory::desc w_plain({k, static_cast<int64_t>(ex.n)},
+                                           dt::s4, tag::ba);
+                dnnl::memory::desc w_md =
+                    pick_any ? dnnl::memory::desc({k, static_cast<int64_t>(ex.n)},
+                                                  dt::s4, tag::any)
+                             : w_plain;
+                dnnl::memory::desc dst_md({1, static_cast<int64_t>(ex.n)}, dt::f32,
+                                          tag::ab);
+                dnnl::primitive_attr attr;
+                attr.set_fpmath_mode(dnnl::fpmath_mode::f16, true);
+                attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1),
+                                {gsize, 1}, dt::f16);
+                dnnl::matmul::primitive_desc pd(st->eng, src_md, w_md, dst_md,
+                                                attr);
+                ex.prim = dnnl::matmul(pd);
+                if (st->segs.empty()) {
+                    fprintf(stderr, "gemv-dnnl impl: %s (mode %d)\n",
+                            pd.impl_info_str(), pick_any ? 2 : 1);
+                }
+                if (pick_any) {
+                    dnnl::memory plain_mem(
+                        w_plain, st->eng,
+                        const_cast<void*>(seg.w->get_data_ptr()));
+                    ex.w_mem = dnnl::memory(pd.weights_desc(), st->eng);
+                    dnnl::reorder(plain_mem, ex.w_mem)
+                        .execute(st->strm, plain_mem, ex.w_mem);
+                    st->strm.wait();
+                } else {
+                    ex.w_mem = dnnl::memory(
+                        w_md, st->eng,
+                        const_cast<void*>(seg.w->get_data_ptr()));
+                }
+                dnnl::memory::desc sc_md(
+                    {groups, static_cast<int64_t>(ex.n)}, dt::f16, tag::ab);
+                ex.sc_mem = dnnl::memory(sc_md, st->eng, ex.scales_gn.data());
+                ex.src_mem = dnnl::memory(src_md, st->eng, DNNL_MEMORY_NONE);
+                ex.dst_mem = dnnl::memory(dst_md, st->eng, DNNL_MEMORY_NONE);
+                st->segs.push_back(std::move(ex));
+            }
+            st->ok = true;
+        } catch (const std::exception& e) {
+            fprintf(stderr,
+                    "gemv-dnnl: primitive creation failed (%s) — falling back "
+                    "to built-in kernels\n",
+                    e.what());
+            st->ok = false;
+            st->segs.clear();
+        }
+        m_dnnl = st;
+        return m_dnnl;
+    }
+    mutable std::shared_ptr<DnnlState> m_dnnl;
+    mutable std::mutex m_dnnl_mu;
+#endif
     std::vector<Segment> m_segs;
     int64_t m_n = 0, m_k = 0, m_groups = 0, m_gsize = 0;
     std::string m_tag;

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -1,0 +1,192 @@
+// CascadiaInt4Gemv: an OpenVINO extension op executing NNCF sym-INT4 grouped
+// GEMV directly from the read_model mmap, so the CPU plugin never makes its
+// own repacked resident copy of the weights (the 2x-residency cost of the
+// hybrid prefill/decode split). Spike scope: decode (M=1..few) matmuls,
+// symmetric INT4 group quantization, f16 activations/scales — exactly what
+// `tools/export_shards.py --target npu` emits (verified: 113/113 MatMuls in
+// a Llama-3.2-1B static stage match). Built on the public extension API —
+// no OpenVINO changes.
+
+#include "gemv_offload.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <vector>
+
+#include <openvino/core/parallel.hpp>
+#include <openvino/openvino.hpp>
+#include <openvino/op/op.hpp>
+#include <openvino/pass/graph_rewrite.hpp>
+#include <openvino/pass/manager.hpp>
+#include <openvino/pass/pattern/op/wrap_type.hpp>
+
+namespace cascadia_gemv {
+namespace {
+
+using ov::op::v0::Constant;
+
+// Custom op holding the i4 weight + f16 scale Constants as MEMBERS (not
+// graph inputs): the plugin sees a weightless node and falls back to
+// evaluate(); the shared_ptrs keep the .bin mapping alive for the compiled
+// model's lifetime.
+class CascadiaInt4Gemv : public ov::op::Op {
+public:
+    OPENVINO_OP("CascadiaInt4Gemv", "cascadia");
+
+    CascadiaInt4Gemv() = default;
+
+    CascadiaInt4Gemv(const ov::Output<ov::Node>& act,
+                     std::shared_ptr<Constant> weights_i4,
+                     std::shared_ptr<Constant> scales_f16,
+                     int64_t n, int64_t k, int64_t groups, int64_t group_size)
+        : ov::op::Op({act}),
+          m_w(std::move(weights_i4)),
+          m_s(std::move(scales_f16)),
+          m_n(n),
+          m_k(k),
+          m_groups(groups),
+          m_gsize(group_size) {
+        constructor_validate_and_infer_types();
+    }
+
+    void validate_and_infer_types() override {
+        auto shape = get_input_partial_shape(0);
+        NODE_VALIDATION_CHECK(this, shape.rank().is_static() && shape.rank().get_length() >= 1,
+                              "activation rank must be static");
+        shape[shape.rank().get_length() - 1] = ov::Dimension(m_n);
+        set_output_type(0, ov::element::f16, shape);
+    }
+
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& args) const override {
+        return std::make_shared<CascadiaInt4Gemv>(args.at(0), m_w, m_s, m_n, m_k, m_groups,
+                                                  m_gsize);
+    }
+
+    bool visit_attributes(ov::AttributeVisitor& visitor) override {
+        visitor.on_attribute("n", m_n);
+        visitor.on_attribute("k", m_k);
+        visitor.on_attribute("groups", m_groups);
+        visitor.on_attribute("group_size", m_gsize);
+        return true;
+    }
+
+    bool has_evaluate() const override { return true; }
+
+    bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override {
+        if (!m_w || !m_s) return false;
+        const auto& act = inputs[0];
+        auto& out = outputs[0];
+        const size_t k = static_cast<size_t>(m_k);
+        const size_t n = static_cast<size_t>(m_n);
+        const size_t groups = static_cast<size_t>(m_groups);
+        const size_t gsize = static_cast<size_t>(m_gsize);
+        const size_t rows = act.get_size() / k;  // seq (decode: 1)
+        if (act.get_size() != rows * k) return false;
+
+        const auto* act16 = act.data<const ov::float16>();
+        auto* out16 = out.data<ov::float16>();
+        // i4 packed two-per-byte, element 0 in the LOW nibble; row-major
+        // [N, G, g] => per-output-row stride k/2 bytes.
+        const auto* wbytes = static_cast<const uint8_t*>(m_w->get_data_ptr());
+        const auto* sc16 = static_cast<const ov::float16*>(m_s->get_data_ptr());
+
+        // f32 scratch of the activation row: read once, reused across N.
+        thread_local std::vector<float> act_f32;
+        for (size_t r = 0; r < rows; ++r) {
+            act_f32.resize(k);
+            for (size_t i = 0; i < k; ++i) act_f32[i] = static_cast<float>(act16[r * k + i]);
+            const float* a = act_f32.data();
+            ov::parallel_for(n, [&](size_t row) {
+                const uint8_t* wrow = wbytes + row * (k / 2);
+                const ov::float16* srow = sc16 + row * groups;
+                float acc = 0.f;
+                for (size_t gi = 0; gi < groups; ++gi) {
+                    const uint8_t* gw = wrow + gi * (gsize / 2);
+                    const float* ga = a + gi * gsize;
+                    float dot = 0.f;
+                    for (size_t j = 0; j < gsize / 2; ++j) {
+                        const uint8_t b = gw[j];
+                        const int lo = static_cast<int8_t>(static_cast<uint8_t>(b << 4)) >> 4;
+                        const int hi = static_cast<int8_t>(b) >> 4;
+                        dot += static_cast<float>(lo) * ga[2 * j];
+                        dot += static_cast<float>(hi) * ga[2 * j + 1];
+                    }
+                    acc += static_cast<float>(srow[gi]) * dot;
+                }
+                out16[r * n + row] = ov::float16(acc);
+            });
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<Constant> m_w;
+    std::shared_ptr<Constant> m_s;
+    int64_t m_n = 0, m_k = 0, m_groups = 0, m_gsize = 0;
+};
+
+// Matcher: the exact NNCF sym-INT4 chain the exporter emits. Anything that
+// deviates (asymmetric zp, non-f16, odd ranks) is left on the stock path.
+class OffloadInt4GemvPass : public ov::pass::MatcherPass {
+public:
+    explicit OffloadInt4GemvPass(std::shared_ptr<std::atomic<uint32_t>> counter) {
+        using namespace ov::pass::pattern;
+        auto w = wrap_type<ov::op::v0::Constant>();
+        auto cvt = wrap_type<ov::op::v0::Convert>({w});
+        auto sc = wrap_type<ov::op::v0::Constant>();
+        auto mul = wrap_type<ov::op::v1::Multiply>({cvt, sc});
+        auto shp = wrap_type<ov::op::v0::Constant>();
+        auto rsh = wrap_type<ov::op::v1::Reshape>({mul, shp});
+        auto act = any_input();
+        auto mm = wrap_type<ov::op::v0::MatMul>({act, rsh});
+
+        auto callback = [=](ov::pass::pattern::Matcher& m) -> bool {
+            const auto& map = m.get_pattern_value_map();
+            auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(map.at(mm).get_node_shared_ptr());
+            auto wconst = ov::as_type_ptr<Constant>(map.at(w).get_node_shared_ptr());
+            auto sconst = ov::as_type_ptr<Constant>(map.at(sc).get_node_shared_ptr());
+            if (!matmul || !wconst || !sconst) return false;
+            if (matmul->get_transpose_a() || !matmul->get_transpose_b()) return false;
+            if (wconst->get_element_type() != ov::element::i4) return false;
+            if (sconst->get_element_type() != ov::element::f16) return false;
+            const auto& ws = wconst->get_shape();
+            const auto& ss = sconst->get_shape();
+            if (ws.size() != 3 || ss.size() != 3) return false;
+            if (ss[0] != ws[0] || ss[1] != ws[1] || ss[2] != 1) return false;
+            const int64_t n = static_cast<int64_t>(ws[0]);
+            const int64_t groups = static_cast<int64_t>(ws[1]);
+            const int64_t gsize = static_cast<int64_t>(ws[2]);
+            if (gsize % 2 != 0) return false;
+            const int64_t k = groups * gsize;
+            const auto& act_out = matmul->input_value(0);
+            if (act_out.get_element_type() != ov::element::f16) return false;
+
+            auto gemv = std::make_shared<CascadiaInt4Gemv>(act_out, wconst, sconst, n, k,
+                                                           groups, gsize);
+            gemv->set_friendly_name(matmul->get_friendly_name());
+            ov::copy_runtime_info(matmul, gemv);
+            ov::replace_node(matmul, gemv);
+            counter->fetch_add(1, std::memory_order_relaxed);
+            return true;
+        };
+        register_matcher(
+            std::make_shared<ov::pass::pattern::Matcher>(mm, "CascadiaInt4GemvOffload"),
+            callback);
+    }
+};
+
+}  // namespace
+
+uint32_t offload_int4_gemv(ov::Core& core, const std::shared_ptr<ov::Model>& model) {
+    core.add_extension(std::make_shared<ov::OpExtension<CascadiaInt4Gemv>>());
+    auto counter = std::make_shared<std::atomic<uint32_t>>(0);
+    ov::pass::Manager manager;
+    manager.register_pass<OffloadInt4GemvPass>(counter);
+    manager.run_passes(model);
+    return counter->load(std::memory_order_relaxed);
+}
+
+}  // namespace cascadia_gemv

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -358,6 +358,16 @@ public:
     const std::string& tag() const { return m_tag; }
 
     void validate_and_infer_types() override {
+        // The weights live as op MEMBERS (invisible to attribute comparison), so
+        // two structurally-identical ops (same dims + same activation input —
+        // e.g. a layer's k_proj/v_proj) would be merged by CSE, silently routing
+        // one projection's weights into the other → wrong output at a clean 200
+        // OK. The per-instance weights_tag is the ONLY thing that defeats that
+        // merge, so it must be non-empty. Enforce it at construction/clone rather
+        // than trust the exporter's friendly names to happen to be unique.
+        NODE_VALIDATION_CHECK(this, !m_tag.empty(),
+                              "CascadiaInt4Gemv requires a non-empty weights_tag "
+                              "(defeats CSE merging of distinct-weight ops)");
         auto shape = get_input_partial_shape(0);
         NODE_VALIDATION_CHECK(this, shape.rank().is_static() && shape.rank().get_length() >= 1,
                               "activation rank must be static");

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -10,15 +10,29 @@
 #include "gemv_offload.hpp"
 
 #include <atomic>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <vector>
 
+#if defined(_MSC_VER) || defined(__x86_64__) || defined(_M_X64)
+#define CASCADIA_GEMV_X86 1
+#include <immintrin.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+#endif
+
 #include <openvino/core/parallel.hpp>
 #include <openvino/openvino.hpp>
+#include <openvino/op/constant.hpp>
+#include <openvino/op/convert.hpp>
+#include <openvino/op/matmul.hpp>
+#include <openvino/op/multiply.hpp>
 #include <openvino/op/op.hpp>
+#include <openvino/op/reshape.hpp>
 #include <openvino/pass/graph_rewrite.hpp>
 #include <openvino/pass/manager.hpp>
 #include <openvino/pass/pattern/op/wrap_type.hpp>
@@ -27,6 +41,67 @@ namespace cascadia_gemv {
 namespace {
 
 using ov::op::v0::Constant;
+
+#ifdef CASCADIA_GEMV_X86
+bool cpu_has_avx2_fma() {
+    static const bool ok = [] {
+#if defined(_MSC_VER)
+        int r[4] = {0};
+        __cpuid(r, 1);
+        const bool fma = (r[2] & (1 << 12)) != 0;
+        const bool osxsave = (r[2] & (1 << 27)) != 0;
+        __cpuidex(r, 7, 0);
+        const bool avx2 = (r[1] & (1 << 5)) != 0;
+        if (!(fma && avx2 && osxsave)) return false;
+        return (_xgetbv(0) & 0x6) == 0x6;
+#else
+        return __builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma");
+#endif
+    }();
+    return ok;
+}
+
+// AVX2 grouped sym-INT4 dot: 16 packed bytes = 32 weights per iteration.
+// Nibble decode via (x ^ 8) - 8 sign trick; _mm_unpacklo/hi_epi8(lo, hi)
+// restores the low-nibble-first element order for free.
+float dot_group_avx2(const uint8_t* gw, const float* ga, size_t gsize) {
+    __m256 acc = _mm256_setzero_ps();
+    const __m128i mask4 = _mm_set1_epi8(0x0F);
+    const __m128i bias = _mm_set1_epi8(8);
+    size_t j = 0;
+    for (; j + 16 <= gsize / 2; j += 16) {
+        const __m128i raw = _mm_loadu_si128(reinterpret_cast<const __m128i*>(gw + j));
+        const __m128i lo = _mm_and_si128(raw, mask4);
+        const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), mask4);
+        // interleave -> element order e0,e1,e2,... then sign-extend 4->8 bit
+        __m128i a = _mm_unpacklo_epi8(lo, hi);
+        __m128i b = _mm_unpackhi_epi8(lo, hi);
+        a = _mm_sub_epi8(_mm_xor_si128(a, bias), bias);
+        b = _mm_sub_epi8(_mm_xor_si128(b, bias), bias);
+        const float* base = ga + 2 * j;
+        const __m256i w0 = _mm256_cvtepi8_epi32(a);
+        const __m256i w1 = _mm256_cvtepi8_epi32(_mm_srli_si128(a, 8));
+        const __m256i w2 = _mm256_cvtepi8_epi32(b);
+        const __m256i w3 = _mm256_cvtepi8_epi32(_mm_srli_si128(b, 8));
+        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w0), _mm256_loadu_ps(base + 0), acc);
+        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w1), _mm256_loadu_ps(base + 8), acc);
+        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w2), _mm256_loadu_ps(base + 16), acc);
+        acc = _mm256_fmadd_ps(_mm256_cvtepi32_ps(w3), _mm256_loadu_ps(base + 24), acc);
+    }
+    __m128 s = _mm_add_ps(_mm256_castps256_ps128(acc), _mm256_extractf128_ps(acc, 1));
+    s = _mm_hadd_ps(s, s);
+    s = _mm_hadd_ps(s, s);
+    float dot = _mm_cvtss_f32(s);
+    for (; j < gsize / 2; ++j) {
+        const uint8_t v = gw[j];
+        const int lo = static_cast<int8_t>(static_cast<uint8_t>(v << 4)) >> 4;
+        const int hi = static_cast<int8_t>(v) >> 4;
+        dot += static_cast<float>(lo) * ga[2 * j];
+        dot += static_cast<float>(hi) * ga[2 * j + 1];
+    }
+    return dot;
+}
+#endif  // CASCADIA_GEMV_X86
 
 // Custom op holding the i4 weight + f16 scale Constants as MEMBERS (not
 // graph inputs): the plugin sees a weightless node and falls back to
@@ -41,14 +116,16 @@ public:
     CascadiaInt4Gemv(const ov::Output<ov::Node>& act,
                      std::shared_ptr<Constant> weights_i4,
                      std::shared_ptr<Constant> scales_f16,
-                     int64_t n, int64_t k, int64_t groups, int64_t group_size)
+                     int64_t n, int64_t k, int64_t groups, int64_t group_size,
+                     std::string tag)
         : ov::op::Op({act}),
           m_w(std::move(weights_i4)),
           m_s(std::move(scales_f16)),
           m_n(n),
           m_k(k),
           m_groups(groups),
-          m_gsize(group_size) {
+          m_gsize(group_size),
+          m_tag(std::move(tag)) {
         constructor_validate_and_infer_types();
     }
 
@@ -57,12 +134,20 @@ public:
         NODE_VALIDATION_CHECK(this, shape.rank().is_static() && shape.rank().get_length() >= 1,
                               "activation rank must be static");
         shape[shape.rank().get_length() - 1] = ov::Dimension(m_n);
-        set_output_type(0, ov::element::f16, shape);
+        // Output element type FOLLOWS the activation: the plugin's precision
+        // pipeline retypes the surrounding graph (f16 IR -> f32 execution on
+        // CPU by default) but cannot retype a custom op — a fixed f16 output
+        // would collide with retyped f32 consumers at plugin validation.
+        auto et = get_input_element_type(0);
+        NODE_VALIDATION_CHECK(
+            this, et.is_dynamic() || et == ov::element::f16 || et == ov::element::f32,
+            "activation must be f16 or f32");
+        set_output_type(0, et.is_dynamic() ? ov::element::f16 : et, shape);
     }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& args) const override {
         return std::make_shared<CascadiaInt4Gemv>(args.at(0), m_w, m_s, m_n, m_k, m_groups,
-                                                  m_gsize);
+                                                  m_gsize, m_tag);
     }
 
     bool visit_attributes(ov::AttributeVisitor& visitor) override {
@@ -70,6 +155,12 @@ public:
         visitor.on_attribute("k", m_k);
         visitor.on_attribute("groups", m_groups);
         visitor.on_attribute("group_size", m_gsize);
+        // The weights live in op MEMBERS, invisible to attribute-based node
+        // comparison — without a distinguishing attribute, common-subexpression
+        // elimination merges two ops with equal dims and the same input (e.g.
+        // a layer's k_proj and v_proj), silently routing one projection's
+        // output into the other. The per-instance tag keeps them distinct.
+        visitor.on_attribute("weights_tag", m_tag);
         return true;
     }
 
@@ -86,19 +177,39 @@ public:
         const size_t rows = act.get_size() / k;  // seq (decode: 1)
         if (act.get_size() != rows * k) return false;
 
-        const auto* act16 = act.data<const ov::float16>();
-        auto* out16 = out.data<ov::float16>();
+        // The plugin may execute this in f16 (IR precision) or f32 (default
+        // CPU execution precision) — handle both on each side.
+        const bool in_f16 = act.get_element_type() == ov::element::f16;
+        const bool out_f16 = out.get_element_type() == ov::element::f16;
+        if (!in_f16 && act.get_element_type() != ov::element::f32) return false;
+        if (!out_f16 && out.get_element_type() != ov::element::f32) return false;
+        const auto* act16 = in_f16 ? act.data<const ov::float16>() : nullptr;
+        const auto* act32 = in_f16 ? nullptr : act.data<const float>();
+        auto* out16 = out_f16 ? out.data<ov::float16>() : nullptr;
+        auto* out32 = out_f16 ? nullptr : out.data<float>();
+
         // i4 packed two-per-byte, element 0 in the LOW nibble; row-major
         // [N, G, g] => per-output-row stride k/2 bytes.
         const auto* wbytes = static_cast<const uint8_t*>(m_w->get_data_ptr());
         const auto* sc16 = static_cast<const ov::float16*>(m_s->get_data_ptr());
 
         // f32 scratch of the activation row: read once, reused across N.
-        thread_local std::vector<float> act_f32;
+        // Deliberately a per-call LOCAL, not thread_local: ov::parallel_for
+        // blocks this thread and TBB work-steals other ready tasks onto it —
+        // including another instance's evaluate(), which would clobber a
+        // shared thread_local while our row lambdas still read it.
+        std::vector<float> act_f32;
         for (size_t r = 0; r < rows; ++r) {
             act_f32.resize(k);
-            for (size_t i = 0; i < k; ++i) act_f32[i] = static_cast<float>(act16[r * k + i]);
+            for (size_t i = 0; i < k; ++i) {
+                act_f32[i] = in_f16 ? static_cast<float>(act16[r * k + i]) : act32[r * k + i];
+            }
             const float* a = act_f32.data();
+#ifdef CASCADIA_GEMV_X86
+            const bool use_avx2 = cpu_has_avx2_fma();
+#else
+            const bool use_avx2 = false;
+#endif
             ov::parallel_for(n, [&](size_t row) {
                 const uint8_t* wrow = wbytes + row * (k / 2);
                 const ov::float16* srow = sc16 + row * groups;
@@ -106,17 +217,30 @@ public:
                 for (size_t gi = 0; gi < groups; ++gi) {
                     const uint8_t* gw = wrow + gi * (gsize / 2);
                     const float* ga = a + gi * gsize;
-                    float dot = 0.f;
-                    for (size_t j = 0; j < gsize / 2; ++j) {
-                        const uint8_t b = gw[j];
-                        const int lo = static_cast<int8_t>(static_cast<uint8_t>(b << 4)) >> 4;
-                        const int hi = static_cast<int8_t>(b) >> 4;
-                        dot += static_cast<float>(lo) * ga[2 * j];
-                        dot += static_cast<float>(hi) * ga[2 * j + 1];
+                    float dot;
+#ifdef CASCADIA_GEMV_X86
+                    if (use_avx2) {
+                        dot = dot_group_avx2(gw, ga, gsize);
+                    } else
+#endif
+                    {
+                        dot = 0.f;
+                        for (size_t j = 0; j < gsize / 2; ++j) {
+                            const uint8_t b = gw[j];
+                            const int lo =
+                                static_cast<int8_t>(static_cast<uint8_t>(b << 4)) >> 4;
+                            const int hi = static_cast<int8_t>(b) >> 4;
+                            dot += static_cast<float>(lo) * ga[2 * j];
+                            dot += static_cast<float>(hi) * ga[2 * j + 1];
+                        }
                     }
                     acc += static_cast<float>(srow[gi]) * dot;
                 }
-                out16[r * n + row] = ov::float16(acc);
+                if (out_f16) {
+                    out16[r * n + row] = ov::float16(acc);
+                } else {
+                    out32[r * n + row] = acc;
+                }
             });
         }
         return true;
@@ -126,6 +250,7 @@ private:
     std::shared_ptr<Constant> m_w;
     std::shared_ptr<Constant> m_s;
     int64_t m_n = 0, m_k = 0, m_groups = 0, m_gsize = 0;
+    std::string m_tag;
 };
 
 // Matcher: the exact NNCF sym-INT4 chain the exporter emits. Anything that
@@ -143,7 +268,36 @@ public:
         auto act = any_input();
         auto mm = wrap_type<ov::op::v0::MatMul>({act, rsh});
 
+        auto match_ordinal = std::make_shared<std::atomic<uint32_t>>(0);
         auto callback = [=](ov::pass::pattern::Matcher& m) -> bool {
+            // Debug bisection knobs (spike-only): CASCADIA_GEMV_MAX caps how
+            // many MatMuls get offloaded; CASCADIA_GEMV_SKIP=i,j leaves the
+            // i-th/j-th matches (in traversal order) on the stock path.
+            static const long cap = [] {
+                const char* v = std::getenv("CASCADIA_GEMV_MAX");
+                return v ? std::atol(v) : -1;
+            }();
+            static const std::set<uint32_t> skip = [] {
+                std::set<uint32_t> s;
+                if (const char* v = std::getenv("CASCADIA_GEMV_SKIP")) {
+                    const char* p = v;
+                    while (*p) {
+                        s.insert(static_cast<uint32_t>(std::atol(p)));
+                        while (*p && *p != ',') ++p;
+                        if (*p == ',') ++p;
+                    }
+                }
+                return s;
+            }();
+            const uint32_t ordinal = match_ordinal->fetch_add(1, std::memory_order_relaxed);
+            if (skip.count(ordinal)) {
+                fprintf(stderr, "gemv-offload: skipping match %u\n", ordinal);
+                return false;
+            }
+            if (cap >= 0 && counter->load(std::memory_order_relaxed) >=
+                                static_cast<uint32_t>(cap)) {
+                return false;
+            }
             const auto& map = m.get_pattern_value_map();
             auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(map.at(mm).get_node_shared_ptr());
             auto wconst = ov::as_type_ptr<Constant>(map.at(w).get_node_shared_ptr());
@@ -165,11 +319,22 @@ public:
             if (act_out.get_element_type() != ov::element::f16) return false;
 
             auto gemv = std::make_shared<CascadiaInt4Gemv>(act_out, wconst, sconst, n, k,
-                                                           groups, gsize);
+                                                           groups, gsize,
+                                                           matmul->get_friendly_name());
             gemv->set_friendly_name(matmul->get_friendly_name());
             ov::copy_runtime_info(matmul, gemv);
             ov::replace_node(matmul, gemv);
-            counter->fetch_add(1, std::memory_order_relaxed);
+            const uint32_t idx = counter->fetch_add(1, std::memory_order_relaxed);
+            if (cap >= 0) {
+                // Bisection mode: name each rewrite so the first bad node is
+                // identifiable from the run log. Spike-only.
+                fprintf(stderr, "gemv-offload[%u]: %s N=%lld K=%lld act_rank=%zu\n", idx,
+                        matmul->get_friendly_name().c_str(), static_cast<long long>(n),
+                        static_cast<long long>(k),
+                        act_out.get_partial_shape().rank().is_static()
+                            ? static_cast<size_t>(act_out.get_partial_shape().rank().get_length())
+                            : 0);
+            }
             return true;
         };
         register_matcher(

--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.hpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.hpp
@@ -1,0 +1,27 @@
+// Internal C++ seam (NOT part of the C ABI): the CascadiaInt4Gemv custom-op
+// offload used by cascadia_runtime_compile_gemv_offload in shim.cpp.
+//
+// offload_int4_gemv registers the op with the core (idempotent per core) and
+// rewrites every NNCF sym-INT4 decompress→MatMul chain
+//   Const(i4 [N,G,g]) → Convert(f16) → Multiply(scales f16 [N,G,1])
+//     → Reshape([N,K]) → MatMul(act, ..., transpose_b=true)
+// into a CascadiaInt4Gemv node that keeps the weight/scale Constants as op
+// members: they never appear as graph constants, so the CPU plugin cannot
+// repack them at compile — resident weights stay the read_model mmap pages
+// of the original .bin. Returns the number of MatMuls offloaded.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace ov {
+class Model;
+class Core;
+}  // namespace ov
+
+namespace cascadia_gemv {
+
+uint32_t offload_int4_gemv(ov::Core& core, const std::shared_ptr<ov::Model>& model);
+
+}  // namespace cascadia_gemv

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -5,6 +5,8 @@
 
 #include "shim.h"
 
+#include "gemv_offload.hpp"
+
 #include <cstring>
 #include <map>
 #include <memory>
@@ -485,6 +487,58 @@ int32_t cascadia_runtime_compile(
 }
 
 void cascadia_runtime_destroy(cascadia_runtime_t* handle) { delete handle; }
+
+int32_t cascadia_runtime_compile_gemv_offload(
+    const char* model_xml_path, const char* device,
+    const char* const* properties_kv, size_t properties_count,
+    uint32_t* out_offloaded,
+    cascadia_runtime_t** out_handle) {
+    if (!model_xml_path || !device || !out_handle) {
+        set_last_error("null arg in runtime_compile_gemv_offload"); return 1;
+    }
+    try {
+        auto handle = std::make_unique<cascadia_runtime_t>();
+        auto props = collect_properties(properties_kv, properties_count);
+        // read_model keeps the .bin mmapped; the offload pass moves the
+        // sym-INT4 weight constants into CascadiaInt4Gemv op members so the
+        // plugin compile below never repacks them into a resident copy.
+        auto model = handle->core.read_model(std::string(model_xml_path));
+        const uint32_t offloaded = cascadia_gemv::offload_int4_gemv(handle->core, model);
+        if (out_offloaded) *out_offloaded = offloaded;
+        auto compiled = handle->core.compile_model(model, std::string(device), props);
+        handle->compiled = std::make_shared<ov::CompiledModel>(std::move(compiled));
+        handle->request = std::make_shared<ov::InferRequest>(
+            handle->compiled->create_infer_request());
+        for (const auto& port : handle->compiled->inputs()) {
+            std::string name;
+            try {
+                name = port.get_any_name();
+            } catch (...) {
+                const auto& names = port.get_names();
+                name = names.empty() ? std::string{} : *names.begin();
+            }
+            handle->input_aliases.push_back(join_port_names(port.get_names()));
+            handle->input_names.push_back(std::move(name));
+        }
+        for (const auto& port : handle->compiled->outputs()) {
+            std::string name;
+            try {
+                name = port.get_any_name();
+            } catch (...) {
+                const auto& names = port.get_names();
+                name = names.empty() ? std::string{} : *names.begin();
+            }
+            handle->output_aliases.push_back(join_port_names(port.get_names()));
+            handle->output_names.push_back(std::move(name));
+        }
+        *out_handle = handle.release();
+        return 0;
+    } catch (const std::exception& e) {
+        set_last_error(e); return 1;
+    } catch (...) {
+        set_last_error("unknown C++ exception in runtime_compile_gemv_offload"); return 1;
+    }
+}
 
 int32_t cascadia_runtime_reset_state(cascadia_runtime_t* handle) {
     if (!handle || !handle->request) {

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -558,6 +558,36 @@ int32_t cascadia_runtime_reset_state(cascadia_runtime_t* handle) {
     }
 }
 
+int32_t cascadia_runtime_profiling(
+    cascadia_runtime_t* handle, char* out_buf, size_t buf_cap, size_t* out_len) {
+    if (!handle || !handle->request || !out_buf || !out_len) {
+        set_last_error("null arg in runtime_profiling"); return 1;
+    }
+    try {
+        std::string acc;
+        for (const auto& pi : handle->request->get_profiling_info()) {
+            acc += pi.node_name;
+            acc += '\t';
+            acc += pi.node_type;
+            acc += '\t';
+            acc += pi.exec_type;
+            acc += '\t';
+            acc += std::to_string(pi.real_time.count());
+            acc += '\t';
+            acc += std::to_string(pi.cpu_time.count());
+            acc += '\n';
+        }
+        const size_t len = acc.size() < buf_cap ? acc.size() : buf_cap;
+        std::memcpy(out_buf, acc.data(), len);
+        *out_len = len;
+        return 0;
+    } catch (const std::exception& e) {
+        set_last_error(e); return 1;
+    } catch (...) {
+        set_last_error("unknown C++ exception in runtime_profiling"); return 1;
+    }
+}
+
 size_t cascadia_runtime_input_count(cascadia_runtime_t* handle) {
     return handle ? handle->input_names.size() : 0;
 }

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -8,6 +8,7 @@
 #include "gemv_offload.hpp"
 
 #include <cstring>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <new>
@@ -487,6 +488,70 @@ int32_t cascadia_runtime_compile(
 }
 
 void cascadia_runtime_destroy(cascadia_runtime_t* handle) { delete handle; }
+
+int32_t cascadia_runtime_import_blob(
+    const char* blob_path, const char* device,
+    const char* const* properties_kv, size_t properties_count,
+    cascadia_runtime_t** out_handle) {
+    if (!blob_path || !device || !out_handle) {
+        set_last_error("null arg in runtime_import_blob"); return 1;
+    }
+    try {
+        auto handle = std::make_unique<cascadia_runtime_t>();
+        auto props = collect_properties(properties_kv, properties_count);
+
+        std::ifstream f(blob_path, std::ios::binary | std::ios::ate);
+        if (!f) {
+            set_last_error(std::string("cannot open blob: ") + blob_path);
+            return 1;
+        }
+        const auto size = static_cast<size_t>(f.tellg());
+        f.seekg(0);
+        ov::Tensor blob(ov::element::u8, ov::Shape{size});
+        if (!f.read(reinterpret_cast<char*>(blob.data()),
+                    static_cast<std::streamsize>(size))) {
+            set_last_error(std::string("short read on blob: ") + blob_path);
+            return 1;
+        }
+        f.close();
+
+        auto compiled =
+            handle->core.import_model(blob, std::string(device), props);
+        handle->compiled = std::make_shared<ov::CompiledModel>(std::move(compiled));
+        handle->request = std::make_shared<ov::InferRequest>(
+            handle->compiled->create_infer_request());
+
+        for (const auto& port : handle->compiled->inputs()) {
+            std::string name;
+            try {
+                name = port.get_any_name();
+            } catch (...) {
+                const auto& names = port.get_names();
+                name = names.empty() ? std::string{} : *names.begin();
+            }
+            handle->input_aliases.push_back(join_port_names(port.get_names()));
+            handle->input_names.push_back(std::move(name));
+        }
+        for (const auto& port : handle->compiled->outputs()) {
+            std::string name;
+            try {
+                name = port.get_any_name();
+            } catch (...) {
+                const auto& names = port.get_names();
+                name = names.empty() ? std::string{} : *names.begin();
+            }
+            handle->output_aliases.push_back(join_port_names(port.get_names()));
+            handle->output_names.push_back(std::move(name));
+        }
+
+        *out_handle = handle.release();
+        return 0;
+    } catch (const std::exception& e) {
+        set_last_error(e); return 1;
+    } catch (...) {
+        set_last_error("unknown C++ exception in runtime_import_blob"); return 1;
+    }
+}
 
 int32_t cascadia_runtime_compile_gemv_offload(
     const char* model_xml_path, const char* device,

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -505,7 +505,13 @@ int32_t cascadia_runtime_import_blob(
             set_last_error((std::string("cannot open blob: ") + blob_path).c_str());
             return 1;
         }
-        const auto size = static_cast<size_t>(f.tellg());
+        const auto pos = f.tellg();
+        if (pos < 0 || pos == std::ifstream::pos_type(0)) {
+            set_last_error(
+                (std::string("cannot size blob (empty or unreadable): ") + blob_path).c_str());
+            return 1;
+        }
+        const auto size = static_cast<size_t>(pos);
         f.seekg(0);
         ov::Tensor blob(ov::element::u8, ov::Shape{size});
         if (!f.read(reinterpret_cast<char*>(blob.data()),

--- a/crates/cascadia-ov-genai-shim/cpp/shim.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.cpp
@@ -502,7 +502,7 @@ int32_t cascadia_runtime_import_blob(
 
         std::ifstream f(blob_path, std::ios::binary | std::ios::ate);
         if (!f) {
-            set_last_error(std::string("cannot open blob: ") + blob_path);
+            set_last_error((std::string("cannot open blob: ") + blob_path).c_str());
             return 1;
         }
         const auto size = static_cast<size_t>(f.tellg());
@@ -510,7 +510,7 @@ int32_t cascadia_runtime_import_blob(
         ov::Tensor blob(ov::element::u8, ov::Shape{size});
         if (!f.read(reinterpret_cast<char*>(blob.data()),
                     static_cast<std::streamsize>(size))) {
-            set_last_error(std::string("short read on blob: ") + blob_path);
+            set_last_error((std::string("short read on blob: ") + blob_path).c_str());
             return 1;
         }
         f.close();

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -164,6 +164,19 @@ int32_t cascadia_runtime_compile_gemv_offload(
     uint32_t* out_offloaded,
     cascadia_runtime_t** out_handle);
 
+/// Import a precompiled blob (produced by ov::CompiledModel::export_model,
+/// e.g. an AOT cross-compile on a big-RAM host with NPU_PLATFORM set) instead
+/// of compiling from IR. Skips the compiler entirely — the NPU compile
+/// transient (~5.5x INT4 bytes host RAM) never happens on this box; peak is
+/// ~the blob size. Same handle contract as cascadia_runtime_compile (the
+/// infer request is created eagerly, which forces device weight load).
+int32_t cascadia_runtime_import_blob(
+    const char* blob_path,
+    const char* device,
+    const char* const* properties_kv,
+    size_t properties_count,
+    cascadia_runtime_t** out_handle);
+
 /// Serialize the last inference's per-node profiling info (requires the
 /// model to have been compiled with the PERF_COUNT=YES plugin property) as
 /// TSV lines "node_name\tnode_type\texec_type\treal_us\tcpu_us\n" into

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -164,6 +164,13 @@ int32_t cascadia_runtime_compile_gemv_offload(
     uint32_t* out_offloaded,
     cascadia_runtime_t** out_handle);
 
+/// Serialize the last inference's per-node profiling info (requires the
+/// model to have been compiled with the PERF_COUNT=YES plugin property) as
+/// TSV lines "node_name\tnode_type\texec_type\treal_us\tcpu_us\n" into
+/// `out_buf` (truncating at `buf_cap`); `out_len` receives the byte count.
+int32_t cascadia_runtime_profiling(
+    cascadia_runtime_t* handle, char* out_buf, size_t buf_cap, size_t* out_len);
+
 /// Reset stateful KV-cache nodes to their initial value. No-op on
 /// stateless models.
 int32_t cascadia_runtime_reset_state(cascadia_runtime_t* handle);

--- a/crates/cascadia-ov-genai-shim/cpp/shim.h
+++ b/crates/cascadia-ov-genai-shim/cpp/shim.h
@@ -149,6 +149,21 @@ int32_t cascadia_runtime_compile(
 
 void cascadia_runtime_destroy(cascadia_runtime_t* handle);
 
+/// Compile like cascadia_runtime_compile, but first rewrite every NNCF
+/// sym-INT4 decompress→MatMul into the CascadiaInt4Gemv extension op whose
+/// weights stay backed by the read_model mmap of the original .bin — the
+/// CPU plugin never makes its own resident repacked copy. CPU-class devices
+/// only (the op executes via the evaluate() fallback). Do not pass CACHE_DIR
+/// (the custom op's member tensors don't survive blob serialization).
+/// `out_offloaded` (optional) receives the number of MatMuls rewritten.
+int32_t cascadia_runtime_compile_gemv_offload(
+    const char* model_xml_path,
+    const char* device,
+    const char* const* properties_kv,
+    size_t properties_count,
+    uint32_t* out_offloaded,
+    cascadia_runtime_t** out_handle);
+
 /// Reset stateful KV-cache nodes to their initial value. No-op on
 /// stateless models.
 int32_t cascadia_runtime_reset_state(cascadia_runtime_t* handle);

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -166,6 +166,14 @@ mod sys {
             out_handle: *mut *mut cascadia_runtime_t,
         ) -> c_int;
 
+        pub fn cascadia_runtime_import_blob(
+            blob_path: *const c_char,
+            device: *const c_char,
+            properties_kv: *const *const c_char,
+            properties_count: usize,
+            out_handle: *mut *mut cascadia_runtime_t,
+        ) -> c_int;
+
         pub fn cascadia_runtime_destroy(handle: *mut cascadia_runtime_t);
         pub fn cascadia_runtime_reset_state(handle: *mut cascadia_runtime_t) -> c_int;
         pub fn cascadia_runtime_profiling(
@@ -638,6 +646,46 @@ impl Runtime {
         let mut handle: *mut sys::cascadia_runtime_t = ptr::null_mut();
         let rc = unsafe {
             sys::cascadia_runtime_compile(
+                path_c.as_ptr(),
+                device_c.as_ptr(),
+                ptrs.as_ptr(),
+                plugin.entries.len(),
+                &mut handle,
+            )
+        };
+        if rc != 0 {
+            return Err(Error::Native(last_native_error()));
+        }
+        Ok(Self { handle })
+    }
+
+    /// Import a precompiled blob (from `ov::CompiledModel::export_model`,
+    /// e.g. an AOT cross-compile on a big-RAM host with `NPU_PLATFORM` set)
+    /// instead of compiling from IR — the compiler (and its ~5.5x-INT4-bytes
+    /// host-RAM transient) never runs on this box.
+    pub fn import_blob(blob_path: &str, device: &str, plugin: &PluginConfig) -> Result<Self> {
+        Self::do_import_blob(blob_path, device, plugin)
+    }
+
+    #[cfg(not(feature = "openvino"))]
+    fn do_import_blob(_path: &str, _device: &str, _plugin: &PluginConfig) -> Result<Self> {
+        Err(Error::Stub)
+    }
+
+    #[cfg(feature = "openvino")]
+    fn do_import_blob(blob_path: &str, device: &str, plugin: &PluginConfig) -> Result<Self> {
+        let path_c = cstr(blob_path)?;
+        let device_c = cstr(device)?;
+        let mut owned: Vec<CString> = Vec::with_capacity(plugin.entries.len() * 2);
+        for (k, v) in &plugin.entries {
+            owned.push(cstr(k)?);
+            owned.push(cstr(v)?);
+        }
+        let ptrs: Vec<*const c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+
+        let mut handle: *mut sys::cascadia_runtime_t = ptr::null_mut();
+        let rc = unsafe {
+            sys::cascadia_runtime_import_blob(
                 path_c.as_ptr(),
                 device_c.as_ptr(),
                 ptrs.as_ptr(),

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -776,8 +776,16 @@ impl Runtime {
             if rc != 0 {
                 return Err(Error::Native(last_native_error()));
             }
+            // The shim truncates at buf_cap, possibly mid-line or mid-UTF-8:
+            // decode lossily and flag the cut instead of erroring out or
+            // silently dropping tail nodes from the attribution.
+            let truncated = len >= buf.len();
             buf.truncate(len);
-            String::from_utf8(buf).map_err(|e| Error::Utf8(e.to_string()))
+            let mut s = String::from_utf8_lossy(&buf).into_owned();
+            if truncated {
+                s.push_str("\n[PROFILING OUTPUT TRUNCATED AT 1 MiB BUFFER CAP]\n");
+            }
+            Ok(s)
         }
     }
 

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -157,6 +157,15 @@ mod sys {
             out_handle: *mut *mut cascadia_runtime_t,
         ) -> c_int;
 
+        pub fn cascadia_runtime_compile_gemv_offload(
+            model_xml_path: *const c_char,
+            device: *const c_char,
+            properties_kv: *const *const c_char,
+            properties_count: usize,
+            out_offloaded: *mut u32,
+            out_handle: *mut *mut cascadia_runtime_t,
+        ) -> c_int;
+
         pub fn cascadia_runtime_destroy(handle: *mut cascadia_runtime_t);
         pub fn cascadia_runtime_reset_state(handle: *mut cascadia_runtime_t) -> c_int;
 
@@ -634,6 +643,62 @@ impl Runtime {
             return Err(Error::Native(last_native_error()));
         }
         Ok(Self { handle })
+    }
+
+    /// Compile with the CascadiaInt4Gemv offload pass: NNCF sym-INT4
+    /// decompress→MatMul chains execute from the read_model mmap through the
+    /// extension op instead of a plugin-repacked resident weight copy.
+    /// Returns the runtime plus the number of MatMuls offloaded. CPU-class
+    /// devices only (the op runs via the evaluate() fallback); do not pass
+    /// CACHE_DIR (op member tensors don't survive blob serialization).
+    pub fn compile_gemv_offload(
+        model_xml_path: &str,
+        device: &str,
+        plugin: &PluginConfig,
+    ) -> Result<(Self, u32)> {
+        Self::do_compile_gemv_offload(model_xml_path, device, plugin)
+    }
+
+    #[cfg(not(feature = "openvino"))]
+    fn do_compile_gemv_offload(
+        _path: &str,
+        _device: &str,
+        _plugin: &PluginConfig,
+    ) -> Result<(Self, u32)> {
+        Err(Error::Stub)
+    }
+
+    #[cfg(feature = "openvino")]
+    fn do_compile_gemv_offload(
+        model_xml_path: &str,
+        device: &str,
+        plugin: &PluginConfig,
+    ) -> Result<(Self, u32)> {
+        let path_c = cstr(model_xml_path)?;
+        let device_c = cstr(device)?;
+        let mut owned: Vec<CString> = Vec::with_capacity(plugin.entries.len() * 2);
+        for (k, v) in &plugin.entries {
+            owned.push(cstr(k)?);
+            owned.push(cstr(v)?);
+        }
+        let ptrs: Vec<*const c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+
+        let mut handle: *mut sys::cascadia_runtime_t = ptr::null_mut();
+        let mut offloaded: u32 = 0;
+        let rc = unsafe {
+            sys::cascadia_runtime_compile_gemv_offload(
+                path_c.as_ptr(),
+                device_c.as_ptr(),
+                ptrs.as_ptr(),
+                plugin.entries.len(),
+                &mut offloaded,
+                &mut handle,
+            )
+        };
+        if rc != 0 {
+            return Err(Error::Native(last_native_error()));
+        }
+        Ok((Self { handle }, offloaded))
     }
 
     pub fn reset_state(&mut self) -> Result<()> {

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -168,6 +168,12 @@ mod sys {
 
         pub fn cascadia_runtime_destroy(handle: *mut cascadia_runtime_t);
         pub fn cascadia_runtime_reset_state(handle: *mut cascadia_runtime_t) -> c_int;
+        pub fn cascadia_runtime_profiling(
+            handle: *mut cascadia_runtime_t,
+            out_buf: *mut c_char,
+            buf_cap: usize,
+            out_len: *mut usize,
+        ) -> c_int;
 
         pub fn cascadia_runtime_input_count(handle: *mut cascadia_runtime_t) -> usize;
         pub fn cascadia_runtime_output_count(handle: *mut cascadia_runtime_t) -> usize;
@@ -699,6 +705,32 @@ impl Runtime {
             return Err(Error::Native(last_native_error()));
         }
         Ok((Self { handle }, offloaded))
+    }
+
+    /// Per-node profiling of the last inference as TSV lines
+    /// `node_name\tnode_type\texec_type\treal_us\tcpu_us` — requires the
+    /// model compiled with the `PERF_COUNT=YES` plugin property.
+    pub fn profiling(&self) -> Result<String> {
+        #[cfg(not(feature = "openvino"))]
+        return Err(Error::Stub);
+        #[cfg(feature = "openvino")]
+        {
+            let mut buf = vec![0u8; 1 << 20];
+            let mut len: usize = 0;
+            let rc = unsafe {
+                sys::cascadia_runtime_profiling(
+                    self.handle,
+                    buf.as_mut_ptr() as *mut c_char,
+                    buf.len(),
+                    &mut len,
+                )
+            };
+            if rc != 0 {
+                return Err(Error::Native(last_native_error()));
+            }
+            buf.truncate(len);
+            String::from_utf8(buf).map_err(|e| Error::Utf8(e.to_string()))
+        }
     }
 
     pub fn reset_state(&mut self) -> Result<()> {

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -173,12 +173,40 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
     header[16..20].copy_from_slice(&tensor.shape[2].to_be_bytes());
 
     sock.write_all(&header).await?;
-    sock.write_all(&tensor.data).await?;
+    // Large single bursts (~750 KB hidden frames at 70B scale) were observed
+    // to intermittently vanish inside DERP-relayed tailscale paths while the
+    // 20-byte header and ≤500 KB frames always arrived (2026-07-19 fleet
+    // debugging, hop-by-hop traced). Pace big payloads into bounded bursts
+    // with explicit flushes; harmless on healthy paths (same total bytes,
+    // one extra flush per 256 KB). Opt out with CASCADIA_SEND_BURST_BYTES=0.
+    let burst = send_burst_bytes();
+    if burst == 0 || tensor.data.len() <= burst {
+        sock.write_all(&tensor.data).await?;
+    } else {
+        for part in tensor.data.chunks(burst) {
+            sock.write_all(part).await?;
+            sock.flush().await?;
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
     sock.flush().await?;
 
     Ok(TransferStats {
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
         bytes: HEADER_SIZE + tensor.data.len(),
+    })
+}
+
+/// Payload burst size for paced sends (bytes). Env-tunable; default 256 KB;
+/// 0 disables pacing entirely.
+fn send_burst_bytes() -> usize {
+    use std::sync::OnceLock;
+    static V: OnceLock<usize> = OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("CASCADIA_SEND_BURST_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(256 * 1024)
     })
 }
 

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -197,8 +197,9 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
     })
 }
 
-/// Payload burst size for paced sends (bytes). Env-tunable; default 256 KB;
-/// 0 disables pacing entirely.
+/// Payload burst size for paced sends (bytes). Env-tunable via
+/// CASCADIA_SEND_BURST_BYTES; default 0 = pacing OFF (it did not resolve the
+/// observed DERP frame loss — kept as an experiment knob).
 fn send_burst_bytes() -> usize {
     use std::sync::OnceLock;
     static V: OnceLock<usize> = OnceLock::new();
@@ -206,7 +207,7 @@ fn send_burst_bytes() -> usize {
         std::env::var("CASCADIA_SEND_BURST_BYTES")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(256 * 1024)
+            .unwrap_or(0)
     })
 }
 

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -213,19 +213,30 @@ fn send_burst_bytes() -> usize {
     *V.get_or_init(|| parse_send_burst(std::env::var("CASCADIA_SEND_BURST_BYTES").ok().as_deref()))
 }
 
-/// Parse the CASCADIA_SEND_BURST_BYTES knob. Unset or `0` → pacing OFF; any
-/// other value is clamped up to 64 KiB (so a 256 MiB frame can't turn into
-/// millions of 2 ms sleeps and blow the receiver's whole-frame deadline). A
-/// set-but-unparseable value (`256k`, a trailing space, …) is warned about and
-/// treated as OFF — otherwise the operator fat-fingering the one knob they
-/// reach for *while chasing an intermittent wedge* gets silence, and "off
-/// because default" is indistinguishable from "off because I mistyped it".
+/// Parse the CASCADIA_SEND_BURST_BYTES knob. Unset or `0` → pacing OFF; a value
+/// below the 64 KiB floor is clamped UP to 64 KiB (so a 256 MiB frame can't turn
+/// into millions of 2 ms sleeps and blow the receiver's whole-frame deadline);
+/// anything at/above the floor is used verbatim. Both a set-but-unparseable
+/// value (`256k`, a trailing space, …) AND a silently-clamped small value are
+/// warned about — otherwise the operator fat-fingering the one knob they reach
+/// for *while chasing an intermittent wedge* gets silence: "off because default"
+/// vs "off because I mistyped it", or "I set 4 KiB" vs "it actually ran 64 KiB".
 fn parse_send_burst(raw: Option<&str>) -> usize {
+    const FLOOR: usize = 64 * 1024;
     match raw {
         None => 0,
         Some(s) => match s.parse::<usize>() {
             Ok(0) => 0,
-            Ok(v) => v.max(64 * 1024),
+            Ok(v) if v < FLOOR => {
+                tracing::warn!(
+                    value = v,
+                    floor = FLOOR,
+                    "CASCADIA_SEND_BURST_BYTES is below the 64 KiB floor; clamped \
+                     up to 65536 (a sub-64 KiB burst wasn't actually tested)"
+                );
+                FLOOR
+            }
+            Ok(v) => v,
             Err(_) => {
                 tracing::warn!(
                     value = %s,

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -183,10 +183,17 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
     if burst == 0 || tensor.data.len() <= burst {
         sock.write_all(&tensor.data).await?;
     } else {
-        for part in tensor.data.chunks(burst) {
+        // No sleep after the FINAL part, and the receiver's whole-frame
+        // recv deadline still applies: total pacing delay must stay far
+        // below recv_timeout (burst is clamped >= 64 KiB so a 256 MiB
+        // frame adds at most ~8 s of sleeps).
+        let mut parts = tensor.data.chunks(burst).peekable();
+        while let Some(part) = parts.next() {
             sock.write_all(part).await?;
             sock.flush().await?;
-            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            if parts.peek().is_some() {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
         }
     }
     sock.flush().await?;
@@ -207,6 +214,7 @@ fn send_burst_bytes() -> usize {
         std::env::var("CASCADIA_SEND_BURST_BYTES")
             .ok()
             .and_then(|s| s.parse().ok())
+            .map(|v: usize| if v == 0 { 0 } else { v.max(64 * 1024) })
             .unwrap_or(0)
     })
 }

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -210,13 +210,32 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
 fn send_burst_bytes() -> usize {
     use std::sync::OnceLock;
     static V: OnceLock<usize> = OnceLock::new();
-    *V.get_or_init(|| {
-        std::env::var("CASCADIA_SEND_BURST_BYTES")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .map(|v: usize| if v == 0 { 0 } else { v.max(64 * 1024) })
-            .unwrap_or(0)
-    })
+    *V.get_or_init(|| parse_send_burst(std::env::var("CASCADIA_SEND_BURST_BYTES").ok().as_deref()))
+}
+
+/// Parse the CASCADIA_SEND_BURST_BYTES knob. Unset or `0` → pacing OFF; any
+/// other value is clamped up to 64 KiB (so a 256 MiB frame can't turn into
+/// millions of 2 ms sleeps and blow the receiver's whole-frame deadline). A
+/// set-but-unparseable value (`256k`, a trailing space, …) is warned about and
+/// treated as OFF — otherwise the operator fat-fingering the one knob they
+/// reach for *while chasing an intermittent wedge* gets silence, and "off
+/// because default" is indistinguishable from "off because I mistyped it".
+fn parse_send_burst(raw: Option<&str>) -> usize {
+    match raw {
+        None => 0,
+        Some(s) => match s.parse::<usize>() {
+            Ok(0) => 0,
+            Ok(v) => v.max(64 * 1024),
+            Err(_) => {
+                tracing::warn!(
+                    value = %s,
+                    "CASCADIA_SEND_BURST_BYTES is not a byte count (e.g. 262144); \
+                     send pacing stays OFF"
+                );
+                0
+            }
+        },
+    }
 }
 
 /// Receive a tensor from a connected stream.
@@ -856,6 +875,17 @@ impl ActivationClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_send_burst_clamp_table() {
+        assert_eq!(parse_send_burst(None), 0); // unset -> off
+        assert_eq!(parse_send_burst(Some("0")), 0); // explicit off
+        assert_eq!(parse_send_burst(Some("1000")), 64 * 1024); // clamped up to 64 KiB
+        assert_eq!(parse_send_burst(Some("65536")), 65536); // at the floor
+        assert_eq!(parse_send_burst(Some("1048576")), 1048576); // above the floor, verbatim
+        assert_eq!(parse_send_burst(Some("256k")), 0); // unparseable -> off (warned)
+        assert_eq!(parse_send_burst(Some("262144 ")), 0); // trailing space -> off (warned)
+    }
 
     #[test]
     fn recv_timeout_precedence_config_over_env_over_default() {

--- a/docs/perf/NPU_TTFT_TIERS.md
+++ b/docs/perf/NPU_TTFT_TIERS.md
@@ -40,17 +40,23 @@ it cost in memory and deployment complexity?
 | 70B 6-box pipeline | health ✓, requests blocked¹ | — | — |
 
 ¹ 70B: all six ranks load from cross-compiled blobs and reach full pipeline
-health in every configuration (≈53 GB of NPU blobs resident across the
-fleet, ~11–16 GB free per box). Request execution is blocked at stage-0 on
-the rank-0 box by isolated causes: (a) both stage-0 blobs resident = 19.4 GB
-L0 → execute-time `ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY`; (b) single-blob +
-`--no-chunked-prefill` = tokenwise stage-0 prefill starves downstream links
-past the transport's 60 s data-frame timeout; (c) stage-0 on iGPU from bins
-= first inference exceeded the 600 s relay timeout (unresolved; suspect
-first-infer UMA behavior with 2×6.9 GB freshly-compiled GPU models — next
-investigation lead). Fix candidates: park-style sequential phase residency
-for pipeline stages, a keep-alive/progress frame in the transport, or a
-64 GB-class rank-0 box.
+health in every configuration (≈53 GB of NPU blobs fleet-wide). Two
+memory-envelope blockers were fixed en route (dual-blob 19.4 GB L0
+execute-OOM on stage-0; tokenwise-fallback transport starvation — timeout
+is env-tunable via `CASCADIA_ACTIVATION_TIMEOUT_SECS`). The remaining
+blocker, hop-by-hop traced with debug builds on ranks 0/1: **inter-stage
+hidden-state frames (~750 KB at hidden=8192) intermittently black-hole on
+DERP-relayed tailscale links** — the 32-byte position frame arrives, the
+hidden frame following it never does, on a varying link per run (0→1 in
+early runs; 1→2 after). Ruled out empirically: the stage graphs (0.2 s
+infers in isolation AND via in-pipeline warmups), every rank-0 device
+config, disk pressure (pawan-01 had silently hit 0 bytes free — fixed),
+stale tailscale sessions (restarting all daemons changed nothing), and
+send-side burst pacing (`CASCADIA_SEND_BURST_BYTES` knob, no effect).
+The 32B pipeline (~470 KB frames, 3 hops, same boxes/links) re-validated
+clean the same day. Next steps: packet capture on a black-holed link,
+direct WireGuard (needs Tiber UDP), or per-frame ack/segmentation in the
+transport protocol.
 
 14B speedups: chunked-GPU is **15× short / 41× long** vs the tokenwise
 static-graph baseline on the same device.

--- a/docs/perf/NPU_TTFT_TIERS.md
+++ b/docs/perf/NPU_TTFT_TIERS.md
@@ -1,0 +1,114 @@
+# NPU TTFT at scale: the 1B→70B tier benchmarks
+
+**Status:** tiers 1B/3B/8B/14B measured; 32B (3-box) and 70B (6-box) pipeline
+tiers in flight — this doc snapshots method + results so far and will be
+finalized with the fleet numbers. Companion to
+docs/perf/HYBRID_NPU_CPU.md (the device × model-size matrix and the
+big-model NPU routes live there).
+
+## The question
+
+Can devices with NPUs give people faster TTFT in real workflows as models
+grow — through 14B on one box and 70B-class on a small fleet — and what does
+it cost in memory and deployment complexity?
+
+## Method
+
+- Models: Llama-3.2-1B/3B, Llama-3.1-8B, Qwen2.5-14B, Qwen2.5-32B (3-stage),
+  Llama-3.3-70B (6-stage); all NNCF sym-INT4 static exports
+  (`--target npu --static-context 1024 --static-prefill-seq 64`).
+- Every NPU model is **AOT cross-compiled on a big-RAM Linux server**
+  (OpenVINO pip wheel + Intel's standalone `intel-driver-compiler-npu`
+  library, `NPU_PLATFORM=4000`) and shipped as an `export_model` blob; boxes
+  import via the engine's `.blob` sibling path — **no compiler and no
+  compile transient ever runs on a 32 GB box**.
+- Fleet boxes run a ~900 MB flat runtime dir (SDK DLLs + `cascadia.exe`,
+  no install); TTFT measured short (~31-token) / long (~435-token) prompts,
+  greedy, request 2+ of a warm process where noted.
+
+## Results so far (Lunar Lake 258V boxes, 32 GB)
+
+| Model / config | TTFT short | TTFT long | decode tok/s |
+|---|---|---|---|
+| 1B hybrid NPU→CPU (steady) | **129 ms** | **644 ms** | 18–19 |
+| 3B hybrid NPU→CPU (steady) | **321 ms** | **1.58 s** | 6.6–6.8 |
+| 8B 2-stage PP all-NPU (1 box, warm e2e incl. 24-tok decode) | 2.0 s | 7.9 s | — |
+| 14B tokenwise CPU | 14.0 s | 166.7 s | 2.2–2.7 |
+| 14B tokenwise GPU | 9.1 s | 114.4 s | 3.4–3.8 |
+| **14B chunked GPU** | **603 ms** | **2.79 s** | 3.4–3.5 |
+| 14B tokenwise NPU (from AOT blob) | 9.0 s | 125.0 s | 3.5 |
+| 32B 3-box all-NPU pipeline | pending | pending | — |
+| 70B 6-box all-NPU pipeline | pending | pending | — |
+
+14B speedups: chunked-GPU is **15× short / 41× long** vs the tokenwise
+static-graph baseline on the same device.
+
+## The 14B memory-envelope finding
+
+On a 32 GB box, ONE 14B model fits any single device; TWO do not (except on
+the iGPU):
+
+- NPU-resident models cost ≈ **blob bytes = 1.4× INT4** in Level-Zero
+  allocations → a 14B pair ≈ 21 GB L0 → first inference dies with
+  `ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY`.
+- CPU pairs OOM during the second plugin compile (silent `bad_alloc` abort).
+- iGPU pairs fit (UMA copies stay ≈ 1× INT4): all-GPU chunked is the 14B
+  single-box config. The NPU is the cheapest device to compile FOR (AOT)
+  and the most expensive to keep models RESIDENT on.
+
+So the single-box ladder is: ≤8B every config; 14B single-model or iGPU
+pairs; beyond that, shard across boxes (or 64 GB-class machines).
+
+## Attribution: is the 41× documented elsewhere?
+
+The *mechanism* is prior art; the *measurement direction* is not:
+
+- Sarathi (arXiv 2308.16369, OSDI'24) coined "chunked prefill" and states
+  the weight-fetch-amortization analysis explicitly — but in datacenter
+  serving the baseline is whole-prompt prefill that already saturates the
+  GPU, so chunking is a scheduling TAX there (their chunk-64 measured ~5×
+  slower prefill; vLLM docs likewise warn smaller chunks worsen TTFT).
+- Client NPUs ship fixed-chunk static prefill as standard practice with no
+  published multipliers: OpenVINO NPUW `NPUW_LLM_PREFILL_CHUNK_SIZE`,
+  Qualcomm's 128-token "prompt processor" graphs, AMD's
+  `hybrid_opt_chunk_context`, llm.npu's 256-token chunks (its 22.4×/43.6×
+  is vs other engines, not vs tokenwise).
+- The seq=1 static-graph baseline is real shipping practice (NITRO,
+  arXiv 2412.11053, on Intel NPUs), not a strawman — but no one publishes
+  "chunked vs token-at-a-time on an integrated GPU". Independent
+  corroboration: llama.cpp community tables on this exact iGPU (Arc 140V)
+  show a ~22–39× implicit gap between batched prompt processing and
+  one-token-at-a-time throughput — our 15–41× approaches that physics
+  ceiling. Closest cousins: Apple's Core ML Llama write-up (~85× fixing the
+  inverse pad-to-max static pathology) and SqueezeBits' ANE-prefill +
+  GPU-decode disaggregation on Apple silicon (same phase-split shape).
+
+## Fleet deployment learnings (all bitten, all fixed)
+
+1. **Transfers need end-to-end integrity, not size checks**: a truncated
+   blob fails as `Blob is missing NPU metadata!` (metadata trailer lives at
+   the file end); a bit-corrupted one can crash the NPU
+   (`ZE_RESULT_ERROR_DEVICE_LOST`). Chunk large files (512 MB parts),
+   retry per part with SSH keep-alives (a stalled stream without
+   ServerAlive* hung 15 h), reassemble, then **sha256-compare** — see
+   experiments/fleet-bench/xfer_blob.sh.
+2. **Windows workers must be started detached via WMI**
+   (`Invoke-CimMethod Win32_Process Create`): processes spawned through a
+   transient ssh session die with the session.
+3. **Inline multi-line PowerShell over ssh is unreliable** (silently
+   produces nothing); ship `.ps1` files and invoke with `-File`.
+4. **Cross-compiled blobs are driver-sensitive per graph**: the same VCL
+   (1.32.1) produced blobs that execute (8B, 14B) and one that reproducibly
+   kills the device (32B stage-0) on a healthy NPU. Validate every blob
+   with one real inference at deploy time; keep the compiler and driver
+   generations pinned together.
+5. Tailscale DERP relays are fine for pipeline hops (16 ms box↔box) but
+   slow for bulk (~1–5 MB/s/stream); parallel part-streams aggregate.
+
+## Reproduction
+
+Scripts under experiments/fleet-bench/; the parity/bench harness is
+`tests/static_prefill_parity.rs` (env knobs in its docstring); single-box
+and pipeline runners are the `run_*.ps1` files. Blob production:
+`export_blobs.py` pattern — `core.compile_model(xml, "NPU",
+{"NPU_PLATFORM": "4000"})` then `export_model` into an `io.BytesIO`.

--- a/docs/perf/NPU_TTFT_TIERS.md
+++ b/docs/perf/NPU_TTFT_TIERS.md
@@ -1,10 +1,9 @@
 # NPU TTFT at scale: the 1B→70B tier benchmarks
 
-**Status:** tiers 1B/3B/8B/14B measured; 32B (3-box) and 70B (6-box) pipeline
-tiers in flight — this doc snapshots method + results so far and will be
-finalized with the fleet numbers. Companion to
-docs/perf/HYBRID_NPU_CPU.md (the device × model-size matrix and the
-big-model NPU routes live there).
+**Status:** tiers 1B/3B/8B/14B/32B measured end-to-end; 70B validated to
+full six-box pipeline health with request execution blocked by two isolated,
+documented constraints (below). Companion to docs/perf/HYBRID_NPU_CPU.md
+(the device × model-size matrix and the big-model NPU routes live there).
 
 ## The question
 
@@ -37,8 +36,21 @@ it cost in memory and deployment complexity?
 | 14B tokenwise GPU | 9.1 s | 114.4 s | 3.4–3.8 |
 | **14B chunked GPU** | **603 ms** | **2.79 s** | 3.4–3.5 |
 | 14B tokenwise NPU (from AOT blob) | 9.0 s | 125.0 s | 3.5 |
-| 32B 3-box all-NPU pipeline | pending | pending | — |
-| 70B 6-box all-NPU pipeline | pending | pending | — |
+| **32B 3-box pipeline** (iGPU stage-0 + 2 NPU stages, warm e2e w/ 24-tok decode) | **6.0 s** | **27.4–27.8 s** | correct + stable |
+| 70B 6-box pipeline | health ✓, requests blocked¹ | — | — |
+
+¹ 70B: all six ranks load from cross-compiled blobs and reach full pipeline
+health in every configuration (≈53 GB of NPU blobs resident across the
+fleet, ~11–16 GB free per box). Request execution is blocked at stage-0 on
+the rank-0 box by isolated causes: (a) both stage-0 blobs resident = 19.4 GB
+L0 → execute-time `ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY`; (b) single-blob +
+`--no-chunked-prefill` = tokenwise stage-0 prefill starves downstream links
+past the transport's 60 s data-frame timeout; (c) stage-0 on iGPU from bins
+= first inference exceeded the 600 s relay timeout (unresolved; suspect
+first-infer UMA behavior with 2×6.9 GB freshly-compiled GPU models — next
+investigation lead). Fix candidates: park-style sequential phase residency
+for pipeline stages, a keep-alive/progress frame in the transport, or a
+64 GB-class rank-0 box.
 
 14B speedups: chunked-GPU is **15× short / 41× long** vs the tokenwise
 static-graph baseline on the same device.
@@ -104,6 +116,17 @@ The *mechanism* is prior art; the *measurement direction* is not:
    generations pinned together.
 5. Tailscale DERP relays are fine for pipeline hops (16 ms box↔box) but
    slow for bulk (~1–5 MB/s/stream); parallel part-streams aggregate.
+6. **A pipeline stage that prefills tokenwise starves its downstream links**:
+   the transport's data-frame recv timeout (60 s) fires while a big stage
+   grinds seq=1 steps, collapsing the pipeline. Graceful degradation
+   (`--no-chunked-prefill`, missing prefill variants) is therefore only safe
+   for stages small/fast enough to emit within the timeout — or the
+   transport needs progress keep-alives (follow-up).
+7. **Mixed Windows shell defaults make inline ssh commands non-portable**
+   (cmd vs PowerShell hosts parse quoting differently; `-File` arg parsing
+   treats single quotes as literal). The only robust remote-orchestration
+   pattern found: ship per-host `.ps1` files with values baked in, invoke
+   argument-free, verify the process actually exists afterward.
 
 ## Reproduction
 

--- a/docs/rfcs/openvino-inplace-int4-gemv.md
+++ b/docs/rfcs/openvino-inplace-int4-gemv.md
@@ -77,6 +77,19 @@ steady state for this IR (steady private 0.11 GB; the big private cost is a
 2. eliminate the compile-time private peak for these constants,
 rather than proposing a wholly new no-repack mode.
 
+## Upstream-gap evidence (2026-07-15, second spike round)
+
+Embedding upstream oneDNN 3.12 inside our extension op (matmul with s4
+weights + grouped f16 decompression scales, `fpmath_mode(f16,
+apply_to_int)`) produced numerically correct output but selected `ref:any`
+even with `format_tag::any` — **upstream oneDNN has no optimized kernel for
+this shape at all**. The ~51 GB/s `FullyConnectedCompressed` path measured
+in the CPU plugin therefore lives in the openvinotoolkit/oneDNN fork /
+OV-internal kernels only. This sharpens the ask: the capability exists and
+is Intel-maintained; exposing it (as a documented plugin behavior or via
+upstreaming the kernels) is the only way third parties can reach it without
+forking.
+
 ## Open questions
 
 1. Does oneDNN's `weights_decompression` brgemm path accept an external

--- a/docs/rfcs/openvino-inplace-int4-gemv.md
+++ b/docs/rfcs/openvino-inplace-int4-gemv.md
@@ -62,6 +62,21 @@ OS page cache of the shared .bin).
 - Weightless blobs / mmap: shares the *source* pages (already the case) but
   not the resident execution copies.
 
+## Spike evidence (2026-07-15, revises the ask)
+
+A working prototype now exists on cascadia's side (`CascadiaInt4Gemv`
+extension op, experiments/gemv-offload-spike/NOTES.md): 113/113 sym-INT4
+MatMuls rewritten, token-parity vs the stock kernel, ~70% of stock decode
+throughput after one AVX2 pass. Its residency probe found the 2026.1 CPU
+executor ALREADY keeps these decompress-subgraph weights mmap-backed at
+steady state for this IR (steady private 0.11 GB; the big private cost is a
+~1 GB compile-time transient). The RFC's ask therefore narrows to:
+1. make the mmap-backed execution of grouped-INT4 decompress weights a
+   DOCUMENTED CONTRACT (per-version/arch behavior today, observed not
+   promised), and
+2. eliminate the compile-time private peak for these constants,
+rather than proposing a wholly new no-repack mode.
+
 ## Open questions
 
 1. Does oneDNN's `weights_decompression` brgemm path accept an external

--- a/experiments/fleet-bench/bench_requests.ps1
+++ b/experiments/fleet-bench/bench_requests.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$Tag = "m",
+    [int]$ApiPort = 8099,
+    [int]$MaxTokens = 24,
+    [int]$HealthTries = 480
+)
+$ErrorActionPreference = "Continue"
+$ok = $false
+for ($i = 0; $i -lt $HealthTries; $i++) {
+    Start-Sleep -Seconds 5
+    try { Invoke-RestMethod -Uri ("http://127.0.0.1:" + $ApiPort + "/health") -TimeoutSec 2 | Out-Null; $ok = $true; break } catch {}
+}
+if (-not $ok) { Write-Output "HEALTH-TIMEOUT"; exit 1 }
+$os = Get-CimInstance Win32_OperatingSystem
+Write-Output ("HEALTH-OK free-GB=" + [math]::Round($os.FreePhysicalMemory/1MB,1))
+$para = "The quick brown fox jumps over the lazy dog near the quiet river bank at dawn. "
+$lp = ($para * 25) + "Now explain how rainbows form."
+$sb = '{"model":"' + $Tag + '","messages":[{"role":"user","content":"In one sentence, what is the capital of France?"}],"max_tokens":' + $MaxTokens + ',"temperature":0}'
+$lb = '{"model":"' + $Tag + '","messages":[{"role":"user","content":"' + $lp + '"}],"max_tokens":' + $MaxTokens + ',"temperature":0}'
+$uri = "http://127.0.0.1:" + $ApiPort + "/v1/chat/completions"
+foreach ($n in 1..2) {
+    $t = Measure-Command { $script:r = Invoke-RestMethod -Uri $uri -Method Post -Body $sb -ContentType "application/json" -TimeoutSec 3600 }
+    Write-Output ("SHORT-REQ${n}: " + [math]::Round($t.TotalSeconds,2) + "s -> " + ($script:r.choices[0].message.content -replace "`n"," "))
+}
+foreach ($n in 1..2) {
+    $t = Measure-Command { $script:r = Invoke-RestMethod -Uri $uri -Method Post -Body $lb -ContentType "application/json" -TimeoutSec 3600 }
+    Write-Output ("LONG-REQ${n}: " + [math]::Round($t.TotalSeconds,2) + "s -> " + ($script:r.choices[0].message.content -replace "`n"," "))
+}
+$os = Get-CimInstance Win32_OperatingSystem
+Write-Output ("free-loaded-GB=" + [math]::Round($os.FreePhysicalMemory/1MB,1))

--- a/experiments/fleet-bench/run_1stage_bench.ps1
+++ b/experiments/fleet-bench/run_1stage_bench.ps1
@@ -1,0 +1,45 @@
+param(
+    [string]$Model = "C:\cascadia\models\hybrid-test\q25-14b-1stage",
+    [string]$Device = "CPU",
+    [string]$PrefillDevice = "NPU",
+    [int]$MaxTokens = 24
+)
+$ErrorActionPreference = "Stop"
+$sdk = "C:\cascadia\ovgenai\openvino_genai_windows_2026.1.0.0_x86_64"
+$env:PATH = "$sdk\runtime\bin\intel64\Release;$sdk\runtime\3rdparty\tbb\bin;C:\cascadia\dnnl\bin;" + $env:PATH
+$bin = "C:\cascadia\oss-hybrid\target\release\cascadia.exe"
+function FreeGB { [math]::Round((Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory/1MB,1) }
+Write-Output ("free-start-GB=" + (FreeGB))
+$args0 = @("worker","--rank","0","--total","1","--engine","ov-runtime","--model",$Model,"--device",$Device,"--api",":8098","--log-level","info")
+if ($PrefillDevice -ne "") { $args0 += @("--prefill-device",$PrefillDevice) }
+$p0 = $null
+try {
+    $p0 = Start-Process -FilePath $bin -ArgumentList $args0 -RedirectStandardError C:\cascadia\one_r0.err -RedirectStandardOutput C:\cascadia\one_r0.out -PassThru -NoNewWindow
+    $ok = $false
+    for ($i = 0; $i -lt 240; $i++) {
+        Start-Sleep -Seconds 5
+        if ($p0.HasExited) { throw "worker exited early" }
+        try { Invoke-RestMethod -Uri http://127.0.0.1:8098/health -TimeoutSec 2 | Out-Null; $ok = $true; break } catch {}
+    }
+    if (-not $ok) { throw "health never came up" }
+    Write-Output ("HEALTH-OK free-GB=" + (FreeGB))
+    $para = "The quick brown fox jumps over the lazy dog near the quiet river bank at dawn. "
+    $lp = ($para * 25) + "Now explain how rainbows form."
+    $sb = '{"model":"m","messages":[{"role":"user","content":"In one sentence, what is the capital of France?"}],"max_tokens":' + $MaxTokens + ',"temperature":0}'
+    $lb = '{"model":"m","messages":[{"role":"user","content":"' + $lp + '"}],"max_tokens":' + $MaxTokens + ',"temperature":0}'
+    foreach ($n in 1..2) {
+        $t = Measure-Command { $script:r = Invoke-RestMethod -Uri http://127.0.0.1:8098/v1/chat/completions -Method Post -Body $sb -ContentType "application/json" -TimeoutSec 1800 }
+        Write-Output ("SHORT-REQ${n}: " + [math]::Round($t.TotalSeconds,2) + "s -> " + ($script:r.choices[0].message.content -replace "`n"," "))
+    }
+    foreach ($n in 1..2) {
+        $t = Measure-Command { $script:r = Invoke-RestMethod -Uri http://127.0.0.1:8098/v1/chat/completions -Method Post -Body $lb -ContentType "application/json" -TimeoutSec 1800 }
+        Write-Output ("LONG-REQ${n}: " + [math]::Round($t.TotalSeconds,2) + "s -> " + ($script:r.choices[0].message.content -replace "`n"," "))
+    }
+    Write-Output ("free-loaded-GB=" + (FreeGB))
+} finally {
+    if ($p0 -and -not $p0.HasExited) { Stop-Process -Id $p0.Id -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Seconds 2
+    Write-Output ("free-end-GB=" + (FreeGB))
+}
+Write-Output "---- worker log tail ----"
+Select-String -Path C:\cascadia\one_r0.err -Pattern "prefill|task done|importing" -ErrorAction SilentlyContinue | Select-Object -Last 6 | ForEach-Object { $_.Line }

--- a/experiments/fleet-bench/run_2stage_8b.ps1
+++ b/experiments/fleet-bench/run_2stage_8b.ps1
@@ -1,0 +1,74 @@
+param(
+    [string]$Model = "C:\cascadia\models\hybrid-test\l31-8b-2stage",
+    [string]$Device = "NPU",
+    [string]$PrefillDevice = "",
+    [string]$CacheDir = "C:\cascadia\ovcache8b2",
+    [int]$MaxTokens = 24
+)
+$ErrorActionPreference = "Stop"
+$sdk = "C:\cascadia\ovgenai\openvino_genai_windows_2026.1.0.0_x86_64"
+$env:PATH = "$sdk\runtime\bin\intel64\Release;$sdk\runtime\3rdparty\tbb\bin;C:\cascadia\dnnl\bin;" + $env:PATH
+$bin = "C:\cascadia\oss-hybrid\target\release\cascadia.exe"
+function FreeGB { [math]::Round((Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory/1MB,1) }
+Write-Output ("free-start-GB=" + (FreeGB))
+
+$commonArgs = @("--engine","ov-runtime","--model",$Model,"--device",$Device,"--ov-cache-dir",$CacheDir,"--log-level","info")
+if ($PrefillDevice -ne "") { $commonArgs += @("--prefill-device",$PrefillDevice) }
+
+$p0 = $null; $p1 = $null
+try {
+    # Both ranks start together (rank 1 blocks in transport accept until
+    # rank 0 dials in — serialized startup deadlocks). NPU compile transients
+    # never overlap because the blob cache is PRE-WARMED sequentially via the
+    # compile_warm_probe test — both stages only import blobs here.
+    Remove-Item C:\cascadia\smoke8b_r1.err,C:\cascadia\smoke8b_r0.err -ErrorAction SilentlyContinue
+    $p1 = Start-Process -FilePath $bin -ArgumentList (@(
+        "worker","--rank","1","--total","2","--listen",":9401") + $commonArgs
+    ) -RedirectStandardError C:\cascadia\smoke8b_r1.err -RedirectStandardOutput C:\cascadia\smoke8b_r1.out -PassThru -NoNewWindow
+    Start-Sleep -Seconds 3
+
+    $p0 = Start-Process -FilePath $bin -ArgumentList (@(
+        "worker","--rank","0","--total","2","--listen",":9400",
+        "--next","127.0.0.1:9401","--api",":8099") + $commonArgs
+    ) -RedirectStandardError C:\cascadia\smoke8b_r0.err -RedirectStandardOutput C:\cascadia\smoke8b_r0.out -PassThru -NoNewWindow
+    $ok = $false
+    for ($i = 0; $i -lt 480; $i++) {
+        Start-Sleep -Seconds 5
+        if ($p0.HasExited -or $p1.HasExited) { throw "a worker exited early" }
+        try {
+            Invoke-RestMethod -Uri http://127.0.0.1:8099/health -TimeoutSec 2 | Out-Null
+            $ok = $true; break
+        } catch {}
+    }
+    if (-not $ok) { throw "health endpoint never came up" }
+    Write-Output ("HEALTH-OK free-GB=" + (FreeGB))
+
+    $para = "The quick brown fox jumps over the lazy dog near the quiet river bank at dawn. "
+    $longPrompt = ($para * 25) + "Now explain how rainbows form."
+    $shortBody = '{"model":"l31","messages":[{"role":"user","content":"In one sentence, what is the capital of France?"}],"max_tokens":' + $MaxTokens + ',"temperature":0}'
+    $longBody = '{"model":"l31","messages":[{"role":"user","content":"' + $longPrompt + '"}],"max_tokens":' + $MaxTokens + ',"temperature":0}'
+
+    foreach ($n in 1..2) {
+        $t = Measure-Command {
+            $script:resp = Invoke-RestMethod -Uri http://127.0.0.1:8099/v1/chat/completions -Method Post -Body $shortBody -ContentType "application/json" -TimeoutSec 900
+        }
+        Write-Output ("SHORT-REQ${n}: " + [math]::Round($t.TotalSeconds,2) + "s -> " + ($script:resp.choices[0].message.content -replace "`n"," "))
+    }
+    foreach ($n in 1..2) {
+        $t = Measure-Command {
+            $script:resp = Invoke-RestMethod -Uri http://127.0.0.1:8099/v1/chat/completions -Method Post -Body $longBody -ContentType "application/json" -TimeoutSec 900
+        }
+        Write-Output ("LONG-REQ${n}: " + [math]::Round($t.TotalSeconds,2) + "s -> " + ($script:resp.choices[0].message.content -replace "`n"," "))
+    }
+    Write-Output ("free-loaded-GB=" + (FreeGB))
+} finally {
+    foreach ($p in @($p0, $p1)) {
+        if ($p -and -not $p.HasExited) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+    }
+    Start-Sleep -Seconds 2
+    $left = @(Get-Process cascadia -ErrorAction SilentlyContinue)
+    Write-Output ("cleanup: remaining cascadia processes = " + $left.Count)
+    Write-Output ("free-end-GB=" + (FreeGB))
+}
+Write-Output "---- rank0 task lines ----"
+Select-String -Path C:\cascadia\smoke8b_r0.err -Pattern "prefill_ms|task done|decode_tok_s" -ErrorAction SilentlyContinue | Select-Object -Last 8 | ForEach-Object { $_.Line }

--- a/experiments/fleet-bench/run_hybrid_test.ps1
+++ b/experiments/fleet-bench/run_hybrid_test.ps1
@@ -1,0 +1,49 @@
+param(
+    [string]$Shards = "C:\cascadia\models\hybrid-test\l32-1b-1stage",
+    [string]$Device = "CPU",
+    [string]$PrefillDevice = "",
+    [int]$MaxNew = 32,
+    [int]$PromptRepeat = 0,
+    [int]$Park = 0,
+    [int]$GemvOffload = 0,
+    [int]$GemvMax = -1,
+    [string]$GemvSkip = "",
+    [int]$GemvStats = 0,
+    [int]$PerfDump = 0,
+    [int]$Dnnl = 0,
+    [int]$ParitySoft = 0,
+    [int]$Tasks = 0,
+    [string]$CacheDir = ""
+)
+$ErrorActionPreference = "Stop"
+$sdk = "C:\cascadia\ovgenai\openvino_genai_windows_2026.1.0.0_x86_64"
+$env:PATH = "$sdk\runtime\bin\intel64\Release;$sdk\runtime\3rdparty\tbb\bin;C:\cascadia\dnnl\bin;" + $env:PATH
+$env:CASCADIA_STATIC_SHARDS = $Shards
+$env:CASCADIA_STATIC_DEVICE = $Device
+if ($PrefillDevice -ne "") { $env:CASCADIA_PREFILL_DEVICE = $PrefillDevice }
+$env:CASCADIA_STATIC_MAX_NEW = "$MaxNew"
+if ($PromptRepeat -gt 0) {
+    $para = "The quick brown fox jumps over the lazy dog near the quiet river bank at dawn. "
+    $env:CASCADIA_STATIC_PROMPT = ($para * $PromptRepeat) + "Now explain how rainbows form."
+}
+if ($CacheDir -ne "") { $env:CASCADIA_OV_CACHE = $CacheDir }
+if ($Park -eq 1) { $env:CASCADIA_PARK = "1" } else { Remove-Item Env:CASCADIA_PARK -ErrorAction SilentlyContinue }
+if ($GemvOffload -eq 1) { $env:CASCADIA_GEMV_OFFLOAD = "1" } else { Remove-Item Env:CASCADIA_GEMV_OFFLOAD -ErrorAction SilentlyContinue }
+if ($GemvMax -ge 0) { $env:CASCADIA_GEMV_MAX = "$GemvMax" } else { Remove-Item Env:CASCADIA_GEMV_MAX -ErrorAction SilentlyContinue }
+if ($GemvSkip -ne "") { $env:CASCADIA_GEMV_SKIP = $GemvSkip } else { Remove-Item Env:CASCADIA_GEMV_SKIP -ErrorAction SilentlyContinue }
+if ($GemvStats -eq 1) { $env:CASCADIA_GEMV_STATS = "1" } else { Remove-Item Env:CASCADIA_GEMV_STATS -ErrorAction SilentlyContinue }
+if ($PerfDump -eq 1) { $env:CASCADIA_PERF_DUMP = "1"; $env:CASCADIA_OV_PROPS = "PERF_COUNT=YES" } else { Remove-Item Env:CASCADIA_PERF_DUMP -ErrorAction SilentlyContinue }
+if ($Dnnl -ge 1) { $env:CASCADIA_GEMV_DNNL = "$Dnnl" } else { Remove-Item Env:CASCADIA_GEMV_DNNL -ErrorAction SilentlyContinue }
+if ($ParitySoft -eq 1) { $env:CASCADIA_PARITY_SOFT = "1" } else { Remove-Item Env:CASCADIA_PARITY_SOFT -ErrorAction SilentlyContinue }
+if ($Tasks -ge 2) { $env:CASCADIA_STATIC_TASKS = "$Tasks" } else { Remove-Item Env:CASCADIA_STATIC_TASKS -ErrorAction SilentlyContinue }
+$os = Get-CimInstance Win32_OperatingSystem
+Write-Output ("free-before-GB=" + [math]::Round($os.FreePhysicalMemory/1MB,1))
+$exe = Get-ChildItem C:\cascadia\oss-hybrid\target\release\deps\static_prefill_parity-*.exe |
+    Sort-Object LastWriteTime -Descending | Select-Object -First 1
+cmd /c "`"$($exe.FullName)`" --nocapture > C:\cascadia\hybrid_run.log 2>&1"
+$code = $LASTEXITCODE
+Get-Content C:\cascadia\hybrid_run.log
+$os = Get-CimInstance Win32_OperatingSystem
+Write-Output ("free-after-GB=" + [math]::Round($os.FreePhysicalMemory/1MB,1))
+Write-Output ("exit=" + $code)
+exit $code

--- a/experiments/fleet-bench/xfer_blob.sh
+++ b/experiments/fleet-bench/xfer_blob.sh
@@ -20,14 +20,20 @@ send_part() {
   done
   echo "PART_FAILED $pn"; return 1
 }
+# NOTE: runs on the Linux blob host (stat -c%s is GNU; not macOS-portable).
 FAIL=0
 i=0
+PIDS=""
 for p in $TMP/part_*; do
   send_part $p &
+  PIDS="$PIDS $!"
   i=$((i+1))
-  [ $((i % 4)) = 0 ] && { wait || FAIL=1; }
+  if [ $((i % 4)) = 0 ]; then
+    for pid in $PIDS; do wait $pid || FAIL=1; done
+    PIDS=""
+  fi
 done
-wait || FAIL=1
+for pid in $PIDS; do wait $pid || FAIL=1; done
 [ $FAIL = 0 ] || { echo "XFER_PARTS_FAILED $(basename $F)"; rm -rf $TMP; exit 1; }
 PLIST=$(for p in $TMP/part_*; do echo "$RD\\$(basename $p)"; done | paste -sd+ -)
 ssh $SSHOPTS "devcloud@$IP" "cmd /c copy /b $PLIST \"$DESTW\"" >/dev/null

--- a/experiments/fleet-bench/xfer_blob.sh
+++ b/experiments/fleet-bench/xfer_blob.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Chunked resilient transfer v3: keep-alives kill dead streams in ~60s so
+# retries actually fire; unique per-invocation remote parts dir.
+set -e
+F="$1"; IP="$2"; DEST="$3"
+SIZE=$(stat -c%s "$F")
+SSHOPTS="-i $HOME/.ssh/fleet_ed25519 -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
+TMP=/tmp/xfer_$(basename "$F" | tr -c 'a-zA-Z0-9' _)$$
+rm -rf $TMP; mkdir -p $TMP
+split -b 512M "$F" $TMP/part_
+DESTW=$(echo "$DEST" | sed 's|/|\\|g')
+RD="C:\\cascadia\\xp_$(basename "$F" | tr -c 'a-zA-Z0-9' _)$$"
+RDF=$(echo "$RD" | sed 's|\\\\|/|g' | sed 's|\\|/|g')
+ssh $SSHOPTS "devcloud@$IP" "powershell -Command \"New-Item -ItemType Directory '$RD' -Force | Out-Null\"" >/dev/null
+send_part() {
+  local p=$1 pn=$(basename $1)
+  for try in 1 2 3 4 5; do
+    scp $SSHOPTS "$p" "devcloud@$IP:$RDF/$pn" 2>/dev/null && return 0
+    sleep 8
+  done
+  echo "PART_FAILED $pn"; return 1
+}
+FAIL=0
+i=0
+for p in $TMP/part_*; do
+  send_part $p &
+  i=$((i+1))
+  [ $((i % 4)) = 0 ] && { wait || FAIL=1; }
+done
+wait || FAIL=1
+[ $FAIL = 0 ] || { echo "XFER_PARTS_FAILED $(basename $F)"; rm -rf $TMP; exit 1; }
+PLIST=$(for p in $TMP/part_*; do echo "$RD\\$(basename $p)"; done | paste -sd+ -)
+ssh $SSHOPTS "devcloud@$IP" "cmd /c copy /b $PLIST \"$DESTW\"" >/dev/null
+ssh $SSHOPTS "devcloud@$IP" "cmd /c rmdir /s /q $RD" >/dev/null 2>&1 || true
+rm -rf $TMP
+RSIZE=$(ssh $SSHOPTS "devcloud@$IP" "powershell -Command \"(Get-Item '$DEST').Length\"" | tr -d '\r')
+if [ "$RSIZE" = "$SIZE" ]; then echo "XFER_VERIFIED $(basename $F) $SIZE"; else echo "XFER_SIZE_MISMATCH $(basename $F) local=$SIZE remote=$RSIZE"; exit 1; fi

--- a/experiments/gemv-offload-spike/NOTES.md
+++ b/experiments/gemv-offload-spike/NOTES.md
@@ -1,0 +1,223 @@
+# GEMV-offload spike: CascadiaInt4Gemv extension op (route 1)
+
+**Question:** can the hybrid split's decode side execute its sym-INT4 weight
+matmuls straight from the mmapped IR `.bin` — on OpenVINO's public extension
+API, no OV changes — removing the decode model's plugin-resident weight copy?
+
+**Answer: the mechanism works end-to-end and is token-parity-correct at ~70%
+of stock decode throughput; the steady-state residency win on the CPU plugin
+is SMALLER than theorized (see Honest surprises).**
+
+## What was built
+
+- `cpp/gemv_offload.cpp` (shim): a load-time `MatcherPass` rewrites every
+  NNCF sym-INT4 chain `Const(i4 [N,G,g]) → Convert(f16) → Multiply(scales
+  f16 [N,G,1]) → Reshape([N,K]) → MatMul(transpose_b)` into a
+  `CascadiaInt4Gemv` op holding the weight/scale Constants as MEMBERS —
+  invisible to the plugin compile, so no repack; the shared_ptrs keep the
+  read_model mmap alive. Registered in-process via `ov::OpExtension`.
+- Kernel: grouped sym-INT4 GEMV, f32 accumulation, `ov::parallel_for` rows;
+  AVX2+FMA path (nibble sign via `(x^8)-8`, `unpacklo/hi_epi8(lo,hi)`
+  restores low-nibble-first element order) with scalar fallback.
+- `cascadia worker --gemv-offload` (ov-runtime, stateless static export,
+  `--device CPU` only); decode compile drops CACHE_DIR (op members don't
+  survive blob serialization). Bisect knobs `CASCADIA_GEMV_MAX/SKIP`.
+
+## Measured (pawan-01, LNL 258V, Llama-3.2-1B INT4, all 113/113 MatMuls offloaded)
+
+- **Parity:** token-identical to the stock kernel across tokenwise/chunked/
+  hybrid legs, full generations (cross-kernel greedy match held despite
+  differing accumulation order).
+- **Throughput:** decode 12.4–13.9 tok/s vs 18.9 stock (~70%; scalar kernel
+  was 5.4). Hybrid leg: TTFT 189.9 ms + 13.9 tok/s.
+- **Memory (decode model only, hold probe, private bytes | working set):**
+  stock steady 0.11 GB | 0.18 GB, stock PEAK-private 1.08 GB (compile);
+  offload steady 0.34 GB | 0.89 GB, peak-private 0.34 GB.
+
+## Honest surprises
+
+1. **Stock CPU steady-state is already cheap for this IR.** Steady private
+   of 0.11 GB says OV 2026.1's CPU executor does NOT hold a large private
+   repacked copy of these decompress-subgraph weights at steady state
+   (weights appear to stay constant/mmap-backed in this executor path) —
+   contrary to the general prepareWeightsMemory repack expectation our
+   research derived for the FC path. The offload's residency value on CPU is
+   therefore: **~0.7 GB lower compile-time private peak** and **file-backed
+   (evictable, cross-process shareable) instead of private pages** — not a
+   large steady RSS delta. Re-verify per OV version/arch before leaning on
+   either behavior.
+2. Three integration traps cost most of the spike (each reproducible,
+   worth knowing for ANY evaluate()-op extension):
+   - **Precision pipeline:** the plugin retypes the graph (f16 IR → f32 CPU
+     execution) but cannot retype a custom op — output type must FOLLOW the
+     input, and evaluate() must handle f16 and f32 on both sides.
+   - **Attribute-blind CSE:** with weights in op members, two ops with equal
+     dims and the same input (a layer's k_proj/v_proj) compare EQUAL and get
+     merged — v silently received k's output. Fix: a per-instance
+     `weights_tag` attribute.
+   - (Avoided by review, worth stating) `ov::parallel_for` blocks its caller
+     and TBB work-steals other evaluates onto that thread — never share
+     thread_local scratch across evaluate calls.
+3. Debug flow that cracked it: numpy-vs-OV ground truth on real weights
+   (kernel math exonerated in one run) + `CASCADIA_GEMV_MAX/SKIP` bisection
+   (q,k ✓ / +v ✗ / v-alone ✓ ⇒ pairwise-merge, not math).
+
+## Throughput push (second pass): 66-73% → 75-79% of stock, frontier mapped
+
+Every step measured on hardware, parity re-asserted each time:
+
+| Config | decode tok/s | kernel eff GB/s | note |
+|---|---|---|---|
+| scalar kernel (spike v1) | 5.4 | ~2.6 | |
+| AVX2 single-acc | 12.4–13.9 | 19.1 | FMA-latency bound |
+| + 4 accumulators, blocked parallel_for | **14.2 (default)** | 21.3 | |
+| private TBB-independent pool | 11.8 | 15.4 | REJECTED: wake latency + oversubscription vs plugin threads |
+| `INFERENCE_NUM_THREADS=8` (add E-cores) | 11.2 (stock drops too: 16.9) | 14.8 | REJECTED: E-cores gate every fork-join lane; OV's P-core-only LATENCY default is right |
+| + AVX-VNNI dpbusd, dyn-quant int8 acts (`CASCADIA_GEMV_VNNI=1`) | **15.0 / 14.9 hybrid (79%)** | 22.1 | opt-in: dynamic quantization — parity HELD on the test prompt, but numerics differ by construction; keep off by default |
+
+Key measurements behind the frontier:
+- Single-core kernel (SEQ=1): 5.7 GB/s → the 4-P-core arena scales 3.7×
+  (LATENCY hint = P-cores only on LNL, confirmed as the right choice).
+- VNNI barely moved aggregate GB/s (21.3→22.1): per-core is no longer
+  compute-bound — per-node fork-join + memory-level parallelism dominate.
+- Floor analysis at 15 tok/s: kernel-wall 27.9 ms/token; non-kernel ≈ 39 ms
+  (stock total: 52.9). Parity needs kernel ≈ 14 ms (≈ 44 GB/s) or fewer,
+  larger nodes. **Identified next lever (follow-up, not this spike):
+  graph-level fusion in the pass — one op for q/k/v and one for gate/up
+  (shared inputs, concat + VariadicSplit) → 113 → ~66 nodes, halves
+  fork-join count and doubles mean GEMV size.** Hybrid TTFT improved to
+  186 ms along the way (best measured).
+- The VNNI trick worth keeping: `w+8 == nibble ^ 8`, and dpbusd(u8,s8)
+  accumulates exactly in i32 (no maddubs-style i16 saturation); bias removed
+  per group via `− 8·Σq` with Σq computed once per token.
+
+### Sibling fusion (third pass): built, measured NEUTRAL — hypothesis refuted
+
+The op now supports multiple weight/scale SEGMENTS sharing one activation
+and K (a layer's q/k/v → one op with N=3072; gate/up → N=16384), with a
+post-rewrite surgery stage grouping siblings and splicing a VariadicSplit to
+route slices back to the original consumers (`CASCADIA_GEMV_NOFUSE=1` A/B
+knob). It works exactly as designed — calls/token 113 → 65, parity held —
+and throughput DID NOT MOVE (fused 14.23 vs 14.16 tok/s; fused+VNNI
+14.84/14.72 vs 15.0/14.9; kernel eff ~21-22 GB/s unchanged). Conclusion:
+per-node fork-join was NOT the floor. Revised frontier:
+
+1. The kernel wall (~29 ms/token) is a **~22 GB/s weight-streaming ceiling
+   on the 4 P-cores** for this access pattern — compute-insensitive (VNNI
+   flat) and node-count-insensitive (fusion flat). Stock's repacked blocked
+   layout streams better (prefetch locality). Next levers here: software
+   prefetch tuning, non-temporal loads, per-thread contiguous weight
+   striping — or conceding the hot loops to a repacked cache (which
+   reintroduces residency, defeating the point).
+2. The remaining ~27 ms/token graph-side delta vs stock needs per-node
+   attribution (OV `PERF_COUNT` profiling exposed through new shim FFI)
+   before more guessing — candidates: broken eltwise fusions around custom
+   ops, per-op output allocation, reference-node dispatch.
+
+Kept fusion enabled by default anyway: fewer nodes, no cost, and it is the
+foundation any future epilogue-fusion work builds on.
+
+## PERF_COUNT attribution (fourth pass): the gap fully named
+
+New instrumentation (kept): `Runtime::profiling()` FFI over OV
+`get_profiling_info()` + `CASCADIA_PERF_DUMP=1` engine dump (compile with
+`PERF_COUNT=YES` via `CASCADIA_OV_PROPS`). Per-node profile of one decode
+infer, stock vs offloaded (times inflated by profiling; use ratios):
+
+> **NPU blob-cache import warning (bitten once, cost a re-sweep):** an NPU
+> compiled model IMPORTED from the blob cache defers ~300 ms of driver init
+> to its FIRST inference (1B/3B prefill blobs, LNL driver 2026.1-era) — a
+> cold in-process compile does not. First-request TTFT measured through a
+> cache-imported prefill blob reads ~+300 ms high (206→~505 ms short,
+> 687→~990 ms long on 1B — reproduced with both a PERF_COUNT-era and a clean
+> cache, which is what exonerated PERF_COUNT "poisoning" as the first
+> theory). Bench either with a cold compile or on request ≥2 of a warm
+> process; production long-lived workers only pay it once at startup.
+
+| node kind | stock | offloaded |
+|---|---|---|
+| weight matmuls | FullyConnectedCompressed ×113: **11.2–12.9 ms** (brgemm_avx2_f32, ≈51 GB/s) | Reference ×65 (our ops): **31.9 ms** (≈22 GB/s) |
+| attention (SDPA subgraphs) | 13.5–16 ms | 13.9 ms (identical) |
+| Broadcast (GQA expand) | 3.7–4.2 ms | 3.8 ms |
+| Concat/RoPE/RMS/Reorder/Convert | ~1.8 ms | ~1.9 ms |
+
+Two prior beliefs corrected by this data:
+1. Stock matmuls are FAST (11–13 ms, not ~45): oneDNN's
+   weights-decompression brgemm streams packed INT4 at ~51 GB/s on the 4
+   P-cores.
+2. The earlier "~27 ms unexplained graph overhead" DISSOLVES: ~25 ms/token
+   of non-graph cost (host KV-ring set_input/present copies ≈ 67 MB/token +
+   engine glue) is SHARED by both paths. There are no extra
+   Converts/Reorders around the custom ops. The offload's entire deficit is
+   kernel streaming: 31.9 vs 11.2 ms.
+
+Kernel-side levers, all built and all measured ~flat (single-core stuck at
+5.7→6.1 GB/s; aggregate ~22 GB/s):
+- flat no-helper loops + __forceinline (kills hypothetical MSVC vector
+  spills): +7% single-core only
+- software prefetch (+128B ahead), 2-row register blocking (one act read
+  feeding two weight streams), VNNI unroll-by-2 without the alternation
+  branch: flat
+
+Conclusion: our loop shape hits a genuine ~6 GB/s/core ceiling on MSVC/Lion
+Cove that resists compute, ILP, MLP, and inlining fixes, while oneDNN's
+brgemm does ~12.8 GB/s/core from an equivalent packed-INT4 stream. The two
+credible endgames, in order:
+1. **Embed oneDNN in the op**: build a dnnl matmul primitive with INT4
+   weights-decompression args pointing at OUR mmapped weight memory —
+   oneDNN-quality streaming, residency goals intact. A dependency/build
+   project (the plugin's oneDNN isn't exported to extensions), not a kernel
+   tweak. This is the recommended follow-up if the last ~4 tok/s matters.
+2. The upstream RFC (docs/rfcs/): make OV's own executor do this
+   contractually.
+
+Also visible in the profile and relevant beyond this spike: attention
+subgraphs (13–16 ms) + the shared ~25 ms/token ring/copy overhead are the
+static path's real whole-pipeline costs — bigger prizes than the remaining
+matmul delta, and they apply to STOCK too (separate workstream).
+
+## oneDNN-embedding endgame (fifth pass): CLOSED BY DATA — the fast kernels are fork-only
+
+Built the full embedding (kept, feature-gated `DNNL_DIR` at build /
+`CASCADIA_GEMV_DNNL` at runtime, permanent fallback to built-in kernels on
+any failure): dnnl 3.12 (conda-forge win-64, TBB runtime sharing the SDK's
+tbb12) matmul primitives with INT4 weights-decompression created inside the
+op — weights zero-copy over our mmapped `[N,K]` packed-i4 rows (dnnl plain
+`ba` for dims `[K,N]`), scales transposed once to resident `[G,N]` f16
+(~4 MB), `fpmath_mode(f16, apply_to_int)` + grouped weight scales
+(mask 3, groups `{gsize,1}`).
+
+Results:
+- **Numerically correct end-to-end** (token-parity held through full
+  generations — nibble order, scales, layout all right).
+- **Mode 1 (our layout, zero-copy): `ref`-slow** — ~165 ms/op, 0.1 GB/s.
+- **Mode 2 (`format_tag::any` + one resident reorder — dnnl's own layout
+  choice): STILL `ref:any`.** Upstream oneDNN 3.12 has NO optimized kernel
+  for s4 grouped-scale weights-decompression matmul on this shape at all.
+
+Conclusion: OpenVINO's ~51 GB/s `FullyConnectedCompressed` kernels live in
+the **openvinotoolkit/oneDNN fork** (and/or OV-internal JIT), not upstream
+oneDNN. Embedding upstream dnnl cannot reach the plugin's throughput for
+this workload, with any layout, at any residency cost. The remaining routes
+to closing the last ~21%:
+1. The upstream RFC (docs/rfcs/) — now with sharpened evidence: the
+   capability demonstrably exists in Intel's fork and is absent upstream;
+   the ask is to expose/contractualize it.
+2. Building OV's oneDNN fork and calling its internal FC-compression
+   primitives — unstable internal API, not sane to ship against.
+3. Hand-writing a brgemm-class INT4 kernel (register-tiled multi-row,
+   software-pipelined) — a multi-week kernel project.
+
+The dnnl integration stays in-tree as the reproducible probe (zero cost
+without DNNL_DIR).
+
+## Verdict
+
+Route 1 is **viable as engineering** (public API, parity-correct, one
+optimization pass from stock-competitive) but its CPU residency payoff today
+is compile-peak + page semantics, not steady RSS. Keep behind
+`--gemv-offload` as an experiment; fold the executor-behavior finding into
+the upstream RFC (docs/rfcs/openvino-inplace-int4-gemv.md) — the RFC's ask
+narrows to making the mmap-backed behavior *contractual* and closing the
+remaining ~30% kernel gap in-plugin. Next if pursued: per-node overhead
+profile, weight-page prefetch, multi-row (chunk) support, GPU-device story.


### PR DESCRIPTION
## GEMV-offload spike + AOT blob deployment: the big-model NPU enablers

Stacked on #108. Two related bodies of work:

### 1. AOT blob machinery (the 14B–70B enabler; graduated well beyond "spike")

- **`Runtime::import_blob` FFI + engine consumption**: a `.blob` sibling of a stage IR (from `ov::CompiledModel::export_model`) imports instead of compiling when the device is NPU. The NPU compiler's measured **6–9× INT4-bytes host-RAM transient never runs on the box** — blobs import in ~7 s at ≈1.4× INT4 resident. Cross-compilation runs on any big-RAM Linux host via the standalone `intel-driver-compiler-npu` library + `NPU_PLATFORM` (no NPU required; proven Linux→Windows with OV pinned 2026.1).
- **`tests/compile_warm_probe.rs`**: sequential cache-warming so multi-model/multi-stage bring-up never overlaps compile transients (how 8B 2-stage compiles on one 32 GB box).
- **`tests/blob_import_probe.rs`** + fleet tooling (`experiments/fleet-bench/`): chunked sha-verified transfers, WMI-detached worker starts, file-based benching — the deployment recipe that ran 32B across 3 boxes and validated 70B to six-box health (`docs/perf/NPU_TTFT_TIERS.md`).
- Caveats documented: blobs are driver-generation-sensitive per graph (one 32B stage reproducibly killed a healthy device under VCL 1.32.1 — validate each blob with a real inference at deploy); CACHE_DIR entries are not portable across machines.

### 2. CascadiaInt4Gemv spike (measured to its ceiling, kept as probe + evidence)

OV-extension custom op executing decode INT4 GEMVs from the mmapped IR: 113/113 rewrites, **near-tie-tolerant** token parity, ~69–79% of stock throughput. PERF_COUNT FFI attributed the gap fully (kernel weight-streaming only; stock brgemm ≈51 GB/s is fork-only per the oneDNN embedding probe) → the RFC in #108 is the load-bearing path. Three extension-op traps documented in `experiments/gemv-offload-spike/NOTES.md` (precision-following outputs, CSE weights-tag, no shared scratch under work-stealing), plus the NPU cache-import init warning.

**Do-not-merge hold per repo owner.**

---

## Rebase + review + validation (2026-07-24)

Rebased onto `main` with #107/#108; **faithful** (`runtime.rs` inference byte-identical pre/post-rebase). Full `pr-review-toolkit` sweep (correctness / silent-failure / tests / types / comments) — no ship-blockers; findings fixed. Hardware-validated on matias-04:
- **CascadiaInt4Gemv**: 113 mmap INT4 matmuls execute (load-log confirmed), near-tie-tolerant token parity, **~69% of stock decode throughput** (release) — consistent with "below stock brgemm, kept as probe; the RFC is the load-bearing path". Added `NODE_VALIDATION_CHECK(!weights_tag.empty())` (the CSE-merge → wrong-output guard) after review.
- **Transport send-pacing**: `parse_send_burst` now warns on an unparseable value AND on a below-64 KiB clamp-up (both were silent).
- The OV/FFI path compiles + initializes on the target NPU (`doctor` enumerates CPU/GPU/NPU).

## Test plan

**Tier A — `just check` (Mac/CI):**
- `npu_aot_blob` blob-vs-compile decision + `npu_aot_blob_rejects_blob_older_than_ir`; `import_plugin_strips_cache_dir_keeps_rest`; `--gemv-offload` gating (`gemv_offload_on_stateful_shard_rejected`, `..._on_non_cpu_device_rejected`); transport `parse_send_burst_clamp_table`.

**Tier B — `--features openvino`:**
- gemv-offload cross-kernel parity: `CASCADIA_GEMV_OFFLOAD=1` (confirm `offloaded>0` in the load log, else the parity check is vacuous).
- `gemv_residency_probe.rs`, `compile_warm_probe.rs`, `npuw_bank_probe.rs`.

## Caveats / not-yet-validated

- **AOT `.blob` import round-trip (`import_blob` / `blob_import_probe`) was NOT hardware-validated this pass** — it needs a cross-compiled `.blob`. The FFI compiles and is reviewed; the import handshake on a real NPU is unrun here.
- The CascadiaInt4Gemv matcher/rewrite has no standalone test (the only signal it fired is the `offloaded` count); numeric parity vs oneDNN is empirical only, and its throughput is fork-only per the embedding probe.
- **`build.rs` compiles the shim TU at the AVX2/FMA/VNNI baseline**, so `gemv_offload.cpp`'s runtime `cpu_has_avx2_fma()` scalar fallback is dead on a non-AVX2 x86_64 CPU. Harmless under the current **Intel-AI-PC-only** deployment scope (all targets have AVX2+VNNI); noted as dead-code to remove if scope broadens.

### Follow-ups (tracked, not in this PR)
Stale-blob **content-hash provenance** — the mtime guard is defeated by the `copy /b` deploy path, so a stale-weights blob can still import (import a blob → validate with a real inference at deploy); non-UTF-8 stage path → misleading "cannot open" error; a stub unit test for the transport paced-send loop.
