### PR TITLE
feat(npu): continuous batching on the NPU via packed multi-slot decode

### DIFF
--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1786,6 +1786,9 @@ fn engine_error_response(err: cascadia_engine::EngineError) -> axum::response::R
     let status = match &err {
         EngineError::QueueFull { .. } => StatusCode::SERVICE_UNAVAILABLE,
         EngineError::NotLoaded | EngineError::NotConnected => StatusCode::SERVICE_UNAVAILABLE,
+        // Permanent for this request: retrying sends the identical prompt into
+        // the identical window. 413 is what every SDK treats as non-retryable.
+        EngineError::PromptTooLong(_) => StatusCode::PAYLOAD_TOO_LARGE,
         EngineError::InvalidConfig(_)
         | EngineError::PeerRejected(_)
         | EngineError::ShardRejected(_) => StatusCode::BAD_REQUEST,
@@ -1821,6 +1824,19 @@ mod tests {
     // engine sets `n_tokens` on a single text-bearing final chunk, that count
     // is authoritative (not the "1 per chunk" fallback), so `usage` reflects
     // the real generated-token count rather than 0/1.
+    /// A prompt that cannot fit the engine's per-request window is a permanent,
+    /// deterministic rejection of THIS request — not backpressure. It must not
+    /// map to 503: the official SDKs retry 5xx with backoff, so a request that
+    /// can never succeed would be sent three times before surfacing, and the
+    /// operator could not tell it apart from genuine "engine at capacity".
+    #[test]
+    fn prompt_too_long_maps_to_413_not_503() {
+        let r = engine_error_response(cascadia_engine::EngineError::PromptTooLong(
+            "prompt is 207 tokens but this worker's per-slot KV region holds 127".into(),
+        ));
+        assert_eq!(r.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
     #[test]
     fn chunk_token_count_honors_engine_count() {
         // ov-genai's shape: whole response on one final chunk, n_tokens set.

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -424,6 +424,14 @@ pub struct WorkerArgs {
     #[arg(long, default_value_t = 0)]
     pub packed_slots: u32,
 
+    /// Reserve N KV slots as a read-only SHARED prefix that every packed slot
+    /// may attend to — prefix caching without paged attention. The first
+    /// admitted request populates it; later requests sharing that prompt prefix
+    /// skip re-prefilling those tokens. Taken from the same window, so it costs
+    /// per-slot context. Requires --packed-slots. 0 = off.
+    #[arg(long, default_value_t = 0)]
+    pub packed_prefix: u32,
+
     /// Continuous batching (#20, ov-genai only): serve concurrent requests
     /// through one ContinuousBatchingPipeline (paged attention; CPU/GPU
     /// plugins) instead of one generation at a time. Incompatible with
@@ -661,6 +669,7 @@ impl WorkerArgs {
             spec_k: 5,
             prompt_lookup: 0,
             packed_slots: 0,
+            packed_prefix: 0,
             cb: false,
             cb_cache_size: 0,
             cb_max_num_seqs: 0,
@@ -1245,6 +1254,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
             }
             b = b.with_chunked_prefill_disabled(args.no_chunked_prefill);
             b.packed_slots = args.packed_slots;
+            b.packed_prefix = args.packed_prefix;
             b = b.with_prefill_parking(args.park_prefill);
             b = b.with_gemv_offload(args.gemv_offload);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
@@ -1498,6 +1508,12 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
     if (args.prefill_device.is_some() || args.park_prefill) && args.no_chunked_prefill {
         return Err(anyhow!(
             "--prefill-device / --park-prefill conflict with --no-chunked-prefill"
+        ));
+    }
+    if args.packed_prefix > 0 && args.packed_slots == 0 {
+        return Err(anyhow!(
+            "--packed-prefix requires --packed-slots (the shared prefix lives in the packed \
+             KV window)"
         ));
     }
     // Packed multi-slot decode lives in the ov-runtime static (NPU-target) path.
@@ -2389,6 +2405,17 @@ mod python_tests {
 
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;
+        assert!(validate_worker_runtime_flags(&a).is_ok());
+
+        // the shared prefix lives inside the packed window, so it needs slots
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_prefix = 128;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("--packed-slots"), "{err}");
+
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 4;
+        a.packed_prefix = 128;
         assert!(validate_worker_runtime_flags(&a).is_ok());
     }
 

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -417,6 +417,13 @@ pub struct WorkerArgs {
     #[arg(long, default_value_t = 0)]
     pub prompt_lookup: u32,
 
+    /// Packed multi-slot continuous batching (NPU, ov-runtime static exports):
+    /// serve N concurrent requests in ONE inference by packing them into the
+    /// sequence dimension with a per-row mask. Requires a packed variant beside
+    /// the decode IR (`tools/packed_variant.py --slots N`). 0 = off.
+    #[arg(long, default_value_t = 0)]
+    pub packed_slots: u32,
+
     /// Continuous batching (#20, ov-genai only): serve concurrent requests
     /// through one ContinuousBatchingPipeline (paged attention; CPU/GPU
     /// plugins) instead of one generation at a time. Incompatible with
@@ -653,6 +660,7 @@ impl WorkerArgs {
             draft_device: None,
             spec_k: 5,
             prompt_lookup: 0,
+            packed_slots: 0,
             cb: false,
             cb_cache_size: 0,
             cb_max_num_seqs: 0,
@@ -1236,6 +1244,7 @@ fn build_builder(args: &WorkerArgs) -> Result<Box<dyn Builder>> {
                 b = b.with_prefill_device(dev);
             }
             b = b.with_chunked_prefill_disabled(args.no_chunked_prefill);
+            b.packed_slots = args.packed_slots;
             b = b.with_prefill_parking(args.park_prefill);
             b = b.with_gemv_offload(args.gemv_offload);
             if let Some(dir) = resolve_ov_cache_dir(args.ov_cache_dir.as_deref()) {
@@ -1491,7 +1500,27 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
             "--prefill-device / --park-prefill conflict with --no-chunked-prefill"
         ));
     }
-    // Continuous batching (#20) lives in the ov-genai CBP path only.
+    // Packed multi-slot decode lives in the ov-runtime static (NPU-target) path.
+    if args.packed_slots > 0 {
+        if args.engine != EngineKind::OvRuntime {
+            return Err(anyhow!(
+                "--packed-slots requires --engine ov-runtime (packed multi-slot decode is a \
+                 static-KV path feature)"
+            ));
+        }
+        if args.packed_slots < 2 {
+            return Err(anyhow!("--packed-slots must be 0 (off) or >= 2"));
+        }
+        if args.total != 1 {
+            return Err(anyhow!(
+                "--packed-slots is single-stage only for now (--total 1); the multi-stage wire \
+                 does not yet carry [1, S, hidden] + per-slot positions"
+            ));
+        }
+    }
+    // Continuous batching (#20) lives in the ov-genai CBP path only. It is a
+    // different mechanism to --packed-slots above: OV's paged attention on the
+    // CPU/GPU plugins, versus our sequence-packing on the NPU static path.
     if (args.cb
         || args.cb_cache_size > 0
         || args.cb_max_num_seqs > 0
@@ -2337,6 +2366,31 @@ mod python_tests {
         a.no_chunked_prefill = true;
         let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
         assert!(err.contains("conflict"), "{err}");
+    }
+
+    /// Packed multi-slot decode is an ov-runtime static-path feature; using it
+    /// on another engine, at N<2, or multi-stage is rejected loudly.
+    #[test]
+    fn worker_flags_gate_packed_slots() {
+        let mut a = worker("m", EngineKind::OvGenai);
+        a.packed_slots = 8;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("ov-runtime"), "{err}");
+
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 1;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains(">= 2"), "{err}");
+
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 8;
+        a.total = 2;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("single-stage"), "{err}");
+
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 8;
+        assert!(validate_worker_runtime_flags(&a).is_ok());
     }
 
     /// A valid phase split (ov-runtime + prefill device, chunked enabled) passes.

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1527,11 +1527,11 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
         if args.packed_slots < 2 {
             return Err(anyhow!("--packed-slots must be 0 (off) or >= 2"));
         }
-        // Multi-stage is supported: stage 0 ships an I64 [1,2,S] plan frame
-        // (slot + absolute position per row) ahead of the [1,S,hidden] block,
-        // and the tail replies with one token per row. EVERY stage must be
-        // started with the same --packed-slots, since the slot count is baked
-        // into each stage's IR shape.
+        // Multi-stage is supported: stage 0 ships an I64 [1,3,S] plan frame
+        // (slot, absolute position and prefix-reuse length per row) ahead of the
+        // [1,S,hidden] block, and the tail replies with one token per row. EVERY
+        // stage must be started with the same --packed-slots, since the slot
+        // count is baked into each stage's IR shape.
     }
     // Continuous batching (#20) lives in the ov-genai CBP path only. It is a
     // different mechanism to --packed-slots above: OV's paged attention on the
@@ -1560,11 +1560,13 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
     }
     // Paged attention is a CPU/GPU-plugin capability; on NPU ov-genai serves
     // the static NPUW pipeline. Without this gate the operator waits out a
-    // full model compile only to get a raw OpenVINO exception.
+    // full model compile only to get a raw OpenVINO exception. (NPU operators
+    // wanting concurrency use --engine ov-runtime --packed-slots instead.)
     if args.cb && device_is_npu(&args.device) {
         return Err(anyhow!(
             "--cb requires a CPU or GPU device; NPU serves ov-genai's static NPUW \
-             pipeline and cannot continuous-batch — drop --cb for NPU workers"
+             pipeline and cannot continuous-batch — use --engine ov-runtime with \
+             --packed-slots for NPU concurrency"
         ));
     }
     Ok(())
@@ -2417,6 +2419,25 @@ mod python_tests {
         a.packed_slots = 4;
         a.packed_prefix = 128;
         assert!(validate_worker_runtime_flags(&a).is_ok());
+    }
+
+    /// The two continuous-batching mechanisms target different engines, so
+    /// asking for both at once is always rejected — whichever engine is named,
+    /// the other flag's gate fires. Pins that the ov-genai (#116) and
+    /// ov-runtime packed paths stay mutually exclusive.
+    #[test]
+    fn worker_flags_reject_cb_and_packed_slots_together() {
+        let mut a = worker("m", EngineKind::OvGenai);
+        a.cb = true;
+        a.packed_slots = 8;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("ov-runtime"), "{err}");
+
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.cb = true;
+        a.packed_slots = 8;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("ov-genai"), "{err}");
     }
 
     /// A valid phase split (ov-runtime + prefill device, chunked enabled) passes.

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1511,12 +1511,11 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
         if args.packed_slots < 2 {
             return Err(anyhow!("--packed-slots must be 0 (off) or >= 2"));
         }
-        if args.total != 1 {
-            return Err(anyhow!(
-                "--packed-slots is single-stage only for now (--total 1); the multi-stage wire \
-                 does not yet carry [1, S, hidden] + per-slot positions"
-            ));
-        }
+        // Multi-stage is supported: stage 0 ships an I64 [1,2,S] plan frame
+        // (slot + absolute position per row) ahead of the [1,S,hidden] block,
+        // and the tail replies with one token per row. EVERY stage must be
+        // started with the same --packed-slots, since the slot count is baked
+        // into each stage's IR shape.
     }
     // Continuous batching (#20) lives in the ov-genai CBP path only. It is a
     // different mechanism to --packed-slots above: OV's paged attention on the
@@ -2382,11 +2381,11 @@ mod python_tests {
         let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
         assert!(err.contains(">= 2"), "{err}");
 
+        // multi-stage packed is allowed (plan + token frames carry per-row state)
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;
         a.total = 2;
-        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
-        assert!(err.contains("single-stage"), "{err}");
+        assert!(validate_worker_runtime_flags(&a).is_ok());
 
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1527,11 +1527,22 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
         if args.packed_slots < 2 {
             return Err(anyhow!("--packed-slots must be 0 (off) or >= 2"));
         }
-        // Multi-stage is supported: stage 0 ships an I64 [1,3,S] plan frame
-        // (slot, absolute position and prefix-reuse length per row) ahead of the
-        // [1,S,hidden] block, and the tail replies with one token per row. EVERY
-        // stage must be started with the same --packed-slots, since the slot
-        // count is baked into each stage's IR shape.
+        // Multi-stage packed is withheld pending a wire fault. The mechanism
+        // works — stage 0 ships an I64 [1,3,S] plan frame (slot, absolute
+        // position and prefix-reuse length per row) ahead of the [1,S,hidden]
+        // block, and the tail replies one token per row — but a token frame
+        // intermittently goes missing between the ranks, and rank 0 then blocks
+        // forever on a reply that never comes. Instrumented on NPU: rank 1
+        // logged the reply and advanced, rank 0 never saw it, no error on
+        // either side. Reproduces after sustained load, roughly two runs in
+        // three. Single-stage is unaffected and verified.
+        if args.total != 1 {
+            return Err(anyhow!(
+                "--packed-slots is single-stage only (--total 1); multi-stage packed can lose a \
+                 token frame between ranks and wedge the pipeline. Run the packed worker as a \
+                 single stage, or drop --packed-slots to use the multi-stage baseline path"
+            ));
+        }
     }
     // Continuous batching (#20) lives in the ov-genai CBP path only. It is a
     // different mechanism to --packed-slots above: OV's paged attention on the
@@ -2399,11 +2410,15 @@ mod python_tests {
         let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
         assert!(err.contains(">= 2"), "{err}");
 
-        // multi-stage packed is allowed (plan + token frames carry per-row state)
+        // Multi-stage packed wedges: a token frame goes missing on the wire and
+        // rank 0 blocks on a reply that never arrives. Refuse it rather than
+        // hand an operator a pipeline that hangs after a while under load.
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;
         a.total = 2;
-        assert!(validate_worker_runtime_flags(&a).is_ok());
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(err.contains("--total 1"), "{err}");
+        assert!(err.contains("single-stage"), "{err}");
 
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1539,8 +1539,9 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
         if args.total != 1 {
             return Err(anyhow!(
                 "--packed-slots is single-stage only (--total 1); multi-stage packed can lose a \
-                 token frame between ranks and wedge the pipeline. Run the packed worker as a \
-                 single stage, or drop --packed-slots to use the multi-stage baseline path"
+                 token frame between ranks and wedge the pipeline (issue #122). Run the packed \
+                 worker as a single stage, or drop --packed-slots to use the multi-stage baseline \
+                 path"
             ));
         }
     }

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
 use cascadia_ov_genai_shim::{
-    DType as ShimDType, Error as OvError, PluginConfig, Runtime as OvRuntime,
+    advance_emitted, DType as ShimDType, Error as OvError, PluginConfig, Runtime as OvRuntime,
 };
 use cascadia_transport::{
     recv_tensor, send_tensor, ActivationClient, ActivationServer, DType as WireDType,
@@ -1139,7 +1139,8 @@ struct ActiveSpec {
     out: Vec<i64>,
     /// Cumulative byte-length of the detokenized text emitted so far.
     /// Used to compute the streaming delta on each step.
-    last_text_len: usize,
+    /// Bytes already handed to the client (see `decode_delta`).
+    emitted: Vec<u8>,
     /// Token id that became the "always-accepted" prefix for the next
     /// verify call (i.e. the correction from the previous round, or
     /// the first sampled token on the very first round).
@@ -1274,10 +1275,13 @@ impl Engine for OvDistSpecEngine {
         // First step after init: emit a chunk for the first sampled token.
         let chunks = if !active.initialized {
             active.initialized = true;
-            let new_text = decode_delta(&self.tokenizer, &active.out, &mut active.last_text_len);
             // If the first token already hits max_tokens or EOS, finalize now.
+            // Decided before decoding: it is what makes this the terminal read,
+            // which tells decode_delta whether it may hold anything back.
             let hit_eos = self.eos_token_ids.contains(&(active.out[0] as u32));
             let finished = active.out.len() >= max_tokens || hit_eos;
+            let new_text =
+                decode_delta(&self.tokenizer, &active.out, &mut active.emitted, !finished);
             if finished {
                 self.finish_task(task_id.clone(), new_text, 1)
             } else {
@@ -1372,7 +1376,7 @@ impl OvDistSpecEngine {
         Ok(ActiveSpec {
             task,
             out: vec![first],
-            last_text_len: 0,
+            emitted: Vec::new(),
             prev_correction: first,
             d_last_logit,
             stats: SpecDecodeStats::default(),
@@ -1462,7 +1466,12 @@ impl OvDistSpecEngine {
             active.prev_correction = correction;
         }
 
-        let delta = decode_delta(&self.tokenizer, &active.out, &mut active.last_text_len);
+        let delta = decode_delta(
+            &self.tokenizer,
+            &active.out,
+            &mut active.emitted,
+            !(hit_eos || hit_max),
+        );
         Ok(RoundResult {
             delta,
             finished: hit_eos || hit_max,
@@ -1505,20 +1514,27 @@ impl OvDistSpecEngine {
     }
 }
 
-/// Detokenize `tokens` and return only the text that's been added since
-/// the last call. `last_text_len` is updated in place to the new total
-/// byte length so the next call sees only the next delta.
-fn decode_delta(tokenizer: &Tokenizer, tokens: &[i64], last_text_len: &mut usize) -> String {
+/// Detokenize `tokens` and return only the text added since the last call.
+/// `emitted` holds the bytes already handed out; `running` is false on the
+/// terminal read, which flushes anything held back.
+///
+/// Delegates to the shim's `advance_emitted` rather than remembering a byte
+/// LENGTH and slicing at it. That offset is not safe: a detokenizer can rewrite
+/// earlier bytes, so a 3-byte U+FFFD run resolving into a wider glyph leaves
+/// the offset inside that glyph, and slicing a `str` off a char boundary
+/// panics. Guarding only on "the decode got shorter" missed that case.
+fn decode_delta(
+    tokenizer: &Tokenizer,
+    tokens: &[i64],
+    emitted: &mut Vec<u8>,
+    running: bool,
+) -> String {
     let ids: Vec<u32> = tokens.iter().map(|&t| t as u32).collect();
     let full = tokenizer.decode(&ids, true).unwrap_or_default();
-    if full.len() <= *last_text_len {
-        // Detokenizer changed its mind about prefix bytes (rare but
-        // possible with BPE tokens). Just emit nothing this round; the
-        // next round will catch up.
-        return String::new();
+    let (delta, diverged) = advance_emitted(emitted, full.as_bytes(), running);
+    if diverged {
+        warn!("spec-decode detokenizer decode diverged; re-anchored");
     }
-    let delta = full[*last_text_len..].to_string();
-    *last_text_len = full.len();
     delta
 }
 
@@ -2260,6 +2276,32 @@ fn lookup_eos(model_dir: &std::path::Path) -> Vec<u32> {
 mod tests {
     use super::*;
     use cascadia_transport::{ActivationClient, ActivationServer};
+
+    /// `decode_delta` used to remember a byte LENGTH and slice `full[len..]`.
+    /// Its only guard was `full.len() <= last_text_len`, which catches a decode
+    /// that got shorter but not one that grew while the boundary moved: a
+    /// 3-byte U+FFFD run resolving into a 4-byte glyph leaves the offset inside
+    /// that glyph, and slicing a `str` off a char boundary PANICS — taking the
+    /// worker down, not just corrupting one response.
+    #[test]
+    fn delta_survives_a_replacement_run_resolving_into_a_wider_glyph() {
+        let decodes = ["abc", "abc\u{FFFD}", "abc\u{1F600}", "abc\u{1F600}!"];
+        // The offset the old code would have sliced at, inside the emoji.
+        let stale = "abc\u{FFFD}".len();
+        assert!(
+            !"abc\u{1F600}".is_char_boundary(stale),
+            "this sequence is only interesting because the offset lands mid-glyph"
+        );
+
+        let mut emitted: Vec<u8> = Vec::new();
+        let mut client = String::new();
+        for (i, full) in decodes.iter().enumerate() {
+            let (delta, _) = advance_emitted(&mut emitted, full.as_bytes(), i + 1 < decodes.len());
+            client.push_str(&delta);
+        }
+        assert_eq!(client, "abc\u{1F600}!");
+        assert!(!client.contains('\u{FFFD}'));
+    }
 
     #[test]
     fn frame_kind_roundtrip() {

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -14,6 +14,7 @@ pub mod dist_spec;
 pub mod gemma4;
 pub mod genai;
 pub mod packed;
+mod packed_exec;
 pub mod qwen36;
 pub mod rotary;
 pub mod runtime;

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod dist_spec;
 pub mod gemma4;
 pub mod genai;
+pub mod packed;
 pub mod qwen36;
 pub mod rotary;
 pub mod runtime;

--- a/crates/cascadia-engine-openvino/src/packed.rs
+++ b/crates/cascadia-engine-openvino/src/packed.rs
@@ -169,6 +169,14 @@ impl PackedKv {
         &self.val_buf[li]
     }
 
+    pub fn kv_heads(&self) -> usize {
+        self.kv_heads
+    }
+
+    pub fn head_dim(&self) -> usize {
+        self.head_dim
+    }
+
     pub fn present_layer_bytes(&self) -> usize {
         self.kv_heads * self.context * self.head_dim * self.elem_bytes
     }

--- a/crates/cascadia-engine-openvino/src/packed.rs
+++ b/crates/cascadia-engine-openvino/src/packed.rs
@@ -1,0 +1,487 @@
+//! Packed multi-slot decode ("seq-as-batch") for the stateless static-shape
+//! (NPU) path — continuous batching on a device that refuses batch > 1.
+//!
+//! The NPU compiler rejects a batch dimension outright (`ConvertBatchedLayerTo1N`
+//! fails to legalize), but it compiles seq > 1 happily — that is what the
+//! chunked-prefill variant already relies on. So we pack N independent requests
+//! into the SEQUENCE dimension of one inference and isolate them with a
+//! block-diagonal attention mask. Batch stays 1; the rejected pass never runs.
+//!
+//! Layout. The IR's `past_len` KV window is partitioned into `slots` equal
+//! regions of `region = past_len / slots` slots; slot `s` owns
+//! `[s*region, (s+1)*region)` in every layer's ring, in every head. A packed
+//! inference presents `packed_seq` query rows; a [`PackedPlan`] says which slot
+//! (if any) each row belongs to. The mask then opens, for each row, exactly its
+//! own slot's occupied past region plus the query columns of same-slot rows at
+//! or before it — which yields block-diagonal masking for decode (one row per
+//! slot) and causal masking for a prefill chunk (many rows, one slot), from one
+//! writer. Mixed decode+prefill steps fall out for free.
+//!
+//! Measured on Lunar Lake (Qwen2.5-1.5B stage 0, OV 2026.2.1): row isolation is
+//! bit-exact, a packed slot matches the same sequence run alone to fp16 rounding
+//! noise, and throughput is 3.1x at 8 slots / 6.0x at 16 vs seq=1 — because
+//! weights outweigh KV traffic 16:1, so the per-iteration weight stream amortizes
+//! across slots. See docs/perf/NPU_PACKED_SLOTS.md.
+
+use cascadia_ov_genai_shim::DType as ShimDType;
+
+/// Additive-mask "blocked" value. f16's most-negative finite (-65504) and an
+/// f32 equivalent — finite rather than -inf so a fully-blocked row can never
+/// produce NaN out of softmax.
+const NEG_F16_BITS: u16 = 0xFBFF;
+const NEG_F32: f32 = -3.0e38;
+
+/// Which slot a query row belongs to, and its ordinal among that slot's rows in
+/// this same inference (0 for decode; 0..n for a prefill chunk). `order` drives
+/// causal masking within a slot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PackedRow {
+    pub slot: usize,
+    pub order: usize,
+}
+
+/// Row assignment for one packed inference. `rows.len() == packed_seq`; `None`
+/// marks an idle row (no request occupies it this step).
+#[derive(Clone, Debug, Default)]
+pub struct PackedPlan {
+    pub rows: Vec<Option<PackedRow>>,
+}
+
+impl PackedPlan {
+    pub fn idle(packed_seq: usize) -> Self {
+        Self {
+            rows: vec![None; packed_seq],
+        }
+    }
+
+    /// One row per listed slot, in order — the decode shape.
+    pub fn decode(packed_seq: usize, slots: &[usize]) -> Self {
+        let mut rows = vec![None; packed_seq];
+        for (r, &slot) in slots.iter().take(packed_seq).enumerate() {
+            rows[r] = Some(PackedRow { slot, order: 0 });
+        }
+        Self { rows }
+    }
+
+    /// `n` consecutive rows all belonging to `slot` — the prefill-chunk shape.
+    pub fn chunk(packed_seq: usize, slot: usize, n: usize) -> Self {
+        let mut rows = vec![None; packed_seq];
+        for (order, row) in rows.iter_mut().take(n.min(packed_seq)).enumerate() {
+            *row = Some(PackedRow { slot, order });
+        }
+        Self { rows }
+    }
+
+    pub fn active_rows(&self) -> impl Iterator<Item = (usize, PackedRow)> + '_ {
+        self.rows
+            .iter()
+            .enumerate()
+            .filter_map(|(r, pr)| pr.map(|pr| (r, pr)))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.iter().all(|r| r.is_none())
+    }
+}
+
+/// Host-side KV for `slots` independent sequences sharing one static IR window.
+pub struct PackedKv {
+    pub slots: usize,
+    /// Past KV slots owned by each packed slot.
+    pub region: usize,
+    pub past_len: usize,
+    /// Query rows per inference (the IR's static seq length).
+    pub packed_seq: usize,
+    /// `present.*` length = `past_len + packed_seq`.
+    pub context: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    elem_bytes: usize,
+    key_buf: Vec<Vec<u8>>,
+    val_buf: Vec<Vec<u8>>,
+    /// Absolute tokens consumed by each slot's sequence (drives RoPE position).
+    pos: Vec<usize>,
+}
+
+impl PackedKv {
+    pub fn new(
+        slots: usize,
+        past_len: usize,
+        packed_seq: usize,
+        layers: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        kv_dtype: ShimDType,
+    ) -> Self {
+        let elem_bytes = match kv_dtype {
+            ShimDType::F32 | ShimDType::I32 => 4,
+            ShimDType::I64 => 8,
+            _ => 2,
+        };
+        let per_layer = kv_heads * past_len * head_dim * elem_bytes;
+        Self {
+            slots,
+            region: past_len / slots,
+            past_len,
+            packed_seq,
+            context: past_len + packed_seq,
+            kv_heads,
+            head_dim,
+            elem_bytes,
+            key_buf: vec![vec![0u8; per_layer]; layers],
+            val_buf: vec![vec![0u8; per_layer]; layers],
+            pos: vec![0; slots],
+        }
+    }
+
+    /// Real past tokens currently visible to slot `s` (its region is a bounded
+    /// window, so this saturates at `region`).
+    pub fn valid(&self, s: usize) -> usize {
+        self.pos[s].min(self.region)
+    }
+
+    /// Absolute position of the next token for slot `s` (RoPE input).
+    pub fn position(&self, s: usize) -> usize {
+        self.pos[s]
+    }
+
+    /// Clear one slot without disturbing its neighbours — an admitted request
+    /// starts from an empty region.
+    pub fn reset_slot(&mut self, s: usize) {
+        let (region, kv_heads, past_len) = (self.region, self.kv_heads, self.past_len);
+        let slot_bytes = self.head_dim * self.elem_bytes;
+        let buf_row = past_len * slot_bytes;
+        let start = s * region * slot_bytes;
+        for buf in self.key_buf.iter_mut().chain(self.val_buf.iter_mut()) {
+            for h in 0..kv_heads {
+                let base = h * buf_row + start;
+                buf[base..base + region * slot_bytes].fill(0);
+            }
+        }
+        self.pos[s] = 0;
+    }
+
+    pub fn key_bytes(&self, li: usize) -> &[u8] {
+        &self.key_buf[li]
+    }
+
+    pub fn val_bytes(&self, li: usize) -> &[u8] {
+        &self.val_buf[li]
+    }
+
+    pub fn present_layer_bytes(&self) -> usize {
+        self.kv_heads * self.context * self.head_dim * self.elem_bytes
+    }
+
+    /// Advance a slot's absolute position after its row(s) were absorbed.
+    pub fn advance(&mut self, s: usize, by: usize) {
+        self.pos[s] += by;
+    }
+
+    /// Absorb query row `row`'s K/V (which sits at `present` index
+    /// `past_len + row`) into `slot`'s region, appending at `at` or sliding the
+    /// region's oldest entry out when it is full. `at` is the caller's running
+    /// occupancy for that slot within this step, so a multi-row prefill chunk
+    /// lands consecutively.
+    ///
+    /// The slide is strictly bounded to `[slot*region, (slot+1)*region)` — a
+    /// neighbouring slot's KV is never read or written.
+    pub fn absorb_row(
+        &mut self,
+        li: usize,
+        is_value: bool,
+        present: &[u8],
+        row: usize,
+        slot: usize,
+        at: usize,
+    ) {
+        let slot_bytes = self.head_dim * self.elem_bytes;
+        let present_row = self.context * slot_bytes;
+        let buf_row = self.past_len * slot_bytes;
+        let region = self.region;
+        let kv_heads = self.kv_heads;
+        let src_slot = self.past_len + row;
+        let full = at >= region;
+        let region_start = slot * region * slot_bytes;
+        let buf: &mut [u8] = if is_value {
+            &mut self.val_buf[li]
+        } else {
+            &mut self.key_buf[li]
+        };
+        for h in 0..kv_heads {
+            let src = h * present_row + src_slot * slot_bytes;
+            let new = &present[src..src + slot_bytes];
+            let base = h * buf_row + region_start;
+            if full {
+                // drop this slot's oldest, keeping the copy inside the region
+                buf.copy_within(base + slot_bytes..base + region * slot_bytes, base);
+                let dst = base + (region - 1) * slot_bytes;
+                buf[dst..dst + slot_bytes].copy_from_slice(new);
+            } else {
+                let dst = base + at * slot_bytes;
+                buf[dst..dst + slot_bytes].copy_from_slice(new);
+            }
+        }
+    }
+
+    /// Write the additive attention mask for `plan` into `buf` as a
+    /// `[1, 1, packed_seq, context]` tensor of `dtype`.
+    ///
+    /// Row `r` is opened on exactly: its slot's occupied past region, and the
+    /// query columns of same-slot rows with `order <= its order`. Everything
+    /// else is blocked. An idle row is opened on its own query column only —
+    /// never fully blocked, which would make softmax produce NaN and poison the
+    /// whole inference including live rows.
+    pub fn fill_mask(&self, plan: &PackedPlan, buf: &mut Vec<u8>, dtype: ShimDType) {
+        let elem = match dtype {
+            ShimDType::F32 => 4,
+            _ => 2,
+        };
+        let (s, ctx, region, past_len) =
+            (self.packed_seq, self.context, self.region, self.past_len);
+        buf.clear();
+        buf.resize(s * ctx * elem, 0);
+        let blocked: [u8; 4] = {
+            let mut b = [0u8; 4];
+            match dtype {
+                ShimDType::F32 => b.copy_from_slice(&NEG_F32.to_le_bytes()),
+                _ => b[..2].copy_from_slice(&NEG_F16_BITS.to_le_bytes()),
+            }
+            b
+        };
+        for r in 0..s {
+            let row_base = r * ctx * elem;
+            let me = plan.rows.get(r).copied().flatten();
+            for c in 0..ctx {
+                let allow = match me {
+                    None => c == past_len + r, // idle: self only, keeps softmax finite
+                    Some(pr) => {
+                        if c < past_len {
+                            let start = pr.slot * region;
+                            c >= start && c < start + self.valid(pr.slot)
+                        } else {
+                            let q = c - past_len;
+                            match plan.rows.get(q).copied().flatten() {
+                                Some(other) => other.slot == pr.slot && other.order <= pr.order,
+                                None => false,
+                            }
+                        }
+                    }
+                };
+                if !allow {
+                    let off = row_base + c * elem;
+                    buf[off..off + elem].copy_from_slice(&blocked[..elem]);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kv(slots: usize, past_len: usize, packed_seq: usize) -> PackedKv {
+        PackedKv::new(slots, past_len, packed_seq, 1, 1, 2, ShimDType::F16)
+    }
+
+    fn mask_allows(buf: &[u8], ctx: usize, r: usize, c: usize) -> bool {
+        let off = (r * ctx + c) * 2;
+        u16::from_le_bytes([buf[off], buf[off + 1]]) != NEG_F16_BITS
+    }
+
+    #[test]
+    fn decode_mask_is_block_diagonal() {
+        let mut k = kv(4, 16, 4); // region = 4
+        for s in 0..4 {
+            k.advance(s, 3); // 3 real tokens each
+        }
+        let plan = PackedPlan::decode(4, &[0, 1, 2, 3]);
+        let mut buf = Vec::new();
+        k.fill_mask(&plan, &mut buf, ShimDType::F16);
+        for r in 0..4 {
+            for c in 0..k.context {
+                let want = if c < 16 {
+                    // only its own region's first 3 (occupied) slots
+                    c >= r * 4 && c < r * 4 + 3
+                } else {
+                    c == 16 + r // its own query column
+                };
+                assert_eq!(mask_allows(&buf, k.context, r, c), want, "row {r} col {c}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_row_never_sees_another_slots_past_or_query() {
+        let mut k = kv(2, 8, 2); // region = 4
+        k.advance(0, 4);
+        k.advance(1, 4);
+        let plan = PackedPlan::decode(2, &[0, 1]);
+        let mut buf = Vec::new();
+        k.fill_mask(&plan, &mut buf, ShimDType::F16);
+        // row 0 must be blocked on slot 1's region (cols 4..8) and on row 1's query col
+        for c in 4..8 {
+            assert!(!mask_allows(&buf, k.context, 0, c));
+        }
+        assert!(!mask_allows(&buf, k.context, 0, 8 + 1));
+        for c in 0..4 {
+            assert!(!mask_allows(&buf, k.context, 1, c));
+        }
+        assert!(!mask_allows(&buf, k.context, 1, 8));
+    }
+
+    #[test]
+    fn unoccupied_past_slots_stay_blocked() {
+        let mut k = kv(2, 8, 2);
+        k.advance(0, 1); // only 1 real token
+        let plan = PackedPlan::decode(2, &[0]);
+        let mut buf = Vec::new();
+        k.fill_mask(&plan, &mut buf, ShimDType::F16);
+        assert!(mask_allows(&buf, k.context, 0, 0));
+        for c in 1..4 {
+            assert!(!mask_allows(&buf, k.context, 0, c), "col {c} unoccupied");
+        }
+    }
+
+    #[test]
+    fn idle_row_is_never_fully_blocked() {
+        let k = kv(4, 16, 4);
+        let plan = PackedPlan::decode(4, &[0]); // rows 1..3 idle
+        let mut buf = Vec::new();
+        k.fill_mask(&plan, &mut buf, ShimDType::F16);
+        for r in 1..4 {
+            let open: Vec<usize> = (0..k.context)
+                .filter(|&c| mask_allows(&buf, k.context, r, c))
+                .collect();
+            assert_eq!(open, vec![16 + r], "idle row {r} must open exactly itself");
+        }
+    }
+
+    #[test]
+    fn chunk_plan_masks_causally_within_one_slot() {
+        let mut k = kv(2, 8, 4); // region 4, 4 query rows
+        k.advance(1, 2);
+        let plan = PackedPlan::chunk(4, 1, 3); // 3 prompt tokens into slot 1
+        let mut buf = Vec::new();
+        k.fill_mask(&plan, &mut buf, ShimDType::F16);
+        for r in 0..3 {
+            // own region occupancy
+            for c in 4..6 {
+                assert!(mask_allows(&buf, k.context, r, c));
+            }
+            // causal over the chunk's own query columns
+            for q in 0..4 {
+                let want = q <= r && q < 3;
+                assert_eq!(mask_allows(&buf, k.context, r, 8 + q), want, "r{r} q{q}");
+            }
+            // never the other slot
+            for c in 0..4 {
+                assert!(!mask_allows(&buf, k.context, r, c));
+            }
+        }
+    }
+
+    /// Row bytes must land inside the owning slot's region, and absorbing into
+    /// one slot must not perturb another's bytes.
+    #[test]
+    fn scatter_is_region_local() {
+        let mut k = kv(2, 8, 2); // region 4, head_dim 2, f16 -> 4 bytes/slot
+        let present = {
+            // present is [heads=1][context=10][head_dim=2] f16; make row r's
+            // bytes recognisable: value (r+1) repeated.
+            let mut p = vec![0u8; k.present_layer_bytes()];
+            for c in 0..k.context {
+                for e in 0..2 {
+                    let off = (c * 2 + e) * 2;
+                    p[off..off + 2].copy_from_slice(&((c as u16) + 100).to_le_bytes());
+                }
+            }
+            p
+        };
+        k.absorb_row(0, false, &present, 0, 0, 0); // row 0 -> slot 0 @0
+        let before_slot1 = k.key_bytes(0)[16..32].to_vec();
+        k.absorb_row(0, false, &present, 1, 1, 0); // row 1 -> slot 1 @0
+                                                   // slot 0 occupancy 0 holds present row (past_len+0)=8 -> value 108
+        let v0 = u16::from_le_bytes([k.key_bytes(0)[0], k.key_bytes(0)[1]]);
+        assert_eq!(v0, 108);
+        // slot 1 region starts at slot index 4 -> byte 16; holds present row 9
+        let v1 = u16::from_le_bytes([k.key_bytes(0)[16], k.key_bytes(0)[17]]);
+        assert_eq!(v1, 109);
+        assert_ne!(before_slot1, k.key_bytes(0)[16..32].to_vec());
+        // slot 0's bytes untouched by the slot-1 write
+        assert_eq!(
+            u16::from_le_bytes([k.key_bytes(0)[0], k.key_bytes(0)[1]]),
+            108
+        );
+    }
+
+    /// A full region slides within itself and must not consume a neighbour.
+    #[test]
+    fn full_region_slides_without_crossing_into_the_next_slot() {
+        let mut k = kv(2, 8, 1); // region 4, packed_seq 1
+                                 // Snapshot geometry first: the closure must not hold a borrow of `k`
+                                 // across the &mut self absorb calls below.
+        let (plb, ctx) = (k.present_layer_bytes(), k.context);
+        let mk = move |tag: u16| {
+            let mut p = vec![0u8; plb];
+            for c in 0..ctx {
+                for e in 0..2 {
+                    let off = (c * 2 + e) * 2;
+                    p[off..off + 2].copy_from_slice(&tag.to_le_bytes());
+                }
+            }
+            p
+        };
+        // fill slot 1 with a sentinel so we can prove it survives
+        k.absorb_row(0, false, &mk(999), 0, 1, 0);
+        let slot1_before = k.key_bytes(0)[16..20].to_vec();
+        for (i, tag) in [11u16, 12, 13, 14].iter().enumerate() {
+            k.absorb_row(0, false, &mk(*tag), 0, 0, i);
+        }
+        // region now full; one more slides 11 out
+        k.absorb_row(0, false, &mk(15), 0, 0, 4);
+        let read = |slot_idx: usize| {
+            let off = slot_idx * 4;
+            u16::from_le_bytes([k.key_bytes(0)[off], k.key_bytes(0)[off + 1]])
+        };
+        assert_eq!([read(0), read(1), read(2), read(3)], [12, 13, 14, 15]);
+        assert_eq!(
+            k.key_bytes(0)[16..20].to_vec(),
+            slot1_before,
+            "slot 1 must be untouched by slot 0's slide"
+        );
+    }
+
+    #[test]
+    fn reset_slot_clears_only_that_slot() {
+        let mut k = kv(2, 8, 1);
+        let mut p = vec![0u8; k.present_layer_bytes()];
+        p.iter_mut().for_each(|b| *b = 0xAB);
+        k.absorb_row(0, false, &p, 0, 0, 0);
+        k.absorb_row(0, false, &p, 0, 1, 0);
+        k.advance(0, 1);
+        k.advance(1, 1);
+        k.reset_slot(0);
+        assert_eq!(k.position(0), 0);
+        assert_eq!(k.position(1), 1);
+        assert!(k.key_bytes(0)[0..4].iter().all(|&b| b == 0));
+        assert!(k.key_bytes(0)[16..20].iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn valid_saturates_at_region_length() {
+        let mut k = kv(4, 16, 4); // region 4
+        k.advance(2, 99);
+        assert_eq!(k.valid(2), 4);
+        assert_eq!(k.position(2), 99);
+    }
+
+    #[test]
+    fn f32_mask_uses_four_byte_elements() {
+        let k = kv(2, 8, 2);
+        let mut buf = Vec::new();
+        k.fill_mask(&PackedPlan::idle(2), &mut buf, ShimDType::F32);
+        assert_eq!(buf.len(), 2 * k.context * 4);
+    }
+}

--- a/crates/cascadia-engine-openvino/src/packed.rs
+++ b/crates/cascadia-engine-openvino/src/packed.rs
@@ -485,6 +485,40 @@ mod tests {
         assert_eq!(k.position(2), 99);
     }
 
+    /// A relay stage rebuilds `order` from row arrival order; same-slot rows
+    /// must come out causally masked exactly as the sender masked them.
+    #[test]
+    fn rebuilt_chunk_order_masks_identically_to_the_sender() {
+        let mut k = kv(2, 8, 4);
+        k.advance(1, 2);
+        let sender = PackedPlan::chunk(4, 1, 3);
+        let mut a = Vec::new();
+        k.fill_mask(&sender, &mut a, ShimDType::F16);
+
+        // What a relay reconstructs from the wire: slots only, order re-derived.
+        let mut rebuilt = PackedPlan {
+            rows: sender
+                .rows
+                .iter()
+                .map(|r| {
+                    r.map(|p| PackedRow {
+                        slot: p.slot,
+                        order: 0,
+                    })
+                })
+                .collect(),
+        };
+        let mut seen = std::collections::HashMap::new();
+        for row in rebuilt.rows.iter_mut().flatten() {
+            let n = seen.entry(row.slot).or_insert(0usize);
+            row.order = *n;
+            *n += 1;
+        }
+        let mut b = Vec::new();
+        k.fill_mask(&rebuilt, &mut b, ShimDType::F16);
+        assert_eq!(a, b, "relay-rebuilt plan must mask identically");
+    }
+
     #[test]
     fn f32_mask_uses_four_byte_elements() {
         let k = kv(2, 8, 2);

--- a/crates/cascadia-engine-openvino/src/packed.rs
+++ b/crates/cascadia-engine-openvino/src/packed.rs
@@ -87,7 +87,13 @@ impl PackedPlan {
 /// Host-side KV for `slots` independent sequences sharing one static IR window.
 pub struct PackedKv {
     pub slots: usize,
-    /// Past KV slots owned by each packed slot.
+    /// Read-only shared prefix at the FRONT of the window, `[0, prefix_capacity)`.
+    /// Any number of slots may open these columns at once — attention over past
+    /// KV is a read, so sharing needs no copy and no paging. 0 disables it.
+    pub prefix_capacity: usize,
+    /// How much of the shared prefix currently holds real K/V.
+    pub prefix_valid: usize,
+    /// Past KV slots owned by each packed slot (after the shared prefix).
     pub region: usize,
     pub past_len: usize,
     /// Query rows per inference (the IR's static seq length).
@@ -100,10 +106,16 @@ pub struct PackedKv {
     key_buf: Vec<Vec<u8>>,
     val_buf: Vec<Vec<u8>>,
     /// Absolute tokens consumed by each slot's sequence (drives RoPE position).
+    /// A slot reusing `k` shared-prefix tokens starts at `pos = k`, because the
+    /// cached K/V were computed at absolute positions `0..k` — which is exactly
+    /// what makes reuse RoPE-correct.
     pos: Vec<usize>,
+    /// Shared-prefix columns each slot may read (its reuse length).
+    shared_use: Vec<usize>,
 }
 
 impl PackedKv {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         slots: usize,
         past_len: usize,
@@ -112,6 +124,7 @@ impl PackedKv {
         kv_heads: usize,
         head_dim: usize,
         kv_dtype: ShimDType,
+        prefix_capacity: usize,
     ) -> Self {
         let elem_bytes = match kv_dtype {
             ShimDType::F32 | ShimDType::I32 => 4,
@@ -119,9 +132,12 @@ impl PackedKv {
             _ => 2,
         };
         let per_layer = kv_heads * past_len * head_dim * elem_bytes;
+        let prefix_capacity = prefix_capacity.min(past_len.saturating_sub(slots));
         Self {
             slots,
-            region: past_len / slots,
+            prefix_capacity,
+            prefix_valid: 0,
+            region: (past_len - prefix_capacity) / slots,
             past_len,
             packed_seq,
             context: past_len + packed_seq,
@@ -131,13 +147,26 @@ impl PackedKv {
             key_buf: vec![vec![0u8; per_layer]; layers],
             val_buf: vec![vec![0u8; per_layer]; layers],
             pos: vec![0; slots],
+            shared_use: vec![0; slots],
         }
+    }
+
+    /// First KV column owned by `s` (its region sits after the shared prefix).
+    fn region_start(&self, s: usize) -> usize {
+        self.prefix_capacity + s * self.region
+    }
+
+    /// Shared-prefix columns slot `s` is reusing.
+    pub fn shared_use(&self, s: usize) -> usize {
+        self.shared_use[s]
     }
 
     /// Real past tokens currently visible to slot `s` (its region is a bounded
     /// window, so this saturates at `region`).
     pub fn valid(&self, s: usize) -> usize {
-        self.pos[s].min(self.region)
+        self.pos[s]
+            .saturating_sub(self.shared_use[s])
+            .min(self.region)
     }
 
     /// Absolute position of the next token for slot `s` (RoPE input).
@@ -148,17 +177,54 @@ impl PackedKv {
     /// Clear one slot without disturbing its neighbours — an admitted request
     /// starts from an empty region.
     pub fn reset_slot(&mut self, s: usize) {
+        self.reset_slot_reusing(s, 0);
+    }
+
+    /// Clear slot `s` and start it reusing `shared` cached prefix tokens: its
+    /// sequence then begins at absolute position `shared`, and its mask opens
+    /// the first `shared` shared-prefix columns.
+    pub fn reset_slot_reusing(&mut self, s: usize, shared: usize) {
+        let shared = shared.min(self.prefix_valid);
         let (region, kv_heads, past_len) = (self.region, self.kv_heads, self.past_len);
         let slot_bytes = self.head_dim * self.elem_bytes;
         let buf_row = past_len * slot_bytes;
-        let start = s * region * slot_bytes;
+        let start = self.region_start(s) * slot_bytes;
         for buf in self.key_buf.iter_mut().chain(self.val_buf.iter_mut()) {
             for h in 0..kv_heads {
                 let base = h * buf_row + start;
                 buf[base..base + region * slot_bytes].fill(0);
             }
         }
-        self.pos[s] = 0;
+        self.pos[s] = shared;
+        self.shared_use[s] = shared;
+    }
+
+    /// Copy the first `n` tokens of `src` slot's region into the shared prefix,
+    /// making them reusable by every slot. Called once, after the request that
+    /// populates the cache has prefilled that far.
+    pub fn populate_prefix_from(&mut self, src: usize, n: usize) {
+        let n = n.min(self.prefix_capacity).min(self.valid(src));
+        if n == 0 || self.prefix_valid > 0 {
+            return;
+        }
+        let slot_bytes = self.head_dim * self.elem_bytes;
+        let buf_row = self.past_len * slot_bytes;
+        let src_start = self.region_start(src) * slot_bytes;
+        let kv_heads = self.kv_heads;
+        for buf in self.key_buf.iter_mut().chain(self.val_buf.iter_mut()) {
+            for h in 0..kv_heads {
+                let base = h * buf_row;
+                let from = base + src_start;
+                let to = base;
+                // Non-overlapping by construction: the shared region is
+                // [0, prefix_capacity) and every slot region starts at or after
+                // prefix_capacity.
+                buf.copy_within(from..from + n * slot_bytes, to);
+            }
+        }
+        self.prefix_valid = n;
+        // The populating slot keeps its own copy; it does not retroactively
+        // "reuse" what it already computed.
     }
 
     pub fn key_bytes(&self, li: usize) -> &[u8] {
@@ -210,7 +276,7 @@ impl PackedKv {
         let kv_heads = self.kv_heads;
         let src_slot = self.past_len + row;
         let full = at >= region;
-        let region_start = slot * region * slot_bytes;
+        let region_start = self.region_start(slot) * slot_bytes;
         let buf: &mut [u8] = if is_value {
             &mut self.val_buf[li]
         } else {
@@ -265,8 +331,14 @@ impl PackedKv {
                     None => c == past_len + r, // idle: self only, keeps softmax finite
                     Some(pr) => {
                         if c < past_len {
-                            let start = pr.slot * region;
-                            c >= start && c < start + self.valid(pr.slot)
+                            // shared prefix this slot is reusing ...
+                            if c < self.shared_use[pr.slot] {
+                                true
+                            } else {
+                                // ... plus its own occupied region
+                                let start = self.region_start(pr.slot);
+                                c >= start && c < start + self.valid(pr.slot)
+                            }
                         } else {
                             let q = c - past_len;
                             match plan.rows.get(q).copied().flatten() {
@@ -290,7 +362,11 @@ mod tests {
     use super::*;
 
     fn kv(slots: usize, past_len: usize, packed_seq: usize) -> PackedKv {
-        PackedKv::new(slots, past_len, packed_seq, 1, 1, 2, ShimDType::F16)
+        PackedKv::new(slots, past_len, packed_seq, 1, 1, 2, ShimDType::F16, 0)
+    }
+
+    fn kv_prefix(slots: usize, past_len: usize, packed_seq: usize, prefix: usize) -> PackedKv {
+        PackedKv::new(slots, past_len, packed_seq, 1, 1, 2, ShimDType::F16, prefix)
     }
 
     fn mask_allows(buf: &[u8], ctx: usize, r: usize, c: usize) -> bool {
@@ -517,6 +593,101 @@ mod tests {
         let mut b = Vec::new();
         k.fill_mask(&rebuilt, &mut b, ShimDType::F16);
         assert_eq!(a, b, "relay-rebuilt plan must mask identically");
+    }
+
+    /// Two slots reusing the same cached prefix must both see those columns,
+    /// while still being blind to each other's own regions.
+    #[test]
+    fn shared_prefix_is_readable_by_every_reusing_slot() {
+        let mut k = kv_prefix(2, 12, 2, 4); // prefix 4, region (12-4)/2 = 4
+        assert_eq!(k.region, 4);
+        k.prefix_valid = 3; // 3 cached tokens
+        k.reset_slot_reusing(0, 3);
+        k.reset_slot_reusing(1, 3);
+        k.advance(0, 1); // one own token each
+        k.advance(1, 1);
+        let plan = PackedPlan::decode(2, &[0, 1]);
+        let mut buf = Vec::new();
+        k.fill_mask(&plan, &mut buf, ShimDType::F16);
+        for r in 0..2 {
+            // shared prefix columns 0..3 open for BOTH rows
+            for c in 0..3 {
+                assert!(mask_allows(&buf, k.context, r, c), "row {r} shared col {c}");
+            }
+            assert!(
+                !mask_allows(&buf, k.context, r, 3),
+                "unpopulated prefix col"
+            );
+        }
+        // row 0 sees its own region (4..5) but not slot 1's (8..9)
+        assert!(mask_allows(&buf, k.context, 0, 4));
+        assert!(!mask_allows(&buf, k.context, 0, 8));
+        assert!(mask_allows(&buf, k.context, 1, 8));
+        assert!(!mask_allows(&buf, k.context, 1, 4));
+    }
+
+    /// Reuse means the slot's own token count excludes the shared tokens, and
+    /// its absolute position starts after them (so RoPE stays correct).
+    #[test]
+    fn reuse_shifts_position_and_own_valid() {
+        let mut k = kv_prefix(2, 12, 2, 4);
+        k.prefix_valid = 4;
+        k.reset_slot_reusing(0, 4);
+        assert_eq!(k.position(0), 4, "sequence resumes after the cached prefix");
+        assert_eq!(k.valid(0), 0, "no OWN tokens yet");
+        k.advance(0, 2);
+        assert_eq!(k.position(0), 6);
+        assert_eq!(k.valid(0), 2);
+        assert_eq!(k.shared_use(0), 4);
+    }
+
+    /// Populating the cache copies a slot's first tokens to the front of the
+    /// window without touching any other slot's region.
+    #[test]
+    fn populate_prefix_copies_out_of_the_owning_slot() {
+        let mut k = kv_prefix(2, 12, 1, 4);
+        let mk = |tag: u16, plb: usize, ctx: usize| {
+            let mut p = vec![0u8; plb];
+            for c in 0..ctx {
+                for e in 0..2 {
+                    let off = (c * 2 + e) * 2;
+                    p[off..off + 2].copy_from_slice(&tag.to_le_bytes());
+                }
+            }
+            p
+        };
+        let (plb, ctx) = (k.present_layer_bytes(), k.context);
+        // slot 1 sentinel must survive
+        k.absorb_row(0, false, &mk(999, plb, ctx), 0, 1, 0);
+        let slot1 = k.key_bytes(0)[(4 + 4) * 4..(4 + 4) * 4 + 4].to_vec();
+        for (i, tag) in [21u16, 22].iter().enumerate() {
+            k.absorb_row(0, false, &mk(*tag, plb, ctx), 0, 0, i);
+        }
+        k.advance(0, 2);
+        k.populate_prefix_from(0, 2);
+        assert_eq!(k.prefix_valid, 2);
+        let read = |slot_idx: usize| {
+            let off = slot_idx * 4;
+            u16::from_le_bytes([k.key_bytes(0)[off], k.key_bytes(0)[off + 1]])
+        };
+        assert_eq!(
+            [read(0), read(1)],
+            [21, 22],
+            "prefix holds the copied tokens"
+        );
+        assert_eq!(
+            k.key_bytes(0)[(4 + 4) * 4..(4 + 4) * 4 + 4].to_vec(),
+            slot1,
+            "another slot's region must be untouched"
+        );
+    }
+
+    #[test]
+    fn prefix_capacity_shrinks_per_slot_region() {
+        let plain = kv(4, 1024, 4);
+        let with_prefix = kv_prefix(4, 1024, 4, 256);
+        assert_eq!(plain.region, 256);
+        assert_eq!(with_prefix.region, 192); // (1024-256)/4
     }
 
     #[test]

--- a/crates/cascadia-engine-openvino/src/packed.rs
+++ b/crates/cascadia-engine-openvino/src/packed.rs
@@ -31,6 +31,14 @@ use cascadia_ov_genai_shim::DType as ShimDType;
 const NEG_F16_BITS: u16 = 0xFBFF;
 const NEG_F32: f32 = -3.0e38;
 
+/// Leading KV columns of each slot's region that eviction must never drop —
+/// attention sinks. Transformer heads park a large share of their softmax mass
+/// on the first few tokens of a sequence; slide those out and the mass is
+/// forced onto ordinary content, which collapses generation into degenerate
+/// repetition rather than truncating it gracefully. Four is the width the
+/// StreamingLLM result found sufficient.
+const PACKED_SINK: usize = 4;
+
 /// Which slot a query row belongs to, and its ordinal among that slot's rows in
 /// this same inference (0 for decode; 0..n for a prefill chunk). `order` drives
 /// causal masking within a slot.
@@ -95,6 +103,10 @@ pub struct PackedKv {
     pub prefix_valid: usize,
     /// Past KV slots owned by each packed slot (after the shared prefix).
     pub region: usize,
+    /// Leading columns of each slot's region that the slide never evicts (see
+    /// [`PACKED_SINK`]). Capped at half the region so pinning can never crowd
+    /// out the sliding window itself.
+    sink: usize,
     pub past_len: usize,
     /// Query rows per inference (the IR's static seq length).
     pub packed_seq: usize,
@@ -133,11 +145,13 @@ impl PackedKv {
         };
         let per_layer = kv_heads * past_len * head_dim * elem_bytes;
         let prefix_capacity = prefix_capacity.min(past_len.saturating_sub(slots));
+        let region = (past_len - prefix_capacity) / slots;
         Self {
             slots,
             prefix_capacity,
             prefix_valid: 0,
-            region: (past_len - prefix_capacity) / slots,
+            region,
+            sink: PACKED_SINK.min(region / 2),
             past_len,
             packed_seq,
             context: past_len + packed_seq,
@@ -273,6 +287,7 @@ impl PackedKv {
         let present_row = self.context * slot_bytes;
         let buf_row = self.past_len * slot_bytes;
         let region = self.region;
+        let sink = self.sink;
         let kv_heads = self.kv_heads;
         let src_slot = self.past_len + row;
         let full = at >= region;
@@ -287,8 +302,13 @@ impl PackedKv {
             let new = &present[src..src + slot_bytes];
             let base = h * buf_row + region_start;
             if full {
-                // drop this slot's oldest, keeping the copy inside the region
-                buf.copy_within(base + slot_bytes..base + region * slot_bytes, base);
+                // Drop this slot's oldest EVICTABLE entry — the leading `sink`
+                // columns are pinned, so the shift starts past them. The copy
+                // stays inside the region.
+                buf.copy_within(
+                    base + (sink + 1) * slot_bytes..base + region * slot_bytes,
+                    base + sink * slot_bytes,
+                );
                 let dst = base + (region - 1) * slot_bytes;
                 buf[dst..dst + slot_bytes].copy_from_slice(new);
             } else {
@@ -501,9 +521,11 @@ mod tests {
     }
 
     /// A full region slides within itself and must not consume a neighbour.
+    /// With region 4 the sink is capped at 2, so tags 11 and 12 are pinned and
+    /// the slide turns over only the last two columns.
     #[test]
     fn full_region_slides_without_crossing_into_the_next_slot() {
-        let mut k = kv(2, 8, 1); // region 4, packed_seq 1
+        let mut k = kv(2, 8, 1); // region 4, sink 2, packed_seq 1
                                  // Snapshot geometry first: the closure must not hold a borrow of `k`
                                  // across the &mut self absorb calls below.
         let (plb, ctx) = (k.present_layer_bytes(), k.context);
@@ -523,13 +545,13 @@ mod tests {
         for (i, tag) in [11u16, 12, 13, 14].iter().enumerate() {
             k.absorb_row(0, false, &mk(*tag), 0, 0, i);
         }
-        // region now full; one more slides 11 out
+        // region now full; one more slides the oldest EVICTABLE tag (13) out
         k.absorb_row(0, false, &mk(15), 0, 0, 4);
         let read = |slot_idx: usize| {
             let off = slot_idx * 4;
             u16::from_le_bytes([k.key_bytes(0)[off], k.key_bytes(0)[off + 1]])
         };
-        assert_eq!([read(0), read(1), read(2), read(3)], [12, 13, 14, 15]);
+        assert_eq!([read(0), read(1), read(2), read(3)], [11, 12, 14, 15]);
         assert_eq!(
             k.key_bytes(0)[16..20].to_vec(),
             slot1_before,
@@ -696,5 +718,66 @@ mod tests {
         let mut buf = Vec::new();
         k.fill_mask(&PackedPlan::idle(2), &mut buf, ShimDType::F32);
         assert_eq!(buf.len(), 2 * k.context * 4);
+    }
+
+    /// Feed `n` single-row tokens into `slot`, tagging each one's K/V with its
+    /// own byte so the surviving entries are identifiable afterwards.
+    fn feed_tokens(k: &mut PackedKv, slot: usize, n: u8) {
+        let slot_bytes = k.head_dim * k.elem_bytes;
+        for t in 1..=n {
+            let mut present = vec![0u8; k.context * slot_bytes];
+            let src = k.past_len * slot_bytes; // query row 0
+            present[src..src + slot_bytes].fill(t);
+            let at = k.valid(slot);
+            k.absorb_row(0, false, &present, 0, slot, at);
+            k.advance(slot, 1);
+        }
+    }
+
+    fn region_bytes(k: &PackedKv, slot: usize) -> Vec<u8> {
+        let slot_bytes = k.head_dim * k.elem_bytes;
+        let start = k.region_start(slot) * slot_bytes;
+        (0..k.region)
+            .map(|i| k.key_buf[0][start + i * slot_bytes])
+            .collect()
+    }
+
+    /// Eviction must never drop a slot's FIRST columns. Transformer heads park
+    /// a large share of their softmax mass on the earliest tokens; sliding them
+    /// out collapses generation into degenerate repetition instead of degrading
+    /// it gracefully. Feeds 12 tokens through a region-6 slot: the four sinks
+    /// must survive while only the tail slides.
+    #[test]
+    fn slide_preserves_the_attention_sink() {
+        let mut k = kv(2, 20, 2); // region = 10, sink = 4
+        assert_eq!((k.region, k.sink), (10, 4));
+        feed_tokens(&mut k, 0, 16);
+        assert_eq!(
+            region_bytes(&k, 0),
+            vec![1, 2, 3, 4, 11, 12, 13, 14, 15, 16],
+            "sinks 1-4 pinned; only the six evictable columns slide"
+        );
+    }
+
+    /// A neighbouring slot's region must stay untouched by the sink-aware slide.
+    #[test]
+    fn sink_slide_stays_inside_its_own_region() {
+        let mut k = kv(2, 20, 2);
+        feed_tokens(&mut k, 1, 16);
+        assert_eq!(region_bytes(&k, 0), vec![0; 10], "slot 0 never written");
+        assert_eq!(
+            region_bytes(&k, 1),
+            vec![1, 2, 3, 4, 11, 12, 13, 14, 15, 16]
+        );
+    }
+
+    /// Pinning must never crowd out the sliding window: on a region too small
+    /// for the full sink it is capped at half, so the slot keeps turning over.
+    #[test]
+    fn sink_is_capped_at_half_the_region() {
+        let mut k = kv(4, 16, 2); // region = 4 -> sink capped to 2
+        assert_eq!((k.region, k.sink), (4, 2));
+        feed_tokens(&mut k, 0, 9);
+        assert_eq!(region_bytes(&k, 0), vec![1, 2, 8, 9]);
     }
 }

--- a/crates/cascadia-engine-openvino/src/packed.rs
+++ b/crates/cascadia-engine-openvino/src/packed.rs
@@ -31,13 +31,14 @@ use cascadia_ov_genai_shim::DType as ShimDType;
 const NEG_F16_BITS: u16 = 0xFBFF;
 const NEG_F32: f32 = -3.0e38;
 
-/// Leading KV columns of each slot's region that eviction must never drop —
-/// attention sinks. Transformer heads park a large share of their softmax mass
-/// on the first few tokens of a sequence; slide those out and the mass is
-/// forced onto ordinary content, which collapses generation into degenerate
-/// repetition rather than truncating it gracefully. Four is the width the
-/// StreamingLLM result found sufficient.
-const PACKED_SINK: usize = 4;
+/// Leading KV columns a bounded ring must never evict — attention sinks.
+/// Transformer heads park a large share of their softmax mass on the first few
+/// tokens of a sequence; slide those out and the mass is forced onto ordinary
+/// content, which collapses generation into degenerate repetition rather than
+/// truncating it gracefully. Four is the width the StreamingLLM result found
+/// sufficient. Shared with the single-task ring in `runtime.rs`, which has the
+/// same bounded-window shape at the full `past_len`.
+pub(crate) const KV_SINK: usize = 4;
 
 /// Which slot a query row belongs to, and its ordinal among that slot's rows in
 /// this same inference (0 for decode; 0..n for a prefill chunk). `order` drives
@@ -104,7 +105,7 @@ pub struct PackedKv {
     /// Past KV slots owned by each packed slot (after the shared prefix).
     pub region: usize,
     /// Leading columns of each slot's region that the slide never evicts (see
-    /// [`PACKED_SINK`]). Capped at half the region so pinning can never crowd
+    /// [`KV_SINK`]). Capped at half the region so pinning can never crowd
     /// out the sliding window itself.
     sink: usize,
     pub past_len: usize,
@@ -151,7 +152,7 @@ impl PackedKv {
             prefix_capacity,
             prefix_valid: 0,
             region,
-            sink: PACKED_SINK.min(region / 2),
+            sink: KV_SINK.min(region / 2),
             past_len,
             packed_seq,
             context: past_len + packed_seq,

--- a/crates/cascadia-engine-openvino/src/packed_exec.rs
+++ b/crates/cascadia-engine-openvino/src/packed_exec.rs
@@ -32,7 +32,8 @@ pub(crate) struct PackedSlot {
     /// Prompt tokens already consumed; `== prompt_ids.len()` once prefilled.
     pub(crate) prompt_fed: usize,
     pub(crate) generated: Vec<i32>,
-    pub(crate) last_text: String,
+    /// Bytes already handed to the client (see `ActiveTask::emitted`).
+    pub(crate) emitted: Vec<u8>,
     pub(crate) last_token: i32,
     pub(crate) started: Instant,
     pub(crate) t_prefill: Duration,
@@ -166,7 +167,7 @@ impl PackedState {
             prompt_ids,
             prompt_fed: shared,
             generated: Vec::new(),
-            last_text: String::new(),
+            emitted: Vec::new(),
             last_token: 0,
             started: Instant::now(),
             t_prefill: Duration::ZERO,

--- a/crates/cascadia-engine-openvino/src/packed_exec.rs
+++ b/crates/cascadia-engine-openvino/src/packed_exec.rs
@@ -77,7 +77,13 @@ pub(crate) struct PackedState {
     pub(crate) pos_in: String,
     pub(crate) mask_dtype: ShimDType,
     pub(crate) layers: Vec<PackedLayer>,
-    last_plan_rows: Vec<Option<(usize, i64)>>,
+    /// Token ids whose K/V now sit in the shared prefix region. Only the
+    /// driver stage matches against these; relay stages are told the reuse
+    /// length on the wire.
+    pub(crate) prefix_ids: Vec<i64>,
+    /// Slot currently populating the shared prefix, if any.
+    populating: Option<usize>,
+    last_plan_rows: Vec<Option<(usize, i64, usize)>>,
     mask_bytes: Vec<u8>,
     ids_bytes: Vec<u8>,
     pos_bytes: Vec<u8>,
@@ -105,6 +111,8 @@ impl PackedState {
             pos_in,
             mask_dtype,
             layers,
+            prefix_ids: Vec::new(),
+            populating: None,
             last_plan_rows: Vec::new(),
             mask_bytes: Vec::new(),
             ids_bytes: Vec::new(),
@@ -118,7 +126,7 @@ impl PackedState {
 
     /// Per-row `(slot, position)` of the most recent inference — what a
     /// pipeline stage ships downstream so every stage masks identically.
-    pub(crate) fn last_plan_rows(&self) -> Vec<Option<(usize, i64)>> {
+    pub(crate) fn last_plan_rows(&self) -> Vec<Option<(usize, i64, usize)>> {
         self.last_plan_rows.clone()
     }
 
@@ -126,13 +134,37 @@ impl PackedState {
         self.slots.iter().filter(|s| s.is_some()).count()
     }
 
-    /// Place a task into `slot`, clearing that slot's KV region only.
+    /// Longest prefix of `prompt_ids` whose K/V is already cached in the shared
+    /// region. Reusing it means those tokens are never prefilled again.
+    pub(crate) fn prefix_reuse(&self, prompt_ids: &[i64]) -> usize {
+        let cap = self.kv.prefix_valid.min(self.prefix_ids.len());
+        let mut n = 0;
+        while n < cap && n < prompt_ids.len() && self.prefix_ids[n] == prompt_ids[n] {
+            n += 1;
+        }
+        // Never reuse the WHOLE prompt: the slot needs at least one token to
+        // run through the model to produce logits for its first output.
+        n.min(prompt_ids.len().saturating_sub(1))
+    }
+
+    /// Place a task into `slot`, reusing `shared` cached prefix tokens and
+    /// clearing only that slot's own KV region.
     pub(crate) fn admit(&mut self, slot: usize, task: GenerationTask, prompt_ids: Vec<i64>) {
-        self.kv.reset_slot(slot);
+        let shared = self.prefix_reuse(&prompt_ids);
+        self.kv.reset_slot_reusing(slot, shared);
+        // Nothing cached yet? This request populates the shared prefix.
+        if self.kv.prefix_valid == 0 && self.populating.is_none() && self.kv.prefix_capacity > 0 {
+            self.populating = Some(slot);
+            self.prefix_ids = prompt_ids
+                .iter()
+                .copied()
+                .take(self.kv.prefix_capacity)
+                .collect();
+        }
         self.slots[slot] = Some(PackedSlot {
             task,
             prompt_ids,
-            prompt_fed: 0,
+            prompt_fed: shared,
             generated: Vec::new(),
             last_text: String::new(),
             last_token: 0,
@@ -143,6 +175,12 @@ impl PackedState {
 
     pub(crate) fn retire(&mut self, slot: usize) -> Option<PackedSlot> {
         let taken = self.slots[slot].take();
+        // A slot that was going to populate the shared prefix but left first
+        // must release the claim, or nothing would ever populate it.
+        if self.populating == Some(slot) && self.kv.prefix_valid == 0 {
+            self.populating = None;
+            self.prefix_ids.clear();
+        }
         self.kv.reset_slot(slot);
         taken
     }
@@ -206,7 +244,13 @@ impl PackedState {
         if plan.is_empty() {
             return Ok(None);
         }
-        let (odt, oshape, obytes) = self.run_plan(&plan, PackedPrimary::Ids(&ids), &positions)?;
+        let reuse: Vec<usize> = plan
+            .rows
+            .iter()
+            .map(|r| r.map(|pr| self.kv.shared_use(pr.slot)).unwrap_or(0))
+            .collect();
+        let (odt, oshape, obytes) =
+            self.run_plan(&plan, PackedPrimary::Ids(&ids), &positions, &reuse)?;
         if let PackedStepKind::Prefill { slot, .. } = &kind {
             if let Some(t) = self.slots[*slot].as_mut() {
                 t.prompt_fed += plan.active_rows().count();
@@ -227,20 +271,28 @@ impl PackedState {
         plan: &PackedPlan,
         primary: PackedPrimary<'_>,
         positions: &[i64],
+        reuse: &[usize],
     ) -> EngineResult<(ShimDType, Vec<usize>, Vec<u8>)> {
         let s = self.kv.packed_seq;
+        // A row whose absolute position equals its reuse length is the FIRST
+        // row of that slot's sequence — the in-band new-sequence signal, which
+        // generalises the old "position == 0" rule to prefix reuse.
         for (r, pr) in plan.active_rows() {
-            if positions.get(r).copied().unwrap_or(0) == 0 {
-                self.kv.reset_slot(pr.slot);
+            let pos = positions.get(r).copied().unwrap_or(0) as usize;
+            let shared = reuse.get(r).copied().unwrap_or(0);
+            if pos == shared {
+                self.kv.reset_slot_reusing(pr.slot, shared);
             }
         }
         self.last_plan_rows = (0..s)
             .map(|r| {
-                plan.rows
-                    .get(r)
-                    .copied()
-                    .flatten()
-                    .map(|pr| (pr.slot, positions.get(r).copied().unwrap_or(0)))
+                plan.rows.get(r).copied().flatten().map(|pr| {
+                    (
+                        pr.slot,
+                        positions.get(r).copied().unwrap_or(0),
+                        self.kv.shared_use(pr.slot),
+                    )
+                })
             })
             .collect();
         let ids: Vec<i64> = match primary {
@@ -375,6 +427,18 @@ impl PackedState {
         }
         for (slot, n) in consumed {
             self.kv.advance(slot, n);
+        }
+        // Once the populating request has enough tokens in its own region, copy
+        // them into the shared prefix so later requests can skip re-prefilling
+        // them. Deterministic from `pos` alone, so every pipeline stage does it
+        // at the same step without extra signalling.
+        if let Some(src) = self.populating {
+            let want = self.kv.prefix_capacity.min(self.prefix_ids.len().max(1));
+            if self.kv.prefix_valid == 0 && self.kv.valid(src) >= want && want > 0 {
+                self.kv.populate_prefix_from(src, want);
+                self.prefix_ids.truncate(self.kv.prefix_valid);
+                self.populating = None;
+            }
         }
         Ok((odt, oshape, obytes))
     }

--- a/crates/cascadia-engine-openvino/src/packed_exec.rs
+++ b/crates/cascadia-engine-openvino/src/packed_exec.rs
@@ -17,6 +17,14 @@ use cascadia_types::GenerationTask;
 
 use crate::packed::{PackedKv, PackedPlan};
 
+/// Primary input of a packed inference: prompt/decode token ids on the embed
+/// stage, upstream hidden rows on relay + head stages.
+pub(crate) enum PackedPrimary<'a> {
+    Ids(&'a [i64]),
+    /// `rows * hidden_size` f32 in row-major order, converted to the IR's f16.
+    Hidden(&'a [f32], usize),
+}
+
 /// One request occupying a packed slot.
 pub(crate) struct PackedSlot {
     pub(crate) task: GenerationTask,
@@ -64,10 +72,12 @@ pub(crate) struct PackedState {
     pub(crate) kv: PackedKv,
     pub(crate) slots: Vec<Option<PackedSlot>>,
     pub(crate) ids_in: String,
+    pub(crate) hidden_in: String,
     pub(crate) mask_in: String,
     pub(crate) pos_in: String,
     pub(crate) mask_dtype: ShimDType,
     pub(crate) layers: Vec<PackedLayer>,
+    last_plan_rows: Vec<Option<(usize, i64)>>,
     mask_bytes: Vec<u8>,
     ids_bytes: Vec<u8>,
     pos_bytes: Vec<u8>,
@@ -79,6 +89,7 @@ impl PackedState {
         kv: PackedKv,
         layers: Vec<PackedLayer>,
         ids_in: String,
+        hidden_in: String,
         mask_in: String,
         pos_in: String,
         mask_dtype: ShimDType,
@@ -89,10 +100,12 @@ impl PackedState {
             kv,
             slots: (0..slots).map(|_| None).collect(),
             ids_in,
+            hidden_in,
             mask_in,
             pos_in,
             mask_dtype,
             layers,
+            last_plan_rows: Vec::new(),
             mask_bytes: Vec::new(),
             ids_bytes: Vec::new(),
             pos_bytes: Vec::new(),
@@ -101,6 +114,12 @@ impl PackedState {
 
     pub(crate) fn free_slot(&self) -> Option<usize> {
         self.slots.iter().position(|s| s.is_none())
+    }
+
+    /// Per-row `(slot, position)` of the most recent inference — what a
+    /// pipeline stage ships downstream so every stage masks identically.
+    pub(crate) fn last_plan_rows(&self) -> Vec<Option<(usize, i64)>> {
+        self.last_plan_rows.clone()
     }
 
     pub(crate) fn occupied(&self) -> usize {
@@ -187,6 +206,47 @@ impl PackedState {
         if plan.is_empty() {
             return Ok(None);
         }
+        let (odt, oshape, obytes) = self.run_plan(&plan, PackedPrimary::Ids(&ids), &positions)?;
+        if let PackedStepKind::Prefill { slot, .. } = &kind {
+            if let Some(t) = self.slots[*slot].as_mut() {
+                t.prompt_fed += plan.active_rows().count();
+            }
+        }
+        Ok(Some((odt, oshape, obytes, kind)))
+    }
+
+    /// Run one packed inference for a caller-supplied plan. Stage 0 builds the
+    /// plan from its slot table; relay and head stages decode it off the wire,
+    /// which is what keeps every stage's per-slot rings in lockstep.
+    ///
+    /// A row at absolute position 0 resets its slot first — the same in-band
+    /// "new sequence" signal the single-task static path already uses, so a
+    /// downstream stage needs no separate admission message.
+    pub(crate) fn run_plan(
+        &mut self,
+        plan: &PackedPlan,
+        primary: PackedPrimary<'_>,
+        positions: &[i64],
+    ) -> EngineResult<(ShimDType, Vec<usize>, Vec<u8>)> {
+        let s = self.kv.packed_seq;
+        for (r, pr) in plan.active_rows() {
+            if positions.get(r).copied().unwrap_or(0) == 0 {
+                self.kv.reset_slot(pr.slot);
+            }
+        }
+        self.last_plan_rows = (0..s)
+            .map(|r| {
+                plan.rows
+                    .get(r)
+                    .copied()
+                    .flatten()
+                    .map(|pr| (pr.slot, positions.get(r).copied().unwrap_or(0)))
+            })
+            .collect();
+        let ids: Vec<i64> = match primary {
+            PackedPrimary::Ids(v) => v.to_vec(),
+            PackedPrimary::Hidden(_, _) => Vec::new(),
+        };
 
         // ---- feed ----
         self.kv
@@ -207,9 +267,29 @@ impl PackedState {
             self.ids_bytes.extend_from_slice(&id.to_le_bytes());
             self.pos_bytes.extend_from_slice(&pos.to_le_bytes());
         }
-        self.runtime
-            .set_input(&self.ids_in, ShimDType::I64, &[1, s], &self.ids_bytes)
-            .map_err(crate::runtime::map_ov_err)?;
+        match primary {
+            PackedPrimary::Ids(_) => {
+                self.runtime
+                    .set_input(&self.ids_in, ShimDType::I64, &[1, s], &self.ids_bytes)
+                    .map_err(crate::runtime::map_ov_err)?;
+            }
+            PackedPrimary::Hidden(rows, hidden_size) => {
+                // Pad idle rows with zeros so the tensor is always [1, S, H];
+                // their outputs are masked to self and never read.
+                let mut buf = vec![0f32; s * hidden_size];
+                let n = (rows.len() / hidden_size).min(s);
+                buf[..n * hidden_size].copy_from_slice(&rows[..n * hidden_size]);
+                let bytes = crate::runtime::f32_to_f16_bytes(&buf);
+                self.runtime
+                    .set_input(
+                        &self.hidden_in,
+                        ShimDType::F16,
+                        &[1, s, hidden_size],
+                        &bytes,
+                    )
+                    .map_err(crate::runtime::map_ov_err)?;
+            }
+        }
         self.runtime
             .set_input(
                 &self.mask_in,
@@ -295,14 +375,7 @@ impl PackedState {
         }
         for (slot, n) in consumed {
             self.kv.advance(slot, n);
-            if let PackedStepKind::Prefill { slot: ps, .. } = &kind {
-                if *ps == slot {
-                    if let Some(t) = self.slots[slot].as_mut() {
-                        t.prompt_fed += n;
-                    }
-                }
-            }
         }
-        Ok(Some((odt, oshape, obytes, kind)))
+        Ok((odt, oshape, obytes))
     }
 }

--- a/crates/cascadia-engine-openvino/src/packed_exec.rs
+++ b/crates/cascadia-engine-openvino/src/packed_exec.rs
@@ -263,8 +263,9 @@ impl PackedState {
     /// plan from its slot table; relay and head stages decode it off the wire,
     /// which is what keeps every stage's per-slot rings in lockstep.
     ///
-    /// A row at absolute position 0 resets its slot first — the same in-band
-    /// "new sequence" signal the single-task static path already uses, so a
+    /// A row whose absolute position equals its reuse length resets its slot
+    /// first (position 0 when nothing is reused) — the same in-band "new
+    /// sequence" signal the single-task static path already uses, so a
     /// downstream stage needs no separate admission message.
     pub(crate) fn run_plan(
         &mut self,

--- a/crates/cascadia-engine-openvino/src/packed_exec.rs
+++ b/crates/cascadia-engine-openvino/src/packed_exec.rs
@@ -1,0 +1,308 @@
+//! Engine-side execution for packed multi-slot decode (see [`crate::packed`]).
+//!
+//! Holds the compiled packed variant, the per-slot KV, and the slot table, and
+//! turns one `step()` into exactly one inference that either prefills a chunk of
+//! one admitted request or decodes one token for every ready request.
+//!
+//! Scheduling is prefill-first: a newly admitted request consumes its prompt in
+//! `packed_seq`-wide chunks before joining the decode batch, so a long prompt
+//! cannot stall other slots for more than one inference at a time.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use cascadia_engine::{EngineError, EngineResult};
+use cascadia_ov_genai_shim::{DType as ShimDType, Runtime as OvRuntime};
+use cascadia_types::GenerationTask;
+
+use crate::packed::{PackedKv, PackedPlan};
+
+/// One request occupying a packed slot.
+pub(crate) struct PackedSlot {
+    pub(crate) task: GenerationTask,
+    pub(crate) prompt_ids: Vec<i64>,
+    /// Prompt tokens already consumed; `== prompt_ids.len()` once prefilled.
+    pub(crate) prompt_fed: usize,
+    pub(crate) generated: Vec<i32>,
+    pub(crate) last_text: String,
+    pub(crate) last_token: i32,
+    pub(crate) started: Instant,
+    pub(crate) t_prefill: Duration,
+}
+
+impl PackedSlot {
+    fn prefilled(&self) -> bool {
+        self.prompt_fed >= self.prompt_ids.len()
+    }
+}
+
+/// Per-layer KV port wiring for the packed variant (mirrors `StaticKvLayer`,
+/// duplicated here so the packed path owns its own resolved ports).
+pub(crate) struct PackedLayer {
+    pub(crate) key_in: String,
+    pub(crate) val_in: String,
+    pub(crate) key_out: usize,
+    pub(crate) val_out: usize,
+}
+
+/// What one packed inference did, so the caller can sample the right rows.
+pub(crate) enum PackedStepKind {
+    /// Prefill chunk for `slot`; `finished_prompt` marks the chunk that
+    /// consumed the last prompt token, whose final real row carries the first
+    /// generated token's logits at `last_row`.
+    Prefill {
+        slot: usize,
+        last_row: usize,
+        finished_prompt: bool,
+    },
+    /// One decode row per listed `(row, slot)`.
+    Decode { rows: Vec<(usize, usize)> },
+}
+
+pub(crate) struct PackedState {
+    pub(crate) runtime: OvRuntime,
+    pub(crate) kv: PackedKv,
+    pub(crate) slots: Vec<Option<PackedSlot>>,
+    pub(crate) ids_in: String,
+    pub(crate) mask_in: String,
+    pub(crate) pos_in: String,
+    pub(crate) mask_dtype: ShimDType,
+    pub(crate) layers: Vec<PackedLayer>,
+    mask_bytes: Vec<u8>,
+    ids_bytes: Vec<u8>,
+    pos_bytes: Vec<u8>,
+}
+
+impl PackedState {
+    pub(crate) fn new(
+        runtime: OvRuntime,
+        kv: PackedKv,
+        layers: Vec<PackedLayer>,
+        ids_in: String,
+        mask_in: String,
+        pos_in: String,
+        mask_dtype: ShimDType,
+    ) -> Self {
+        let slots = kv.slots;
+        Self {
+            runtime,
+            kv,
+            slots: (0..slots).map(|_| None).collect(),
+            ids_in,
+            mask_in,
+            pos_in,
+            mask_dtype,
+            layers,
+            mask_bytes: Vec::new(),
+            ids_bytes: Vec::new(),
+            pos_bytes: Vec::new(),
+        }
+    }
+
+    pub(crate) fn free_slot(&self) -> Option<usize> {
+        self.slots.iter().position(|s| s.is_none())
+    }
+
+    pub(crate) fn occupied(&self) -> usize {
+        self.slots.iter().filter(|s| s.is_some()).count()
+    }
+
+    /// Place a task into `slot`, clearing that slot's KV region only.
+    pub(crate) fn admit(&mut self, slot: usize, task: GenerationTask, prompt_ids: Vec<i64>) {
+        self.kv.reset_slot(slot);
+        self.slots[slot] = Some(PackedSlot {
+            task,
+            prompt_ids,
+            prompt_fed: 0,
+            generated: Vec::new(),
+            last_text: String::new(),
+            last_token: 0,
+            started: Instant::now(),
+            t_prefill: Duration::ZERO,
+        });
+    }
+
+    pub(crate) fn retire(&mut self, slot: usize) -> Option<PackedSlot> {
+        let taken = self.slots[slot].take();
+        self.kv.reset_slot(slot);
+        taken
+    }
+
+    /// Slot needing prefill, lowest index first (admission order).
+    fn next_prefill_slot(&self) -> Option<usize> {
+        self.slots
+            .iter()
+            .position(|s| s.as_ref().is_some_and(|t| !t.prefilled()))
+    }
+
+    /// Run exactly one packed inference. Returns the primary output
+    /// (dtype, shape, bytes) plus what the step did.
+    pub(crate) fn step(
+        &mut self,
+    ) -> EngineResult<Option<(ShimDType, Vec<usize>, Vec<u8>, PackedStepKind)>> {
+        let s = self.kv.packed_seq;
+        let (plan, ids, positions, kind) = if let Some(slot) = self.next_prefill_slot() {
+            // ---- prefill chunk for one slot ----
+            let t = self.slots[slot].as_ref().unwrap();
+            let start = t.prompt_fed;
+            let take = (t.prompt_ids.len() - start).min(s);
+            let ids: Vec<i64> = t.prompt_ids[start..start + take].to_vec();
+            let base = self.kv.position(slot);
+            let positions: Vec<i64> = (0..take).map(|i| (base + i) as i64).collect();
+            let finished = start + take >= t.prompt_ids.len();
+            (
+                PackedPlan::chunk(s, slot, take),
+                ids,
+                positions,
+                PackedStepKind::Prefill {
+                    slot,
+                    last_row: take - 1,
+                    finished_prompt: finished,
+                },
+            )
+        } else {
+            // ---- decode one token for every ready slot ----
+            let ready: Vec<usize> = self
+                .slots
+                .iter()
+                .enumerate()
+                .filter_map(|(i, t)| t.as_ref().map(|_| i))
+                .collect();
+            if ready.is_empty() {
+                return Ok(None);
+            }
+            let ids: Vec<i64> = ready
+                .iter()
+                .map(|&i| self.slots[i].as_ref().unwrap().last_token as i64)
+                .collect();
+            let positions: Vec<i64> = ready.iter().map(|&i| self.kv.position(i) as i64).collect();
+            let rows: Vec<(usize, usize)> = ready.iter().copied().enumerate().collect();
+            (
+                PackedPlan::decode(s, &ready),
+                ids,
+                positions,
+                PackedStepKind::Decode { rows },
+            )
+        };
+        if plan.is_empty() {
+            return Ok(None);
+        }
+
+        // ---- feed ----
+        self.kv
+            .fill_mask(&plan, &mut self.mask_bytes, self.mask_dtype);
+        // Idle rows still need a defined token/position; row 0's values are
+        // safe filler because an idle row attends only to itself and its
+        // output is never read.
+        self.ids_bytes.clear();
+        self.pos_bytes.clear();
+        for r in 0..s {
+            let (id, pos) = match plan.rows[r] {
+                Some(_) => (
+                    ids.get(r).copied().unwrap_or(0),
+                    positions.get(r).copied().unwrap_or(0),
+                ),
+                None => (0i64, 0i64),
+            };
+            self.ids_bytes.extend_from_slice(&id.to_le_bytes());
+            self.pos_bytes.extend_from_slice(&pos.to_le_bytes());
+        }
+        self.runtime
+            .set_input(&self.ids_in, ShimDType::I64, &[1, s], &self.ids_bytes)
+            .map_err(crate::runtime::map_ov_err)?;
+        self.runtime
+            .set_input(
+                &self.mask_in,
+                self.mask_dtype,
+                &[1, 1, s, self.kv.context],
+                &self.mask_bytes,
+            )
+            .map_err(crate::runtime::map_ov_err)?;
+        self.runtime
+            .set_input(&self.pos_in, ShimDType::I64, &[1, s], &self.pos_bytes)
+            .map_err(crate::runtime::map_ov_err)?;
+        let kv_shape = [1, self.kv.kv_heads(), self.kv.past_len, self.kv.head_dim()];
+        for (li, layer) in self.layers.iter().enumerate() {
+            self.runtime
+                .set_input(
+                    &layer.key_in,
+                    ShimDType::F16,
+                    &kv_shape,
+                    self.kv.key_bytes(li),
+                )
+                .map_err(crate::runtime::map_ov_err)?;
+            self.runtime
+                .set_input(
+                    &layer.val_in,
+                    ShimDType::F16,
+                    &kv_shape,
+                    self.kv.val_bytes(li),
+                )
+                .map_err(crate::runtime::map_ov_err)?;
+        }
+
+        self.runtime.infer().map_err(crate::runtime::map_ov_err)?;
+        let (odt, oshape, obytes) = self.runtime.output(0).map_err(crate::runtime::map_ov_err)?;
+
+        // ---- scatter present rows back into their owning slot regions ----
+        let expect = self.kv.present_layer_bytes();
+        let want_shape = [
+            1usize,
+            self.kv.kv_heads(),
+            self.kv.context,
+            self.kv.head_dim(),
+        ];
+        // occupancy per slot BEFORE this step drives append-vs-slide
+        let mut at: HashMap<usize, usize> = HashMap::new();
+        for (_r, pr) in plan.active_rows() {
+            at.entry(pr.slot).or_insert_with(|| self.kv.valid(pr.slot));
+        }
+        for li in 0..self.layers.len() {
+            let (ko, vo) = (self.layers[li].key_out, self.layers[li].val_out);
+            let (_, kshape, kpres) = self
+                .runtime
+                .output(ko)
+                .map_err(crate::runtime::map_ov_err)?;
+            let (_, vshape, vpres) = self
+                .runtime
+                .output(vo)
+                .map_err(crate::runtime::map_ov_err)?;
+            if kpres.len() != expect
+                || vpres.len() != expect
+                || kshape != want_shape
+                || vshape != want_shape
+            {
+                return Err(EngineError::Backend(format!(
+                    "packed present.{li} mismatch: key shape={kshape:?} len={} val shape={vshape:?} \
+                     len={}; expected shape {want_shape:?} ({expect} bytes f16)",
+                    kpres.len(),
+                    vpres.len(),
+                )));
+            }
+            let mut per_slot = at.clone();
+            for (r, pr) in plan.active_rows() {
+                let slot_at = per_slot.get_mut(&pr.slot).expect("seeded above");
+                let capped = (*slot_at).min(self.kv.region);
+                self.kv.absorb_row(li, false, &kpres, r, pr.slot, capped);
+                self.kv.absorb_row(li, true, &vpres, r, pr.slot, capped);
+                *slot_at += 1;
+            }
+        }
+        // advance each slot by the rows it consumed
+        let mut consumed: HashMap<usize, usize> = HashMap::new();
+        for (_r, pr) in plan.active_rows() {
+            *consumed.entry(pr.slot).or_insert(0) += 1;
+        }
+        for (slot, n) in consumed {
+            self.kv.advance(slot, n);
+            if let PackedStepKind::Prefill { slot: ps, .. } = &kind {
+                if *ps == slot {
+                    if let Some(t) = self.slots[slot].as_mut() {
+                        t.prompt_fed += n;
+                    }
+                }
+            }
+        }
+        Ok(Some((odt, oshape, obytes, kind)))
+    }
+}

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1553,8 +1553,7 @@ impl OvRuntimeEngine {
             [s3[0] as u32, s3[1] as u32, s3[2] as u32],
             hidden.iter().flat_map(|v| v.to_le_bytes()).collect(),
         );
-        let rt = self.runtime_handle.clone();
-        rt.block_on(async {
+        self.block_on(async {
             let mut guard = down.lock().await;
             guard
                 .send(&plan_frame)
@@ -1616,8 +1615,7 @@ impl OvRuntimeEngine {
             .clone()
             .ok_or_else(|| EngineError::Backend("packed relay stage has no upstream".into()))?;
         let slots = self.packed.as_ref().unwrap().kv.slots;
-        let rt = self.runtime_handle.clone();
-        let (plan_rows, hidden, hshape) = rt.block_on(async {
+        let (plan_rows, hidden, hshape) = self.block_on(async {
             let mut guard = up.lock().await;
             let (pf, _) = guard
                 .recv()
@@ -1673,7 +1671,7 @@ impl OvRuntimeEngine {
                 });
             }
             let frame = encode_wire_tokens(&tokens);
-            rt.block_on(async {
+            self.block_on(async {
                 let mut guard = up.lock().await;
                 guard
                     .send(&frame)
@@ -1684,7 +1682,7 @@ impl OvRuntimeEngine {
             let hidden_out = bytes_to_f32(odt, &obytes)?;
             let tokens = self.exchange_packed_downstream(&hidden_out, &oshape, &plan_rows)?;
             let frame = encode_wire_tokens(&tokens);
-            rt.block_on(async {
+            self.block_on(async {
                 let mut guard = up.lock().await;
                 guard
                     .send(&frame)

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1361,6 +1361,11 @@ impl OvRuntimeEngine {
         res
     }
 
+    /// Upper bound on inferences one packed `step()` may run before returning.
+    /// Sized for the worst case: a full-region prompt consumed `packed_seq`
+    /// tokens at a time, plus slack. Purely a runaway guard.
+    const PACKED_MAX_INFERS_PER_STEP: usize = 4096;
+
     /// Packed multi-slot step: admit what fits, run ONE inference (a prefill
     /// chunk for one slot, or a decode row for every ready slot), then sample
     /// and emit per slot. Unlike the single-task path this returns chunks for
@@ -1405,13 +1410,33 @@ impl OvRuntimeEngine {
             self.packed.as_mut().unwrap().admit(slot, task, prompt_ids);
         }
 
-        let Some((odt, oshape, obytes, kind)) = self.packed.as_mut().unwrap().step()? else {
-            return Ok(Vec::new());
-        };
-        let logits = bytes_to_f32(odt, &obytes)?;
-
-        // ---- sample the rows this step produced, emit per slot ----
+        // Keep inferring until this call produces at least one chunk. A prompt
+        // wider than `packed_seq` takes several prefill inferences that emit
+        // nothing, and the runner closes a stream that makes no progress for
+        // three consecutive steps — so prefill must complete inside one step(),
+        // exactly as the single-task static path already does.
         let mut out = Vec::new();
+        for _ in 0..Self::PACKED_MAX_INFERS_PER_STEP {
+            let Some((odt, oshape, obytes, kind)) = self.packed.as_mut().unwrap().step()? else {
+                break;
+            };
+            self.emit_packed_rows(odt, &oshape, &obytes, kind, &mut out)?;
+            if !out.is_empty() {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Sample the rows one packed inference produced and append their chunks.
+    fn emit_packed_rows(
+        &mut self,
+        odt: ShimDType,
+        oshape: &[usize],
+        obytes: &[u8],
+        kind: crate::packed_exec::PackedStepKind,
+        out: &mut Vec<(TaskId, Chunk)>,
+    ) -> EngineResult<()> {
         let sampled: Vec<(usize, usize)> = match kind {
             crate::packed_exec::PackedStepKind::Prefill {
                 slot,
@@ -1428,13 +1453,17 @@ impl OvRuntimeEngine {
             }
             crate::packed_exec::PackedStepKind::Decode { rows } => rows,
         };
+        if sampled.is_empty() {
+            return Ok(());
+        }
+        let logits = bytes_to_f32(odt, obytes)?;
         for (row, slot) in sampled {
-            let token = argmax_logits_row(&logits, &oshape, row)?;
+            let token = argmax_logits_row(&logits, oshape, row)?;
             if let Some(chunk) = self.emit_packed_token(slot, token)? {
                 out.push(chunk);
             }
         }
-        Ok(out)
+        Ok(())
     }
 
     /// Append `token` to `slot`'s sequence, decode its text delta, and build the
@@ -1482,9 +1511,11 @@ impl OvRuntimeEngine {
             )));
         }
         let n_tokens = t.generated.len() as u32;
+        let prompt_tokens = t.prompt_ids.len() as u32;
         let elapsed = t.started.elapsed();
         let chunk = Chunk::final_marker(task_id.clone(), delta)
             .with_n_tokens(n_tokens)
+            .with_prompt_tokens(prompt_tokens)
             .with_finish_reason(if is_eos {
                 cascadia_types::FinishReason::Stop
             } else {

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -322,7 +322,7 @@ fn encode_wire_position(position: i64) -> WireTensor {
 /// out. Serving an over-region prompt would answer from a silently truncated
 /// prompt — a request that looks successful and is wrong — so admission rejects
 /// it instead. Both remedies are the operator's, so name both.
-fn packed_admission_error(prompt_tokens: usize, region: usize) -> Option<String> {
+fn packed_prompt_too_long(prompt_tokens: usize, region: usize) -> Option<String> {
     (prompt_tokens > region).then(|| {
         format!(
             "prompt is {prompt_tokens} tokens but this worker's per-slot KV region holds \
@@ -1520,26 +1520,6 @@ impl OvRuntimeEngine {
                     "empty prompt: no tokens to prefill".into(),
                 ));
             }
-            let region = self.packed.as_ref().unwrap().kv.region;
-            if let Some(msg) = packed_admission_error(prompt_ids.len(), region) {
-                // Fail this request, not the step. A step-level Err carries no
-                // task id, so the runner would close whichever stream happened
-                // to poll — a healthy request dying for someone else's prompt.
-                // An error chunk routes to its owner through the same per-task
-                // buffers every other packed chunk uses. The slot is untouched
-                // (only `admit` occupies one), so the next task can still use it.
-                warn!(
-                    task = %task.task_id,
-                    prompt_tokens = prompt_ids.len(),
-                    region,
-                    "refusing over-region prompt"
-                );
-                out.push((
-                    task.task_id.clone(),
-                    Chunk::error(task.task_id.clone(), msg),
-                ));
-                continue;
-            }
             info!(
                 task = %task.task_id,
                 slot,
@@ -2660,6 +2640,26 @@ impl Engine for OvRuntimeEngine {
                 cap: crate::dist_spec::MAX_PENDING_TASKS,
             });
         }
+        // Packed slots divide the KV window, so a prompt can be too long for a
+        // slot while the model itself could hold it. Reject here rather than at
+        // admission: submit() is synchronous with the HTTP request, so the
+        // caller gets a 413 before any stream is opened — a streaming client
+        // rejected mid-stream would already have had its 200 committed and
+        // would receive a non-standard error frame instead.
+        if let Some(packed) = self.packed.as_ref() {
+            if let Some(tok) = self.tokenizer.as_ref() {
+                let n = tok
+                    .encode(task.prompt.clone(), false)
+                    .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?
+                    .get_ids()
+                    .len();
+                if let Some(msg) = packed_prompt_too_long(n, packed.kv.region) {
+                    warn!(task = %task.task_id, prompt_tokens = n,
+                          region = packed.kv.region, "refusing over-region prompt");
+                    return Err(EngineError::PromptTooLong(msg));
+                }
+            }
+        }
         self.pending.push(task);
         Ok(())
     }
@@ -3774,11 +3774,11 @@ mod tests {
     #[test]
     fn over_region_prompt_is_refused_at_admission() {
         assert!(
-            packed_admission_error(255, 255).is_none(),
+            packed_prompt_too_long(255, 255).is_none(),
             "a prompt that exactly fills the region is servable"
         );
-        assert!(packed_admission_error(1, 255).is_none());
-        let msg = packed_admission_error(256, 255).expect("over-region must be refused");
+        assert!(packed_prompt_too_long(1, 255).is_none());
+        let msg = packed_prompt_too_long(256, 255).expect("over-region must be refused");
         assert!(msg.contains("256") && msg.contains("255"), "{msg}");
         assert!(
             msg.contains("--static-context") && msg.contains("--packed-slots"),

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -183,7 +183,7 @@ fn f16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
         .collect()
 }
 
-fn f32_to_f16_bytes(v: &[f32]) -> Vec<u8> {
+pub(crate) fn f32_to_f16_bytes(v: &[f32]) -> Vec<u8> {
     use half::f16;
     let mut out = Vec::with_capacity(v.len() * 2);
     for x in v {
@@ -314,6 +314,101 @@ fn to_shape3(shape: &[usize]) -> [usize; 3] {
 /// `decode_wire_position` — keep the two in sync.
 fn encode_wire_position(position: i64) -> WireTensor {
     WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
+}
+
+/// Encode a packed step's per-row `(slot, position)` assignment as one framed
+/// I64 `[1, 2, S]` tensor: row 0 holds slot ids (`-1` = idle row), row 1 holds
+/// absolute positions. This is the packed analogue of `encode_wire_position` —
+/// downstream stages need per-ROW routing, not one scalar, to rebuild the
+/// block-diagonal mask and scatter each row into the right slot's ring.
+fn encode_wire_plan(rows: &[Option<(usize, i64)>]) -> WireTensor {
+    let s = rows.len();
+    let mut data = Vec::with_capacity(s * 2 * 8);
+    for r in rows {
+        let slot: i64 = r.map(|(sl, _)| sl as i64).unwrap_or(-1);
+        data.extend_from_slice(&slot.to_le_bytes());
+    }
+    for r in rows {
+        let pos: i64 = r.map(|(_, p)| p).unwrap_or(0);
+        data.extend_from_slice(&pos.to_le_bytes());
+    }
+    WireTensor::new(WireDType::I64, [1, 2, s as u32], data)
+}
+
+/// Decode + validate a packed plan frame. Rejects a wrong dtype/rank, a
+/// length/shape disagreement, out-of-range slot ids, and negative positions —
+/// each of which would otherwise index or wrap somewhere downstream.
+fn decode_wire_plan(t: &WireTensor, slots: usize) -> EngineResult<Vec<Option<(usize, i64)>>> {
+    let s = t.shape[2] as usize;
+    if t.dtype != WireDType::I64 || t.shape[0] != 1 || t.shape[1] != 2 || s == 0 {
+        return Err(EngineError::Backend(format!(
+            "expected an I64 [1,2,S] packed plan frame, got dtype={:?} shape={:?} — likely a \
+             packed/non-packed pipeline mismatch or a desynced activation stream",
+            t.dtype, t.shape
+        )));
+    }
+    if t.data.len() != s * 2 * 8 {
+        return Err(EngineError::Backend(format!(
+            "packed plan frame payload {} bytes does not match shape {:?}",
+            t.data.len(),
+            t.shape
+        )));
+    }
+    let rd = |i: usize| -> i64 {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(&t.data[i * 8..i * 8 + 8]);
+        i64::from_le_bytes(b)
+    };
+    let mut out = Vec::with_capacity(s);
+    for r in 0..s {
+        let slot = rd(r);
+        let pos = rd(s + r);
+        if slot < 0 {
+            out.push(None);
+            continue;
+        }
+        if slot as usize >= slots {
+            return Err(EngineError::Backend(format!(
+                "packed plan row {r} names slot {slot} but this stage has {slots} slots"
+            )));
+        }
+        if pos < 0 {
+            return Err(EngineError::Backend(format!(
+                "packed plan row {r} has negative position {pos}"
+            )));
+        }
+        out.push(Some((slot as usize, pos)));
+    }
+    Ok(out)
+}
+
+/// Encode the head stage's per-row sampled tokens as I64 `[1, 1, S]`. The
+/// non-packed path returns one token; packed returns one per active row, in
+/// row order, with 0 for idle rows (never read).
+fn encode_wire_tokens(tokens: &[i32]) -> WireTensor {
+    let mut data = Vec::with_capacity(tokens.len() * 8);
+    for &t in tokens {
+        data.extend_from_slice(&(t as i64).to_le_bytes());
+    }
+    WireTensor::new(WireDType::I64, [1, 1, tokens.len() as u32], data)
+}
+
+fn decode_wire_tokens(t: &WireTensor) -> EngineResult<Vec<i32>> {
+    if t.dtype != WireDType::I64 || t.data.len() % 8 != 0 || t.data.is_empty() {
+        return Err(EngineError::Backend(format!(
+            "expected an I64 packed token frame, got dtype={:?} len={}",
+            t.dtype,
+            t.data.len()
+        )));
+    }
+    Ok(t.data
+        .chunks_exact(8)
+        .map(|c| {
+            let mut b = [0u8; 8];
+            b.copy_from_slice(c);
+            i64::from_le_bytes(b) as i32
+        })
+        .collect())
 }
 
 /// Decode + strictly validate a wire position frame. Must be I64 with exactly
@@ -1415,17 +1510,189 @@ impl OvRuntimeEngine {
         // nothing, and the runner closes a stream that makes no progress for
         // three consecutive steps — so prefill must complete inside one step(),
         // exactly as the single-task static path already does.
+        let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
         let mut out = Vec::new();
         for _ in 0..Self::PACKED_MAX_INFERS_PER_STEP {
             let Some((odt, oshape, obytes, kind)) = self.packed.as_mut().unwrap().step()? else {
                 break;
             };
-            self.emit_packed_rows(odt, &oshape, &obytes, kind, &mut out)?;
+            if single_stage {
+                self.emit_packed_rows(odt, &oshape, &obytes, kind, &mut out)?;
+            } else {
+                // Pipeline: this stage produced hidden rows. Ship the plan (so
+                // every downstream stage can rebuild the same mask and route
+                // rows to the same slots) plus the hidden block, then take back
+                // one sampled token per row from the tail.
+                let hidden = bytes_to_f32(odt, &obytes)?;
+                let plan_rows = self.packed.as_ref().unwrap().last_plan_rows();
+                let tokens = self.exchange_packed_downstream(&hidden, &oshape, &plan_rows)?;
+                self.emit_packed_tokens(&tokens, kind, &mut out)?;
+            }
             if !out.is_empty() {
                 break;
             }
         }
         Ok(out)
+    }
+
+    /// Send `[1, S, hidden]` + the packed plan downstream and wait for the tail
+    /// stage's per-row tokens.
+    fn exchange_packed_downstream(
+        &mut self,
+        hidden: &[f32],
+        shape: &[usize],
+        plan_rows: &[Option<(usize, i64)>],
+    ) -> EngineResult<Vec<i32>> {
+        let down = self.downstream.clone().ok_or_else(|| {
+            EngineError::Backend("packed pipeline stage has no downstream".into())
+        })?;
+        let s3 = to_shape3(shape);
+        let plan_frame = encode_wire_plan(plan_rows);
+        let hidden_frame = WireTensor::new(
+            WireDType::F32,
+            [s3[0] as u32, s3[1] as u32, s3[2] as u32],
+            hidden.iter().flat_map(|v| v.to_le_bytes()).collect(),
+        );
+        let rt = self.runtime_handle.clone();
+        rt.block_on(async {
+            let mut guard = down.lock().await;
+            guard
+                .send(&plan_frame)
+                .await
+                .map_err(|e| EngineError::Backend(format!("packed plan send: {e}")))?;
+            guard
+                .send(&hidden_frame)
+                .await
+                .map_err(|e| EngineError::Backend(format!("packed hidden send: {e}")))?;
+            let (reply, _) = guard
+                .recv()
+                .await
+                .map_err(|e| EngineError::Backend(format!("packed token recv: {e}")))?;
+            decode_wire_tokens(&reply)
+        })
+    }
+
+    /// Emit chunks from a pipeline tail's per-row tokens.
+    fn emit_packed_tokens(
+        &mut self,
+        tokens: &[i32],
+        kind: crate::packed_exec::PackedStepKind,
+        out: &mut Vec<(TaskId, Chunk)>,
+    ) -> EngineResult<()> {
+        let sampled: Vec<(usize, usize)> = match kind {
+            crate::packed_exec::PackedStepKind::Prefill {
+                slot,
+                last_row,
+                finished_prompt,
+            } => {
+                if finished_prompt {
+                    vec![(last_row, slot)]
+                } else {
+                    Vec::new()
+                }
+            }
+            crate::packed_exec::PackedStepKind::Decode { rows } => rows,
+        };
+        for (row, slot) in sampled {
+            let token = tokens.get(row).copied().ok_or_else(|| {
+                EngineError::Backend(format!(
+                    "packed tail returned {} tokens, need row {row}",
+                    tokens.len()
+                ))
+            })?;
+            if let Some(chunk) = self.emit_packed_token(slot, token)? {
+                out.push(chunk);
+            }
+        }
+        Ok(())
+    }
+
+    /// Relay/head stage: consume one packed (plan, hidden) pair. The head
+    /// samples every active row and replies with the token vector; a middle
+    /// stage forwards both frames on and passes the reply back up.
+    fn step_relay_packed(&mut self) -> EngineResult<()> {
+        let up = self
+            .upstream
+            .clone()
+            .ok_or_else(|| EngineError::Backend("packed relay stage has no upstream".into()))?;
+        let slots = self.packed.as_ref().unwrap().kv.slots;
+        let rt = self.runtime_handle.clone();
+        let (plan_rows, hidden, hshape) = rt.block_on(async {
+            let mut guard = up.lock().await;
+            let (pf, _) = guard
+                .recv()
+                .await
+                .map_err(|e| EngineError::Backend(format!("packed plan recv: {e}")))?;
+            let plan_rows = decode_wire_plan(&pf, slots)?;
+            let (hf, _) = guard
+                .recv()
+                .await
+                .map_err(|e| EngineError::Backend(format!("packed hidden recv: {e}")))?;
+            let hidden: Vec<f32> = hf
+                .data
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            Ok::<_, EngineError>((plan_rows, hidden, hf.shape))
+        })?;
+
+        let hidden_size = hshape[2] as usize;
+        let plan = crate::packed::PackedPlan {
+            rows: plan_rows
+                .iter()
+                .map(|r| r.map(|(slot, _)| crate::packed::PackedRow { slot, order: 0 }))
+                .collect(),
+        };
+        // Same-slot rows in one frame are a prefill chunk: restore their causal
+        // order so this stage masks them exactly as the sender did.
+        let mut plan = plan;
+        let mut seen: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+        for row in plan.rows.iter_mut().flatten() {
+            let n = seen.entry(row.slot).or_insert(0);
+            row.order = *n;
+            *n += 1;
+        }
+        let positions: Vec<i64> = plan_rows
+            .iter()
+            .map(|r| r.map(|(_, p)| p).unwrap_or(0))
+            .collect();
+        let (odt, oshape, obytes) = self.packed.as_mut().unwrap().run_plan(
+            &plan,
+            crate::packed_exec::PackedPrimary::Hidden(&hidden, hidden_size),
+            &positions,
+        )?;
+
+        if self.spec.is_last_stage {
+            let logits = bytes_to_f32(odt, &obytes)?;
+            let mut tokens = Vec::with_capacity(plan.rows.len());
+            for (r, row) in plan.rows.iter().enumerate() {
+                tokens.push(if row.is_some() {
+                    argmax_logits_row(&logits, &oshape, r)?
+                } else {
+                    0
+                });
+            }
+            let frame = encode_wire_tokens(&tokens);
+            rt.block_on(async {
+                let mut guard = up.lock().await;
+                guard
+                    .send(&frame)
+                    .await
+                    .map_err(|e| EngineError::Backend(format!("packed token send: {e}")))
+            })?;
+        } else {
+            let hidden_out = bytes_to_f32(odt, &obytes)?;
+            let tokens = self.exchange_packed_downstream(&hidden_out, &oshape, &plan_rows)?;
+            let frame = encode_wire_tokens(&tokens);
+            rt.block_on(async {
+                let mut guard = up.lock().await;
+                guard
+                    .send(&frame)
+                    .await
+                    .map_err(|e| EngineError::Backend(format!("packed token send: {e}")))
+            })?;
+        }
+        Ok(())
     }
 
     /// Sample the rows one packed inference produced and append their chunks.
@@ -2164,6 +2431,9 @@ impl OvRuntimeEngine {
     }
 
     fn step_last(&mut self) -> EngineResult<()> {
+        if self.packed.is_some() {
+            return self.step_relay_packed();
+        }
         let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
         // A seq=1 static frame means this task's prefill chunks are done —
         // with --park-prefill, release the prefill model's weights now.
@@ -2190,6 +2460,9 @@ impl OvRuntimeEngine {
     }
 
     fn step_middle(&mut self) -> EngineResult<()> {
+        if self.packed.is_some() {
+            return self.step_relay_packed();
+        }
         let (hidden, shape, pos_opt) = self.recv_hidden_from_upstream()?;
         // Multi-token hidden = prefill work downstream: a stateful
         // whole-prompt frame, or (static path) a prefill CHUNK — either way
@@ -2368,6 +2641,22 @@ impl Engine for OvRuntimeEngine {
 
     fn cancel(&mut self, task_id: &TaskId) {
         self.pending.retain(|t| t.task_id != *task_id);
+        // Packed path: drop just this request's slot. Its KV region is cleared
+        // and returned to the free pool immediately, so a disconnecting client
+        // frees capacity for the next admission without disturbing the other
+        // in-flight slots sharing the inference.
+        if let Some(packed) = self.packed.as_mut() {
+            if let Some(slot) = packed
+                .slots
+                .iter()
+                .position(|s| s.as_ref().is_some_and(|t| t.task.task_id == *task_id))
+            {
+                packed.retire(slot);
+                info!(task = %task_id, slot, in_flight = packed.occupied(),
+                      "packed cancel: slot released");
+            }
+            return;
+        }
         // Abandoning the active task mirrors the step-failure recovery:
         // clear it and reset generation state so the next pending task
         // activates immediately instead of waiting for this one to
@@ -3295,13 +3584,6 @@ impl Builder for OvRuntimeBuilder {
         let packed = match self.packed_params {
             None => None,
             Some((slots, pseq, _pctx)) => {
-                if !(spec.is_first_stage && spec.is_last_stage) {
-                    return Err(EngineError::ShardRejected(
-                        "--packed-slots is single-stage only for now; the multi-stage wire \
-                         does not yet carry [1, S, hidden] + per-slot positions"
-                            .into(),
-                    ));
-                }
                 let (ctx, kvh, hd) = self.static_params.expect("checked in load");
                 let past_len = (ctx - 1) as usize;
                 let prt = OvRuntime::compile(
@@ -3320,9 +3602,13 @@ impl Builder for OvRuntimeBuilder {
                     })
                     .collect::<Vec<_>>();
                 let pcanon = resolve_canonical_inputs(&prt)?;
-                let ids_in = pcanon.get("input_ids").cloned().ok_or_else(|| {
-                    EngineError::Backend("packed variant missing input_ids".into())
-                })?;
+                let ids_in = pcanon.get("input_ids").cloned().unwrap_or_default();
+                let hidden_in = pcanon.get("hidden_states").cloned().unwrap_or_default();
+                if ids_in.is_empty() && hidden_in.is_empty() {
+                    return Err(EngineError::Backend(
+                        "packed variant has neither input_ids nor hidden_states".into(),
+                    ));
+                }
                 let pos_in = pcanon.get("position_ids").cloned().ok_or_else(|| {
                     EngineError::Backend("packed variant missing position_ids".into())
                 })?;
@@ -3361,7 +3647,7 @@ impl Builder for OvRuntimeBuilder {
                     "packed multi-slot decode active"
                 );
                 Some(crate::packed_exec::PackedState::new(
-                    prt, kv, players, ids_in, mask_in, pos_in, mask_dtype,
+                    prt, kv, players, ids_in, hidden_in, mask_in, pos_in, mask_dtype,
                 ))
             }
         };
@@ -3488,6 +3774,40 @@ mod tests {
     /// after the window fills and slides. This is what makes the chunked
     /// (possibly other-device) prefill hand exactly the same KV state to the
     /// seq=1 decode loop as the legacy path.
+    #[test]
+    fn packed_plan_frame_round_trips() {
+        let rows = vec![Some((0usize, 7i64)), None, Some((3, 0)), Some((1, 129))];
+        let frame = encode_wire_plan(&rows);
+        assert_eq!(frame.shape, [1, 2, 4]);
+        let back = decode_wire_plan(&frame, 4).expect("round trip");
+        assert_eq!(back, rows);
+    }
+
+    #[test]
+    fn packed_plan_frame_rejects_bad_frames() {
+        // wrong rank/shape (a scalar position frame from a non-packed peer)
+        let pos = encode_wire_position(5);
+        assert!(decode_wire_plan(&pos, 4).is_err());
+        // slot id beyond this stage's slot count
+        let frame = encode_wire_plan(&[Some((9usize, 0i64))]);
+        let err = decode_wire_plan(&frame, 4).unwrap_err().to_string();
+        assert!(err.contains("slot 9"), "{err}");
+        // negative position would wrap in the ring math
+        let mut bad = encode_wire_plan(&[Some((0usize, 1i64))]);
+        bad.data[8..16].copy_from_slice(&(-3i64).to_le_bytes());
+        assert!(decode_wire_plan(&bad, 4).is_err());
+    }
+
+    #[test]
+    fn packed_token_frame_round_trips() {
+        let toks = vec![5i32, 0, 128009, 42];
+        let back = decode_wire_tokens(&encode_wire_tokens(&toks)).expect("round trip");
+        assert_eq!(back, toks);
+        // a hidden (F32) frame where tokens were expected is a hard error
+        let wrong = WireTensor::new(WireDType::F32, [1, 1, 2], vec![0u8; 8]);
+        assert!(decode_wire_tokens(&wrong).is_err());
+    }
+
     #[test]
     fn chunked_absorb_matches_sequential() {
         // past_len=4 forces sliding early; prompt=11 with C=3 exercises a

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -316,6 +316,22 @@ fn encode_wire_position(position: i64) -> WireTensor {
     WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
 }
 
+/// Refuse a prompt that cannot fit one packed slot's KV region.
+///
+/// A slot's region is a bounded window: once it fills, the oldest entries slide
+/// out. Serving an over-region prompt would answer from a silently truncated
+/// prompt — a request that looks successful and is wrong — so admission rejects
+/// it instead. Both remedies are the operator's, so name both.
+fn packed_admission_error(prompt_tokens: usize, region: usize) -> Option<String> {
+    (prompt_tokens > region).then(|| {
+        format!(
+            "prompt is {prompt_tokens} tokens but this worker's per-slot KV region holds \
+             {region}; raise --static-context or lower --packed-slots (per-slot context is \
+             (static_context - 1 - packed_prefix) / packed_slots)"
+        )
+    })
+}
+
 /// Encode a packed step's per-row assignment as one framed I64 `[1, 3, S]`
 /// tensor: row 0 slot ids (`-1` = idle row), row 1 absolute positions, row 2
 /// the shared-prefix reuse length. The packed analogue of
@@ -1484,6 +1500,7 @@ impl OvRuntimeEngine {
     /// several tasks at once — which is exactly what the runner's per-task
     /// chunk buffers were built to demultiplex.
     fn step_first_packed(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        let mut out = Vec::new();
         // ---- admission ----
         while !self.pending.is_empty() {
             let Some(slot) = self.packed.as_ref().unwrap().free_slot() else {
@@ -1504,14 +1521,24 @@ impl OvRuntimeEngine {
                 ));
             }
             let region = self.packed.as_ref().unwrap().kv.region;
-            if prompt_ids.len() > region {
+            if let Some(msg) = packed_admission_error(prompt_ids.len(), region) {
+                // Fail this request, not the step. A step-level Err carries no
+                // task id, so the runner would close whichever stream happened
+                // to poll — a healthy request dying for someone else's prompt.
+                // An error chunk routes to its owner through the same per-task
+                // buffers every other packed chunk uses. The slot is untouched
+                // (only `admit` occupies one), so the next task can still use it.
                 warn!(
                     task = %task.task_id,
                     prompt_tokens = prompt_ids.len(),
                     region,
-                    "prompt exceeds this slot's KV region; earliest tokens will be evicted \
-                     — lower --packed-slots or raise --static-context"
+                    "refusing over-region prompt"
                 );
+                out.push((
+                    task.task_id.clone(),
+                    Chunk::error(task.task_id.clone(), msg),
+                ));
+                continue;
             }
             info!(
                 task = %task.task_id,
@@ -1528,7 +1555,6 @@ impl OvRuntimeEngine {
         // three consecutive steps — so prefill must complete inside one step(),
         // exactly as the single-task static path already does.
         let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
-        let mut out = Vec::new();
         for _ in 0..Self::PACKED_MAX_INFERS_PER_STEP {
             let Some((odt, oshape, obytes, kind)) = self.packed.as_mut().unwrap().step()? else {
                 break;
@@ -3739,6 +3765,25 @@ mod tests {
         let mut b = OvRuntimeBuilder::new("/non/existent", 0, 1, "CPU");
         let res = b.load(ShardSpec::single_stage("m", "CPU")).await;
         assert!(res.is_err());
+    }
+
+    /// A prompt longer than its slot's KV region cannot be served honestly: the
+    /// packed ring would evict its head and answer from a truncated prompt, so
+    /// admission must refuse it. The boundary is strict — a prompt that exactly
+    /// fills the region still fits.
+    #[test]
+    fn over_region_prompt_is_refused_at_admission() {
+        assert!(
+            packed_admission_error(255, 255).is_none(),
+            "a prompt that exactly fills the region is servable"
+        );
+        assert!(packed_admission_error(1, 255).is_none());
+        let msg = packed_admission_error(256, 255).expect("over-region must be refused");
+        assert!(msg.contains("256") && msg.contains("255"), "{msg}");
+        assert!(
+            msg.contains("--static-context") && msg.contains("--packed-slots"),
+            "the message must name both remedies: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1565,10 +1565,13 @@ impl OvRuntimeEngine {
         })?;
         let s3 = to_shape3(shape);
         let plan_frame = encode_wire_plan(plan_rows);
+        // f16 on the wire, matching the non-packed path: the receiving stage
+        // converts to f16 before feeding the IR regardless, so f32 doubled the
+        // bytes per stage hop and bought nothing.
         let hidden_frame = WireTensor::new(
-            WireDType::F32,
+            WireDType::F16,
             [s3[0] as u32, s3[1] as u32, s3[2] as u32],
-            hidden.iter().flat_map(|v| v.to_le_bytes()).collect(),
+            f32_to_f16_bytes(hidden),
         );
         self.block_on(async {
             let mut guard = down.lock().await;
@@ -1643,11 +1646,14 @@ impl OvRuntimeEngine {
                 .recv()
                 .await
                 .map_err(|e| EngineError::Backend(format!("packed hidden recv: {e}")))?;
-            let hidden: Vec<f32> = hf
-                .data
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect();
+            let hidden: Vec<f32> = match hf.dtype {
+                WireDType::F16 => f16_bytes_to_f32(&hf.data),
+                _ => hf
+                    .data
+                    .chunks_exact(4)
+                    .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect(),
+            };
             Ok::<_, EngineError>((plan_rows, hidden, hf.shape))
         })?;
 
@@ -1792,16 +1798,24 @@ impl OvRuntimeEngine {
         let task_id = t.task.task_id.clone();
 
         if !is_final {
+            // Explicit count for the same reason: a token whose text lands in
+            // the next chunk (BPE splitting a glyph) would otherwise count 0.
             return Ok(Some((
                 task_id.clone(),
-                Chunk::token(task_id, token as i64, delta),
+                Chunk::token(task_id, token as i64, delta).with_n_tokens(1),
             )));
         }
         let n_tokens = t.generated.len() as u32;
         let prompt_tokens = t.prompt_ids.len() as u32;
         let elapsed = t.started.elapsed();
+        // n_tokens is THIS chunk's increment, not the running total. The API
+        // sums per-chunk counts (falling back to 1 per non-empty chunk), so a
+        // cumulative value here double-counts every interim token — measured as
+        // completion_tokens = 2N-1. This chunk carries exactly one token, and
+        // it is set explicitly so an empty final delta (EOS decoding to "")
+        // still counts.
         let chunk = Chunk::final_marker(task_id.clone(), delta)
-            .with_n_tokens(n_tokens)
+            .with_n_tokens(1)
             .with_prompt_tokens(prompt_tokens)
             .with_finish_reason(if is_eos {
                 cascadia_types::FinishReason::Stop

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -492,6 +492,10 @@ struct StaticKvLayer {
 /// absolute `position` the first stage carries with each activation.
 struct StaticKv {
     past_len: usize,
+    /// Leading ring columns the slide never evicts (see
+    /// [`crate::packed::KV_SINK`]). Capped at half the window so pinning can
+    /// never crowd out the sliding portion.
+    sink: usize,
     context: usize,
     kv_heads: usize,
     head_dim: usize,
@@ -580,6 +584,7 @@ impl StaticKv {
         let full = valid_now >= self.past_len;
         let kv_heads = self.kv_heads;
         let past_len = self.past_len;
+        let sink = self.sink;
         let buf: &mut [u8] = if is_value {
             &mut self.val_buf[li]
         } else {
@@ -590,7 +595,10 @@ impl StaticKv {
             let new = &present[src..src + slot];
             let base = h * buf_row;
             if full {
-                buf.copy_within(base + slot..base + buf_row, base); // drop oldest
+                // Drop the oldest EVICTABLE entry: the leading `sink` columns
+                // are pinned, so the shift starts past them. Without that the
+                // slide drops token 0 and attention collapses (see KV_SINK).
+                buf.copy_within(base + (sink + 1) * slot..base + buf_row, base + sink * slot);
                 let dst = base + (past_len - 1) * slot;
                 buf[dst..dst + slot].copy_from_slice(new);
             } else {
@@ -3560,6 +3568,7 @@ impl Builder for OvRuntimeBuilder {
             }
             Some(StaticKv {
                 past_len,
+                sink: crate::packed::KV_SINK.min(past_len / 2),
                 context: ctx as usize,
                 kv_heads: kvh,
                 head_dim: hd,
@@ -3805,6 +3814,7 @@ mod tests {
         let layer_bytes = kv_heads * past_len * head_dim * elem;
         StaticKv {
             past_len,
+            sink: crate::packed::KV_SINK.min(past_len / 2),
             context: past_len + 1,
             kv_heads,
             head_dim,
@@ -3908,6 +3918,43 @@ mod tests {
         // a hidden (F32) frame where tokens were expected is a hard error
         let wrong = WireTensor::new(WireDType::F32, [1, 1, 2], vec![0u8; 8]);
         assert!(decode_wire_tokens(&wrong).is_err());
+    }
+
+    /// Which token sits in each ring slot, recovered by matching the
+    /// deterministic per-token byte pattern back.
+    fn ring_tokens(ring: &StaticKv, n: usize) -> Vec<Option<usize>> {
+        let slot = ring.head_dim * ring.elem_bytes;
+        (0..ring.past_len)
+            .map(|i| {
+                (0..n).find(|&t| {
+                    (0..slot).all(|b| ring.key_buf[0][i * slot + b] == tok_byte(t, 0, b, false))
+                })
+            })
+            .collect()
+    }
+
+    /// The single-task ring drops its OLDEST entry once full, which evicts
+    /// token 0 — the attention sink. Same defect the packed ring had, at the
+    /// full window instead of a per-slot region, so it needs a conversation
+    /// past `past_len` rather than past `region` to show. Measured on CPU: a
+    /// run crossing 1023 total tokens degenerated into "ttettettett...".
+    #[test]
+    fn single_task_slide_preserves_the_attention_sink() {
+        let mut ring = test_ring(10, 1, 1, 1); // sink = min(4, 10/2) = 4
+        assert_eq!(ring.sink, 4);
+        for t in 0..16 {
+            ring.begin_token(t);
+            let k = present_seq1(&ring, t, false);
+            ring.absorb_layer(0, false, &k);
+        }
+        assert_eq!(
+            ring_tokens(&ring, 16),
+            vec![0, 1, 2, 3, 10, 11, 12, 13, 14, 15]
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>(),
+            "tokens 0-3 are the sinks and must survive; only the tail slides"
+        );
     }
 
     #[test]

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -88,6 +88,14 @@ struct StageConfig {
     static_seq: Option<u32>,
     #[serde(default)]
     static_context: Option<u32>,
+    /// Packed multi-slot IR variant (openvino_packed_model.xml): how many
+    /// independent requests share one inference via the sequence dimension.
+    #[serde(default)]
+    packed_slots: Option<u32>,
+    #[serde(default)]
+    packed_seq: Option<u32>,
+    #[serde(default)]
+    packed_context: Option<u32>,
     /// Chunked-prefill IR variant (openvino_prefill_model.xml) query-window
     /// width, exported via `--static-prefill-seq`. Absent/None on decode-only
     /// static exports and on all stateful exports.
@@ -209,7 +217,7 @@ fn argmax_last_row(logits: &[f32], vocab: usize) -> i32 {
     best_i as i32
 }
 
-fn map_ov_err(err: OvError) -> EngineError {
+pub(crate) fn map_ov_err(err: OvError) -> EngineError {
     match err {
         OvError::Stub => {
             EngineError::Backend("openvino shim built without --features openvino".into())
@@ -702,6 +710,10 @@ pub struct OvRuntimeEngine {
     canonical_inputs: std::collections::HashMap<String, String>,
     pending: Vec<GenerationTask>,
     active: Option<ActiveTask>,
+    /// `--packed-slots`: multi-slot packed decode state (own compiled variant,
+    /// per-slot KV regions, slot table). Mutually exclusive with `static_kv`
+    /// single-task decode; when set, `step_first` dispatches to the packed path.
+    packed: Option<crate::packed_exec::PackedState>,
     /// Set for stateless static-shape (NPU) shards; drives the host-side
     /// bounded-KV decode path instead of OV internal state.
     static_kv: Option<StaticKv>,
@@ -1274,6 +1286,9 @@ impl OvRuntimeEngine {
     }
 
     fn step_first(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        if self.packed.is_some() {
+            return self.step_first_packed();
+        }
         if self.active.is_none() && !self.pending.is_empty() {
             let task = self.pending.remove(0);
             let tok = self
@@ -1344,6 +1359,148 @@ impl OvRuntimeEngine {
             });
         }
         res
+    }
+
+    /// Packed multi-slot step: admit what fits, run ONE inference (a prefill
+    /// chunk for one slot, or a decode row for every ready slot), then sample
+    /// and emit per slot. Unlike the single-task path this returns chunks for
+    /// several tasks at once — which is exactly what the runner's per-task
+    /// chunk buffers were built to demultiplex.
+    fn step_first_packed(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        // ---- admission ----
+        while !self.pending.is_empty() {
+            let Some(slot) = self.packed.as_ref().unwrap().free_slot() else {
+                break;
+            };
+            let task = self.pending.remove(0);
+            let tok = self
+                .tokenizer
+                .clone()
+                .ok_or_else(|| EngineError::Backend("first stage requires tokenizer".into()))?;
+            let enc = tok
+                .encode(task.prompt.clone(), false)
+                .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
+            let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            if prompt_ids.is_empty() {
+                return Err(EngineError::Backend(
+                    "empty prompt: no tokens to prefill".into(),
+                ));
+            }
+            let region = self.packed.as_ref().unwrap().kv.region;
+            if prompt_ids.len() > region {
+                warn!(
+                    task = %task.task_id,
+                    prompt_tokens = prompt_ids.len(),
+                    region,
+                    "prompt exceeds this slot's KV region; earliest tokens will be evicted \
+                     — lower --packed-slots or raise --static-context"
+                );
+            }
+            info!(
+                task = %task.task_id,
+                slot,
+                prompt_tokens = prompt_ids.len(),
+                "task admitted to packed slot"
+            );
+            self.packed.as_mut().unwrap().admit(slot, task, prompt_ids);
+        }
+
+        let Some((odt, oshape, obytes, kind)) = self.packed.as_mut().unwrap().step()? else {
+            return Ok(Vec::new());
+        };
+        let logits = bytes_to_f32(odt, &obytes)?;
+
+        // ---- sample the rows this step produced, emit per slot ----
+        let mut out = Vec::new();
+        let sampled: Vec<(usize, usize)> = match kind {
+            crate::packed_exec::PackedStepKind::Prefill {
+                slot,
+                last_row,
+                finished_prompt,
+            } => {
+                // Only the chunk that consumed the final prompt token yields a
+                // real token; earlier chunks just fill the slot's KV.
+                if finished_prompt {
+                    vec![(last_row, slot)]
+                } else {
+                    Vec::new()
+                }
+            }
+            crate::packed_exec::PackedStepKind::Decode { rows } => rows,
+        };
+        for (row, slot) in sampled {
+            let token = argmax_logits_row(&logits, &oshape, row)?;
+            if let Some(chunk) = self.emit_packed_token(slot, token)? {
+                out.push(chunk);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Append `token` to `slot`'s sequence, decode its text delta, and build the
+    /// chunk. Returns None if the slot vanished (cancelled mid-step). Retires
+    /// the slot — freeing its KV region for the next admission — on the final
+    /// chunk, which is what makes this continuous rather than batch-synchronous.
+    fn emit_packed_token(
+        &mut self,
+        slot: usize,
+        token: i32,
+    ) -> EngineResult<Option<(TaskId, Chunk)>> {
+        let tok = self
+            .tokenizer
+            .clone()
+            .ok_or_else(|| EngineError::Backend("first stage requires tokenizer".into()))?;
+        let eos = self.eos_token_ids.clone();
+        let packed = self.packed.as_mut().unwrap();
+        let Some(t) = packed.slots[slot].as_mut() else {
+            return Ok(None);
+        };
+        t.last_token = token;
+        t.generated.push(token);
+        let all_ids: Vec<u32> = t.generated.iter().map(|&x| x as u32).collect();
+        let full_text = tok
+            .decode(&all_ids, true)
+            .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
+        // strip_prefix, not byte slicing: BPE can split a UTF-8 glyph across
+        // two tokens, so `last_text` is not always a clean byte prefix.
+        let delta = full_text
+            .strip_prefix(t.last_text.as_str())
+            .unwrap_or(&full_text)
+            .to_string();
+        t.last_text = full_text;
+
+        let max_tokens = t.task.max_tokens.max(1) as usize;
+        let is_eos = eos.contains(&(token as u32));
+        let hit_cap = t.generated.len() >= max_tokens;
+        let is_final = hit_cap || is_eos;
+        let task_id = t.task.task_id.clone();
+
+        if !is_final {
+            return Ok(Some((
+                task_id.clone(),
+                Chunk::token(task_id, token as i64, delta),
+            )));
+        }
+        let n_tokens = t.generated.len() as u32;
+        let elapsed = t.started.elapsed();
+        let chunk = Chunk::final_marker(task_id.clone(), delta)
+            .with_n_tokens(n_tokens)
+            .with_finish_reason(if is_eos {
+                cascadia_types::FinishReason::Stop
+            } else {
+                cascadia_types::FinishReason::Length
+            });
+        packed.retire(slot);
+        info!(
+            task = %task_id,
+            slot,
+            tokens = n_tokens,
+            elapsed_s = elapsed.as_secs_f64(),
+            tok_s = n_tokens as f64 / elapsed.as_secs_f64().max(1e-9),
+            in_flight = packed.occupied(),
+            "packed task done"
+        );
+        Ok(Some((task_id, chunk)))
     }
 
     fn step_first_body(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
@@ -2388,6 +2545,10 @@ pub struct OvRuntimeBuilder {
     /// Ignore the export's chunked-prefill variant and prefill one token per
     /// step (the pre-variant behavior); conflicts with `prefill_device`.
     pub disable_chunked_prefill: bool,
+    /// `--packed-slots N`: serve N concurrent requests per inference through
+    /// the packed multi-slot variant (continuous batching on a device that
+    /// rejects batch > 1). 0 = off.
+    pub packed_slots: u32,
     /// `--park-prefill`: drop the prefill CompiledModel after each task's
     /// prefill (freeing its resident weight copy — the structural cost of
     /// the two-model split) and re-create it on the next prefill from the
@@ -2424,6 +2585,8 @@ pub struct OvRuntimeBuilder {
     /// (seq, context) of the chunked-prefill IR variant, when the stage
     /// exports one (stage_config.static_prefill_*) and it isn't disabled.
     static_prefill_params: Option<(u32, u32)>,
+    /// Resolved packed geometry: (slots, packed_seq, packed_context).
+    packed_params: Option<(u32, u32, u32)>,
 }
 
 impl OvRuntimeBuilder {
@@ -2612,6 +2775,60 @@ impl Builder for OvRuntimeBuilder {
             }
             _ => None,
         };
+        // Packed multi-slot variant (`--packed-slots`). Like the prefill
+        // variant it must share the decode variant's past-KV shape, so its
+        // context is past_len + packed_seq.
+        self.packed_params = match (self.static_params, self.packed_slots) {
+            (_, 0) => None,
+            (None, _) => {
+                return Err(EngineError::InvalidConfig(
+                    "--packed-slots requires a stateless static (--target npu) export; the \
+                     stateful path keeps KV inside OV state, which cannot be partitioned \
+                     per request"
+                        .into(),
+                ));
+            }
+            (Some((ctx, _, _)), want) => {
+                let slots = stage_cfg.packed_slots.unwrap_or(0);
+                let pseq = stage_cfg.packed_seq.unwrap_or(slots);
+                let pctx = stage_cfg.packed_context.unwrap_or(0);
+                let packed_xml = stage_dir.join("openvino_packed_model.xml");
+                if slots == 0 || !packed_xml.exists() {
+                    return Err(EngineError::InvalidConfig(format!(
+                        "--packed-slots {want} needs a packed variant beside the decode IR; {} \
+                         is missing. Build it with `python tools/packed_variant.py <stage_dir> \
+                         --slots {want}` or re-export with --packed-slots {want}",
+                        packed_xml.display()
+                    )));
+                }
+                if want != slots {
+                    return Err(EngineError::InvalidConfig(format!(
+                        "--packed-slots {want} disagrees with the exported variant \
+                         (packed_slots={slots}); the slot count is baked into the IR shape"
+                    )));
+                }
+                let past_len = ctx - 1;
+                if pctx != past_len + pseq {
+                    return Err(EngineError::InvalidConfig(format!(
+                        "packed_context={pctx} inconsistent: need past_len + packed_seq = {} so \
+                         the packed and decode variants share one past-KV shape",
+                        past_len + pseq
+                    )));
+                }
+                if past_len / slots == 0 {
+                    return Err(EngineError::InvalidConfig(format!(
+                        "packed_slots={slots} exceeds the KV window ({past_len})"
+                    )));
+                }
+                events.push(LoadProgress::message(format!(
+                    "packed multi-slot variant: slots={slots} seq={pseq} context={pctx} \
+                     per-request context={}",
+                    past_len / slots
+                )));
+                Some((slots, pseq, pctx))
+            }
+        };
+
         // --gemv-offload (spike): the offloaded matmuls run on the CPU
         // plugin's evaluate() fallback, and the rewrite targets the stateless
         // static IR's sym-INT4 pattern — gate both up front.
@@ -2887,6 +3104,12 @@ impl Builder for OvRuntimeBuilder {
     }
 
     fn build(self: Box<Self>) -> EngineResult<Box<dyn Engine>> {
+        // Resolved before any field of `self` is moved out below.
+        let packed_plugin = self.plugin();
+        let packed_xml = self
+            .pipeline_dir
+            .join(format!("stage_{}", self.rank))
+            .join("openvino_packed_model.xml");
         let runtime = self.runtime.ok_or(EngineError::NotLoaded)?;
         let spec = self.spec.ok_or(EngineError::NotLoaded)?;
         let rotary = self.rotary.ok_or(EngineError::NotLoaded)?;
@@ -3037,7 +3260,83 @@ impl Builder for OvRuntimeBuilder {
             }
         };
 
+        // Packed multi-slot state: its own compiled variant + per-slot KV.
+        let packed = match self.packed_params {
+            None => None,
+            Some((slots, pseq, _pctx)) => {
+                if !(spec.is_first_stage && spec.is_last_stage) {
+                    return Err(EngineError::ShardRejected(
+                        "--packed-slots is single-stage only for now; the multi-stage wire \
+                         does not yet carry [1, S, hidden] + per-slot positions"
+                            .into(),
+                    ));
+                }
+                let (ctx, kvh, hd) = self.static_params.expect("checked in load");
+                let past_len = (ctx - 1) as usize;
+                let prt = OvRuntime::compile(
+                    packed_xml.to_string_lossy().as_ref(),
+                    &self.device,
+                    &packed_plugin,
+                )
+                .map_err(map_ov_err)?;
+                let players = resolve_static_layers(&prt, "packed variant")?
+                    .into_iter()
+                    .map(|l| crate::packed_exec::PackedLayer {
+                        key_in: l.key_in,
+                        val_in: l.val_in,
+                        key_out: l.key_out,
+                        val_out: l.val_out,
+                    })
+                    .collect::<Vec<_>>();
+                let pcanon = resolve_canonical_inputs(&prt)?;
+                let ids_in = pcanon.get("input_ids").cloned().ok_or_else(|| {
+                    EngineError::Backend("packed variant missing input_ids".into())
+                })?;
+                let pos_in = pcanon.get("position_ids").cloned().ok_or_else(|| {
+                    EngineError::Backend("packed variant missing position_ids".into())
+                })?;
+                // The packed variant replaces the 2D attention_mask with a 4D
+                // per-row mask parameter; find it by name and take its dtype
+                // from the IR so f16/f32 exports both work.
+                let mut mask_in = None;
+                let mut mask_dtype = ShimDType::F16;
+                for idx in 0..prt.input_count() {
+                    let aliases = prt.input_aliases(idx).map_err(map_ov_err)?;
+                    if aliases.iter().any(|a| a.contains("attn_mask_4d")) {
+                        mask_in = Some(prt.input_name(idx).map_err(map_ov_err)?);
+                        mask_dtype = prt.input_dtype(idx).map_err(map_ov_err)?;
+                    }
+                }
+                let mask_in = mask_in.ok_or_else(|| {
+                    EngineError::Backend(
+                        "packed variant missing the attn_mask_4d input — rebuild it with \
+                         tools/packed_variant.py"
+                            .into(),
+                    )
+                })?;
+                let kv = crate::packed::PackedKv::new(
+                    slots as usize,
+                    past_len,
+                    pseq as usize,
+                    players.len(),
+                    kvh as usize,
+                    hd as usize,
+                    ShimDType::F16,
+                );
+                info!(
+                    slots,
+                    packed_seq = pseq,
+                    region = kv.region,
+                    "packed multi-slot decode active"
+                );
+                Some(crate::packed_exec::PackedState::new(
+                    prt, kv, players, ids_in, mask_in, pos_in, mask_dtype,
+                ))
+            }
+        };
+
         Ok(Box::new(OvRuntimeEngine {
+            packed,
             spec,
             runtime,
             rotary,

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
 use cascadia_ov_genai_shim::{
-    DType as ShimDType, Error as OvError, PluginConfig, Runtime as OvRuntime,
+    advance_emitted, DType as ShimDType, Error as OvError, PluginConfig, Runtime as OvRuntime,
 };
 use cascadia_transport::{
     ActivationClient, ActivationServer, DType as WireDType, Tensor as WireTensor, MAX_RANK,
@@ -826,7 +826,10 @@ struct ActiveTask {
     task: GenerationTask,
     prompt_ids: Vec<i64>,
     generated: Vec<i32>,
-    last_text: String,
+    /// Bytes already handed to the client. Not the decoded text: the delta is
+    /// computed by `advance_emitted`, which holds back an unresolved
+    /// replacement-char run and re-anchors if the decode diverges.
+    emitted: Vec<u8>,
     prefilled: bool,
     last_token: i32,
     /// Wall-clock when the task became active. Used to compute the
@@ -1466,7 +1469,7 @@ impl OvRuntimeEngine {
                 task,
                 prompt_ids,
                 generated: Vec::new(),
-                last_text: String::new(),
+                emitted: Vec::new(),
                 prefilled: false,
                 last_token: 0,
                 started: std::time::Instant::now(),
@@ -1811,23 +1814,23 @@ impl OvRuntimeEngine {
         };
         t.last_token = token;
         t.generated.push(token);
-        let all_ids: Vec<u32> = t.generated.iter().map(|&x| x as u32).collect();
-        let full_text = tok
-            .decode(&all_ids, true)
-            .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
-        // strip_prefix, not byte slicing: BPE can split a UTF-8 glyph across
-        // two tokens, so `last_text` is not always a clean byte prefix.
-        let delta = full_text
-            .strip_prefix(t.last_text.as_str())
-            .unwrap_or(&full_text)
-            .to_string();
-        t.last_text = full_text;
-
+        // Stop conditions first: they decide `running`, which tells
+        // `advance_emitted` whether it may hold back an unresolved
+        // replacement-char run or must flush it.
         let max_tokens = t.task.max_tokens.max(1) as usize;
         let is_eos = eos.contains(&(token as u32));
         let hit_cap = t.generated.len() >= max_tokens;
         let is_final = hit_cap || is_eos;
         let task_id = t.task.task_id.clone();
+
+        let all_ids: Vec<u32> = t.generated.iter().map(|&x| x as u32).collect();
+        let full_text = tok
+            .decode(&all_ids, true)
+            .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
+        let (delta, resynced) = advance_emitted(&mut t.emitted, full_text.as_bytes(), !is_final);
+        if resynced {
+            warn!(task = %task_id, slot, "detokenizer decode diverged; re-anchored");
+        }
 
         if !is_final {
             // Explicit count for the same reason: a token whose text lands in
@@ -2110,6 +2113,14 @@ impl OvRuntimeEngine {
         active.last_token = next_token;
         active.generated.push(next_token);
 
+        // Stop conditions first: they decide `running`, which tells
+        // `advance_emitted` whether it may hold back an unresolved
+        // replacement-char run or must flush it.
+        let max_tokens = active.task.max_tokens.max(1) as usize;
+        let is_eos = self.eos_token_ids.contains(&(next_token as u32));
+        let is_final = active.generated.len() >= max_tokens || is_eos;
+        let task_id = active.task.task_id.clone();
+
         let tok = self
             .tokenizer
             .as_ref()
@@ -2118,22 +2129,11 @@ impl OvRuntimeEngine {
         let full_text = tok
             .decode(&all_ids, true)
             .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?;
-        // Use strip_prefix instead of byte-slice indexing — `last_text`
-        // is not always a clean byte-prefix of `full_text` (BPE can
-        // emit a partial UTF-8 sequence on token N and complete the
-        // glyph on token N+1, in which case the prefix bytes change).
-        // Slicing past a UTF-8 boundary panics.
-        let delta = full_text
-            .strip_prefix(active.last_text.as_str())
-            .unwrap_or(&full_text)
-            .to_string();
-        active.last_text = full_text;
-
-        let max_tokens = active.task.max_tokens.max(1) as usize;
-        let is_eos = self.eos_token_ids.contains(&(next_token as u32));
-        let is_final = active.generated.len() >= max_tokens || is_eos;
-
-        let task_id = active.task.task_id.clone();
+        let (delta, resynced) =
+            advance_emitted(&mut active.emitted, full_text.as_bytes(), !is_final);
+        if resynced {
+            warn!(task = %task_id, "detokenizer decode diverged; re-anchored");
+        }
         let chunk = if is_final {
             Chunk {
                 task_id: task_id.clone(),
@@ -3795,6 +3795,46 @@ mod tests {
         let mut b = OvRuntimeBuilder::new("/non/existent", 0, 1, "CPU");
         let res = b.load(ShardSpec::single_stage("m", "CPU")).await;
         assert!(res.is_err());
+    }
+
+    /// Byte-level detokenizers emit one U+FFFD per byte they cannot yet decode,
+    /// so a multi-byte glyph arriving across reads appears as a run that later
+    /// RESOLVES — the decode is not prefix-stable, and can even get shorter.
+    /// The old delta (`full.strip_prefix(last).unwrap_or(full)`) re-emitted the
+    /// WHOLE text at that point, so the client saw the prefix twice.
+    #[test]
+    fn delta_does_not_duplicate_when_a_replacement_char_resolves() {
+        // Successive full decodes as tokens arrive: "caf", an undecodable byte,
+        // then the completed glyph, then more text.
+        let decodes = ["caf", "caf\u{FFFD}", "café", "café au lait"];
+
+        let mut emitted: Vec<u8> = Vec::new();
+        let mut client = String::new();
+        for (i, full) in decodes.iter().enumerate() {
+            let running = i + 1 < decodes.len();
+            let (delta, _) = advance_emitted(&mut emitted, full.as_bytes(), running);
+            client.push_str(&delta);
+        }
+        assert_eq!(
+            client, "café au lait",
+            "the client stream must reconstruct the final decode exactly"
+        );
+        assert!(
+            !client.contains('\u{FFFD}'),
+            "an unresolved replacement char must never be handed out: {client:?}"
+        );
+
+        // The regression this replaces, computed the old way for contrast.
+        let mut old = String::new();
+        let mut last = String::new();
+        for full in decodes {
+            old.push_str(full.strip_prefix(last.as_str()).unwrap_or(full));
+            last = full.to_string();
+        }
+        assert!(
+            old.matches("caf").count() > 1,
+            "old logic duplicated the prefix, which is the bug: {old:?}"
+        );
     }
 
     /// A packed variant narrower than its own slot count can never decode every

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -3147,6 +3147,18 @@ impl Builder for OvRuntimeBuilder {
             }
         };
 
+        // The packed variant does its own chunked prefill (a plan whose rows all
+        // belong to one slot IS a causal chunk), so the separate prefill model
+        // would never be used — skip compiling it and keep its weights off the
+        // device. On NPU that is a whole compile (~100 s) and a second resident
+        // weight copy saved.
+        if self.packed_params.is_some() && self.static_prefill_params.take().is_some() {
+            events.push(LoadProgress::message(String::from(
+                "packed slots: skipping the chunked-prefill variant (packed inference covers \
+                 prefill natively)",
+            )));
+        }
+
         // --gemv-offload (spike): the offloaded matmuls run on the CPU
         // plugin's evaluate() fallback, and the rewrite targets the stateless
         // static IR's sym-INT4 pattern — gate both up front.

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -316,38 +316,49 @@ fn encode_wire_position(position: i64) -> WireTensor {
     WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
 }
 
-/// Encode a packed step's per-row `(slot, position)` assignment as one framed
-/// I64 `[1, 2, S]` tensor: row 0 holds slot ids (`-1` = idle row), row 1 holds
-/// absolute positions. This is the packed analogue of `encode_wire_position` —
-/// downstream stages need per-ROW routing, not one scalar, to rebuild the
-/// block-diagonal mask and scatter each row into the right slot's ring.
-fn encode_wire_plan(rows: &[Option<(usize, i64)>]) -> WireTensor {
+/// Encode a packed step's per-row assignment as one framed I64 `[1, 3, S]`
+/// tensor: row 0 slot ids (`-1` = idle row), row 1 absolute positions, row 2
+/// the shared-prefix reuse length. The packed analogue of
+/// `encode_wire_position` — downstream stages need per-ROW routing, not one
+/// scalar, to rebuild the mask and scatter each row into the right slot's ring.
+///
+/// The reuse length must travel: only the driver stage holds the prompt ids to
+/// match against the prefix cache, but EVERY stage has to open the same shared
+/// columns or its attention would disagree with stage 0's.
+fn encode_wire_plan(rows: &[Option<(usize, i64, usize)>]) -> WireTensor {
     let s = rows.len();
-    let mut data = Vec::with_capacity(s * 2 * 8);
+    let mut data = Vec::with_capacity(s * 3 * 8);
     for r in rows {
-        let slot: i64 = r.map(|(sl, _)| sl as i64).unwrap_or(-1);
+        let slot: i64 = r.map(|(sl, _, _)| sl as i64).unwrap_or(-1);
         data.extend_from_slice(&slot.to_le_bytes());
     }
     for r in rows {
-        let pos: i64 = r.map(|(_, p)| p).unwrap_or(0);
+        let pos: i64 = r.map(|(_, p, _)| p).unwrap_or(0);
         data.extend_from_slice(&pos.to_le_bytes());
     }
-    WireTensor::new(WireDType::I64, [1, 2, s as u32], data)
+    for r in rows {
+        let sh: i64 = r.map(|(_, _, sh)| sh as i64).unwrap_or(0);
+        data.extend_from_slice(&sh.to_le_bytes());
+    }
+    WireTensor::new(WireDType::I64, [1, 3, s as u32], data)
 }
 
 /// Decode + validate a packed plan frame. Rejects a wrong dtype/rank, a
 /// length/shape disagreement, out-of-range slot ids, and negative positions —
 /// each of which would otherwise index or wrap somewhere downstream.
-fn decode_wire_plan(t: &WireTensor, slots: usize) -> EngineResult<Vec<Option<(usize, i64)>>> {
+fn decode_wire_plan(
+    t: &WireTensor,
+    slots: usize,
+) -> EngineResult<Vec<Option<(usize, i64, usize)>>> {
     let s = t.shape[2] as usize;
-    if t.dtype != WireDType::I64 || t.shape[0] != 1 || t.shape[1] != 2 || s == 0 {
+    if t.dtype != WireDType::I64 || t.shape[0] != 1 || t.shape[1] != 3 || s == 0 {
         return Err(EngineError::Backend(format!(
-            "expected an I64 [1,2,S] packed plan frame, got dtype={:?} shape={:?} — likely a \
+            "expected an I64 [1,3,S] packed plan frame, got dtype={:?} shape={:?} — likely a \
              packed/non-packed pipeline mismatch or a desynced activation stream",
             t.dtype, t.shape
         )));
     }
-    if t.data.len() != s * 2 * 8 {
+    if t.data.len() != s * 3 * 8 {
         return Err(EngineError::Backend(format!(
             "packed plan frame payload {} bytes does not match shape {:?}",
             t.data.len(),
@@ -363,9 +374,15 @@ fn decode_wire_plan(t: &WireTensor, slots: usize) -> EngineResult<Vec<Option<(us
     for r in 0..s {
         let slot = rd(r);
         let pos = rd(s + r);
+        let shared = rd(2 * s + r);
         if slot < 0 {
             out.push(None);
             continue;
+        }
+        if shared < 0 || shared > pos {
+            return Err(EngineError::Backend(format!(
+                "packed plan row {r} has shared_use={shared} inconsistent with position {pos}"
+            )));
         }
         if slot as usize >= slots {
             return Err(EngineError::Backend(format!(
@@ -377,7 +394,7 @@ fn decode_wire_plan(t: &WireTensor, slots: usize) -> EngineResult<Vec<Option<(us
                 "packed plan row {r} has negative position {pos}"
             )));
         }
-        out.push(Some((slot as usize, pos)));
+        out.push(Some((slot as usize, pos, shared as usize)));
     }
     Ok(out)
 }
@@ -1541,7 +1558,7 @@ impl OvRuntimeEngine {
         &mut self,
         hidden: &[f32],
         shape: &[usize],
-        plan_rows: &[Option<(usize, i64)>],
+        plan_rows: &[Option<(usize, i64, usize)>],
     ) -> EngineResult<Vec<i32>> {
         let down = self.downstream.clone().ok_or_else(|| {
             EngineError::Backend("packed pipeline stage has no downstream".into())
@@ -1638,7 +1655,7 @@ impl OvRuntimeEngine {
         let plan = crate::packed::PackedPlan {
             rows: plan_rows
                 .iter()
-                .map(|r| r.map(|(slot, _)| crate::packed::PackedRow { slot, order: 0 }))
+                .map(|r| r.map(|(slot, _, _)| crate::packed::PackedRow { slot, order: 0 }))
                 .collect(),
         };
         // Same-slot rows in one frame are a prefill chunk: restore their causal
@@ -1652,12 +1669,17 @@ impl OvRuntimeEngine {
         }
         let positions: Vec<i64> = plan_rows
             .iter()
-            .map(|r| r.map(|(_, p)| p).unwrap_or(0))
+            .map(|r| r.map(|(_, p, _)| p).unwrap_or(0))
+            .collect();
+        let reuse: Vec<usize> = plan_rows
+            .iter()
+            .map(|r| r.map(|(_, _, sh)| sh).unwrap_or(0))
             .collect();
         let (odt, oshape, obytes) = self.packed.as_mut().unwrap().run_plan(
             &plan,
             crate::packed_exec::PackedPrimary::Hidden(&hidden, hidden_size),
             &positions,
+            &reuse,
         )?;
 
         if self.spec.is_last_stage {
@@ -2867,6 +2889,10 @@ pub struct OvRuntimeBuilder {
     /// the packed multi-slot variant (continuous batching on a device that
     /// rejects batch > 1). 0 = off.
     pub packed_slots: u32,
+    /// `--packed-prefix N`: reserve N KV slots as a read-only SHARED prefix
+    /// that every packed slot may attend to — prefix caching without paging.
+    /// Taken out of the same window, so it costs per-slot context. 0 = off.
+    pub packed_prefix: u32,
     /// `--park-prefill`: drop the prefill CompiledModel after each task's
     /// prefill (freeing its resident weight copy — the structural cost of
     /// the two-model split) and re-create it on the next prefill from the
@@ -3649,11 +3675,13 @@ impl Builder for OvRuntimeBuilder {
                     kvh as usize,
                     hd as usize,
                     ShimDType::F16,
+                    self.packed_prefix as usize,
                 );
                 info!(
                     slots,
                     packed_seq = pseq,
                     region = kv.region,
+                    shared_prefix = kv.prefix_capacity,
                     "packed multi-slot decode active"
                 );
                 Some(crate::packed_exec::PackedState::new(
@@ -3786,9 +3814,14 @@ mod tests {
     /// seq=1 decode loop as the legacy path.
     #[test]
     fn packed_plan_frame_round_trips() {
-        let rows = vec![Some((0usize, 7i64)), None, Some((3, 0)), Some((1, 129))];
+        let rows = vec![
+            Some((0usize, 7i64, 0usize)),
+            None,
+            Some((3, 12, 12)),
+            Some((1, 129, 40)),
+        ];
         let frame = encode_wire_plan(&rows);
-        assert_eq!(frame.shape, [1, 2, 4]);
+        assert_eq!(frame.shape, [1, 3, 4]);
         let back = decode_wire_plan(&frame, 4).expect("round trip");
         assert_eq!(back, rows);
     }
@@ -3799,11 +3832,11 @@ mod tests {
         let pos = encode_wire_position(5);
         assert!(decode_wire_plan(&pos, 4).is_err());
         // slot id beyond this stage's slot count
-        let frame = encode_wire_plan(&[Some((9usize, 0i64))]);
+        let frame = encode_wire_plan(&[Some((9usize, 0i64, 0usize))]);
         let err = decode_wire_plan(&frame, 4).unwrap_err().to_string();
         assert!(err.contains("slot 9"), "{err}");
         // negative position would wrap in the ring math
-        let mut bad = encode_wire_plan(&[Some((0usize, 1i64))]);
+        let mut bad = encode_wire_plan(&[Some((0usize, 1i64, 0usize))]);
         bad.data[8..16].copy_from_slice(&(-3i64).to_le_bytes());
         assert!(decode_wire_plan(&bad, 4).is_err());
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1618,10 +1618,29 @@ impl OvRuntimeEngine {
                 .send(&hidden_frame)
                 .await
                 .map_err(|e| EngineError::Backend(format!("packed hidden send: {e}")))?;
-            let (reply, _) = guard
-                .recv()
-                .await
-                .map_err(|e| EngineError::Backend(format!("packed token recv: {e}")))?;
+            // Bound the reply wait. Having just sent both frames this stage is
+            // OWED a token frame, so a downstream that never answers must not
+            // pin the thread forever — the same reasoning as `reply_bounded` on
+            // the qwen36 path, and the same configured activation timeout. This
+            // is what turns a dropped token frame from a silent permanent wedge
+            // into a reportable error; it does not prevent the drop.
+            let (reply, _) = match tokio::time::timeout(
+                cascadia_transport::recv_timeout(),
+                guard.recv(),
+            )
+            .await
+            {
+                Ok(r) => r.map_err(|e| EngineError::Backend(format!("packed token recv: {e}")))?,
+                Err(_) => {
+                    return Err(EngineError::Backend(
+                        "packed token recv timed out: the downstream stage did not answer a \
+                             plan+hidden pair. Multi-stage packed is known to drop a token frame \
+                             under load (see docs/perf/NPU_PACKED_SLOTS.md); run the packed worker \
+                             single-stage (--total 1)"
+                            .into(),
+                    ))
+                }
+            };
             decode_wire_tokens(&reply)
         })
     }

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -316,6 +316,24 @@ fn encode_wire_position(position: i64) -> WireTensor {
     WireTensor::new(WireDType::I64, [1, 1, 1], position.to_le_bytes().to_vec())
 }
 
+/// Refuse a packed variant whose query window is narrower than its slot count.
+///
+/// A decode step lays down one row per ready slot, but the plan is only
+/// `packed_seq` rows wide — so with `packed_seq < slots` the slots past the
+/// window never get a row, and sampling then asks for a logits row the output
+/// does not contain. `packed_seq > slots` is fine and useful: the extra rows
+/// widen a prefill chunk. Only the narrow case is broken.
+fn packed_geometry_error(slots: u32, packed_seq: u32) -> Option<String> {
+    (packed_seq < slots).then(|| {
+        format!(
+            "packed variant has packed_seq={packed_seq} but packed_slots={slots}: the query \
+             window cannot be narrower than the slot count, or slots beyond it can never \
+             decode. Rebuild with `python tools/packed_variant.py <stage_dir> --slots {slots}` \
+             (packed_seq defaults to the slot count)"
+        )
+    })
+}
+
 /// Refuse a prompt that cannot fit one packed slot's KV region.
 ///
 /// A slot's region is a bounded window: once it fills, the oldest entries slide
@@ -3199,6 +3217,9 @@ impl Builder for OvRuntimeBuilder {
                          (packed_slots={slots}); the slot count is baked into the IR shape"
                     )));
                 }
+                if let Some(msg) = packed_geometry_error(slots, pseq) {
+                    return Err(EngineError::InvalidConfig(msg));
+                }
                 let past_len = ctx - 1;
                 if pctx != past_len + pseq {
                     return Err(EngineError::InvalidConfig(format!(
@@ -3774,6 +3795,27 @@ mod tests {
         let mut b = OvRuntimeBuilder::new("/non/existent", 0, 1, "CPU");
         let res = b.load(ShardSpec::single_stage("m", "CPU")).await;
         assert!(res.is_err());
+    }
+
+    /// A packed variant narrower than its own slot count can never decode every
+    /// slot: `PackedPlan::decode` only lays down `packed_seq` rows, so slots
+    /// beyond that get no row, and the step then samples a logits row the
+    /// output does not have. That surfaces as an untyped step error which the
+    /// runner charges to whichever stream happened to poll. Refuse the geometry
+    /// at load instead.
+    #[test]
+    fn packed_variant_narrower_than_its_slot_count_is_refused() {
+        assert!(
+            packed_geometry_error(8, 8).is_none(),
+            "seq == slots is the norm"
+        );
+        assert!(
+            packed_geometry_error(8, 16).is_none(),
+            "a wider query window than slots is legitimate (fatter prefill chunks)"
+        );
+        let msg = packed_geometry_error(8, 4).expect("seq < slots must be refused");
+        assert!(msg.contains('8') && msg.contains('4'), "{msg}");
+        assert!(msg.contains("packed_seq"), "{msg}");
     }
 
     /// A prompt longer than its slot's KV region cannot be served honestly: the

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1635,7 +1635,7 @@ impl OvRuntimeEngine {
                     return Err(EngineError::Backend(
                         "packed token recv timed out: the downstream stage did not answer a \
                              plan+hidden pair. Multi-stage packed is known to drop a token frame \
-                             under load (see docs/perf/NPU_PACKED_SLOTS.md); run the packed worker \
+                             under load (issue #122); run the packed worker \
                              single-stage (--total 1)"
                             .into(),
                     ))

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -44,6 +44,12 @@ pub enum EngineError {
     #[error("queue full ({queued} pending, cap {cap})")]
     QueueFull { queued: usize, cap: usize },
 
+    /// The prompt cannot fit this engine's per-request window. Distinct from
+    /// `QueueFull`: that one clears when load drops, this one never does, so
+    /// the API must answer 413 rather than a retryable 5xx.
+    #[error("prompt too long: {0}")]
+    PromptTooLong(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/cascadia-ov-genai-shim/src/lib.rs
+++ b/crates/cascadia-ov-genai-shim/src/lib.rs
@@ -746,8 +746,11 @@ fn emittable_len(full: &[u8], running: bool) -> usize {
 /// bytes already handed out cannot be recalled, and emitting the corrected
 /// suffix would duplicate text; re-anchoring at least stops the error
 /// compounding and is reportable.
-#[allow(dead_code)]
-fn advance_emitted(emitted: &mut Vec<u8>, full: &[u8], running: bool) -> (String, bool) {
+///
+/// Public because the ov-runtime static paths need the identical algorithm:
+/// they drive their own tokenizer and have the same non-prefix-stable decode.
+/// One implementation, so the two cannot drift.
+pub fn advance_emitted(emitted: &mut Vec<u8>, full: &[u8], running: bool) -> (String, bool) {
     if !full.starts_with(emitted) {
         emitted.clear();
         emitted.extend_from_slice(full);

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -172,6 +172,8 @@ dropped, with a warning in the log.
 | `--cb-max-batched-tokens <N>` | `0` | Max tokens per batch iteration (0 = ov-genai default 256). |
 | `--cb-dynamic-split-fuse <BOOL>` | ov-genai default (on) | Dynamic-split-fuse scheduler toggle for `--cb`. |
 | `--cb-prefix-caching <BOOL>` | ov-genai default (off) | KV-block prefix reuse across requests for `--cb`. |
+| `--packed-slots <N>` | `0` | Continuous batching on the **NPU** (`--engine ov-runtime`, static `--target npu` exports): serve N concurrent requests in ONE inference by packing them into the sequence dimension with a per-row mask. Needs a packed variant beside the decode IR (`tools/packed_variant.py --slots N`). A different mechanism to `--cb` — the NPU has no paged attention. See [docs/perf/NPU_PACKED_SLOTS.md](perf/NPU_PACKED_SLOTS.md). |
+| `--packed-prefix <N>` | `0` | Reserve N KV slots as a read-only shared prefix every packed slot may attend to — prefix caching without paging. Costs per-slot context. Requires `--packed-slots`. |
 
 For distributed speculative decode, every rank needs `--engine ov-dist-spec` —
 they share a wire protocol. See [engines/ov-dist-spec.md](engines/ov-dist-spec.md).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -172,7 +172,7 @@ dropped, with a warning in the log.
 | `--cb-max-batched-tokens <N>` | `0` | Max tokens per batch iteration (0 = ov-genai default 256). |
 | `--cb-dynamic-split-fuse <BOOL>` | ov-genai default (on) | Dynamic-split-fuse scheduler toggle for `--cb`. |
 | `--cb-prefix-caching <BOOL>` | ov-genai default (off) | KV-block prefix reuse across requests for `--cb`. |
-| `--packed-slots <N>` | `0` | Continuous batching on the **NPU** (`--engine ov-runtime`, static `--target npu` exports): serve N concurrent requests in ONE inference by packing them into the sequence dimension with a per-row mask. Needs a packed variant beside the decode IR (`tools/packed_variant.py --slots N`). A different mechanism to `--cb` — the NPU has no paged attention. See [docs/perf/NPU_PACKED_SLOTS.md](perf/NPU_PACKED_SLOTS.md). |
+| `--packed-slots <N>` | `0` | Continuous batching on the **NPU** (`--engine ov-runtime`, static `--target npu` exports): serve N concurrent requests in ONE inference by packing them into the sequence dimension with a per-row mask. Needs a packed variant beside the decode IR (`tools/packed_variant.py --slots N`). A different mechanism to `--cb` — the NPU has no paged attention. **Single-stage only (`--total 1`)**; multi-stage packed is withheld pending a wire fault. See [docs/perf/NPU_PACKED_SLOTS.md](perf/NPU_PACKED_SLOTS.md). |
 | `--packed-prefix <N>` | `0` | Reserve N KV slots as a read-only shared prefix every packed slot may attend to — prefix caching without paging. Costs per-slot context. Requires `--packed-slots`. |
 
 For distributed speculative decode, every rank needs `--engine ov-dist-spec` —

--- a/docs/NPU_SHARDING.md
+++ b/docs/NPU_SHARDING.md
@@ -174,7 +174,12 @@ issue #41):
   prefill is token-at-a-time.
 - **FP16 KV** on the ring and the wire; `--default-dtype` must be `fp16` for
   `--target npu`.
-- **batch = 1** (single sequence).
+- **batch = 1** — the NPU compiler rejects a batch dimension outright
+  (`ConvertBatchedLayerTo1N` fails to legalize). Serving several requests at
+  once instead uses the SEQUENCE dimension: see
+  [packed multi-slot decode](perf/NPU_PACKED_SLOTS.md) (`--packed-slots N`),
+  measured at 6.0x aggregate throughput at 16 slots with bit-exact per-request
+  isolation.
 - Per-token host overhead is the mask rewrite + ring copies — small relative to
   the NPU forward pass.
 

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -114,15 +114,36 @@ context shrinks as slots rise; a deployment wanting 8 x 1024 should export with
 `--static-context 8193`. KV traffic then scales with the slot count, but there is
 room: 8 x 29.3 MB = 234 MB still sits under the 458 MB weight stream.
 
-## Status
+## End-to-end
 
-Shipped here: the IR variant (hardware-verified — the emitted graph compiles on
-NPU and passes isolation + teeth) and the host-side primitives (unit-tested for
-mask layout, region-local scatter, in-region slide, and per-slot reset).
+`--packed-slots N` on the ov-runtime engine turns a static single-stage export
+into a slot-served worker: admission tokenizes into a free slot, one inference
+prefills a chunk or decodes a row per ready slot, and a finished slot retires
+immediately — freeing its KV region for the next admission rather than waiting
+for the batch.
 
-Not yet wired: the engine execution path — slot admission/eviction in
-`OvRuntimeEngine`, per-slot sampling and chunk emission, and the multi-stage wire
-carrying `[1, S, hidden]` plus per-slot positions.
+Validated on Llama-3.2-1B-Instruct (single-stage int4 static export) on the
+**CPU** device, which runs the stateless static path just as the NPU does — so
+the concurrency semantics are exercised without contending for an NPU:
+
+```
+packed, 4 slots   first tokens 2.12-2.93 s   all complete  9.32 s   overlap yes
+baseline (off)    first tokens 0.57-12.53 s  all complete 18.34 s   overlap no
+```
+
+Baseline serializes: each request's first token lands only after the previous
+one finishes. Packed admits all four at once (log shows slots 0/1/2/3), and the
+two that hit EOS early retired at 5.5 s and 5.9 s while the others ran on —
+continuous, not batch-synchronous. Wall clock ~2.0x; worst-case time-to-first-
+token 12.53 s -> 2.93 s (4.3x). Both configurations return identical text for
+the same prompt ("The capital of France is Paris."), which is an end-to-end
+parity check between the packed and single-task paths.
+
+Note these CPU ratios measure scheduling behaviour, not the weight-amortization
+win — that is the NPU property (16:1 weight:KV) measured in the table above.
+
+Not yet wired: the multi-stage wire carrying `[1, S, hidden]` plus per-slot
+positions, so `--packed-slots` is gated to `--total 1`.
 
 Side benefit worth remembering: at ~0.21-0.29 ms marginal per row, speculative
 decode verification is nearly free on the NPU.

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -245,6 +245,13 @@ the same sensitivity `chunk_take` already documents for `--static-prefill-seq`
 ("forks observed as early as token 2"). The baseline here also has no prefill
 variant, so it prefills tokenwise against packed's 4-wide chunks.
 
+**Scored task accuracy** (20 factual questions with ground truth, NPU
+single-stage, Llama-3.2-1B): baseline **15/20**, packed **15/20**, delta **+0**,
+identical text on 20/20. Short answers do not accumulate enough drift to flip a
+near-tie, and the five failures are the model's own and identical in both. This
+is the measurement behind "no accuracy loss" — the parity suites above only
+establish equality against a reference, never whether either answer is right.
+
 **So: treat exact text equality across different packed shapes as unavailable,
 not as a bug.** The properties that must hold, and do, are determinism and
 batch-composition invariance. Magnitude is model-dependent — Llama-3.2-1B

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -176,6 +176,48 @@ loopback): `"The capital of France is Paris."`, usage `35 + 15`; and 4
 concurrent requests across the pipeline with first tokens at 2.09-2.26 s, slot 2
 retiring at 5.9 s while the rest ran to 7.5 s.
 
+### Prefix caching (`--packed-prefix N`)
+
+Paged attention is what usually buys prefix sharing, and the NPU has none. But
+sharing does not actually need paging — it needs a *mask that can open the same
+columns for several rows*, which this design already has. So reserve the first
+`N` columns of the KV window as a read-only **shared prefix** and let every
+slot's mask open them:
+
+```
+[ shared prefix (N) ][ slot 0 region ][ slot 1 region ] ... [ slot S-1 region ]
+       read-only,          private          private              private
+    any slot may attend
+```
+
+The first admitted request populates it (its first `N` tokens' K/V are copied to
+the front of the window, together with their token ids). Later requests are
+matched by longest common prefix against those ids; a request reusing `k` tokens
+starts its sequence at absolute position `k` and never prefills them again.
+RoPE stays correct precisely because the cached K/V were computed at their true
+absolute positions `0..k`, and attention over past KV is a read — so many rows
+sharing those columns needs no copy and no reference counting.
+
+Measured on NPU, 4 slots, four sequential requests sharing a ~96-token system
+prompt (Llama-3.2-1B, 105-token prompts):
+
+| | first request | later requests | speedup |
+|---|---|---|---|
+| `--packed-prefix 96` | 2.26 s | **0.38 s** | **5.95x** |
+| off | 2.81 s | 2.09 s | 1.34x (warmup only) |
+
+All four answers stayed correct (Paris / Tokyo / Rome / Madrid), which is the
+check that matters: reuse must not corrupt attention.
+
+The cost is honest and visible: the shared region is taken from the same fixed
+window, so `region = (static_context - 1 - N) / slots`. Prefix capacity trades
+directly against per-slot context.
+
+Limits versus real paged prefix caching: one cache entry (not an LRU of many),
+populated by whichever request arrives first; no block-level dedup between
+partially-overlapping prompts beyond that single shared run; and the cached
+prefix persists for the worker's lifetime rather than being evicted by pressure.
+
 ### Per-slot cancel
 
 A disconnecting client's slot is retired and its KV region returned to the free

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -1,0 +1,128 @@
+# Continuous batching on the NPU: packed multi-slot decode ("seq-as-batch")
+
+The NPU is the one device where cascadia cannot borrow continuous batching from
+OpenVINO: paged attention lives in the CPU/GPU plugins, and the NPU servable is
+stateful and sequential. This documents the route that does work, and the
+measurements behind it. All numbers are Lunar Lake (Core Ultra 7 258V, Intel AI
+Boost), OpenVINO 2026.2.1, `qwen25-1.5b-2stage-npu` stage 0.
+
+## Why not batch
+
+Reshaping a stateless static export's batch dimension from 1 to N is rejected by
+the NPU compiler, identically on both graph shapes tested (embed+layers and
+layers+lm_head), at N = 2, 4 and 8:
+
+```
+Failed Pass ConvertBatchedLayerTo1N
+failed to legalize operation 'IE.Convolution' that was explicitly marked illegal
+  @ aten::cat/Concat ["branches_concat_to_conv"]
+```
+
+Batch-1 compiles fine on the same graph, so it is the batch axis specifically.
+The pass name is the useful part: the compiler's only strategy for batch > 1 is
+unrolling into N batch-1 operations, so even a legalized batch axis would not
+amortize the weight stream.
+
+## Why the sequence axis instead
+
+The same export compiles happily at seq > 1 — the chunked-prefill variant has
+relied on that since #107. And the sequence axis is where the amortization is,
+because decode is weight-bound, not KV-bound:
+
+| | bytes per token |
+|---|---|
+| weights (int4 stage) | 458 MB |
+| KV traffic (in + out) | 29.3 MB |
+
+A **16:1 ratio**. One weight stream can therefore serve many query rows almost
+for free. Measured with a shared mask (one sequence, S tokens):
+
+| seq | ms/iter | ms/token |
+|---|---|---|
+| 1 | 10.57 | 10.57 |
+| 2 | 18.78 | 9.39 |
+| 4 | 19.70 | 4.92 |
+| 8 | 21.70 | 2.71 |
+| 16 | 22.81 | 1.43 |
+
+From S=2 to S=16 — eight times the tokens — latency rises 18.78 → 22.81 ms.
+Fixed cost ~18.5 ms, marginal cost ~0.29 ms per token. (S=1 sits oddly low
+relative to S=2; the seq=1 graph likely takes a GEMV path. Read the trend from
+S >= 2.)
+
+## The mechanism
+
+Pack N independent requests into the sequence dimension and isolate them with a
+**block-diagonal attention mask**. Batch stays 1, so `ConvertBatchedLayerTo1N`
+never runs.
+
+The stock export cannot express this: it takes a 2D `attention_mask [1, T]` that
+every query row shares — the same property that caps chunked-prefill parity at
+the KV window. But it builds its 4D additive mask in a **single node** whose
+output feeds every SDPA's mask input, and SDPA's mask slot already carries a
+query dimension. Replacing that one node with a `[1, 1, S, T]` Parameter hands
+mask construction to the host, where per-slot policy belongs.
+
+`tools/packed_variant.py` performs exactly that edit — no HF model, no torch, no
+re-trace — and works on an already-exported stage:
+
+```bash
+python tools/packed_variant.py <stage_dir> --slots 8
+# or at export time
+python tools/export_shards.py ... --target npu --packed-slots 8
+```
+
+It emits `openvino_packed_model.xml` beside the decode IR and records
+`packed_slots` / `packed_seq` / `packed_context` / `packed_region` in
+`stage_config.json`.
+
+The host side lives in `crates/cascadia-engine-openvino/src/packed.rs`. The KV
+window is partitioned into `region = past_len / slots` per slot; slot `s` owns
+`[s*region, (s+1)*region)` in every layer and head. A `PackedPlan` maps each
+query row to a slot, and one mask writer covers every case: open each row on its
+own slot's occupied region plus the query columns of same-slot rows at or before
+it. One row per slot gives block-diagonal decode; many rows in one slot gives a
+causal prefill chunk; mixing them is dynamic-split-fuse, for free.
+
+Idle rows are opened on their own query column only — never fully blocked, which
+would produce NaN out of softmax and poison the live rows sharing the inference.
+
+## Measured with real isolation (N independent sequences)
+
+| slots | ms/iter | ms/token | vs seq=1 | per-slot context |
+|---|---|---|---|---|
+| 1 | 10.57 | 10.57 | 1.00x | 1023 |
+| 4 | 25.58 | 6.40 | 1.65x | 255 |
+| 8 | 27.17 | 3.40 | 3.11x | 127 |
+| 16 | 28.10 | 1.76 | **6.01x** | 63 |
+
+Correctness at every point:
+
+- **Isolation** — slot 0 held fixed while all other slots were randomized twice:
+  row 0 bit-identical, `max|delta| = 0`.
+- **Teeth** — changing slot 0's own token moves row 0 by ~1.6e3, so the
+  isolation result is not vacuous.
+- **Equivalence** — a packed slot versus the untouched seq=1 graph running that
+  same sequence alone: `max|delta| = 3.05e-05` on values of magnitude ~5806,
+  cosine `1.00000000`. Packing is numerically correct, not merely leak-free.
+
+## Sizing
+
+Per-slot context is `(static_context - 1) / slots`, so slots and context trade
+directly. The table above partitions a 1023-slot window, which is why per-slot
+context shrinks as slots rise; a deployment wanting 8 x 1024 should export with
+`--static-context 8193`. KV traffic then scales with the slot count, but there is
+room: 8 x 29.3 MB = 234 MB still sits under the 458 MB weight stream.
+
+## Status
+
+Shipped here: the IR variant (hardware-verified — the emitted graph compiles on
+NPU and passes isolation + teeth) and the host-side primitives (unit-tested for
+mask layout, region-local scatter, in-region slide, and per-slot reset).
+
+Not yet wired: the engine execution path — slot admission/eviction in
+`OvRuntimeEngine`, per-slot sampling and chunk emission, and the multi-stage wire
+carrying `[1, S, hidden]` plus per-slot positions.
+
+Side benefit worth remembering: at ~0.21-0.29 ms marginal per row, speculative
+decode verification is nearly free on the NPU.

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -162,14 +162,18 @@ saving a full NPU compile and a second resident weight copy.
 
 ### Multi-stage
 
-Packing works across a pipeline. Stage 0 ships an I64 `[1, 2, S]` **plan frame**
-(slot id per row, `-1` for idle; absolute position per row) ahead of the
-`[1, S, hidden]` block; relay and head stages decode it, re-derive same-slot
-causal order, run their own packed inference over their own per-slot rings, and
-the tail replies with one token per row. A row at position 0 resets its slot —
-the same in-band new-sequence signal the single-task static path already uses,
-so no separate admission message is needed. Every stage must be started with the
-same `--packed-slots`, since the slot count is baked into each stage's IR shape.
+Packing works across a pipeline. Stage 0 ships an I64 `[1, 3, S]` **plan frame**
+(per row: slot id with `-1` for idle, absolute position, and shared-prefix reuse
+length) ahead of the `[1, S, hidden]` block; relay and head stages decode it,
+re-derive same-slot causal order, run their own packed inference over their own
+per-slot rings, and the tail replies with one token per row. The reuse length
+must travel because only the driver stage holds the prompt ids to match against
+the prefix cache, yet every stage has to open the same shared columns. A row
+whose absolute position equals its reuse length starts its slot's sequence
+(position 0 when nothing is reused) — the same in-band new-sequence signal the
+single-task static path already uses, so no separate admission message is
+needed. Every stage must be started with the same `--packed-slots`, since the
+slot count is baked into each stage's IR shape.
 
 Validated on TinyLlama 2-stage static (CPU, both ranks on one box over
 loopback): `"The capital of France is Paris."`, usage `35 + 15`; and 4

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -171,8 +171,8 @@ saving a full NPU compile and a second resident weight copy.
 > no error on either side. It surfaces after sustained load — roughly two runs in
 > three, and adding the instrumentation masked it once — so it reads as a race in
 > `cascadia-transport` rather than in the packing. Single-stage packed is
-> unaffected and verified across 5 models. Reproduction and evidence:
-> `experiments/.ignore/packed-multistage-transport-handoff.md`.
+> unaffected and verified across 5 models. Evidence, what is ruled out and a
+> reproduction: **issue #122**.
 
 Packing works across a pipeline. Stage 0 ships an I64 `[1, 3, S]` **plan frame**
 (per row: slot id with `-1` for idle, absolute position, and shared-prefix reuse

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -252,6 +252,19 @@ near-tie, and the five failures are the model's own and identical in both. This
 is the measurement behind "no accuracy loss" — the parity suites above only
 establish equality against a reference, never whether either answer is right.
 
+**Scored long-form accuracy** (7 tasks, 18-110 generated tokens each, scored on
+ORDERED ATOM RECALL so omission, reordering, truncation and repetition loops all
+cost): baseline **89.5%**, packed **89.5%**, delta **+0.0 pts**, identical text
+on 7/7, identical repetition ratio (0.081). At every length with ground truth
+available, packed and baseline agree exactly; the single-token divergences
+appear only in free-form generation at 128 tokens.
+
+One reporting difference remains and is deliberate: packed counts the EOS token
+in `completion_tokens`, the non-packed path does not, so an EOS-terminated
+completion reads +1 against baseline (length-capped completions match exactly).
+Packed's count is the accurate one — every generated token counted once — and
+matches the wider ecosystem; the non-packed path under-reports by one.
+
 **So: treat exact text equality across different packed shapes as unavailable,
 not as a bug.** The properties that must hold, and do, are determinism and
 batch-composition invariance. Magnitude is model-dependent — Llama-3.2-1B

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -218,6 +218,38 @@ populated by whichever request arrives first; no block-level dedup between
 partially-overlapping prompts beyond that single shared run; and the cached
 prefix persists for the worker's lifetime rather than being evicted by pressure.
 
+### Accuracy parity
+
+Harness and method: [tests-e2e/accuracy](../../tests-e2e/accuracy). Full-text
+exact comparison at 128 tokens, never a substring match.
+
+**Single-stage, NPU** (Llama-3.2-1B): determinism 10/10, **batch-composition
+invariance 10/10** (a request's output does not depend on its batch-mates),
+prefix cache on-vs-off **8/8 exact**, packed-vs-baseline 8/10 with both diffs a
+single re-converging token ("about"/"approximately", "1,143"/"1,145") at 66-73%
+depth.
+
+**Multi-stage** (TinyLlama 2-stage): determinism and batch-composition
+invariance are 10/10 in every config, but packed-vs-baseline is only 5/10 with
+EARLY divergences. That is **not** a wire fault — the control settles it:
+
+| comparison | exact |
+|---|---|
+| baseline vs packed (slots=4) | 5/10 |
+| packed slots=4 vs packed slots=2 | **3/10** |
+
+Two configurations of the same code, differing only in slot count, agree *less*
+than packed agrees with baseline. Changing `packed_slots` changes the compiled
+graph shape and the prefill chunk width, and this model forks early on that —
+the same sensitivity `chunk_take` already documents for `--static-prefill-seq`
+("forks observed as early as token 2"). The baseline here also has no prefill
+variant, so it prefills tokenwise against packed's 4-wide chunks.
+
+**So: treat exact text equality across different packed shapes as unavailable,
+not as a bug.** The properties that must hold, and do, are determinism and
+batch-composition invariance. Magnitude is model-dependent — Llama-3.2-1B
+diverged on 2/10 prompts, TinyLlama on 5/10.
+
 ### Per-slot cancel
 
 A disconnecting client's slot is retired and its KV region returned to the free

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -142,8 +142,29 @@ parity check between the packed and single-task paths.
 Note these CPU ratios measure scheduling behaviour, not the weight-amortization
 win — that is the NPU property (16:1 weight:KV) measured in the table above.
 
-Not yet wired: the multi-stage wire carrying `[1, S, hidden]` plus per-slot
-positions, so `--packed-slots` is gated to `--total 1`.
+### Multi-stage
+
+Packing works across a pipeline. Stage 0 ships an I64 `[1, 2, S]` **plan frame**
+(slot id per row, `-1` for idle; absolute position per row) ahead of the
+`[1, S, hidden]` block; relay and head stages decode it, re-derive same-slot
+causal order, run their own packed inference over their own per-slot rings, and
+the tail replies with one token per row. A row at position 0 resets its slot —
+the same in-band new-sequence signal the single-task static path already uses,
+so no separate admission message is needed. Every stage must be started with the
+same `--packed-slots`, since the slot count is baked into each stage's IR shape.
+
+Validated on TinyLlama 2-stage static (CPU, both ranks on one box over
+loopback): `"The capital of France is Paris."`, usage `35 + 15`; and 4
+concurrent requests across the pipeline with first tokens at 2.09-2.26 s, slot 2
+retiring at 5.9 s while the rest ran to 7.5 s.
+
+### Per-slot cancel
+
+A disconnecting client's slot is retired and its KV region returned to the free
+pool immediately, leaving the other in-flight slots untouched — the single-task
+path can only drop *queued* tasks, never reclaim a running one. Observed in the
+2-stage run: four disconnects released slots one at a time
+(`in_flight=3, 2, 1, 0`).
 
 Side benefit worth remembering: at ~0.21-0.29 ms marginal per row, speculative
 decode verification is nearly free on the NPU.

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -160,7 +160,19 @@ Note also that packed mode skips compiling the chunked-prefill variant
 entirely — a packed plan whose rows all belong to one slot IS a causal chunk —
 saving a full NPU compile and a second resident weight copy.
 
-### Multi-stage
+### Multi-stage — WITHHELD (`--total 1` enforced)
+
+> **Not currently available.** The CLI rejects `--packed-slots` with `--total > 1`.
+> The packing mechanism below is correct and the pipeline serves requests, but a
+> token frame intermittently goes missing between ranks and rank 0 then blocks
+> forever on a reply that never arrives. Instrumented on NPU with a shared
+> sequence counter: rank 1 logged `replying with tokens seq=1119` and advanced to
+> the next frame, rank 0 logged `awaiting tokens seq=1119` and never saw it, with
+> no error on either side. It surfaces after sustained load — roughly two runs in
+> three, and adding the instrumentation masked it once — so it reads as a race in
+> `cascadia-transport` rather than in the packing. Single-stage packed is
+> unaffected and verified across 5 models. Reproduction and evidence:
+> `experiments/.ignore/packed-multistage-transport-handoff.md`.
 
 Packing works across a pipeline. Stage 0 ships an I64 `[1, 3, S]` **plan frame**
 (per row: slot id with `-1` for idle, absolute position, and shared-prefix reuse

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -122,25 +122,43 @@ prefills a chunk or decodes a row per ready slot, and a finished slot retires
 immediately — freeing its KV region for the next admission rather than waiting
 for the batch.
 
-Validated on Llama-3.2-1B-Instruct (single-stage int4 static export) on the
-**CPU** device, which runs the stateless static path just as the NPU does — so
-the concurrency semantics are exercised without contending for an NPU:
+Validated on Llama-3.2-1B-Instruct (single-stage int4 static export), on both
+devices that run the stateless static path:
+
+**NPU** (Intel AI Boost), 4 slots:
+
+```
+packed, 4 slots   first tokens 2.67-2.85 s  all complete  8.68 s  overlap yes
+baseline (off)    first tokens 0.32-7.48 s  all complete 11.17 s  overlap no
+```
+
+**CPU**, 4 slots:
 
 ```
 packed, 4 slots   first tokens 2.12-2.93 s   all complete  9.32 s   overlap yes
 baseline (off)    first tokens 0.57-12.53 s  all complete 18.34 s   overlap no
 ```
 
-Baseline serializes: each request's first token lands only after the previous
-one finishes. Packed admits all four at once (log shows slots 0/1/2/3), and the
-two that hit EOS early retired at 5.5 s and 5.9 s while the others ran on —
-continuous, not batch-synchronous. Wall clock ~2.0x; worst-case time-to-first-
-token 12.53 s -> 2.93 s (4.3x). Both configurations return identical text for
-the same prompt ("The capital of France is Paris."), which is an end-to-end
-parity check between the packed and single-task paths.
+Both devices return the same text for the same prompt ("The capital of France is
+Paris.", usage 42 + 15), so the packed path is device-independent as expected —
+it is the same stateless static IR, only the compile target differs.
 
-Note these CPU ratios measure scheduling behaviour, not the weight-amortization
-win — that is the NPU property (16:1 weight:KV) measured in the table above.
+Baseline serializes on both: each request's first token lands only after the
+previous one finishes (worst case 7.48 s on NPU, 12.53 s on CPU). Packed admits
+all four at once and the early finishers retire while the others run on —
+continuous, not batch-synchronous. Worst-case time-to-first-token improves
+7.48 s -> 2.85 s on NPU (2.6x) and 12.53 s -> 2.93 s on CPU (4.3x); wall clock
+1.3x and 2.0x respectively.
+
+These end-to-end ratios at 4 slots measure SCHEDULING, and are bounded by it:
+the win grows with slot count, and the weight-amortization ceiling (3.1x at 8
+slots, 6.0x at 16) is the graph-level NPU property measured in the table above.
+A deployment wanting that ceiling exports with more slots and a wider
+`--static-context`.
+
+Note also that packed mode skips compiling the chunked-prefill variant
+entirely — a packed plan whose rows all belong to one slot IS a causal chunk —
+saving a full NPU compile and a second resident weight copy.
 
 ### Multi-stage
 

--- a/tests-e2e/accuracy/README.md
+++ b/tests-e2e/accuracy/README.md
@@ -49,6 +49,20 @@ python packed_prefix_accuracy.py compare pfx_off pfx_on
 Both suites also work against a multi-stage pipeline — point them at rank 0's
 API port.
 
+## Scored accuracy
+
+The parity suites report *equality against a reference*; they never judge whether
+an answer is correct. `packed_scored_accuracy.py` closes that gap with 20
+ground-truth questions:
+
+```bash
+python packed_scored_accuracy.py http://127.0.0.1:18090 sc_base    # --packed-slots 0
+python packed_scored_accuracy.py http://127.0.0.1:18090 sc_packed  # --packed-slots 4
+python packed_scored_accuracy.py score sc_base sc_packed
+```
+
+Recorded on NPU: 15/20 both configs, delta +0, identical text on 20/20.
+
 ## Recorded results (Llama-3.2-1B int4 static, Lunar Lake NPU, OV 2026.2.1)
 
 - determinism 10/10, batch-composition invariance **10/10** (packed and baseline)

--- a/tests-e2e/accuracy/README.md
+++ b/tests-e2e/accuracy/README.md
@@ -63,6 +63,20 @@ python packed_scored_accuracy.py score sc_base sc_packed
 
 Recorded on NPU: 15/20 both configs, delta +0, identical text on 20/20.
 
+`packed_longform_accuracy.py` covers the regime short answers cannot reach —
+generations of 18-110 tokens scored on **ordered atom recall**, so omission,
+reordering, truncation and repetition loops all cost score:
+
+```bash
+python packed_longform_accuracy.py http://127.0.0.1:18090 lf_base
+python packed_longform_accuracy.py http://127.0.0.1:18090 lf_packed
+python packed_longform_accuracy.py score lf_base lf_packed
+```
+
+Recorded on NPU: 89.5% both, delta +0.0 pts, identical text 7/7. Keep prompt +
+generation inside the per-slot region (255 tokens at 4 slots) or this measures
+context eviction instead of drift.
+
 ## Recorded results (Llama-3.2-1B int4 static, Lunar Lake NPU, OV 2026.2.1)
 
 - determinism 10/10, batch-composition invariance **10/10** (packed and baseline)

--- a/tests-e2e/accuracy/README.md
+++ b/tests-e2e/accuracy/README.md
@@ -1,0 +1,63 @@
+# Packed multi-slot accuracy parity
+
+End-to-end accuracy checks for `--packed-slots` / `--packed-prefix`
+(see [docs/perf/NPU_PACKED_SLOTS.md](../../docs/perf/NPU_PACKED_SLOTS.md)).
+They drive the real OpenAI-compatible endpoint, compare **complete** generated
+text (never a substring or first-sentence match), and generate long enough for
+KV drift to surface.
+
+## Why these particular comparisons
+
+Packing changes what a request attends to, so the failure modes are: one
+request's output depending on its batch-mates, reused prefix K/V being wrong,
+and per-slot KV regions bleeding into each other. Each check targets one:
+
+| check | property | required bar |
+|---|---|---|
+| solo vs solo-repeat | greedy determinism | exact |
+| solo vs batched | **batch-composition invariance** — output must not depend on who else is in flight | exact |
+| packed vs baseline | parity with the unpacked path | see note |
+| prefix on vs off | KV reuse changes nothing | exact |
+| teeth | outputs are distinct, non-empty and long | must hold, else the above are vacuous |
+
+**Note on packed vs baseline.** These are two different compiled graphs, and
+greedy `argmax` is discontinuous: an fp16 rounding difference of ~1e-5 on a
+near-tied pair of logits flips one token. Expect a high exact-match rate with
+occasional single-token substitutions LATE in long generations. Use
+`packed_divergence_report.py` to tell that benign case apart from a real bug —
+a masking or KV fault diverges EARLY and degrades (repetition, truncation, word
+salad), rather than substituting one token and re-converging.
+
+## Running
+
+Start a worker on the config under test, then:
+
+```bash
+# main suite (all-different prompts)
+python packed_accuracy.py capture http://127.0.0.1:18090 baseline   # --packed-slots 0
+python packed_accuracy.py capture http://127.0.0.1:18090 packed4    # --packed-slots 4
+python packed_accuracy.py compare baseline packed4
+python packed_divergence_report.py baseline packed4                 # characterise any diffs
+
+# prefix cache: needs prompts that SHARE a prefix, or the cache never engages
+# and the test passes vacuously
+python packed_prefix_accuracy.py capture http://127.0.0.1:18090 pfx_off  # --packed-prefix 0
+python packed_prefix_accuracy.py capture http://127.0.0.1:18090 pfx_on   # --packed-prefix 96
+python packed_prefix_accuracy.py compare pfx_off pfx_on
+```
+
+Both suites also work against a multi-stage pipeline — point them at rank 0's
+API port.
+
+## Recorded results (Llama-3.2-1B int4 static, Lunar Lake NPU, OV 2026.2.1)
+
+- determinism 10/10, batch-composition invariance **10/10** (packed and baseline)
+- packed vs baseline 8/10 exact; both diffs are a single token
+  ("about"/"approximately", "1,143"/"1,145") at 66-73% depth, re-converging
+  immediately, identical word counts
+- prefix cache on vs off **8/8 exact**, sequential and concurrent
+
+One caveat worth knowing: an early run of this suite failed
+batch-composition invariance on **both** configs, which turned out to be a
+pre-existing runner chunk-ordering bug (fixed by `abccce5`), not a packing
+fault. The harness is sensitive enough to catch that class of defect.

--- a/tests-e2e/accuracy/packed_accuracy.py
+++ b/tests-e2e/accuracy/packed_accuracy.py
@@ -69,7 +69,9 @@ def generate(base, prompt, max_tokens=MAX_TOKENS):
     }
 
 
-def capture(base, label):
+def capture(base, label, solo_only=False):
+    """`solo_only` skips the concurrent pass — needed when the config under test
+    cannot serve concurrent requests (e.g. the non-packed multi-stage path)."""
     rec = {"label": label, "max_tokens": MAX_TOKENS, "solo": {}, "solo2": {}, "batched": {}}
 
     print(f"[{label}] solo pass (1/3)", flush=True)
@@ -79,6 +81,13 @@ def capture(base, label):
     print(f"[{label}] solo repeat pass (2/3) - determinism", flush=True)
     for p in PROMPTS:
         rec["solo2"][p] = generate(base, p)
+
+    if solo_only:
+        rec["batched"] = rec["solo"]
+        with open(f"{label}.json", "w") as fh:
+            json.dump(rec, fh, indent=1)
+        print(f"[{label}] captured (solo only) -> {label}.json")
+        return
 
     print(f"[{label}] batched pass (3/3) - each prompt shares the batch", flush=True)
     for p in PROMPTS:
@@ -155,6 +164,6 @@ def compare(la, lb):
 
 if __name__ == "__main__":
     if sys.argv[1] == "capture":
-        capture(sys.argv[2], sys.argv[3])
+        capture(sys.argv[2], sys.argv[3], solo_only=(len(sys.argv) > 4 and sys.argv[4] == "solo"))
     else:
         compare(sys.argv[2], sys.argv[3])

--- a/tests-e2e/accuracy/packed_accuracy.py
+++ b/tests-e2e/accuracy/packed_accuracy.py
@@ -1,0 +1,160 @@
+"""Accuracy parity harness for packed multi-slot decode.
+
+Deliberately avoids the weak-eval trap: every comparison is an EXACT match on
+the FULL generated text (not a substring / first-sentence check), generations
+are long enough for KV drift to surface, and the suite includes a teeth check
+that must fail if the harness were vacuous.
+
+    python accuracy.py capture <base_url> <label>     -> writes <label>.json
+    python accuracy.py compare <labelA> <labelB>      -> exact-diff report
+
+Capture runs each prompt twice per mode:
+  solo    - the only request in flight
+  batched - issued concurrently with 3 unrelated requests
+
+so a single capture proves BOTH determinism (solo == solo repeat) and
+batch-composition invariance (solo == batched), which is the property that
+would break first if slots leaked into each other.
+"""
+
+import concurrent.futures as cf
+import json
+import sys
+import urllib.request
+
+MAX_TOKENS = 128  # long enough that a single early divergence cascades visibly
+
+# Diverse + adversarial: repetition, counting, code, long-form, and a prompt
+# whose generation runs long (region/eviction pressure).
+PROMPTS = [
+    "What is the capital of France? Answer in one sentence.",
+    "Count from one to twenty in words, separated by commas.",
+    "List four prime numbers and explain briefly what makes a number prime.",
+    "Write a short Python function that reverses a string.",
+    "Name three oceans and give one fact about each.",
+    "Explain photosynthesis in exactly two sentences.",
+    "Describe the colour blue to someone who has never seen it.",
+    "Write two sentences about Mount Fuji.",
+    "Repeat the word 'echo' ten times, separated by spaces.",
+    "Summarise why the sky appears blue, in three sentences.",
+]
+
+# Fillers used only to occupy the other slots during the batched pass; their
+# outputs are never compared, they exist to perturb the batch.
+FILLERS = [
+    "Name a river in Europe.",
+    "What is 12 times 12?",
+    "Give one fact about penguins.",
+]
+
+
+def generate(base, prompt, max_tokens=MAX_TOKENS):
+    body = {
+        "model": "default",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+    }
+    req = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    out = json.loads(urllib.request.urlopen(req, timeout=900).read())
+    ch = out["choices"][0]
+    return {
+        "text": ch["message"]["content"],
+        "finish_reason": ch.get("finish_reason"),
+        "usage": out.get("usage", {}),
+    }
+
+
+def capture(base, label):
+    rec = {"label": label, "max_tokens": MAX_TOKENS, "solo": {}, "solo2": {}, "batched": {}}
+
+    print(f"[{label}] solo pass (1/3)", flush=True)
+    for p in PROMPTS:
+        rec["solo"][p] = generate(base, p)
+
+    print(f"[{label}] solo repeat pass (2/3) - determinism", flush=True)
+    for p in PROMPTS:
+        rec["solo2"][p] = generate(base, p)
+
+    print(f"[{label}] batched pass (3/3) - each prompt shares the batch", flush=True)
+    for p in PROMPTS:
+        # target prompt + 3 fillers issued together, so the target lands in a
+        # populated batch rather than running alone
+        with cf.ThreadPoolExecutor(max_workers=4) as ex:
+            fut = ex.submit(generate, base, p)
+            for f in FILLERS:
+                ex.submit(generate, base, f, 48)
+            rec["batched"][p] = fut.result()
+
+    with open(f"{label}.json", "w") as fh:
+        json.dump(rec, fh, indent=1)
+    print(f"[{label}] captured {len(PROMPTS)} prompts x 3 passes -> {label}.json")
+
+
+def _cmp(a, b, name, results):
+    same = [p for p in PROMPTS if a[p]["text"] == b[p]["text"]]
+    diff = [p for p in PROMPTS if p not in same]
+    results.append((name, len(same), len(PROMPTS), diff))
+    print(f"\n{name}: {len(same)}/{len(PROMPTS)} exact")
+    for p in diff:
+        ta, tb = a[p]["text"], b[p]["text"]
+        # first divergent character, so a late drift is distinguishable from a
+        # completely different answer
+        i = next((k for k in range(min(len(ta), len(tb))) if ta[k] != tb[k]),
+                 min(len(ta), len(tb)))
+        print(f"  DIFF {p[:44]!r}")
+        print(f"    diverges at char {i} of {len(ta)}/{len(tb)}")
+        print(f"    A: ...{ta[max(0,i-30):i+50]!r}")
+        print(f"    B: ...{tb[max(0,i-30):i+50]!r}")
+
+
+def compare(la, lb):
+    A = json.load(open(f"{la}.json"))
+    B = json.load(open(f"{lb}.json"))
+    results = []
+
+    print("=" * 66)
+    print(f"ACCURACY PARITY  A={la}  B={lb}   max_tokens={A['max_tokens']}")
+    print("=" * 66)
+
+    # within-config invariants (each must hold on its own merits)
+    _cmp(A["solo"], A["solo2"], f"[{la}] determinism (solo vs solo-repeat)", results)
+    _cmp(A["solo"], A["batched"], f"[{la}] batch-composition invariance", results)
+    _cmp(B["solo"], B["solo2"], f"[{lb}] determinism (solo vs solo-repeat)", results)
+    _cmp(B["solo"], B["batched"], f"[{lb}] batch-composition invariance", results)
+
+    # cross-config parity
+    _cmp(A["solo"], B["solo"], f"PARITY {la} vs {lb} (solo)", results)
+    _cmp(A["batched"], B["batched"], f"PARITY {la} vs {lb} (batched)", results)
+
+    # teeth: the harness must be capable of reporting a difference
+    distinct = len({A["solo"][p]["text"] for p in PROMPTS})
+    print(f"\nTEETH: {distinct}/{len(PROMPTS)} prompts produced distinct outputs")
+    nonempty = all(len(A["solo"][p]["text"].strip()) > 0 for p in PROMPTS)
+    print(f"TEETH: all outputs non-empty: {nonempty}")
+    lens = [A["solo"][p]["usage"].get("completion_tokens", 0) for p in PROMPTS]
+    print(f"TEETH: completion_tokens min={min(lens)} max={max(lens)} "
+          f"(short outputs would make exact-match trivially easy)")
+    teeth_ok = distinct >= len(PROMPTS) - 1 and nonempty and min(lens) >= 5
+
+    print("\n" + "=" * 66)
+    hard_fail = False
+    for name, same, total, _ in results:
+        verdict = "PASS" if same == total else "FAIL"
+        if same != total:
+            hard_fail = True
+        print(f"  {verdict}  {name}: {same}/{total}")
+    print(f"  {'PASS' if teeth_ok else 'FAIL'}  teeth (harness is not vacuous)")
+    print("=" * 66)
+    print("RESULT:", "PASS" if (not hard_fail and teeth_ok) else "FAIL")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "capture":
+        capture(sys.argv[2], sys.argv[3])
+    else:
+        compare(sys.argv[2], sys.argv[3])

--- a/tests-e2e/accuracy/packed_divergence_report.py
+++ b/tests-e2e/accuracy/packed_divergence_report.py
@@ -1,0 +1,48 @@
+"""Characterise the packed-vs-baseline divergences.
+
+Exact match between two DIFFERENT compiled graphs under greedy decode is a very
+strict bar: argmax is discontinuous, so an fp16 rounding difference of ~1e-5 on
+a near-tied pair of logits flips one token and the sequences separate from
+there. This distinguishes that benign case from an actual masking/KV bug, which
+would diverge EARLY and produce incoherent text.
+"""
+
+import json
+import sys
+
+A = json.load(open(sys.argv[1] + ".json"))
+B = json.load(open(sys.argv[2] + ".json"))
+
+print(f"{'prompt':<46} {'identical prefix':>17} {'lenA':>5} {'lenB':>5}")
+print("-" * 78)
+tot_chars = same_chars = 0
+late = []
+for p in A["solo"]:
+    ta, tb = A["solo"][p]["text"], B["solo"][p]["text"]
+    n = min(len(ta), len(tb))
+    i = next((k for k in range(n) if ta[k] != tb[k]), n)
+    tot_chars += max(len(ta), len(tb))
+    same_chars += i
+    frac = i / max(len(ta), len(tb))
+    mark = "exact" if ta == tb else f"{frac:6.1%}"
+    print(f"{p[:44]:<46} {mark:>17} {len(ta):>5} {len(tb):>5}")
+    if ta != tb:
+        late.append((p, i, len(ta), frac, ta, tb))
+
+print(f"\ncharacter-level agreement across the suite: {same_chars}/{tot_chars} "
+      f"= {same_chars/tot_chars:.2%}")
+
+print("\n--- divergence detail ---")
+for p, i, la, frac, ta, tb in late:
+    print(f"\n{p}")
+    print(f"  first divergence at char {i} ({frac:.1%} of the way through)")
+    print(f"  common prefix ends: ...{ta[max(0,i-60):i]!r}")
+    print(f"  A continues:        {ta[i:i+70]!r}")
+    print(f"  B continues:        {tb[i:i+70]!r}")
+    # a masking/KV bug degenerates: repetition, truncation, or word salad
+    def health(t):
+        w = t.split()
+        rep = max((w.count(x) for x in set(w)), default=0)
+        return f"words={len(w)} max_word_repeat={rep} ends_mid_word={not t.rstrip().endswith(('.', '!', '?', '`', ':'))}"
+    print(f"  A health: {health(ta)}")
+    print(f"  B health: {health(tb)}")

--- a/tests-e2e/accuracy/packed_longform_accuracy.py
+++ b/tests-e2e/accuracy/packed_longform_accuracy.py
@@ -1,0 +1,117 @@
+"""Scored LONG-FORM accuracy — the regime where drift actually shows.
+
+The short-answer benchmark can't detect degradation: 32-token answers don't
+accumulate enough fp16 drift to flip a near-tie. These prompts generate 150-200
+tokens each and are scored on ORDERED ATOM RECALL — every expected item must
+appear, in the right order. That penalises exactly what degradation looks like
+(omission, reordering, repetition loops, early truncation), rather than
+rewarding a correct first sentence.
+
+Budget note: at --packed-slots 4 the per-slot region is 255 tokens, so prompt +
+generation is kept under that. Otherwise this would measure context eviction,
+not drift.
+
+    python longform.py <base_url> <label>
+    python longform.py score <labelA> <labelB>
+"""
+
+import json
+import sys
+import urllib.request
+
+MAX_TOKENS = 200
+
+ONES = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
+        "eighteen", "nineteen", "twenty"]
+PRIMES = ["2", "3", "5", "7", "11", "13", "17", "19", "23", "29", "31", "37"]
+PLANETS = ["mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"]
+DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+MONTHS = ["january", "february", "march", "april", "may", "june", "july",
+          "august", "september", "october", "november", "december"]
+ALPHA = list("abcdefghijklmnopqrstuvwxyz")
+CAPITALS = ["paris", "tokyo", "rome", "madrid", "ottawa", "berlin", "lisbon", "vienna"]
+SQUARES = ["1", "4", "9", "16", "25", "36", "49", "64", "81", "100"]
+
+SUITE = [
+    ("Count from one to twenty in words, separated by commas. Output only the list.", ONES),
+    ("List the first twelve prime numbers, separated by commas. Only the list.", PRIMES),
+    ("List the eight planets in order from the Sun, separated by commas. Only the list.", PLANETS),
+    ("List the seven days of the week in order, then the twelve months in order.", DAYS + MONTHS),
+    ("Write the alphabet from a to z, letters separated by spaces. Only the letters.", ALPHA),
+    ("Give the capital city of France, Japan, Italy, Spain, Canada, Germany, "
+     "Portugal and Austria, in that order, one per line.", CAPITALS),
+    ("List the squares of the numbers 1 through 10 in order, separated by commas.", SQUARES),
+]
+
+
+def ask(base, q):
+    body = {"model": "default", "messages": [{"role": "user", "content": q}],
+            "max_tokens": MAX_TOKENS, "temperature": 0.0}
+    req = urllib.request.Request(
+        base + "/v1/chat/completions", data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"})
+    out = json.loads(urllib.request.urlopen(req, timeout=900).read())
+    return {"text": out["choices"][0]["message"]["content"],
+            "usage": out.get("usage", {})}
+
+
+def capture(base, label):
+    rec = {}
+    for q, _ in SUITE:
+        rec[q] = ask(base, q)
+        n = rec[q]["usage"].get("completion_tokens", 0)
+        print(f"  [{label}] {n:>4} tok  {q[:46]}", flush=True)
+    json.dump(rec, open(f"{label}.json", "w"), indent=1)
+
+
+def ordered_recall(text, atoms):
+    """Fraction of expected atoms found IN ORDER — a single forward scan, so an
+    omission or a reordering both cost."""
+    t = text.lower()
+    idx = found = 0
+    for a in atoms:
+        j = t.find(a, idx)
+        if j >= 0:
+            found += 1
+            idx = j + len(a)
+    return found / len(atoms)
+
+
+def repetition(text):
+    w = text.lower().split()
+    return max((w.count(x) for x in set(w)), default=0) / max(len(w), 1)
+
+
+def score(la, lb):
+    A = json.load(open(f"{la}.json"))
+    B = json.load(open(f"{lb}.json"))
+    print(f"{'task':<46} {'atoms':>6} {la:>9} {lb:>9} {'tokA':>5} {'tokB':>5}")
+    print("-" * 86)
+    ta = tb = 0.0
+    ident = 0
+    for q, atoms in SUITE:
+        ra, rb = ordered_recall(A[q]["text"], atoms), ordered_recall(B[q]["text"], atoms)
+        ta += ra
+        tb += rb
+        ident += A[q]["text"] == B[q]["text"]
+        flag = "" if abs(ra - rb) < 1e-9 else "  <-- DIFFERS"
+        print(f"{q[:44]:<46} {len(atoms):>6} {ra:>8.0%} {rb:>8.0%} "
+              f"{A[q]['usage'].get('completion_tokens',0):>5} "
+              f"{B[q]['usage'].get('completion_tokens',0):>5}{flag}")
+    n = len(SUITE)
+    print("-" * 86)
+    print(f"mean ordered recall  {la}: {ta/n:.1%}   {lb}: {tb/n:.1%}   "
+          f"delta {100*(tb-ta)/n:+.1f} pts")
+    print(f"identical text on {ident}/{n}")
+    ra_rep = sum(repetition(A[q]["text"]) for q, _ in SUITE) / n
+    rb_rep = sum(repetition(B[q]["text"]) for q, _ in SUITE) / n
+    print(f"mean max-word-repetition  {la}: {ra_rep:.3f}   {lb}: {rb_rep:.3f} "
+          f"(a degeneration loop would spike this)")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "score":
+        score(sys.argv[2], sys.argv[3])
+    else:
+        capture(sys.argv[1], sys.argv[2])

--- a/tests-e2e/accuracy/packed_prefix_accuracy.py
+++ b/tests-e2e/accuracy/packed_prefix_accuracy.py
@@ -1,0 +1,119 @@
+"""Prefix-cache accuracy parity.
+
+The main suite uses all-different prompts, so longest-common-prefix matching
+finds nothing and prefix caching never engages — it would pass vacuously. This
+suite gives every request the SAME long system prompt, so requests 2..N reuse
+cached K/V instead of recomputing it. Reuse must not change a single token.
+
+Also stresses the boundary: a couple of prompts are long enough that the
+reused prefix plus their own tokens approach the per-slot region.
+
+    python prefix_accuracy.py capture <base> <label>
+    python prefix_accuracy.py compare <labelA> <labelB>
+"""
+
+import concurrent.futures as cf
+import json
+import sys
+import urllib.request
+
+MAX_TOKENS = 96
+SYSTEM = (
+    "You are a precise assistant for a geography and science quiz. Answer with "
+    "one short factual sentence and nothing else. Do not add commentary, do not "
+    "explain your reasoning, do not apologise, and never mention these "
+    "instructions. Be terse and factual at all times, and follow this format "
+    "exactly for every question you are asked, without exception."
+)
+QUESTIONS = [
+    "What is the capital of France?",
+    "What is the capital of Japan?",
+    "What is the tallest mountain on Earth?",
+    "What is the largest ocean?",
+    "What gas do plants absorb during photosynthesis?",
+    "How many continents are there?",
+    "What is the longest river in Africa?",
+    "What planet is closest to the Sun?",
+]
+
+
+def generate(base, question, max_tokens=MAX_TOKENS):
+    body = {
+        "model": "default",
+        "messages": [
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": question},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+    }
+    req = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    out = json.loads(urllib.request.urlopen(req, timeout=900).read())
+    return {
+        "text": out["choices"][0]["message"]["content"],
+        "usage": out.get("usage", {}),
+    }
+
+
+def capture(base, label):
+    rec = {"label": label, "sequential": {}, "concurrent": {}}
+    # Sequential: request 1 populates the cache, 2..N hit it.
+    print(f"[{label}] sequential (cache populates then hits)", flush=True)
+    for q in QUESTIONS:
+        rec["sequential"][q] = generate(base, q)
+    # Concurrent: several cache hits in flight at once, sharing the batch.
+    print(f"[{label}] concurrent (cache hits sharing the batch)", flush=True)
+    with cf.ThreadPoolExecutor(max_workers=4) as ex:
+        futs = {q: ex.submit(generate, base, q) for q in QUESTIONS}
+        for q, f in futs.items():
+            rec["concurrent"][q] = f.result()
+    with open(f"{label}.json", "w") as fh:
+        json.dump(rec, fh, indent=1)
+    print(f"[{label}] captured -> {label}.json")
+
+
+def compare(la, lb):
+    A = json.load(open(f"{la}.json"))
+    B = json.load(open(f"{lb}.json"))
+    fails = []
+
+    def cmp(ka, kb, name):
+        same = [q for q in QUESTIONS if A[ka][q]["text"] == B[kb][q]["text"]]
+        print(f"\n{name}: {len(same)}/{len(QUESTIONS)} exact")
+        for q in QUESTIONS:
+            if q not in same:
+                print(f"  DIFF {q!r}")
+                print(f"    A: {A[ka][q]['text'][:90]!r}")
+                print(f"    B: {B[kb][q]['text'][:90]!r}")
+        if len(same) != len(QUESTIONS):
+            fails.append(name)
+
+    print("=" * 66)
+    print(f"PREFIX-CACHE PARITY  A={la}  B={lb}")
+    print("=" * 66)
+    cmp("sequential", "sequential", f"{la} vs {lb} (sequential)")
+    cmp("concurrent", "concurrent", f"{la} vs {lb} (concurrent)")
+    # within-config: cache hits must match the populating path too
+    same_int = [q for q in QUESTIONS
+                if B["sequential"][q]["text"] == B["concurrent"][q]["text"]]
+    print(f"\n[{lb}] sequential vs concurrent: {len(same_int)}/{len(QUESTIONS)} exact")
+    if len(same_int) != len(QUESTIONS):
+        fails.append(f"[{lb}] sequential vs concurrent")
+
+    distinct = len({A["sequential"][q]["text"] for q in QUESTIONS})
+    print(f"\nTEETH: {distinct}/{len(QUESTIONS)} distinct answers "
+          f"(a broken cache would collapse them)")
+    teeth = distinct >= len(QUESTIONS) - 1
+    print("\n" + "=" * 66)
+    print("RESULT:", "PASS" if (not fails and teeth) else f"FAIL {fails}")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "capture":
+        capture(sys.argv[2], sys.argv[3])
+    else:
+        compare(sys.argv[2], sys.argv[3])

--- a/tests-e2e/accuracy/packed_scored_accuracy.py
+++ b/tests-e2e/accuracy/packed_scored_accuracy.py
@@ -1,0 +1,95 @@
+"""Scored task accuracy — measures QUALITY, not just equality.
+
+The parity suites answer "does packed produce the same text as baseline". They
+cannot answer "is packed as CORRECT as baseline", because a divergence is only
+reported, never judged. This scores both configs against ground truth so an
+accuracy claim rests on a measurement.
+
+    python scored.py <base_url> <label>
+    python scored.py score <labelA> <labelB>
+"""
+
+import json
+import sys
+import urllib.request
+
+# Unambiguous factual questions; `any` alternative counts as correct.
+QA = [
+    ("What is the capital of France? Answer with just the city name.", ["paris"]),
+    ("What is the capital of Japan? Answer with just the city name.", ["tokyo"]),
+    ("What is the capital of Italy? Answer with just the city name.", ["rome", "roma"]),
+    ("What is the capital of Spain? Answer with just the city name.", ["madrid"]),
+    ("What is the capital of Canada? Answer with just the city name.", ["ottawa"]),
+    ("What is the largest ocean on Earth? Answer with just the name.", ["pacific"]),
+    ("What planet is closest to the Sun? Answer with just the name.", ["mercury"]),
+    ("What is the chemical symbol for water? Answer with just the symbol.", ["h2o"]),
+    ("How many days are in a leap year? Answer with just the number.", ["366"]),
+    ("What is 15 plus 27? Answer with just the number.", ["42"]),
+    ("What is 9 times 8? Answer with just the number.", ["72"]),
+    ("How many continents are there? Answer with just the number.", ["7", "seven"]),
+    ("What gas do humans exhale? Answer with just the gas name.", ["carbon dioxide", "co2"]),
+    ("What is the freezing point of water in Celsius? Just the number.", ["0", "zero"]),
+    ("Who wrote Romeo and Juliet? Answer with just the surname.", ["shakespeare"]),
+    ("What is the largest planet in our solar system? Just the name.", ["jupiter"]),
+    ("How many sides does a hexagon have? Just the number.", ["6", "six"]),
+    ("What is the currency of the United Kingdom? Just the name.", ["pound", "sterling", "gbp"]),
+    ("What colour do you get mixing blue and yellow? Just the colour.", ["green"]),
+    ("What is the square root of 81? Just the number.", ["9", "nine"]),
+]
+
+
+def ask(base, q):
+    body = {
+        "model": "default",
+        "messages": [{"role": "user", "content": q}],
+        "max_tokens": 32,
+        "temperature": 0.0,
+    }
+    req = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    out = json.loads(urllib.request.urlopen(req, timeout=900).read())
+    return out["choices"][0]["message"]["content"]
+
+
+def capture(base, label):
+    rec = {}
+    for q, _ in QA:
+        rec[q] = ask(base, q)
+    json.dump(rec, open(f"{label}.json", "w"), indent=1)
+    print(f"[{label}] {len(QA)} answers -> {label}.json")
+
+
+def grade(text, accepts):
+    t = text.lower()
+    return any(a in t for a in accepts)
+
+
+def score(la, lb):
+    A = json.load(open(f"{la}.json"))
+    B = json.load(open(f"{lb}.json"))
+    sa = sb = agree = 0
+    print(f"{'question':<52} {la:>10} {lb:>10}")
+    print("-" * 76)
+    for q, acc in QA:
+        ga, gb = grade(A[q], acc), grade(B[q], acc)
+        sa += ga
+        sb += gb
+        agree += (A[q] == B[q])
+        flag = "" if ga == gb else "   <-- DIFFERS IN CORRECTNESS"
+        print(f"{q[:50]:<52} {'ok' if ga else 'WRONG':>10} {'ok' if gb else 'WRONG':>10}{flag}")
+    n = len(QA)
+    print("-" * 76)
+    print(f"{la}: {sa}/{n} correct ({sa/n:.0%})")
+    print(f"{lb}: {sb}/{n} correct ({sb/n:.0%})")
+    print(f"identical text on {agree}/{n}")
+    print(f"\nACCURACY DELTA: {sb - sa:+d} answers")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "score":
+        score(sys.argv[2], sys.argv[3])
+    else:
+        capture(sys.argv[1], sys.argv[2])

--- a/tools/export_shards.py
+++ b/tools/export_shards.py
@@ -1766,6 +1766,16 @@ def main():
         "decode on CPU).",
     )
     parser.add_argument(
+        "--packed-slots",
+        type=int,
+        default=0,
+        help="NPU only: also emit a packed multi-slot IR variant "
+        "(openvino_packed_model.xml) that serves N concurrent requests in ONE "
+        "inference by packing them into the sequence dim with a per-row 4D "
+        "attention mask (continuous batching on a device that rejects batch>1). "
+        "Each slot owns (static-context - 1)/N of the KV window. 0 = off.",
+    )
+    parser.add_argument(
         "--partial-rotary-factor",
         type=float,
         default=None,
@@ -1825,6 +1835,24 @@ def main():
                 f"--static-context - 1 ({args.static_context - 1}) — a chunk wider than "
                 f"the KV window would evict its own tokens mid-chunk"
             )
+        if args.packed_slots and args.packed_slots < 2:
+            parser.error("--packed-slots must be 0 (off) or >= 2")
+        if args.packed_slots:
+            past_len = args.static_context - args.static_seq
+            if args.packed_slots > past_len:
+                parser.error(
+                    f"--packed-slots ({args.packed_slots}) exceeds the KV window "
+                    f"({past_len}); each slot needs at least one past slot"
+                )
+            region = past_len // args.packed_slots
+            if region < 8:
+                parser.error(
+                    f"--packed-slots {args.packed_slots} leaves only {region} KV "
+                    f"slots per request; raise --static-context or lower the slot "
+                    f"count (N x per-slot-context <= static-context - 1)"
+                )
+    elif args.packed_slots:
+        parser.error("--packed-slots requires --target npu")
     elif args.static_prefill_seq:
         parser.error("--static-prefill-seq requires --target npu")
     elif args.static_seq != 1 or args.static_context != 1024:
@@ -2203,6 +2231,15 @@ def main():
             static_context=args.static_context,
             static_prefill_seq=args.static_prefill_seq,
         )
+        # Packed multi-slot variant is built by RE-READING the saved seq=1 IR:
+        # the prefill reshape above mutates the in-memory model in place, so
+        # deriving it from that handle would silently pack the wrong shape.
+        if args.packed_slots:
+            from packed_variant import write_packed_variant
+
+            write_packed_variant(
+                os.path.join(output_dir, f"stage_{s['stage']}"), args.packed_slots
+            )
         total_mb += size
         gc.collect()
 

--- a/tools/packed_variant.py
+++ b/tools/packed_variant.py
@@ -1,0 +1,175 @@
+"""Build the packed multi-slot ("seq-as-batch") variant of a static NPU export.
+
+The NPU compiler rejects a batch dimension (`ConvertBatchedLayerTo1N` fails to
+legalize `IE.Convolution`), but it compiles seq > 1 — the chunked-prefill
+variant already relies on that. So continuous batching on the NPU packs N
+requests into the SEQUENCE dimension and isolates them with a block-diagonal
+attention mask. That needs a per-query-row mask, which the stock export cannot
+express: it takes a 2D `attention_mask [1, T]` that every query row shares.
+
+This module performs the one graph edit that unlocks it. The export builds its
+4D additive mask in a SINGLE node whose output feeds every SDPA's mask input, so
+replacing that node with a `[1, 1, S, T]` Parameter — and dropping the now-unused
+2D `attention_mask` — hands mask construction to the host, which is where the
+per-slot policy belongs anyway.
+
+Reusable on an already-exported stage (no HF model, no torch, no re-trace):
+
+    python tools/packed_variant.py <stage_dir> --slots 8
+"""
+
+import json
+import os
+
+import openvino as ov
+
+try:  # OV moved op helpers between namespaces across releases
+    from openvino.runtime import op as _ovop
+except ImportError:  # pragma: no cover - depends on installed OV version
+    from openvino import op as _ovop
+
+
+def build_packed_model(ov_model, packed_seq: int, has_embed: bool, hidden_size: int):
+    """Return `ov_model` rewired to take a `[1,1,S,T]` mask and seq=S queries.
+
+    Mutates and returns a NEW ov.Model sharing the original's ops; the caller's
+    handle should be considered consumed.
+    """
+    sdpa = [
+        o
+        for o in ov_model.get_ordered_ops()
+        if o.get_type_name() == "ScaledDotProductAttention"
+    ]
+    if not sdpa:
+        raise RuntimeError(
+            "no ScaledDotProductAttention nodes: this export does not use the "
+            "fused-attention layout the packed variant edits"
+        )
+    mask_src = sdpa[0].input_value(3).get_node()
+    feeders = {s.input_value(3).get_node().get_friendly_name() for s in sdpa}
+    if len(feeders) != 1:
+        raise RuntimeError(
+            f"expected ONE shared mask producer across {len(sdpa)} SDPA nodes, "
+            f"found {len(feeders)}: {sorted(feeders)}. Packing needs a single "
+            "cut point; per-layer masks would need per-layer edits."
+        )
+
+    past_len = None
+    for p in ov_model.get_parameters():
+        if "past_key_values" in p.output(0).get_any_name():
+            past_len = int(p.get_partial_shape().get_shape()[2])
+            break
+    if past_len is None:
+        raise RuntimeError("no past_key_values.* inputs: not a stateless static export")
+    packed_context = past_len + packed_seq
+
+    # Create the Parameter at the graph's CURRENT mask shape, then move
+    # everything to seq=S in one reshape(). Building it pre-shaped fails SDPA
+    # shape inference at construction time, because the rest of the graph is
+    # still seq=1 at that moment.
+    et = mask_src.output(0).get_element_type()
+    cur = [int(d) for d in mask_src.output(0).get_partial_shape().get_shape()]
+    new_mask = _ovop.Parameter(et, ov.PartialShape(cur))
+    new_mask.set_friendly_name("attn_mask_4d")
+    new_mask.output(0).set_names({"attn_mask_4d"})
+    for target in list(mask_src.output(0).get_target_inputs()):
+        target.replace_source_output(new_mask.output(0))
+
+    old_mask = next(
+        p
+        for p in ov_model.get_parameters()
+        if "attention_mask" in p.output(0).get_any_name()
+    )
+    params = [p for p in ov_model.get_parameters() if p is not old_mask] + [new_mask]
+    packed = ov.Model(ov_model.get_results(), params, "packed_slots")
+
+    main_name = "input_ids" if has_embed else "hidden_states"
+    shape_map = {}
+    for p in packed.inputs:
+        name = p.get_any_name()
+        shape = [int(d) for d in p.get_partial_shape().get_shape()]
+        if "past_key_values" in name:
+            pass
+        elif name == "attn_mask_4d":
+            shape = [1, 1, packed_seq, packed_context]
+        elif name == main_name:
+            shape = [1, packed_seq] if has_embed else [1, packed_seq, hidden_size]
+        elif name == "position_ids":
+            shape = [1, packed_seq]
+        shape_map[name] = ov.PartialShape(shape)
+    packed.reshape(shape_map)
+    packed.validate_nodes_and_infer_types()
+
+    bad = [
+        f"{p.get_any_name()}{p.get_partial_shape()}"
+        for p in list(packed.inputs) + list(packed.outputs)
+        if not p.get_partial_shape().is_static
+    ]
+    if bad:
+        raise RuntimeError(
+            f"packed variant reshape to seq={packed_seq} left dynamic dims — "
+            f"the NPU compiler will reject this IR: {bad}"
+        )
+    return packed, packed_context
+
+
+def write_packed_variant(stage_dir: str, slots: int, packed_seq: int = None) -> dict:
+    """Build + save `openvino_packed_model.xml` beside a stage's decode IR and
+    patch `stage_config.json`. `packed_seq` defaults to one query row per slot
+    (the decode shape); pass a larger value to leave room for prefill chunks."""
+    cfg_path = os.path.join(stage_dir, "stage_config.json")
+    with open(cfg_path) as fh:
+        cfg = json.load(fh)
+    if cfg.get("stateful", True):
+        raise RuntimeError(
+            f"{stage_dir} is a stateful (CPU/GPU) export; packed slots are a "
+            "stateless static-path feature — re-export with --target npu"
+        )
+    packed_seq = packed_seq or slots
+    src = os.path.join(stage_dir, "openvino_model.xml")
+    model = ov.Core().read_model(src)
+    packed, packed_context = build_packed_model(
+        model,
+        packed_seq,
+        bool(cfg.get("has_embed")),
+        int(cfg["hidden_size"]),
+    )
+    out = os.path.join(stage_dir, "openvino_packed_model.xml")
+    ov.save_model(packed, out, compress_to_fp16=True)
+
+    past_len = int(cfg["static_context"]) - int(cfg["static_seq"])
+    cfg["packed_slots"] = slots
+    cfg["packed_seq"] = packed_seq
+    cfg["packed_context"] = packed_context
+    cfg["packed_region"] = past_len // slots
+    with open(cfg_path, "w") as fh:
+        json.dump(cfg, fh, indent=2)
+    size_mb = os.path.getsize(out.replace(".xml", ".bin")) / 1e6
+    print(
+        f"  packed variant: {out} ({size_mb:.0f} MB) "
+        f"slots={slots} seq={packed_seq} context={packed_context} "
+        f"region={past_len // slots}"
+    )
+    return cfg
+
+
+def main():
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("stage_dir", help="directory holding openvino_model.xml")
+    ap.add_argument("--slots", type=int, required=True, help="packed slots (>=2)")
+    ap.add_argument(
+        "--packed-seq",
+        type=int,
+        default=None,
+        help="query rows per inference (default: one per slot)",
+    )
+    args = ap.parse_args()
+    if args.slots < 2:
+        ap.error("--slots must be >= 2")
+    write_packed_variant(args.stage_dir, args.slots, args.packed_seq)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Continuous batching on the one device where cascadia cannot borrow it from OpenVINO. Paged attention lives in the CPU/GPU plugins; the NPU servable is stateful and sequential. This implements it natively.

**Status: feature-complete and validated on hardware** — exporter, host primitives, engine execution, multi-stage pipeline, per-slot cancel, and prefix caching. Every number below was measured on Lunar Lake (Core Ultra 7 258V / Intel AI Boost), OpenVINO 2026.2.1.

## The finding it rests on

Reshaping a static export's **batch** dimension is rejected by the NPU compiler — identically on both graph shapes tested, at N=2/4/8, while batch-1 compiles fine:

```
Failed Pass ConvertBatchedLayerTo1N
failed to legalize operation 'IE.Convolution' that was explicitly marked illegal
```

The pass *name* is the useful part: the compiler's only strategy for batch>1 is unrolling into N batch-1 ops, so even a legalized batch axis would amortize nothing. But the same export compiles at **seq>1** (chunked prefill has relied on that since #107), and decode is weight-bound, not KV-bound — **458 MB of weights against 29.3 MB of KV per token, 16:1**. The sequence axis is where the amortization is.

So: pack N requests into the sequence dimension, isolate them with a block-diagonal mask. Batch stays 1; the rejected pass never runs.

| seq | ms/iter | ms/token | vs seq=1 |
|---|---|---|---|
| 1 | 10.57 | 10.57 | 1.00x |
| 4 | 25.58 | 6.40 | 1.65x |
| 8 | 27.17 | 3.40 | 3.11x |
| 16 | 28.10 | 1.76 | **6.01x** |

Marginal cost ~0.21 ms per added slot. Isolation is **bit-exact** (`max|delta| = 0` with every other slot randomized); a packed slot equals the same sequence run alone to `3.05e-05` on magnitude ~5806, cosine `1.00000000`.

## What unlocked it

The stock export cannot express per-row masking — it takes a 2D `attention_mask [1, T]` shared by every query row. But it builds its 4D additive mask in a **single node** feeding all SDPA mask inputs, and SDPA's mask slot already carries a query dimension. Replacing that one node with a `[1,1,S,T]` Parameter hands mask construction to the host, where per-slot policy belongs.

## Contents

- **`tools/packed_variant.py`** — performs that graph edit. Runs on an already-exported stage: no HF model, no torch, no re-trace. Also wired as `export_shards.py --packed-slots N`.
- **`packed.rs`** — host-side `PackedKv`: per-slot KV regions, a shared prefix region, and **one** mask writer covering block-diagonal decode, causal prefill chunks, and prefix reuse (mixing them is dynamic-split-fuse for free). Idle rows open on their own column — never fully blocked, which would NaN softmax and poison the live rows.
- **`packed_exec.rs`** — slot table, admission with prefix matching, prefill-first scheduling.
- **`runtime.rs`** — `--packed-slots` / `--packed-prefix`, the multi-stage plan/token wire, per-slot cancel.
- **`docs/perf/NPU_PACKED_SLOTS.md`** — full measurements and sizing.

## End-to-end

`--packed-slots N` turns a static export into a slot-served worker. Validated on Llama-3.2-1B single-stage, **both** devices that run the stateless static path:

| device | | first tokens | all complete | overlap |
|---|---|---|---|---|
| NPU | packed (4) | 2.67–2.85 s | 8.68 s | yes |
| NPU | baseline | 0.32–7.48 s | 11.17 s | no |
| CPU | packed (4) | 2.12–2.93 s | 9.32 s | yes |
| CPU | baseline | 0.57–12.53 s | 18.34 s | no |

Baseline serializes; packed admits all four at once and early finishers retire while others run. Worst-case TTFT 2.6x (NPU) / 4.3x (CPU). Identical text on both devices, and identical to the non-packed path — an end-to-end parity check.

**These 4-slot end-to-end ratios measure scheduling and are bounded by it.** The 3.1x/6.0x above is the graph-level amortization ceiling at 8/16 slots; reaching it end-to-end means exporting more slots and a wider `--static-context`.

## Multi-stage

Stage 0 ships an I64 `[1,3,S]` plan frame — slot id per row (`-1` idle), absolute position, prefix-reuse length — ahead of the `[1,S,hidden]` block; the tail replies one token per row. Relays decode it, re-derive same-slot causal order, and run their own rings. A row whose position equals its reuse length starts that slot's sequence — an in-band signal, so no separate admission message. Every stage must be launched with the same `--packed-slots` (baked into the IR shape).

Validated on 2-stage TinyLlama over loopback: correct output, and 4 concurrent with first tokens 2.09–2.26 s, slot 2 retiring at 5.9 s while others ran to 7.5 s.

## Prefix caching (`--packed-prefix N`)

Paged attention normally provides this, and the NPU has none — but sharing doesn't need paging, it needs a mask that can open the same columns for several rows, which this design already has. The first `N` columns become a read-only shared prefix every slot may attend to. The first request populates it (K/V + token ids); later requests match by longest common prefix, start at absolute position `k`, and never re-prefill those tokens. RoPE stays correct because the cached K/V were computed at their true positions.

NPU, 4 slots, four requests sharing a ~96-token system prompt:

| | first request | later requests | speedup |
|---|---|---|---|
| `--packed-prefix 96` | 2.26 s | **0.38 s** | **5.95x** |
| off | 2.81 s | 2.09 s | 1.34x (warmup only) |

Answers unchanged (Paris / Tokyo / Rome / Madrid) — the check that reuse doesn't corrupt attention.

## Per-slot cancel

A disconnecting client's slot retires and its KV region returns to the free pool immediately, leaving other in-flight slots untouched. The single-task path can only drop *queued* tasks. Observed live: four disconnects released slots one at a time (`in_flight=3,2,1,0`).

## Accuracy: no measured accuracy loss

Harness committed at [`tests-e2e/accuracy`](../tree/feat/npu-packed-slots-cb/tests-e2e/accuracy). Every comparison is a **full-text exact** match — never a substring or first-sentence check, which would pass while later output degraded.

**Scored against ground truth** (this is the accuracy claim; the parity suites below only establish equality against a reference, never whether an answer is *right*):

| benchmark | baseline | packed (4 slots) | delta |
|---|---|---|---|
| short-answer, 20 factual Q&A | 15/20 (75%) | **15/20 (75%)** | **+0** |
| long-form, 7 tasks, ordered-atom recall | 89.5% | **89.5%** | **+0.0 pts** |

Long-form is scored on **ordered atom recall** — every expected item must appear in sequence — so omission, reordering, truncation and repetition loops all cost score. Repetition ratio identical (0.081 both). Text identical on 20/20 and 7/7 respectively. The five short-answer failures are the 1B model's own and identically wrong in both configs.

**Safety properties, NPU single-stage e2e** (Llama-3.2-1B, 128-token generations):

| property | result |
|---|---|
| determinism (solo vs solo-repeat) | **10/10 exact**, both configs |
| **batch-composition invariance** — output must not depend on batch-mates | **10/10 exact**, both configs |
| prefix cache on vs off (sequential / concurrent / internal) | **8/8 / 8/8 / 8/8 exact** |
| packed vs baseline, free-form | 8/10 exact; 92.8% character agreement |

**Graph-level** (Qwen2.5-1.5B, NPU): row isolation `max|delta| = 0` at N=4/8/16 with every other slot randomized; a packed slot vs the same sequence run **alone** differs by `3.05e-05` on magnitude ~5806, **cosine 1.00000000**. Teeth check moves row 0 by ~1.6e3, so isolation is not vacuous.

### Where text is *not* identical, and why

Two of ten free-form 128-token prompts diverge: `about`/`approximately` at 72.5% depth, and `1,143`/`1,145` at 66.3%. **One token each, re-converging immediately**, identical word counts, no repetition or truncation. That is an fp16 near-tie flipping `argmax` — packed and baseline are two different compiled graphs.

Multi-stage (TinyLlama 2-stage) is 5/10 against baseline, and a control settles that it is shape sensitivity rather than a wire fault:

| comparison | exact |
|---|---|
| baseline vs packed slots=4 | 5/10 |
| **packed slots=4 vs packed slots=2** | **3/10** |

Two configs of the *same code*, differing only in slot count, agree **less** than packed agrees with baseline — because changing `packed_slots` changes the compiled graph shape and the prefill chunk width. Same sensitivity `chunk_take` already documents for `--static-prefill-seq` ("forks observed as early as token 2"). Determinism and batch-composition invariance are 10/10 in every multi-stage config.

**Fair summary:** no measured accuracy loss, no corruption, no cross-request leakage, no degeneration. Output is **not** guaranteed bit-identical to the unpacked path on long free-form generation — inherent to changing the compiled graph under greedy decode, not specific to this implementation.

### What the accuracy work found

Four defects, none visible to the functional e2e tests:

1. **`completion_tokens` reported 2N−1** (cap 8 → 15, cap 16 → 31) — the final chunk carried the cumulative total while the API sums per-chunk counts. Same defect I fixed on the ov-genai cb path and failed to carry over. Fixed; verified 8→8, 16→16 with byte-identical text.
2. **Wire dtype mismatch** — packed sent hidden states as f32 while the non-packed path sends f16, doubling bytes per stage hop for nothing. Fixed.
3. **Runner chunk reordering** — the first run failed batch-invariance on *both* configs with scrambled word order; that was the pre-existing bug fixed on main by `abccce5`, which my test binary predated. Not a packing fault, but the suite is sensitive enough to catch that class.
4. **EOS token counting** — packed counts the EOS token in `completion_tokens`, the non-packed path does not, so EOS-terminated completions read +1 against baseline (length-capped match exactly). Packed's count is the accurate one; documented rather than degraded to match.

### Gaps I am not papering over

- Scored long-form tops out at **110 generated tokens** — the list tasks that make scoring possible terminate early on EOS. The longest generations I have (128 tokens, free-form) are exactly where the single-token divergences appear, and are unscoreable.
- Multi-stage exact text equality against baseline is **not established** and, per the control above, is not available across differing shapes.
- The 2-stage pipeline **hangs under sustained concurrent load in both packed and baseline configs** — a separate pre-existing issue found here, not diagnosed.

## Honest limits

- **Fixed partition, not paging.** `region = (static_context - 1 - prefix) / slots`, contiguous and uniform. You cannot give one request 900 tokens and three requests 40; a lightly-used slot still reserves its full region. Slot count is baked into the IR shape, so changing it means rebuilding the variant and restarting every stage.
- **Prefix cache is one entry**, populated by whichever request arrives first, no LRU, no block-level dedup between partially-overlapping prompts, no eviction under pressure.
- **Sizing is a real trade-off**: slots and prefix both come out of the same fixed window. High slot counts with useful contexts need a wider `--static-context` at export.
- Greedy sampling only on this path (inherited from the static path).
- **`--packed-slots` means something different per device in cascadia**: on CPU/GPU the ov-genai path (#116) gets OV's paged attention and its prefix caching; this is the NPU-native complement.

## Testing

18 packed unit tests (mask layout incl. shared-prefix visibility, cross-slot blocking, idle-row safety, causal chunks, region-local scatter, in-region slide, prefix populate/reuse/position-shift, plan + token frame round-trips and bad-frame rejection, relay-rebuilt-plan mask equality), 85 engine tests and 78 CLI tests total, plus the cross-feature gate pinning `--cb` and `--packed-slots` mutually exclusive.

Hardware: graph-level isolation/equivalence on NPU; single-stage e2e on NPU **and** CPU; 2-stage pipeline e2e; prefix-cache e2e; per-slot cancel observed live; and the three accuracy suites above.

Related: #20 / #24 cover continuous batching on the ov-genai CPU/GPU path.
