### PR TITLE
feat(transport): Unix domain socket activation links for in-host pipeline stages (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ cascadia worker --rank 0 --total 2 --engine ov-runtime --device GPU \
 
 Not sure of a node's address? `cascadia discover` lists Cascadia peers on the LAN and the `host:port` to pass to `--next`.
 
+Two stages on the **same host** (e.g. iGPU + dGPU in one box)? Link them over a Unix domain socket instead of loopback TCP — `--listen unix:/tmp/cascadia-1.sock` on the downstream, the same path as `--next` on the upstream. Measured 85–92 % lower per-frame round-trip latency for decode-sized frames (Unix only; see [docs/CLI.md](docs/CLI.md#unix-domain-sockets)).
+
 For distributed speculative decoding, run **every** rank with `--engine ov-dist-spec` (they share a wire protocol) and give rank 0 `--draft-model ~/models/llama-3.2-1b-int4-ov --spec-k 4` — the draft is a local OpenVINO IR directory, not an HF id. See ([docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
 
 ### Engines

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -813,7 +813,21 @@ fn cmd_engines() -> Result<()> {
     Ok(())
 }
 
+/// Unix-domain-socket address form (#17): `unix:/path.sock`, an absolute
+/// path, or a `.sock`-suffixed name. Valid for --listen/--next (in-host
+/// pipeline hand-offs); NOT for --api (HTTP stays TCP).
+fn is_unix_addr(s: &str) -> bool {
+    s.starts_with("unix:") || s.starts_with('/') || s.ends_with(".sock")
+}
+
 fn parse_addr(s: &str, default_host: &str) -> Result<(String, u16)> {
+    // A UDS address travels whole in the host slot with port 0 — the
+    // transport layer classifies it (TransportAddr::from_host_port).
+    // Recognized before the colon split: "unix:/tmp/x.sock" would
+    // otherwise split at its last ':' and fail the port parse.
+    if is_unix_addr(s) {
+        return Ok((s.to_string(), 0));
+    }
     if let Some(port) = s.strip_prefix(':') {
         return Ok((default_host.to_string(), port.parse().context("port")?));
     }
@@ -1361,7 +1375,17 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         "cascadia worker starting"
     );
 
+    // HTTP must stay TCP: reject a unix --api up-front, before any engine
+    // work, rather than failing the TcpListener bind minutes later.
+    if args.api.as_deref().is_some_and(is_unix_addr) {
+        return Err(anyhow!(
+            "--api must be a TCP address (host:port); unix socket addresses are \
+             supported only for --listen/--next (in-host pipeline hand-offs)"
+        ));
+    }
+
     let (listen_host, listen_port) = parse_addr(&args.listen, "0.0.0.0")?;
+    let listen_is_unix = is_unix_addr(&listen_host);
 
     let upstream = if is_first {
         None
@@ -1414,31 +1438,40 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
     // dashboard demo. If the engine already bound the port, `bind`
     // fails with AddrInUse and we silently step aside (the engine's
     // listener handles probes identically at the TCP layer).
+    //
+    // A unix --listen has no TCP relay port: binding 0.0.0.0:0 here would
+    // grab a meaningless ephemeral port, so skip it (the node also
+    // advertises port 0 via mDNS — cross-host latency probes don't apply
+    // to an in-host UDS stage).
     let probe_addr = format!("0.0.0.0:{listen_port}");
-    match tokio::net::TcpListener::bind(&probe_addr).await {
-        Ok(listener) => {
-            info!(addr = %probe_addr, "probe listener bound");
-            tokio::spawn(async move {
-                loop {
-                    match listener.accept().await {
-                        Ok(_) => {
-                            // Drop the connection immediately — the
-                            // probe only needs the connect handshake.
-                        }
-                        Err(e) => {
-                            tracing::debug!(error = %e, "probe accept failed");
-                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    if listen_is_unix {
+        tracing::debug!("unix --listen; skipping TCP probe listener");
+    } else {
+        match tokio::net::TcpListener::bind(&probe_addr).await {
+            Ok(listener) => {
+                info!(addr = %probe_addr, "probe listener bound");
+                tokio::spawn(async move {
+                    loop {
+                        match listener.accept().await {
+                            Ok(_) => {
+                                // Drop the connection immediately — the
+                                // probe only needs the connect handshake.
+                            }
+                            Err(e) => {
+                                tracing::debug!(error = %e, "probe accept failed");
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            }
                         }
                     }
-                }
-            });
-        }
-        Err(e) => {
-            tracing::debug!(
-                error = %e,
-                addr = %probe_addr,
-                "probe listener could not bind; engine likely owns the port"
-            );
+                });
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    addr = %probe_addr,
+                    "probe listener could not bind; engine likely owns the port"
+                );
+            }
         }
     }
 

--- a/crates/cascadia-engine-sparse-moe/tests/dist_wire.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/dist_wire.rs
@@ -17,8 +17,11 @@ use cascadia_engine_sparse_moe::SamplingConfig;
 use cascadia_transport::{ActivationClient, ActivationServer};
 use tokio::sync::Mutex;
 
-async fn make_pair() -> (Arc<Mutex<ActivationServer>>, Arc<Mutex<ActivationClient>>) {
-    let mut server = ActivationServer::new("127.0.0.1", 0);
+async fn make_pair_at(
+    server_host: &str,
+    client_host_of: impl FnOnce(u16) -> (String, u16),
+) -> (Arc<Mutex<ActivationServer>>, Arc<Mutex<ActivationClient>>) {
+    let mut server = ActivationServer::new(server_host, 0);
     server.start().await.expect("server.start");
     let port = server.port();
     let server = Arc::new(Mutex::new(server));
@@ -31,7 +34,8 @@ async fn make_pair() -> (Arc<Mutex<ActivationServer>>, Arc<Mutex<ActivationClien
             .await
             .expect("server.accept");
     });
-    let mut client = ActivationClient::new("127.0.0.1", port);
+    let (client_host, client_port) = client_host_of(port);
+    let mut client = ActivationClient::new(client_host, client_port);
     client
         .connect_with_timeout(std::time::Duration::from_secs(5))
         .await
@@ -39,6 +43,29 @@ async fn make_pair() -> (Arc<Mutex<ActivationServer>>, Arc<Mutex<ActivationClien
     let client = Arc::new(Mutex::new(client));
     server_task.await.expect("server task panicked");
     (server, client)
+}
+
+async fn make_pair() -> (Arc<Mutex<ActivationServer>>, Arc<Mutex<ActivationClient>>) {
+    make_pair_at("127.0.0.1", |port| ("127.0.0.1".to_string(), port)).await
+}
+
+/// Same pair over a Unix domain socket (#17) — the engine wire protocol
+/// must be byte-identical on both stream flavors.
+#[cfg(unix)]
+async fn make_pair_uds(
+    tag: &str,
+) -> (
+    Arc<Mutex<ActivationServer>>,
+    Arc<Mutex<ActivationClient>>,
+    std::path::PathBuf,
+) {
+    let dir = std::env::temp_dir().join("cascadia-dist-wire-uds");
+    let _ = std::fs::create_dir_all(&dir);
+    let sock = dir.join(format!("{tag}-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&sock);
+    let addr = format!("unix:{}", sock.display());
+    let (server, client) = make_pair_at(&addr, |_| (addr.clone(), 0)).await;
+    (server, client, sock)
 }
 
 #[tokio::test]
@@ -421,6 +448,59 @@ async fn forward_batch_rejects_mismatched_shape() {
         res.is_err(),
         "send_forward_batch with K vs shape mismatch should error"
     );
+}
+
+/// #17 acceptance (UDS wire smoke): the FULL driver↔worker frame sequence —
+/// Reset → Forward(K2.6-sized hidden state) downstream, Token upstream —
+/// over a Unix domain socket, consumed on both ends. The engine wire
+/// protocol must be byte-identical on UDS and TCP; this is the same
+/// sequence `sequence_reset_then_forward_then_token` pins on TCP.
+#[cfg(unix)]
+#[tokio::test]
+async fn uds_sequence_reset_then_forward_then_token() {
+    let (server, client, sock_path) = make_pair_uds("seq").await;
+    let hidden: Vec<f32> = vec![0.123; 7168];
+    let hidden_for_send = hidden.clone();
+    let shape = [1u32, 1, 7168];
+
+    let server_for_token = server.clone();
+    let client_for_token = client.clone();
+    let cfg = SamplingConfig::default();
+    let send_task = tokio::spawn(async move {
+        send_reset(&client).await.unwrap();
+        send_forward(&client, 0, &cfg, &hidden_for_send, shape)
+            .await
+            .unwrap();
+    });
+
+    assert_eq!(
+        recv_kind_server(&server).await.unwrap(),
+        Some(FrameKind::Reset)
+    );
+    assert_eq!(
+        recv_kind_server(&server).await.unwrap(),
+        Some(FrameKind::Forward)
+    );
+    let (past, _cfg_back, h_back, sh) = recv_forward_body_server(&server).await.unwrap();
+    assert_eq!(past, 0);
+    assert_eq!(sh, shape);
+    assert_eq!(h_back.len(), 7168);
+    for (i, &got) in h_back.iter().enumerate() {
+        assert!((got - 0.123).abs() < 1e-6, "hidden[{i}] corrupted: {got}");
+    }
+    send_task.await.unwrap();
+
+    // The worker rank returns a token upstream on the same unix socket;
+    // the driver must receive it intact.
+    send_token_upstream(&server_for_token, 42).await.unwrap();
+    assert_eq!(
+        recv_kind_client(&client_for_token).await.unwrap(),
+        Some(FrameKind::Token)
+    );
+    let token = recv_token_body_client(&client_for_token).await.unwrap();
+    assert_eq!(token, 42);
+
+    let _ = std::fs::remove_file(&sock_path);
 }
 
 #[test]

--- a/crates/cascadia-transport/src/lib.rs
+++ b/crates/cascadia-transport/src/lib.rs
@@ -12,16 +12,26 @@
 //! Tensors up to 3D supported. Lower-rank tensors are wire-padded with
 //! leading-1 dimensions; receiver returns the wire-encoded shape.
 //!
-//! This is intentionally simple — raw TCP, point-to-point. It is the
-//! data plane between adjacent pipeline stages.
+//! This is intentionally simple — raw byte streams, point-to-point. It is
+//! the data plane between adjacent pipeline stages. Two stream flavors
+//! carry the identical wire format:
+//!
+//! * **TCP** (the default) — cross-host pipeline stages.
+//! * **Unix domain sockets** (`unix:/path/to.sock`, Unix only, #17) —
+//!   in-host stages (e.g. iGPU stage 0 → dGPU stage 1 on one box), which
+//!   skip the loopback TCP stack on every Forward/Reset/Token frame.
 
 use std::io;
-use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
 use std::time::{Duration, Instant};
 
 use thiserror::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
 use tracing::{info, warn};
 
 /// Tune an inter-rank pipeline socket: TCP_NODELAY (activations are latency-
@@ -37,6 +47,119 @@ fn tune_pipeline_socket(sock: &TcpStream) {
         .with_time(Duration::from_secs(30))
         .with_interval(Duration::from_secs(15));
     let _ = socket2::SockRef::from(sock).set_tcp_keepalive(&ka);
+}
+
+/// A connected pipeline byte stream: TCP (cross-host) or a Unix domain
+/// socket (in-host, #17). Both carry the identical length-prefixed wire
+/// format; every frame helper in this crate is generic over
+/// `AsyncRead`/`AsyncWrite`, so the two arms share one code path.
+#[derive(Debug)]
+pub enum ActivationStream {
+    Tcp(TcpStream),
+    #[cfg(unix)]
+    Unix(UnixStream),
+}
+
+impl ActivationStream {
+    /// Apply the per-flavor socket tuning: TCP gets NODELAY + keepalive
+    /// (see [`tune_pipeline_socket`]); UDS gets enlarged kernel buffers —
+    /// AF_UNIX defaults are tiny on macOS (~8 KiB) which throttles MB-class
+    /// prefill/logits frames well below loopback TCP. Nagle/keepalive don't
+    /// apply to UDS (no coalescing, and the kernel never drops an idle
+    /// local socket). Best-effort: option failures are ignored, never
+    /// fatal.
+    fn tune(&self) {
+        match self {
+            ActivationStream::Tcp(s) => tune_pipeline_socket(s),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => {
+                let sock = socket2::SockRef::from(s);
+                let _ = sock.set_send_buffer_size(1024 * 1024);
+                let _ = sock.set_recv_buffer_size(1024 * 1024);
+            }
+        }
+    }
+
+    /// Graceful write-side shutdown (best-effort, both flavors).
+    async fn shutdown(&mut self) -> io::Result<()> {
+        match self {
+            ActivationStream::Tcp(s) => s.shutdown().await,
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => s.shutdown().await,
+        }
+    }
+}
+
+impl AsyncRead for ActivationStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            ActivationStream::Tcp(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for ActivationStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            ActivationStream::Tcp(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            ActivationStream::Tcp(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            ActivationStream::Tcp(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            ActivationStream::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            ActivationStream::Tcp(s) => s.is_write_vectored(),
+            #[cfg(unix)]
+            ActivationStream::Unix(s) => s.is_write_vectored(),
+        }
+    }
+}
+
+/// The listening side of [`ActivationStream`].
+#[derive(Debug)]
+enum ActivationListener {
+    Tcp(TcpListener),
+    #[cfg(unix)]
+    Unix(UnixListener),
 }
 
 pub const HEADER_SIZE: usize = 20;
@@ -59,10 +182,97 @@ pub const MAX_TENSOR_BYTES: usize = 256 * 1024 * 1024;
 /// gigabyte of "control bytes".
 pub const MAX_RAW_BYTES: usize = 64 * 1024;
 
+/// Where a pipeline endpoint lives: a TCP `host:port`, or a Unix domain
+/// socket path (in-host stages, #17). The wire format on top is identical.
+///
+/// Recognized string forms (see [`FromStr`]):
+/// * `unix:/tmp/cascadia-stage-1.sock` — explicit UDS
+/// * `/tmp/cascadia-stage-1.sock` — absolute path (UDS)
+/// * `stage-1.sock` — `.sock` suffix (UDS)
+/// * `127.0.0.1:9100` / `cascadia-matias-03:9100` — TCP (existing)
+///
+/// At the `(host, port)` seams the codebase already has everywhere
+/// (`PeerEndpoint`, `configure_listen`, the transport constructors), a UDS
+/// address travels as `host = "unix:/path"` (or a bare path) with the port
+/// ignored — see [`TransportAddr::from_host_port`]. No struct or wire
+/// schema changes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransportAddr {
+    Tcp { host: String, port: u16 },
+    Unix(PathBuf),
+}
+
+impl TransportAddr {
+    /// Classify the `(host, port)` pair the existing plumbing carries.
+    /// `unix:`-prefixed, absolute-path, or `.sock`-suffixed hosts are UDS
+    /// (the port is ignored); anything else is TCP, byte-for-byte the
+    /// historical behavior.
+    pub fn from_host_port(host: &str, port: u16) -> Self {
+        if let Some(path) = host.strip_prefix("unix:") {
+            TransportAddr::Unix(PathBuf::from(path))
+        } else if host.starts_with('/') || host.ends_with(".sock") {
+            TransportAddr::Unix(PathBuf::from(host))
+        } else {
+            TransportAddr::Tcp {
+                host: host.to_string(),
+                port,
+            }
+        }
+    }
+
+    pub fn is_unix(&self) -> bool {
+        matches!(self, TransportAddr::Unix(_))
+    }
+}
+
+impl std::str::FromStr for TransportAddr {
+    type Err = TransportError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(path) = s.strip_prefix("unix:") {
+            if path.is_empty() {
+                return Err(TransportError::InvalidAddr(s.to_string()));
+            }
+            return Ok(TransportAddr::Unix(PathBuf::from(path)));
+        }
+        if s.starts_with('/') || s.ends_with(".sock") {
+            return Ok(TransportAddr::Unix(PathBuf::from(s)));
+        }
+        let (host, port) = s
+            .rsplit_once(':')
+            .ok_or_else(|| TransportError::InvalidAddr(s.to_string()))?;
+        let port = port
+            .parse::<u16>()
+            .map_err(|_| TransportError::InvalidAddr(s.to_string()))?;
+        Ok(TransportAddr::Tcp {
+            host: host.to_string(),
+            port,
+        })
+    }
+}
+
+impl std::fmt::Display for TransportAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransportAddr::Tcp { host, port } => write!(f, "{host}:{port}"),
+            TransportAddr::Unix(path) => write!(f, "unix:{}", path.display()),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum TransportError {
     #[error("socket closed during recv")]
     SocketClosed,
+
+    #[error("invalid transport address: {0:?} (expected host:port or unix:/path.sock)")]
+    InvalidAddr(String),
+
+    #[error("unix domain sockets are not supported on this platform: {0}")]
+    UnixUnsupported(String),
+
+    #[error("refusing to unlink non-socket file at unix socket path: {0}")]
+    NotASocketFile(String),
 
     #[error("tensor rank > {MAX_RANK} not supported (got {0} dims)")]
     RankTooHigh(usize),
@@ -163,7 +373,10 @@ pub struct TransferStats {
 }
 
 /// Send a tensor over a connected stream.
-pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResult<TransferStats> {
+pub async fn send_tensor<W: AsyncWrite + Unpin>(
+    sock: &mut W,
+    tensor: &Tensor,
+) -> TransportResult<TransferStats> {
     let start = Instant::now();
     let mut header = [0u8; HEADER_SIZE];
     header[0..4].copy_from_slice(&(tensor.data.len() as u32).to_be_bytes());
@@ -189,7 +402,9 @@ pub async fn send_tensor(sock: &mut TcpStream, tensor: &Tensor) -> TransportResu
 /// Also cross-checks the per-element count against the declared
 /// payload length so a peer can't claim `shape=[u32::MAX, ...]` to
 /// trigger overflow downstream.
-pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
+pub async fn recv_tensor<R: AsyncRead + Unpin>(
+    sock: &mut R,
+) -> TransportResult<(Tensor, TransferStats)> {
     recv_tensor_inner(sock, None).await
 }
 
@@ -205,7 +420,9 @@ pub async fn recv_tensor(sock: &mut TcpStream) -> TransportResult<(Tensor, Trans
 /// step loop for the whole idle ceiling with the task slot held
 /// (overload-backlog Item 5: forwarded-to head wedges, task never
 /// finalizes).
-pub async fn recv_tensor_reply(sock: &mut TcpStream) -> TransportResult<(Tensor, TransferStats)> {
+pub async fn recv_tensor_reply<R: AsyncRead + Unpin>(
+    sock: &mut R,
+) -> TransportResult<(Tensor, TransferStats)> {
     recv_tensor_inner(sock, Some(recv_timeout())).await
 }
 
@@ -222,8 +439,8 @@ pub const PREFILL_REPLY_TIMEOUT_FACTOR: u32 = 10;
 /// [`recv_tensor_reply`] with the widened prefill budget. Use for the token
 /// reply to a multi-token (prefill) hidden state; everything else uses
 /// `recv_tensor_reply`.
-pub async fn recv_tensor_reply_prefill(
-    sock: &mut TcpStream,
+pub async fn recv_tensor_reply_prefill<R: AsyncRead + Unpin>(
+    sock: &mut R,
 ) -> TransportResult<(Tensor, TransferStats)> {
     // saturating_mul: an absurdly large configured base must clamp, not
     // panic the engine thread (Duration's Mul panics on overflow).
@@ -234,8 +451,8 @@ pub async fn recv_tensor_reply_prefill(
     .await
 }
 
-async fn recv_tensor_inner(
-    sock: &mut TcpStream,
+async fn recv_tensor_inner<R: AsyncRead + Unpin>(
+    sock: &mut R,
     deadline_first_byte: Option<Duration>,
 ) -> TransportResult<(Tensor, TransferStats)> {
     let start = Instant::now();
@@ -437,7 +654,10 @@ fn frame_idle_ceiling() -> Option<Duration> {
 /// [`TransportError::FrameIdleCeiling`] — distinguishable from the
 /// per-frame deadline's `Io(TimedOut)` so the wrappers can treat it as
 /// connection-fatal.
-async fn recv_exact_frame_start(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()> {
+async fn recv_exact_frame_start<R: AsyncRead + Unpin>(
+    sock: &mut R,
+    buf: &mut [u8],
+) -> TransportResult<()> {
     let first_read = sock.read(buf);
     let n = match frame_idle_ceiling() {
         Some(ceiling) => match tokio::time::timeout(ceiling, first_read).await {
@@ -455,7 +675,7 @@ async fn recv_exact_frame_start(sock: &mut TcpStream, buf: &mut [u8]) -> Transpo
     Ok(())
 }
 
-async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()> {
+async fn recv_exact<R: AsyncRead + Unpin>(sock: &mut R, buf: &mut [u8]) -> TransportResult<()> {
     // DEFAULT_TIMEOUT bounds total wall-clock time we'll wait for `buf`
     // to fill. A peer that opens a connection and stops sending — or
     // sends one byte per second — must not be able to pin a worker
@@ -477,8 +697,8 @@ async fn recv_exact(sock: &mut TcpStream, buf: &mut [u8]) -> TransportResult<()>
     recv_exact_within(sock, buf, recv_timeout()).await
 }
 
-async fn recv_exact_within(
-    sock: &mut TcpStream,
+async fn recv_exact_within<R: AsyncRead + Unpin>(
+    sock: &mut R,
     buf: &mut [u8],
     to: Duration,
 ) -> TransportResult<()> {
@@ -502,51 +722,117 @@ async fn recv_exact_within(
     }
 }
 
-/// TCP server that receives activations from upstream.
+/// Server side of an activation link: receives activations from upstream.
+/// Binds TCP (`host:port`) or a Unix domain socket (`unix:/path.sock`,
+/// in-host stages) — the frame protocol on top is identical.
 pub struct ActivationServer {
-    bind_host: String,
-    bind_port: u16,
-    listener: Option<TcpListener>,
-    client: Option<TcpStream>,
-    accepted_addr: Option<SocketAddr>,
+    addr: TransportAddr,
+    listener: Option<ActivationListener>,
+    client: Option<ActivationStream>,
+    accepted_peer: Option<String>,
     actual_port: u16,
+    /// Unix socket path this server bound and therefore OWNS — unlinked on
+    /// [`close`](Self::close) and on `Drop` so a crash-restart can re-bind.
+    #[cfg(unix)]
+    owned_unix_path: Option<PathBuf>,
 }
 
 impl ActivationServer {
+    /// `host` may be a hostname/IP (TCP, with `port`) or a UDS form
+    /// (`unix:/path.sock`, `/abs/path.sock` — `port` ignored). See
+    /// [`TransportAddr::from_host_port`].
     pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self::for_addr(TransportAddr::from_host_port(&host.into(), port))
+    }
+
+    pub fn for_addr(addr: TransportAddr) -> Self {
+        let actual_port = match &addr {
+            TransportAddr::Tcp { port, .. } => *port,
+            TransportAddr::Unix(_) => 0,
+        };
         Self {
-            bind_host: host.into(),
-            bind_port: port,
+            addr,
             listener: None,
             client: None,
-            accepted_addr: None,
-            actual_port: port,
+            accepted_peer: None,
+            actual_port,
+            #[cfg(unix)]
+            owned_unix_path: None,
         }
     }
 
     pub async fn start(&mut self) -> TransportResult<()> {
-        let listener = TcpListener::bind((self.bind_host.as_str(), self.bind_port)).await?;
-        self.actual_port = listener.local_addr()?.port();
-        self.listener = Some(listener);
-        info!(
-            host = %self.bind_host,
-            port = self.actual_port,
-            "ActivationServer listening"
-        );
+        match &self.addr {
+            TransportAddr::Tcp { host, port } => {
+                let listener = TcpListener::bind((host.as_str(), *port)).await?;
+                self.actual_port = listener.local_addr()?.port();
+                self.listener = Some(ActivationListener::Tcp(listener));
+                info!(
+                    host = %host,
+                    port = self.actual_port,
+                    "ActivationServer listening"
+                );
+            }
+            #[cfg(unix)]
+            TransportAddr::Unix(path) => {
+                // Crash recovery: a stale socket file from a previous run
+                // blocks bind with AddrInUse — unlink it first. ONLY a
+                // socket file: refusing to delete a regular file/dir at a
+                // mistyped path beats silently destroying user data.
+                match std::fs::symlink_metadata(path) {
+                    Ok(md) => {
+                        use std::os::unix::fs::FileTypeExt;
+                        if md.file_type().is_socket() {
+                            std::fs::remove_file(path)?;
+                            info!(path = %path.display(), "unlinked stale unix socket");
+                        } else {
+                            return Err(TransportError::NotASocketFile(path.display().to_string()));
+                        }
+                    }
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.into()),
+                }
+                let listener = UnixListener::bind(path)?;
+                // Owner-only: the socket is an unauthenticated pipeline
+                // endpoint; other users on a shared box must not reach it.
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+                self.actual_port = 0;
+                self.owned_unix_path = Some(path.clone());
+                self.listener = Some(ActivationListener::Unix(listener));
+                info!(path = %path.display(), "ActivationServer listening (unix)");
+            }
+            #[cfg(not(unix))]
+            TransportAddr::Unix(path) => {
+                return Err(TransportError::UnixUnsupported(path.display().to_string()));
+            }
+        }
         Ok(())
     }
 
+    /// Bound TCP port (resolves `:0` ephemeral binds); 0 for unix sockets.
     pub fn port(&self) -> u16 {
         self.actual_port
     }
 
     pub async fn accept(&mut self) -> TransportResult<()> {
         let listener = self.listener.as_ref().ok_or(TransportError::NotStarted)?;
-        let (sock, addr) = listener.accept().await?;
-        tune_pipeline_socket(&sock);
-        info!(peer = %addr, "ActivationServer accepted connection");
-        self.client = Some(sock);
-        self.accepted_addr = Some(addr);
+        let (stream, peer) = match listener {
+            ActivationListener::Tcp(l) => {
+                let (sock, addr) = l.accept().await?;
+                (ActivationStream::Tcp(sock), addr.to_string())
+            }
+            #[cfg(unix)]
+            ActivationListener::Unix(l) => {
+                let (sock, _addr) = l.accept().await?;
+                // UDS peers are almost always unnamed; identify by our path.
+                (ActivationStream::Unix(sock), format!("{}", self.addr))
+            }
+        };
+        stream.tune();
+        info!(peer = %peer, "ActivationServer accepted connection");
+        self.client = Some(stream);
+        self.accepted_peer = Some(peer);
         Ok(())
     }
 
@@ -566,7 +852,7 @@ impl ActivationServer {
     fn drop_connection_if_recv_fatal(&mut self, err: Option<&TransportError>) {
         if err.is_some_and(recv_error_is_connection_fatal) {
             self.client = None; // drop closes the fd
-            self.accepted_addr = None;
+            self.accepted_peer = None;
         }
     }
 
@@ -607,7 +893,7 @@ impl ActivationServer {
         if let Some(mut s) = self.client.take() {
             let _ = s.shutdown().await;
         }
-        self.accepted_addr = None;
+        self.accepted_peer = None;
     }
 
     pub async fn send(&mut self, tensor: &Tensor) -> TransportResult<TransferStats> {
@@ -645,29 +931,79 @@ impl ActivationServer {
             let _ = sock.shutdown().await;
         }
         self.listener = None;
-        self.accepted_addr = None;
+        self.accepted_peer = None;
+        self.unlink_owned_unix_socket();
+    }
+
+    /// Remove the unix socket file this server bound (no-op for TCP or if
+    /// already unlinked). Idempotent; called from `close()` and `Drop` so
+    /// graceful shutdown and panics both leave no stale socket behind.
+    #[cfg(unix)]
+    fn unlink_owned_unix_socket(&mut self) {
+        if let Some(path) = self.owned_unix_path.take() {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn unlink_owned_unix_socket(&mut self) {}
+}
+
+impl Drop for ActivationServer {
+    fn drop(&mut self) {
+        self.unlink_owned_unix_socket();
     }
 }
 
-/// TCP client that sends activations to downstream.
+/// Client side of an activation link: sends activations to downstream.
+/// Dials TCP (`host:port`) or a Unix domain socket (`unix:/path.sock`).
 pub struct ActivationClient {
-    host: String,
-    port: u16,
-    sock: Option<TcpStream>,
+    target: TransportAddr,
+    sock: Option<ActivationStream>,
 }
 
 impl ActivationClient {
+    /// `host` may be a hostname/IP (TCP, with `port`) or a UDS form
+    /// (`unix:/path.sock`, `/abs/path.sock` — `port` ignored). See
+    /// [`TransportAddr::from_host_port`].
     pub fn new(host: impl Into<String>, port: u16) -> Self {
         Self {
-            host: host.into(),
-            port,
+            target: TransportAddr::from_host_port(&host.into(), port),
             sock: None,
+        }
+    }
+
+    pub fn for_addr(target: TransportAddr) -> Self {
+        Self { target, sock: None }
+    }
+
+    /// One connect attempt for the configured target flavor.
+    async fn dial(&self) -> io::Result<ActivationStream> {
+        match &self.target {
+            TransportAddr::Tcp { host, port } => Ok(ActivationStream::Tcp(
+                TcpStream::connect((host.as_str(), *port)).await?,
+            )),
+            #[cfg(unix)]
+            TransportAddr::Unix(path) => {
+                Ok(ActivationStream::Unix(UnixStream::connect(path).await?))
+            }
+            #[cfg(not(unix))]
+            TransportAddr::Unix(_) => unreachable!("guarded in connect_with_timeout"),
         }
     }
 
     /// Connect with retries until `timeout` elapses (mirrors the Python
     /// implementation's wait-for-peer behaviour during pipeline startup).
+    /// The retry loop is flavor-agnostic: a UDS downstream that hasn't
+    /// bound its socket yet fails with NotFound/ConnectionRefused and is
+    /// retried exactly like a TCP peer that isn't accepting yet.
     pub async fn connect_with_timeout(&mut self, timeout: Duration) -> TransportResult<()> {
+        // A unix target on a non-unix platform can never succeed — fail
+        // fast instead of burning the whole connect timeout retrying.
+        #[cfg(not(unix))]
+        if let TransportAddr::Unix(path) = &self.target {
+            return Err(TransportError::UnixUnsupported(path.display().to_string()));
+        }
         let start = Instant::now();
         let deadline = start + timeout;
         // Tell the operator up-front what we're waiting on. Without this
@@ -676,18 +1012,17 @@ impl ActivationClient {
         // bring-up. We log the target and the budget so the wait is
         // legible, then a progress line every few seconds.
         info!(
-            host = %self.host,
-            port = self.port,
+            target = %self.target,
             timeout_s = timeout.as_secs(),
             "waiting for downstream peer to accept (start the downstream worker first)"
         );
         let mut last_err: Option<io::Error> = None;
         let mut next_progress = start + Duration::from_secs(5);
         while Instant::now() < deadline {
-            match TcpStream::connect((self.host.as_str(), self.port)).await {
+            match self.dial().await {
                 Ok(sock) => {
-                    tune_pipeline_socket(&sock);
-                    info!(host = %self.host, port = self.port, "ActivationClient connected");
+                    sock.tune();
+                    info!(target = %self.target, "ActivationClient connected");
                     self.sock = Some(sock);
                     return Ok(());
                 }
@@ -696,8 +1031,7 @@ impl ActivationClient {
                     let now = Instant::now();
                     if now >= next_progress {
                         warn!(
-                            host = %self.host,
-                            port = self.port,
+                            target = %self.target,
                             waited_s = now.duration_since(start).as_secs(),
                             timeout_s = timeout.as_secs(),
                             "still waiting for downstream peer (not accepting yet)"
@@ -711,13 +1045,13 @@ impl ActivationClient {
         // Actionable timeout: name the address and the usual causes so an
         // operator doesn't have to reverse-engineer a bare io::Error.
         warn!(
-            host = %self.host,
-            port = self.port,
+            target = %self.target,
             timeout_s = timeout.as_secs(),
             last_error = ?last_err.as_ref().map(|e| e.to_string()),
             "could not connect to downstream peer within timeout — check that the \
-             downstream worker is running, that its --listen port matches this \
-             --next, and that no firewall blocks the port"
+             downstream worker is running, that its --listen address matches this \
+             --next, and that no firewall blocks the port (TCP) or that both \
+             stages use the same socket path (unix)"
         );
         if let Some(err) = last_err {
             return Err(err.into());
@@ -1377,6 +1711,287 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_millis(500),
             "recv after peer RST must fail fast"
+        );
+    }
+
+    // --- TransportAddr parsing (#17 acceptance) ---------------------------
+
+    #[test]
+    fn transport_addr_recognizes_all_forms() {
+        use std::str::FromStr;
+        // Explicit unix: prefix.
+        assert_eq!(
+            TransportAddr::from_str("unix:/tmp/cascadia-1.sock").unwrap(),
+            TransportAddr::Unix(PathBuf::from("/tmp/cascadia-1.sock"))
+        );
+        // Absolute path.
+        assert_eq!(
+            TransportAddr::from_str("/tmp/cascadia-1.sock").unwrap(),
+            TransportAddr::Unix(PathBuf::from("/tmp/cascadia-1.sock"))
+        );
+        // Relative path with .sock suffix.
+        assert_eq!(
+            TransportAddr::from_str("stage-1.sock").unwrap(),
+            TransportAddr::Unix(PathBuf::from("stage-1.sock"))
+        );
+        // IP:port.
+        assert_eq!(
+            TransportAddr::from_str("127.0.0.1:9100").unwrap(),
+            TransportAddr::Tcp {
+                host: "127.0.0.1".into(),
+                port: 9100
+            }
+        );
+        // hostname:port.
+        assert_eq!(
+            TransportAddr::from_str("cascadia-matias-03:9100").unwrap(),
+            TransportAddr::Tcp {
+                host: "cascadia-matias-03".into(),
+                port: 9100
+            }
+        );
+        // Rejects: empty unix path, missing port, junk port.
+        assert!(TransportAddr::from_str("unix:").is_err());
+        assert!(TransportAddr::from_str("justahost").is_err());
+        assert!(TransportAddr::from_str("host:notaport").is_err());
+    }
+
+    #[test]
+    fn from_host_port_matches_the_peer_endpoint_seam() {
+        // The (host, port) forms the CLI/PeerEndpoint plumbing carries.
+        assert_eq!(
+            TransportAddr::from_host_port("unix:/tmp/x.sock", 0),
+            TransportAddr::Unix(PathBuf::from("/tmp/x.sock"))
+        );
+        assert_eq!(
+            TransportAddr::from_host_port("/tmp/x.sock", 9100),
+            TransportAddr::Unix(PathBuf::from("/tmp/x.sock"))
+        );
+        assert_eq!(
+            TransportAddr::from_host_port("10.0.0.2", 9100),
+            TransportAddr::Tcp {
+                host: "10.0.0.2".into(),
+                port: 9100
+            }
+        );
+    }
+
+    // --- Unix-domain-socket transport (#17) --------------------------------
+
+    /// Per-test socket path in a short tmp dir (macOS sun_path caps at 104
+    /// bytes; the default TMPDIR + a long test name can exceed it).
+    #[cfg(unix)]
+    fn test_sock_path(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("cascadia-uds-tests");
+        let _ = std::fs::create_dir_all(&dir);
+        dir.join(format!("{tag}-{}.sock", std::process::id()))
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_roundtrip_f32_2d() {
+        let sock_path = test_sock_path("roundtrip");
+        let _ = std::fs::remove_file(&sock_path);
+        let mut server = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        server.start().await.unwrap();
+        assert_eq!(server.port(), 0, "unix listeners have no TCP port");
+
+        let addr = format!("unix:{}", sock_path.display());
+        let server_handle = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            let (got, _) = server.recv().await.unwrap();
+            server.close().await;
+            got
+        });
+
+        let mut client = ActivationClient::new(addr, 0);
+        client.connect().await.unwrap();
+        let payload = vec![0u8, 0, 128, 63, 0, 0, 0, 64]; // f32: 1.0, 2.0
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, payload.clone());
+        client.send(&tensor).await.unwrap();
+        let got = server_handle.await.unwrap();
+        assert_eq!(got.dtype, DType::F32);
+        assert_eq!(got.shape, [1, 1, 2]);
+        assert_eq!(got.data, payload);
+        assert!(
+            !sock_path.exists(),
+            "close() must unlink the socket file it bound"
+        );
+    }
+
+    /// Raw control bytes (the dist-spec frame protocol) over UDS.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_raw_bytes_roundtrip() {
+        let sock_path = test_sock_path("raw");
+        let _ = std::fs::remove_file(&sock_path);
+        let mut server = ActivationServer::new(sock_path.display().to_string(), 0);
+        server.start().await.unwrap();
+        let addr = sock_path.display().to_string();
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            let kind = server.recv_raw(4).await.unwrap();
+            server.send_raw(&[9, 9]).await.unwrap();
+            kind
+        });
+        let mut client = ActivationClient::new(addr, 0);
+        client.connect().await.unwrap();
+        client.send_raw(&[1, 2, 3, 4]).await.unwrap();
+        let reply = client.recv_raw(2).await.unwrap();
+        let kind = h.await.unwrap();
+        assert_eq!(kind, vec![1, 2, 3, 4]);
+        assert_eq!(reply, vec![9, 9]);
+    }
+
+    /// A stale socket file from a crashed prior run must be unlinked and
+    /// re-bound automatically (#17 acceptance: crash recovery).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_stale_socket_is_unlinked_and_rebound() {
+        let sock_path = test_sock_path("stale");
+        let _ = std::fs::remove_file(&sock_path);
+        // Simulate the crash: bind a socket, then leak the file by
+        // mem::forgetting the server (Drop would unlink it).
+        let mut first = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        first.start().await.unwrap();
+        std::mem::forget(first);
+        assert!(sock_path.exists(), "precondition: stale socket file left");
+
+        let mut second = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        second
+            .start()
+            .await
+            .expect("stale socket must be unlinked and re-bound");
+        second.close().await;
+        let _ = std::fs::remove_file(&sock_path);
+    }
+
+    /// A REGULAR file at the socket path must NOT be deleted — fail loud.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_refuses_to_unlink_non_socket_file() {
+        let sock_path = test_sock_path("nonsock");
+        std::fs::write(&sock_path, b"precious data").unwrap();
+        let mut server = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        let res = server.start().await;
+        assert!(
+            matches!(res, Err(TransportError::NotASocketFile(_))),
+            "must refuse to clobber a regular file: {res:?}"
+        );
+        assert_eq!(
+            std::fs::read(&sock_path).unwrap(),
+            b"precious data",
+            "the file must be untouched"
+        );
+        let _ = std::fs::remove_file(&sock_path);
+    }
+
+    /// The bound socket must be owner-only (0600) — it is an
+    /// unauthenticated pipeline endpoint on a possibly-shared box.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_socket_mode_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let sock_path = test_sock_path("mode");
+        let _ = std::fs::remove_file(&sock_path);
+        let mut server = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        server.start().await.unwrap();
+        let mode = std::fs::metadata(&sock_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "socket mode {:o}", mode & 0o777);
+        server.close().await;
+    }
+
+    /// The dialer's retry loop must wait out a not-yet-bound UDS peer the
+    /// same way it waits for a not-yet-listening TCP peer (downstream-first
+    /// startup contract).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_connect_retries_until_server_binds() {
+        let sock_path = test_sock_path("retry");
+        let _ = std::fs::remove_file(&sock_path);
+        let addr = format!("unix:{}", sock_path.display());
+        let dial_addr = addr.clone();
+        let dialer = tokio::spawn(async move {
+            let mut client = ActivationClient::new(dial_addr, 0);
+            client
+                .connect_with_timeout(Duration::from_secs(10))
+                .await
+                .map(|_| client)
+        });
+        // Bind late: the client must be mid-retry by now.
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+        let mut server = ActivationServer::new(addr, 0);
+        server.start().await.unwrap();
+        server.accept().await.unwrap();
+        let mut client = dialer
+            .await
+            .unwrap()
+            .expect("late-bound unix peer must be reachable via the retry loop");
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        client.send(&tensor).await.unwrap();
+        let (got, _) = server.recv().await.unwrap();
+        assert_eq!(got.data, tensor.data);
+        server.close().await;
+    }
+
+    /// Reply-deadline semantics are flavor-independent: a silent UDS peer
+    /// that owes a mid-task reply must fail fast and poison the connection,
+    /// exactly like TCP.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_reply_timeout_fails_fast_and_poisons() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let sock_path = test_sock_path("reply");
+        let _ = std::fs::remove_file(&sock_path);
+        let mut server = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        server.start().await.unwrap();
+        let addr = format!("unix:{}", sock_path.display());
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            let first = server.recv_reply().await;
+            let second = server.recv().await;
+            (first, second)
+        });
+        let mut client = ActivationClient::new(addr, 0);
+        client.connect().await.unwrap();
+        // Send nothing: the reply never comes.
+        let (first, second) = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(first.is_err(), "missing reply must time out, got {first:?}");
+        assert!(
+            matches!(second, Err(TransportError::NotConnected)),
+            "poisoned unix connection must fail fast: {second:?}"
+        );
+    }
+
+    /// Idle-tolerance parity: an idle gap longer than the strict recv
+    /// timeout must not kill a UDS link waiting for its NEXT frame.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_idle_gap_longer_than_timeout_does_not_kill_recv() {
+        let _g = TIMEOUT_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_activation_timeout_secs(1);
+        let sock_path = test_sock_path("idle");
+        let _ = std::fs::remove_file(&sock_path);
+        let mut server = ActivationServer::new(format!("unix:{}", sock_path.display()), 0);
+        server.start().await.unwrap();
+        let addr = format!("unix:{}", sock_path.display());
+        let h = tokio::spawn(async move {
+            server.accept().await.unwrap();
+            server.recv().await
+        });
+        let mut client = ActivationClient::new(addr, 0);
+        client.connect().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(2500)).await; // idle > timeout
+        let tensor = Tensor::from_2d(DType::F32, 1, 2, vec![0, 0, 128, 63, 0, 0, 0, 64]);
+        client.send(&tensor).await.unwrap();
+        let got = h.await.unwrap();
+        set_activation_timeout_secs(0);
+        assert!(
+            got.is_ok(),
+            "idle unix link must not time out waiting for the next frame: {:?}",
+            got.err()
         );
     }
 

--- a/crates/cascadia-transport/tests/uds_vs_tcp_bench.rs
+++ b/crates/cascadia-transport/tests/uds_vs_tcp_bench.rs
@@ -1,0 +1,98 @@
+//! #17 acceptance micro-benchmark: round-trip latency for pipeline-sized
+//! tensor frames over a Unix domain socket vs loopback TCP on one host.
+//!
+//! Ignored by default (it's a timing measurement, not a pass/fail test).
+//! Run manually:
+//!
+//! ```bash
+//! cargo test -p cascadia-transport --release --test uds_vs_tcp_bench -- --ignored --nocapture
+//! ```
+//!
+//! Results are recorded in docs/CLI.md ("Unix domain sockets").
+
+#![cfg(unix)]
+
+use std::time::Instant;
+
+use cascadia_transport::{ActivationClient, ActivationServer, DType, Tensor};
+
+const ROUNDS: usize = 300;
+const WARMUP: usize = 30;
+
+/// One echo server: recv a tensor, send it straight back, forever.
+async fn echo_server(mut server: ActivationServer) {
+    server.accept().await.unwrap();
+    loop {
+        let Ok((tensor, _)) = server.recv().await else {
+            return;
+        };
+        if server.send(&tensor).await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Drive ROUNDS round trips of `frame_bytes`-sized frames; returns
+/// (mean_us, p50_us, p99_us) per round trip.
+async fn bench_roundtrips(client: &mut ActivationClient, frame_bytes: usize) -> (f64, f64, f64) {
+    let cols = (frame_bytes / 4) as u32; // f32 elements
+    let tensor = Tensor::from_2d(DType::F32, 1, cols, vec![0u8; cols as usize * 4]);
+    for _ in 0..WARMUP {
+        client.send(&tensor).await.unwrap();
+        client.recv_reply().await.unwrap();
+    }
+    let mut samples_us = Vec::with_capacity(ROUNDS);
+    for _ in 0..ROUNDS {
+        let start = Instant::now();
+        client.send(&tensor).await.unwrap();
+        let (echoed, _) = client.recv_reply().await.unwrap();
+        samples_us.push(start.elapsed().as_secs_f64() * 1e6);
+        assert_eq!(echoed.data.len(), tensor.data.len());
+    }
+    samples_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mean = samples_us.iter().sum::<f64>() / samples_us.len() as f64;
+    let p50 = samples_us[samples_us.len() / 2];
+    let p99 = samples_us[samples_us.len() * 99 / 100];
+    (mean, p50, p99)
+}
+
+#[tokio::test]
+#[ignore = "timing benchmark; run with --ignored --nocapture"]
+async fn uds_vs_tcp_roundtrip_latency() {
+    // Frame sizes: 14 KiB ≈ a 7168-dim bf16 hidden state (K2.6-class decode
+    // step), 1 MiB ≈ a large prefill/logits frame.
+    for &frame in &[14 * 1024usize, 1024 * 1024] {
+        // TCP over loopback.
+        let mut tcp_server = ActivationServer::new("127.0.0.1", 0);
+        tcp_server.start().await.unwrap();
+        let port = tcp_server.port();
+        tokio::spawn(echo_server(tcp_server));
+        let mut tcp_client = ActivationClient::new("127.0.0.1", port);
+        tcp_client.connect().await.unwrap();
+        let (tcp_mean, tcp_p50, tcp_p99) = bench_roundtrips(&mut tcp_client, frame).await;
+
+        // Unix domain socket.
+        let sock = std::env::temp_dir().join(format!("cascadia-bench-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let addr = format!("unix:{}", sock.display());
+        let mut uds_server = ActivationServer::new(addr.clone(), 0);
+        uds_server.start().await.unwrap();
+        tokio::spawn(echo_server(uds_server));
+        let mut uds_client = ActivationClient::new(addr, 0);
+        uds_client.connect().await.unwrap();
+        let (uds_mean, uds_p50, uds_p99) = bench_roundtrips(&mut uds_client, frame).await;
+        let _ = std::fs::remove_file(&sock);
+
+        println!(
+            "frame {:>7} B | tcp mean {:>8.1} us p50 {:>8.1} p99 {:>8.1} | uds mean {:>8.1} us p50 {:>8.1} p99 {:>8.1} | p50 win {:>5.1}%",
+            frame,
+            tcp_mean,
+            tcp_p50,
+            tcp_p99,
+            uds_mean,
+            uds_p50,
+            uds_p99,
+            (1.0 - uds_p50 / tcp_p50) * 100.0
+        );
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,15 +98,56 @@ cascadia worker --rank <N> --total <N> --model <DIR> [OPTIONS]
 | `--rank <RANK>` | *required* | 0-based stage index. |
 | `--total <TOTAL>` | *required* | Total number of stages. |
 | `--model <MODEL>` | *required* | Local model directory. Not an HF repo id. |
-| `--listen <LISTEN>` | `:9100` | Bind address for the upstream-receiving socket. |
-| `--next <NEXT>` | — | Downstream peer `host:port`. Required for every stage but the last. |
-| `--api <API>` | — | API bind address. **Rank 0 only** — other ranks enter the relay loop and never bind it. Passing it there logs a warning and is otherwise ignored. |
+| `--listen <LISTEN>` | `:9100` | Bind address for the upstream-receiving socket: `host:port`, `:port`, or a [unix socket](#unix-domain-sockets) `unix:/path.sock`. |
+| `--next <NEXT>` | — | Downstream peer: `host:port` or `unix:/path.sock`. Required for every stage but the last. |
+| `--api <API>` | — | API bind address (TCP only). **Rank 0 only** — other ranks enter the relay loop and never bind it. Passing it there logs a warning and is otherwise ignored. |
 | `--engine <ENGINE>` | `mock` | Inference engine. `mock` runs without OpenVINO. |
 | `--device <DEVICE>` | `CPU` | OpenVINO device target — see [below](#device-forms). |
 
 Rank 0 serves the API and holds the first layers; the last rank produces tokens
 and returns them up the chain. Start the *downstream* worker first — engines
 wait 60 s for a downstream peer, then give up.
+
+### Unix domain sockets
+
+When two adjacent stages run on the SAME host (iGPU stage 0 → dGPU stage 1 on
+one workstation, or single-box stage testing), link them over a Unix domain
+socket instead of loopback TCP ([#17](https://github.com/labscommunity/cascadia/issues/17)):
+
+```bash
+# stage 1 (start first)
+cascadia worker --rank 1 --total 2 --model <DIR> --listen unix:/tmp/cascadia-1.sock
+
+# stage 0
+cascadia worker --rank 0 --total 2 --model <DIR> --next unix:/tmp/cascadia-1.sock --api :8416
+```
+
+Address forms recognized for `--listen`/`--next`: `unix:/path.sock`
+(explicit), an absolute path, or any `.sock`-suffixed path. The wire format
+is identical to TCP; the two stages must simply agree on the path.
+
+Measured round-trip latency vs `127.0.0.1` TCP (Apple Silicon macOS, release
+build, `cargo test -p cascadia-transport --release --test uds_vs_tcp_bench --
+--ignored --nocapture`):
+
+| Frame | TCP p50 | UDS p50 | Win |
+|---|---|---|---|
+| 14 KiB (decode-step hidden state) | ~32–55 µs | ~4–5 µs | ~85–92 % |
+| 1 MiB (prefill/logits class) | ~145–180 µs | ~108–111 µs | ~24–40 % |
+
+Notes:
+
+- Unix only (Linux/macOS). On Windows a `unix:` address fails fast with a
+  clear error; use TCP there.
+- The socket file is created mode `0600` (owner-only) and unlinked on
+  shutdown; a stale socket left by a crash is unlinked and re-bound
+  automatically. A **non-socket** file at the path is never deleted — the
+  worker refuses to start instead.
+- `--api` stays TCP; unix addresses are for the inter-stage activation
+  relay only.
+- Cross-host topology probing doesn't apply: a UDS-listening stage
+  advertises no TCP relay port over mDNS, so the dashboard's latency matrix
+  skips it (in-host links aren't cross-host topology).
 
 ### Layer split
 

--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -126,12 +126,36 @@ impl MockPipeline {
     /// Spawn an N-stage mock pipeline on 127.0.0.1, downstream-first (each
     /// upstream needs its downstream listening before it connects).
     pub async fn spawn(stages: usize) -> Self {
+        let listen_addrs: Vec<String> = (0..stages)
+            .map(|_| format!("127.0.0.1:{}", pick_free_port()))
+            .collect();
+        Self::spawn_with_links(stages, &listen_addrs).await
+    }
+
+    /// Spawn an N-stage mock pipeline linked over Unix domain sockets
+    /// (`unix:/path.sock` --listen/--next, #17) instead of loopback TCP.
+    /// Unix-only.
+    #[cfg(unix)]
+    pub async fn spawn_uds(stages: usize) -> Self {
+        let dir = std::env::temp_dir().join("cascadia-e2e-uds");
+        let _ = std::fs::create_dir_all(&dir);
+        let pid = std::process::id();
+        let listen_addrs: Vec<String> = (0..stages)
+            .map(|rank| format!("unix:{}/p{pid}-r{rank}.sock", dir.display()))
+            .collect();
+        Self::spawn_with_links(stages, &listen_addrs).await
+    }
+
+    /// Shared spawner: `listen_addrs[rank]` is the address stage `rank`
+    /// listens on (TCP `host:port` or `unix:/path.sock`); stage N-1's
+    /// `--next` is `listen_addrs[N]`.
+    async fn spawn_with_links(stages: usize, listen_addrs: &[String]) -> Self {
         assert!(stages >= 1, "need at least one stage");
+        assert_eq!(listen_addrs.len(), stages);
         let bin = binary_path();
         assert!(bin.exists(), "cascadia binary not built ({:?})", bin);
 
         let api_port = pick_free_port();
-        let listen_ports: Vec<u16> = (0..stages).map(|_| pick_free_port()).collect();
         let mut procs = Vec::with_capacity(stages);
 
         for rank in (0..stages).rev() {
@@ -152,11 +176,11 @@ impl MockPipeline {
             ];
             if !is_first {
                 args.push("--listen".into());
-                args.push(format!("127.0.0.1:{}", listen_ports[rank]));
+                args.push(listen_addrs[rank].clone());
             }
             if !is_last {
                 args.push("--next".into());
-                args.push(format!("127.0.0.1:{}", listen_ports[rank + 1]));
+                args.push(listen_addrs[rank + 1].clone());
             }
             if is_first {
                 args.push("--api".into());
@@ -173,7 +197,8 @@ impl MockPipeline {
             // No inter-stage sleep needed: stages are spawned downstream-first
             // and the activation transport retries its connect (every 500ms up
             // to DEFAULT_CONNECT_TIMEOUT = 30s), so an upstream simply waits out
-            // the gap until its downstream is bound and accepting.
+            // the gap until its downstream is bound and accepting. The same
+            // retry contract covers a not-yet-bound unix socket path.
         }
         Self {
             api_port,
@@ -324,6 +349,65 @@ mod tests {
             .as_str()
             .expect("content string");
         assert!(!content.is_empty(), "pipeline produced empty completion");
+    }
+
+    /// Ask a pipeline's API for one deterministic mock completion; returns
+    /// the assistant content.
+    async fn chat_once(pipe: &MockPipeline, prompt: &str) -> String {
+        let client = reqwest::Client::new();
+        let body = serde_json::json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 4,
+            "stream": false,
+        });
+        let r = client
+            .post(pipe.url("/v1/chat/completions"))
+            .json(&body)
+            .send()
+            .await
+            .expect("post chat");
+        assert!(r.status().is_success(), "chat status: {}", r.status());
+        let v: serde_json::Value = r.json().await.unwrap();
+        v["choices"][0]["message"]["content"]
+            .as_str()
+            .expect("content string")
+            .to_string()
+    }
+
+    /// #17: a 2-stage worker chain configured with `unix:` --listen/--next
+    /// comes up healthy and answers identically to the TCP chain.
+    ///
+    /// Scope honesty: the MOCK engine's connect/configure_listen are
+    /// no-ops, so no activation tensors cross the socket here — this test
+    /// pins the CLI surface (unix address parsing, worker startup, no
+    /// bogus TCP probe bind, identical output). The actual frame protocol
+    /// over a real UnixStream is exercised by
+    /// `cascadia-engine-sparse-moe/tests/dist_wire.rs::
+    /// uds_sequence_reset_then_forward_then_token` (engine wire) and the
+    /// `uds_*` tests in cascadia-transport (framing/timeout semantics).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_pipeline_matches_tcp_pipeline_output() {
+        let tcp = MockPipeline::spawn(2).await;
+        let uds = MockPipeline::spawn_uds(2).await;
+        assert!(
+            tcp.wait_for_health(Duration::from_secs(20)).await,
+            "TCP 2-stage pipeline did not become healthy"
+        );
+        assert!(
+            uds.wait_for_health(Duration::from_secs(20)).await,
+            "UDS 2-stage pipeline did not become healthy"
+        );
+
+        let prompt = "alpha bravo charlie delta echo foxtrot";
+        let tcp_out = chat_once(&tcp, prompt).await;
+        let uds_out = chat_once(&uds, prompt).await;
+        assert!(!uds_out.is_empty(), "UDS chain produced empty completion");
+        assert_eq!(
+            tcp_out, uds_out,
+            "UDS chain must produce byte-identical output to the TCP chain"
+        );
     }
 
     /// Cross-node sharded e2e: brings up an N-stage topology across real fleet


### PR DESCRIPTION
Closes #17.

## What

`--listen` / `--next` now accept `unix:/path/to.sock` (also a bare absolute path or any `.sock`-suffixed path) and link two same-host stages over a Unix domain socket instead of loopback TCP — the case #17 targets (iGPU stage 0 → dGPU stage 1 in one box, single-box stage testing). TCP stays the default and the only cross-host path; the wire format is byte-identical on both flavors.

```bash
# stage 1 (start first)
cascadia worker --rank 1 --total 2 --model <DIR> --listen unix:/tmp/cascadia-1.sock
# stage 0
cascadia worker --rank 0 --total 2 --model <DIR> --next unix:/tmp/cascadia-1.sock --api :8416
```

## Measured win

Round-trip latency vs `127.0.0.1` TCP (Apple Silicon macOS, release, `--test uds_vs_tcp_bench -- --ignored --nocapture`):

| Frame | TCP p50 | UDS p50 | Win |
|---|---|---|---|
| 14 KiB (decode-step hidden state) | ~32–55 µs | ~4–5 µs | **~85–92 %** |
| 1 MiB (prefill/logits class) | ~145–180 µs | ~108–111 µs | ~24–40 % |

Above the issue's 10–20 % expectation. One tuning knob was load-bearing: AF_UNIX default kernel buffers (~8 KiB on macOS) throttled MB-class frames *below* TCP loopback until the streams got 1 MiB SO_SNDBUF/SO_RCVBUF — without it, large frames were 2× **slower** on UDS.

## Design

- **`TransportAddr`** (`Tcp{host,port}` | `Unix(PathBuf)`) classifies addresses at the `(host, port)` seams the codebase already has: a UDS address travels as `host="unix:/path", port=0` through `PeerEndpoint` / `configure_listen` / the transport constructors — **zero engine, `PeerLayout`, or wire-schema changes** (nothing serializes `PeerLayout`, verified).
- **`ActivationStream`** (`Tcp` | `Unix`) implements `AsyncRead`/`AsyncWrite` by delegation; every frame helper (`send_tensor`, `recv_tensor*`, `recv_exact*`) is genericized over the stream traits, so both flavors share one code path and existing raw-`TcpStream` callers compile unchanged. Per-flavor tuning: TCP keeps NODELAY+keepalive; UDS gets the 1 MiB buffers (no Nagle/keepalive concepts apply).
- **Socket lifecycle** (issue acceptance): bound mode `0600` (unauthenticated endpoint on possibly-shared boxes); unlinked on `close()` **and** `Drop`; a stale socket from a crashed run is unlinked + re-bound automatically, but a **non-socket** file at the path is never deleted — the worker refuses to start (`NotASocketFile`).
- **Windows**: all UDS code is `#[cfg(unix)]`; a `unix:` address fails fast with a clear error instead of burning the 60–300 s connect retry budget. Verified via `cargo check --target x86_64-pc-windows-msvc` on the UDS-bearing crates (the AI-PC runner is still offline — see #112's note).
- **CLI**: `parse_addr` recognizes unix forms before its colon split; `--api` rejects unix addresses up-front (HTTP stays TCP); the mock-engine TCP probe listener is skipped for a unix `--listen`, and such a stage advertises no relay port over mDNS (cross-host latency probing doesn't apply to an in-host link — documented).
- The dialer's 500 ms retry loop is flavor-agnostic, so the downstream-first startup contract (`--next` waits for the listener) holds identically for a not-yet-bound socket path.

## Testing

- **Transport**: `TransportAddr` parse matrix (all four #17 forms + rejects); UDS roundtrip (tensor + raw control bytes); stale-socket rebind; non-socket-file refusal; 0600 mode; connect-retry-until-late-bind; reply-timeout fail-fast + connection poison; idle-gap tolerance — semantics parity with the existing TCP tests. 36/36 green.
- **Engine wire protocol**: `dist_wire.rs::uds_sequence_reset_then_forward_then_token` drives the real sparse-MoE frame sequence (Reset → Forward with a 7168-dim K2.6-sized hidden state → Token upstream, both directions consumed) over a real `UnixStream`.
- **e2e**: a 2-stage `cascadia worker` chain with `unix:` links comes up healthy and produces byte-identical output to the TCP chain. Scope stated honestly in the test: the mock engine's connect is a no-op, so this pins the CLI surface (parsing, startup, probe-listener skip), not tensor traffic — that's what the two layers above cover.
- Full workspace: `fmt`, `clippy` (no new warnings vs baseline, verified by stash-diff), `cargo test --workspace --all-targets` 49/49 suites, all local-only.

## Deferred / notes

- The issue's "K2.6 3-prompt eval over UDS on a single host" needs a real model on fleet hardware — off-limits for this autonomous run. The engine-wire UDS test is the deepest local equivalent; happy to run the K2.6 eval on the fleet as a follow-up when convenient.
- Relates to #76 (injected byte streams): `ActivationStream` + the genericized frame helpers are the groundwork that proposal needs; full stream injection (re-attach on a live engine) remains open there.
- Touches the same `cascadia-transport` functions as #112 (metrics); whichever merges second has a small, mechanical conflict to resolve in `send_tensor`/`recv_tensor_inner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)