### PR TITLE
fix(shim): explicit bool return type in AVX-VNNI probe lambda

### DIFF
--- a/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
+++ b/crates/cascadia-ov-genai-shim/cpp/gemv_offload.cpp
@@ -133,7 +133,11 @@ bool cpu_has_avx2_fma() {
 }
 
 bool cpu_has_avx_vnni() {
-    static const bool ok = [] {
+    // Explicit `-> bool`: GCC's __builtin_cpu_supports returns int (Clang
+    // returns bool), so a deduced return type collides with the `return false`
+    // above and fails to compile on GCC. Only the #else branch is affected,
+    // and MSVC builds never reach it.
+    static const bool ok = []() -> bool {
         if (!cpu_has_avx2_fma()) return false;
 #if defined(_MSC_VER)
         int r[4] = {0};


### PR DESCRIPTION
The `linux-x86_64 (openvino)` release job has failed since v0.1.3, which skips
the `promote` job and leaves releases stuck as pre-releases with no Linux
bundle. v0.1.3 and v0.1.4 are both in that state; v0.1.2 is still marked Latest.

## Cause

```
cpp/gemv_offload.cpp:143:38: error: inconsistent types 'bool' and 'int'
deduced for lambda return type
```

GCC's `__builtin_cpu_supports` returns `int`; Clang's returns `bool`. In
`cpu_has_avx_vnni()` the lambda had a deduced return type, so the `int` from
line 143 collided with the `bool` from the `return false` guard above it.

Only the non-MSVC branch is affected. That is why the Windows release bundle
and the `ai-pc` CI job stayed green — both are MSVC and take the `_MSC_VER`
branch. The GCC `#else` branch is compiled nowhere else: the Linux PR CI job
builds the stub (no `openvino` feature), so the C++ shim never compiles there.
The release workflow is the only place this code path sees a compiler.

Introduced in 25d4133 (#109), which reused the idiom from the sibling
`cpu_has_avx2_fma()`, where a trailing `&&` happens to yield `bool`.

## Fix

Explicit `-> bool` on the lambda. Chosen over `!= 0` on the builtin so both
`#if` branches are covered if a return is added later.

## Verification

Reproduced and fixed on an x86_64 Ubuntu box with g++-12 (12.4.0), against the
same OpenVINO GenAI 2026.2.0.0 ubuntu22 SDK the release workflow downloads:

| Build | Result |
|---|---|
| `41c7f57` (pre-fix), `cargo build --release -p cascadia-ov-genai-shim --features openvino` | fails, `exit 101`, identical error at `143:38` |
| this branch, same command | clean, `exit 0` |
| this branch, `cargo build --release -p cascadia --features openvino` with the release workflow's `RUSTFLAGS` | clean, `exit 0`, 1m02s |

Resulting binary: 16M x86-64 ELF PIE, `RPATH [$ORIGIN/lib]` (RPATH not RUNPATH,
so `--disable-new-dtags` took effect), linking `libopenvino_genai.so.2620`,
`libopenvino.so.2620`, `libtbb.so.12`.

Workspace suite on macOS (stub mode) is green, `cargo fmt --check` clean.

## Follow-up (not in this PR)

Nothing compiles the GCC branch before merge, so this class of break can recur.
A Linux OpenVINO build job on PRs touching `crates/cascadia-ov-genai-shim/**`
would close the gap.