### PR TITLE
fix: multi-stage packed pipeline wedge — rank 0 starved its own I/O driver (#122)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "cascadia-engine",
  "cascadia-engine-mock",
  "cascadia-metrics",
+ "cascadia-transport",
  "cascadia-types",
  "futures",
  "parking_lot",

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1865,7 +1865,10 @@ fn engine_error_response(err: cascadia_engine::EngineError) -> axum::response::R
         EngineError::QueueFull { .. } => "capacity",
         EngineError::PromptTooLong(_) => "prompt_over_window",
         EngineError::NotLoaded | EngineError::NotConnected => "engine_unavailable",
-        EngineError::Backend(_) | EngineError::Io(_) | EngineError::Task { .. } => "engine_error",
+        EngineError::Backend(_)
+        | EngineError::Io(_)
+        | EngineError::Task { .. }
+        | EngineError::BatchAborted(_) => "engine_error",
         EngineError::InvalidConfig(_)
         | EngineError::PeerRejected(_)
         | EngineError::ShardRejected(_)
@@ -1885,6 +1888,9 @@ fn engine_error_response(err: cascadia_engine::EngineError) -> axum::response::R
         // A task-attributed step failure: the engine abandoned a task; the
         // underlying cause is a backend/transport failure.
         EngineError::Task { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+        // A pipeline stage abandoned the in-flight batch. Server-side and
+        // this node's to explain, like any other engine failure.
+        EngineError::BatchAborted(_) => StatusCode::INTERNAL_SERVER_ERROR,
     };
     (status, Json(serde_json::json!({"error": err.to_string()}))).into_response()
 }
@@ -1949,6 +1955,7 @@ mod tests {
             (EngineError::NotLoaded, "engine_unavailable"),
             (EngineError::NotConnected, "engine_unavailable"),
             (EngineError::Backend("boom".into()), "engine_error"),
+            (EngineError::BatchAborted("x".into()), "engine_error"),
             (EngineError::InvalidConfig("bad".into()), "invalid_request"),
             (EngineError::ModelNotFound("nope".into()), "invalid_request"),
         ];

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1132,11 +1132,13 @@ async fn chat_completions(
         trust_remote_code: false,
     };
 
-    // Acquire a request slot before touching the engine. Without this
-    // a flood of concurrent SSE callers would hammer one engine mutex
-    // and starve everyone (the `MAX_CONSECUTIVE_EMPTY_STEPS=3` guard
-    // in the runner would then truncate streams). Backpressure is
-    // 503; clients should retry with backoff.
+    // Acquire a request slot before touching the engine. Contended streams
+    // no longer block a tokio worker (#122: they park on a failed `try_lock`,
+    // and submits go out via `spawn_blocking`), so this gate is not what
+    // keeps the runtime alive — it bounds the two resources that are still
+    // finite: the engine's own queue/slot depth, and the blocking pool the
+    // submits land on. Backpressure is 503; clients should retry with
+    // backoff.
     let permit = match state.permits.clone().try_acquire_owned() {
         Ok(p) => p,
         Err(_) => {

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1183,7 +1183,7 @@ async fn chat_completions(
     // until the task completes; drop frees the slot.
     let _permit = permit;
     let _inflight = inflight;
-    let mut chunk_stream = match state.runner.generate(task.clone()) {
+    let mut chunk_stream = match state.runner.generate_async(task.clone()).await {
         Ok(s) => s,
         Err(err) => return engine_error_response(err),
     };
@@ -1381,7 +1381,7 @@ async fn completions(
 
     let _permit = permit;
     let _inflight = inflight;
-    let mut chunk_stream = match state.runner.generate(task) {
+    let mut chunk_stream = match state.runner.generate_async(task).await {
         Ok(s) => s,
         Err(err) => return engine_error_response(err),
     };
@@ -1476,7 +1476,7 @@ async fn stream_text_completion(
     include_usage: bool,
 ) -> axum::response::Response {
     let task_id = task.task_id.clone();
-    let chunk_stream = match state.runner.generate(task) {
+    let chunk_stream = match state.runner.generate_async(task).await {
         Ok(s) => s,
         Err(err) => {
             warn!(error = %err, "completions-stream: generate failed");
@@ -1599,7 +1599,7 @@ async fn stream_completion(
     let task_id = task.task_id.clone();
     let _ = SystemTime::now();
 
-    let chunk_stream = match state.runner.generate(task) {
+    let chunk_stream = match state.runner.generate_async(task).await {
         Ok(s) => s,
         Err(err) => {
             warn!(error = %err, "ov-stream: generate failed");

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1527,23 +1527,13 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
         if args.packed_slots < 2 {
             return Err(anyhow!("--packed-slots must be 0 (off) or >= 2"));
         }
-        // Multi-stage packed is withheld pending a wire fault. The mechanism
-        // works — stage 0 ships an I64 [1,3,S] plan frame (slot, absolute
-        // position and prefix-reuse length per row) ahead of the [1,S,hidden]
-        // block, and the tail replies one token per row — but a token frame
-        // intermittently goes missing between the ranks, and rank 0 then blocks
-        // forever on a reply that never comes. Instrumented on NPU: rank 1
-        // logged the reply and advanced, rank 0 never saw it, no error on
-        // either side. Reproduces after sustained load, roughly two runs in
-        // three. Single-stage is unaffected and verified.
-        if args.total != 1 {
-            return Err(anyhow!(
-                "--packed-slots is single-stage only (--total 1); multi-stage packed can lose a \
-                 token frame between ranks and wedge the pipeline (issue #122). Run the packed \
-                 worker as a single stage, or drop --packed-slots to use the multi-stage baseline \
-                 path"
-            ));
-        }
+        // Multi-stage packed is allowed again: the #122 wedge was driver
+        // starvation on rank 0 (sync engine-mutex blocking pinned every
+        // tokio worker, so the token-frame reply could neither be read nor
+        // timed out), fixed in cascadia-runner (non-blocking poll/submit/
+        // cancel) plus deadlined+poisoning reply recvs and an on-wire NACK
+        // in the packed exchange. Every stage must run the same
+        // --packed-slots value (baked into the packed IR shape).
     }
     // Continuous batching (#20) lives in the ov-genai CBP path only. It is a
     // different mechanism to --packed-slots above: OV's paged attention on the
@@ -2398,7 +2388,10 @@ mod python_tests {
     }
 
     /// Packed multi-slot decode is an ov-runtime static-path feature; using it
-    /// on another engine, at N<2, or multi-stage is rejected loudly.
+    /// on another engine or at N<2 is rejected loudly. Multi-stage packed is
+    /// ACCEPTED again — the #122 wedge (worker-thread starvation on rank 0)
+    /// is fixed, so the old `--total 1` gate would only block a working
+    /// configuration.
     #[test]
     fn worker_flags_gate_packed_slots() {
         let mut a = worker("m", EngineKind::OvGenai);
@@ -2411,15 +2404,10 @@ mod python_tests {
         let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
         assert!(err.contains(">= 2"), "{err}");
 
-        // Multi-stage packed wedges: a token frame goes missing on the wire and
-        // rank 0 blocks on a reply that never arrives. Refuse it rather than
-        // hand an operator a pipeline that hangs after a while under load.
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;
         a.total = 2;
-        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
-        assert!(err.contains("--total 1"), "{err}");
-        assert!(err.contains("single-stage"), "{err}");
+        assert!(validate_worker_runtime_flags(&a).is_ok());
 
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 8;

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1543,10 +1543,12 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
         // Multi-stage packed is allowed again: the #122 wedge was driver
         // starvation on rank 0 (sync engine-mutex blocking pinned every
         // tokio worker, so the token-frame reply could neither be read nor
-        // timed out), fixed in cascadia-runner (non-blocking poll/submit/
-        // cancel) plus deadlined+poisoning reply recvs and an on-wire NACK
-        // in the packed exchange. Every stage must run the same
-        // --packed-slots value (baked into the packed IR shape).
+        // timed out), fixed in cascadia-runner (tokio workers never block on
+        // the engine mutex: polls park on a failed try_lock, cancels/drops
+        // defer, and submits go off-worker via spawn_blocking) plus
+        // deadlined+poisoning reply recvs and an on-wire NACK in the packed
+        // exchange. Every stage must run the same --packed-slots value
+        // (baked into the packed IR shape).
     }
     // Continuous batching (#20) lives in the ov-genai CBP path only. It is a
     // different mechanism to --packed-slots above: OV's paged attention on the

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1516,6 +1516,19 @@ fn validate_worker_runtime_flags(args: &WorkerArgs) -> Result<()> {
              KV window)"
         ));
     }
+    // Prefix reuse is first-stage-only state. Only rank 0 admits requests, and
+    // admission is what populates the shared prefix region; a relay stage never
+    // admits, so its `prefix_valid` stays 0 and it clamps every plan row's reuse
+    // length to 0. Rank 0 would then skip prefilling the reused tokens while the
+    // downstream stages hold no KV for them — wrong tokens, no error, on any rank.
+    if args.packed_prefix > 0 && args.total != 1 {
+        return Err(anyhow!(
+            "--packed-prefix is single-stage only (--total 1); a relay stage cannot populate the \
+             shared prefix, so it would open zero shared columns for the prompt tokens rank 0 \
+             skipped prefilling and silently corrupt multi-stage output. Drop --packed-prefix to \
+             keep packed multi-stage decode, or run the worker as a single stage"
+        ));
+    }
     // Packed multi-slot decode lives in the ov-runtime static (NPU-target) path.
     if args.packed_slots > 0 {
         if args.engine != EngineKind::OvRuntime {
@@ -2422,6 +2435,39 @@ mod python_tests {
         let mut a = worker("m", EngineKind::OvRuntime);
         a.packed_slots = 4;
         a.packed_prefix = 128;
+        assert!(validate_worker_runtime_flags(&a).is_ok());
+    }
+
+    /// Prefix reuse is first-stage-only state: only rank 0 admits requests, and
+    /// admission is what fills the shared prefix region, so a relay stage clamps
+    /// every plan row's reuse to 0 and holds no KV for the tokens rank 0 skipped
+    /// prefilling — wrong output with no error anywhere. Rejected at the CLI
+    /// until relay-side prefix population exists. Multi-stage packed WITHOUT
+    /// --packed-prefix must stay accepted (it was un-gated deliberately).
+    #[test]
+    fn worker_flags_gate_packed_prefix_multi_stage() {
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 4;
+        a.packed_prefix = 128;
+        a.total = 2;
+        let err = validate_worker_runtime_flags(&a).unwrap_err().to_string();
+        assert!(
+            err.contains("--packed-prefix is single-stage only"),
+            "{err}"
+        );
+        assert!(err.contains("--total 1"), "{err}");
+
+        // Single stage is the supported configuration.
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 4;
+        a.packed_prefix = 128;
+        a.total = 1;
+        assert!(validate_worker_runtime_flags(&a).is_ok());
+
+        // Packed multi-stage decode without prefix reuse is untouched.
+        let mut a = worker("m", EngineKind::OvRuntime);
+        a.packed_slots = 4;
+        a.total = 2;
         assert!(validate_worker_runtime_flags(&a).is_ok());
     }
 

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -2003,7 +2003,11 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
             enable_thinking: false,
             trust_remote_code: false,
         };
-        let mut stream = runner.generate(task)?;
+        // `generate_async`, not `generate`: this loop runs on the tokio
+        // runtime, and the sync path would block a worker on the engine
+        // mutex for a full step (#122). Benign while stdin is serial, but
+        // it is the exact pattern the API layer had to unwind.
+        let mut stream = runner.generate_async(task).await?;
         while let Some(chunk) = stream.next().await {
             print!("{}", chunk.text);
             if chunk.is_final {

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -475,6 +475,27 @@ fn decode_wire_tokens(t: &WireTensor) -> EngineResult<Vec<i32>> {
         .collect())
 }
 
+/// Type the error that retires an in-flight packed batch.
+///
+/// A lost batch is not a lost link, and [`EngineError::BatchAborted`] says so
+/// structurally instead of leaving the answer to whichever substrings the
+/// message happens to carry — abort messages quote their cause, and that
+/// cause is routinely a transport failure on some *other* rank's socket.
+///
+/// A cause that is itself connection-fatal (this stage's own poisoned or dead
+/// socket) is passed through untouched: that link really is gone, and
+/// anything downstream of here that classifies the error — the relay loop
+/// today, a dead-wire latch later — must still see it as fatal.
+fn packed_abort_error(e: EngineError) -> EngineError {
+    match e {
+        // Already a lost batch (a downstream NACK relayed up to this stage):
+        // reuse it rather than wrapping the same words twice.
+        already @ EngineError::BatchAborted(_) => already,
+        fatal if fatal.is_connection_fatal() => fatal,
+        other => EngineError::BatchAborted(format!("the packed step failed: {other}")),
+    }
+}
+
 /// The relay failed to answer its upstream. When the step it was answering
 /// for ALSO failed, the send error on its own hides why the batch died — and
 /// those two failures are correlated, not independent: a dead upstream is
@@ -1648,12 +1669,20 @@ impl OvRuntimeEngine {
         mut out: Vec<(TaskId, Chunk)>,
     ) -> EngineResult<Vec<(TaskId, Chunk)>> {
         warn!(error = %e, "packed step failed; aborting the in-flight packed batch");
+        let aborted = packed_abort_error(e);
+        // A `BatchAborted` already says "batch aborted: …" in its Display;
+        // a cause left connection-fatal keeps its own wording, so name the
+        // abort for the client here rather than prefixing it twice.
+        let msg = match &aborted {
+            EngineError::BatchAborted(_) => aborted.to_string(),
+            fatal => format!("packed batch aborted: {fatal}"),
+        };
         let packed = self.packed.as_mut().unwrap();
         for slot in 0..packed.slots.len() {
             if let Some(ps) = packed.retire(slot) {
                 out.push((
                     ps.task.task_id.clone(),
-                    Chunk::error(ps.task.task_id, format!("packed batch aborted: {e}")),
+                    Chunk::error(ps.task.task_id, msg.clone()),
                 ));
             }
         }
@@ -1705,7 +1734,8 @@ impl OvRuntimeEngine {
             // poisoned-socket errors ("recv_exact timed out" / "not
             // connected") are connection-fatal, so a middle rank's relay
             // loop exits for a supervisor rebuild rather than grinding on a
-            // desynced stream.
+            // desynced stream. Those keep their `Backend` type on purpose:
+            // the link really is dead, and that classification must survive.
             let (reply, _) = if prefill {
                 guard.recv_reply_prefill().await
             } else {
@@ -1716,8 +1746,15 @@ impl OvRuntimeEngine {
             // `step_relay_packed`): its step failed AFTER it consumed our
             // pair, so the batch is lost but the link is still
             // frame-aligned. Abort the batch; do not poison the connection.
+            //
+            // `BatchAborted`, not `Backend`: this error travels up a middle
+            // rank's relay loop, which must back off and keep driving rather
+            // than exit for a supervisor rebuild. The variant says "healthy
+            // link" structurally instead of relying on this message never
+            // happening to contain a word the fatal-substring classifier
+            // looks for.
             if reply.elements() == Some(0) {
-                return Err(EngineError::Backend(
+                return Err(EngineError::BatchAborted(
                     "downstream stage failed its packed step and NACKed this batch \
                      (empty token frame); the pipeline link stays aligned"
                         .into(),
@@ -4157,6 +4194,34 @@ mod tests {
         assert!(decode_wire_tokens(&nack).is_err()); // NACK check must come first
         let real = encode_wire_tokens(&[7]);
         assert_ne!(real.elements(), Some(0));
+    }
+
+    /// Aborting a packed batch types its cause, so classification never rides
+    /// on the message text. A downstream NACK or a plain step failure lost the
+    /// batch, not the link, and must not push a relay rank into a rebuild — but
+    /// this stage's own dead socket has to stay connection-fatal.
+    #[test]
+    fn packed_abort_error_types_the_cause() {
+        // A downstream NACK arrives already typed — no double wrapping.
+        let nack = EngineError::BatchAborted("downstream NACKed this batch".into());
+        let out = packed_abort_error(nack);
+        assert_eq!(
+            out.to_string(),
+            "batch aborted: downstream NACKed this batch"
+        );
+        assert!(!out.is_connection_fatal());
+
+        // A local step failure becomes an abort, keeping its cause readable.
+        let out = packed_abort_error(EngineError::Backend("bad logits shape [1, 0]".into()));
+        assert!(matches!(out, EngineError::BatchAborted(_)), "{out:?}");
+        assert!(out.to_string().contains("bad logits shape [1, 0]"), "{out}");
+        assert!(!out.is_connection_fatal());
+
+        // This stage's own poisoned socket keeps its type AND its fatality.
+        let dead = EngineError::Backend("packed token recv: recv_exact timed out after 60s".into());
+        let out = packed_abort_error(dead);
+        assert!(matches!(out, EngineError::Backend(_)), "{out:?}");
+        assert!(out.is_connection_fatal(), "{out}");
     }
 
     /// A dead upstream fails the step AND the NACK that reports it, so the two

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -475,6 +475,38 @@ fn decode_wire_tokens(t: &WireTensor) -> EngineResult<Vec<i32>> {
         .collect())
 }
 
+/// The NACK a stage sends instead of a token reply: an EMPTY token frame,
+/// `[1, 1, 0]` I64 with no payload.
+///
+/// A stage that has consumed a (plan, hidden) pair OWES its upstream a reply,
+/// so a failed step must still answer — and this is the answer that means
+/// "the batch is lost, the link is not". Emptiness is what carries that: the
+/// frame is wire-valid (shape and payload agree, so the stream stays aligned)
+/// while a real reply always carries one token per row and can never be
+/// empty. Paired with [`is_packed_nack`] deliberately — the sender and the
+/// recogniser have to agree on one shape, so they are defined together and
+/// tested together.
+fn packed_nack_frame() -> WireTensor {
+    encode_wire_tokens(&[])
+}
+
+/// Is this reply the downstream's NACK rather than a token frame?
+///
+/// The test is "carries no tokens" — a zero element count, exactly what
+/// [`packed_nack_frame`] sends and exactly what a real reply (one token per
+/// row, rows >= 1) can never be.
+///
+/// Deliberately NOT an equality check against the whole frame: a zero-element
+/// frame holds no tokens whatever its dtype byte claims, so reading it as a
+/// lost batch is right either way, and a stricter test would instead hand it
+/// to [`decode_wire_tokens`] to be reported as wire corruption.
+///
+/// Call this BEFORE `decode_wire_tokens`, which rejects an empty payload as
+/// malformed and would otherwise turn every NACK into a bogus frame error.
+fn is_packed_nack(reply: &WireTensor) -> bool {
+    reply.elements() == Some(0)
+}
+
 /// Type the error that retires an in-flight packed batch.
 ///
 /// A lost batch is not a lost link, and [`EngineError::BatchAborted`] says so
@@ -1876,7 +1908,7 @@ impl OvRuntimeEngine {
             // link" structurally instead of relying on this message never
             // happening to contain a word the fatal-substring classifier
             // looks for.
-            if reply.elements() == Some(0) {
+            if is_packed_nack(&reply) {
                 return Err(EngineError::BatchAborted(
                     "downstream stage failed its packed step and NACKed this batch \
                      (empty token frame); the pipeline link stays aligned"
@@ -1980,7 +2012,7 @@ impl OvRuntimeEngine {
                 // operator. This rank is where the batch actually died, so
                 // this is where the reason has to be recorded.
                 warn!(error = %e, "packed relay step failed; NACKing the upstream");
-                encode_wire_tokens(&[])
+                packed_nack_frame()
             }
         };
         let sent = self.block_on(async {
@@ -4322,18 +4354,44 @@ mod tests {
 
     /// The relay's NACK is an EMPTY token frame — it must be wire-valid
     /// (shape/payload consistent so the transport delivers it), detectable
-    /// via `elements() == 0` BEFORE `decode_wire_tokens` (which rejects
-    /// empties as malformed), and impossible to confuse with a real reply
-    /// (a real reply always carries one token per row, S >= 1).
+    /// BEFORE `decode_wire_tokens` (which rejects empties as malformed), and
+    /// impossible to confuse with a real reply (a real reply always carries
+    /// one token per row, S >= 1).
+    ///
+    /// Pinned to the NAMED pair, [`packed_nack_frame`] + [`is_packed_nack`],
+    /// rather than to an open-coded `elements() == 0`: the sender and the
+    /// recogniser only work if they agree, and an anonymous predicate at the
+    /// consumer could drift from the producer without anything failing here.
     #[test]
     fn packed_nack_frame_is_empty_and_detectable() {
-        let nack = encode_wire_tokens(&[]);
+        let nack = packed_nack_frame();
+        // The frame the relay puts on the wire is exactly "no tokens".
+        assert_eq!(nack, encode_wire_tokens(&[]));
         assert_eq!(nack.shape, [1, 1, 0]);
         assert!(nack.data.is_empty());
         assert_eq!(nack.elements(), Some(0));
+        // Same dtype as a real token reply: only the emptiness distinguishes
+        // it, so a peer reading the header cannot mistake it for a hidden
+        // state or a plan frame.
+        assert_eq!(nack.dtype, WireDType::I64);
+        // Payload length and shape agree, or the transport would reject the
+        // frame outright and the NACK would never arrive.
+        assert_eq!(
+            nack.data.len() as u64,
+            nack.elements().unwrap() * nack.dtype.bytes_per_element() as u64
+        );
+        assert!(is_packed_nack(&nack));
         assert!(decode_wire_tokens(&nack).is_err()); // NACK check must come first
-        let real = encode_wire_tokens(&[7]);
-        assert_ne!(real.elements(), Some(0));
+
+        // No real reply is ever mistaken for one, at any row count — and
+        // each of them still decodes to exactly its tokens.
+        for rows in 1..=8usize {
+            let toks: Vec<i32> = (0..rows as i32).collect();
+            let real = encode_wire_tokens(&toks);
+            assert!(!is_packed_nack(&real), "{rows}-row reply read as a NACK");
+            assert_ne!(real.elements(), Some(0));
+            assert_eq!(decode_wire_tokens(&real).expect("real reply"), toks);
+        }
     }
 
     /// Aborting a packed batch types its cause, so classification never rides

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -475,6 +475,23 @@ fn decode_wire_tokens(t: &WireTensor) -> EngineResult<Vec<i32>> {
         .collect())
 }
 
+/// The relay failed to answer its upstream. When the step it was answering
+/// for ALSO failed, the send error on its own hides why the batch died — and
+/// those two failures are correlated, not independent: a dead upstream is
+/// precisely the case where the NACK cannot be delivered either. So carry
+/// both in one error.
+///
+/// The send error stays outermost: it is the transport failure, and its text
+/// is what [`EngineError::is_connection_fatal`] inspects to decide whether the
+/// relay loop exits for a supervisor rebuild. Embedding the body error's text
+/// after it keeps the root cause visible without hiding the link failure.
+fn nack_send_error(send_err: EngineError, body_err: Option<&EngineError>) -> EngineError {
+    match body_err {
+        Some(body) => EngineError::Backend(format!("{send_err} (NACK sent because: {body})")),
+        None => send_err,
+    }
+}
+
 /// Decode + strictly validate a wire position frame. Must be I64 with exactly
 /// 8 payload bytes and non-negative; anything else (a desynced stream, a
 /// stateful peer that sent a hidden tensor where a position was expected, or
@@ -1796,15 +1813,26 @@ impl OvRuntimeEngine {
         let step = self.relay_packed_body(plan_res, hidden, hshape);
         let frame = match &step {
             Ok(tokens) => encode_wire_tokens(tokens),
-            Err(_) => encode_wire_tokens(&[]),
+            Err(e) => {
+                // Log the root cause HERE, before the NACK goes out: a dead
+                // upstream is exactly when the send fails too, and then the
+                // send error is the only thing that would ever reach the
+                // operator. This rank is where the batch actually died, so
+                // this is where the reason has to be recorded.
+                warn!(error = %e, "packed relay step failed; NACKing the upstream");
+                encode_wire_tokens(&[])
+            }
         };
-        self.block_on(async {
+        let sent = self.block_on(async {
             let mut guard = up.lock().await;
             guard
                 .send(&frame)
                 .await
                 .map_err(|e| EngineError::Backend(format!("packed token send: {e}")))
-        })?;
+        });
+        if let Err(send_err) = sent {
+            return Err(nack_send_error(send_err, step.as_ref().err()));
+        }
         step.map(|_| ())
     }
 
@@ -4129,6 +4157,34 @@ mod tests {
         assert!(decode_wire_tokens(&nack).is_err()); // NACK check must come first
         let real = encode_wire_tokens(&[7]);
         assert_ne!(real.elements(), Some(0));
+    }
+
+    /// A dead upstream fails the step AND the NACK that reports it, so the two
+    /// arrive together. Returning only the send error would drop the reason
+    /// the batch died — the operator would see "packed token send: …" and
+    /// never learn it was a plan decode error, a failed inference, or a
+    /// downstream NACK. Both texts must survive, and the send error must stay
+    /// classifiable so the relay loop still exits for a supervisor rebuild.
+    #[test]
+    fn nack_send_failure_carries_the_step_error_too() {
+        let send = EngineError::Backend("packed token send: broken pipe".into());
+        let body = EngineError::Backend("packed plan decode: slot 9 beyond 4 slots".into());
+        let combined = nack_send_error(send, Some(&body));
+        let msg = combined.to_string();
+        assert!(msg.contains("packed token send: broken pipe"), "{msg}");
+        assert!(msg.contains("slot 9 beyond 4 slots"), "{msg}");
+        // The transport failure still classifies: a dead link must not be
+        // downgraded to a retryable error just because it now carries context.
+        assert!(combined.is_connection_fatal(), "{msg}");
+
+        // A successful step that merely failed to send back keeps the send
+        // error untouched — there is no root cause to attach.
+        let send = EngineError::Backend("packed token send: broken pipe".into());
+        let alone = nack_send_error(send, None);
+        assert_eq!(
+            alone.to_string(),
+            "backend error: packed token send: broken pipe"
+        );
     }
 
     /// Prefill chunks (several rows for one slot) get the widened reply

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -43,7 +43,7 @@ use cascadia_types::{Chunk, GenerationTask, LoadProgress, PeerLayout, ShardSpec,
 use futures::stream;
 use serde::Deserialize;
 use tokenizers::Tokenizer;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::rotary::{load_model_config, Rotary};
 use crate::warn_limit::{StepWarn, StepWarnLimiter};
@@ -496,6 +496,93 @@ fn packed_abort_error(e: EngineError) -> EngineError {
     }
 }
 
+/// The client-facing text every task retired by one aborted packed batch
+/// receives. A [`EngineError::BatchAborted`] already reads "batch aborted: …"
+/// in its Display, and a cause left connection-fatal keeps its own wording, so
+/// name the abort here rather than prefixing it twice.
+fn packed_abort_message(aborted: &EngineError) -> String {
+    match aborted {
+        EngineError::BatchAborted(_) => aborted.to_string(),
+        fatal => format!("packed batch aborted: {fatal}"),
+    }
+}
+
+/// One-way latch: this stage's packed downstream link is dead for the rest of
+/// the process.
+///
+/// A reply-deadline miss POISONS the downstream socket (the transport drops
+/// it, so every later use answers `NotConnected`), and nothing reconnects:
+/// [`ActivationClient`] dials once, at startup. On a relay rank that is
+/// survivable — the step error is connection-fatal, the relay loop exits, and
+/// the supervisor rebuilds the stage. Rank 0 has no relay loop: it is driven
+/// by stream polls, so it would otherwise admit every new request, run the
+/// local prefill, fail the exchange on a socket that can never come back, and
+/// abort the batch — 100% failures, forever, behind one uniform per-batch WARN
+/// while the rebuilt relay ranks sit in `accept()`.
+///
+/// The latch turns that into fail-fast-and-loud: the first fatal cause is
+/// recorded once (with an `error!` naming the restart as the remedy) and every
+/// later request is refused immediately, before any local inference is burned.
+/// It is deliberately NOT a recovery mechanism — see [`Self::fail_fast_error`].
+#[derive(Default)]
+struct WireDeadLatch {
+    /// Display text of the FIRST connection-fatal cause observed. `Some` means
+    /// latched; the value is kept for attribution, never re-classified.
+    cause: Option<String>,
+}
+
+impl WireDeadLatch {
+    /// Feed the typed cause that just retired a packed batch.
+    ///
+    /// Classification is structural — [`EngineError::is_connection_fatal`] on
+    /// the typed value, exactly as `packed_abort_error` left it. The message is
+    /// only ever stored, never re-parsed: a batch abort whose text happens to
+    /// quote some other rank's transport failure must not arm this latch, and
+    /// [`EngineError::BatchAborted`] answers `false` before any substring is
+    /// examined.
+    ///
+    /// Returns `true` on the latching transition ONLY — the caller logs there,
+    /// so the operator-facing error is emitted once per process rather than
+    /// once per aborted batch. Later fatal causes are redundant (the first one
+    /// killed the link) and leave the stored cause untouched.
+    fn observe(&mut self, aborted: &EngineError) -> bool {
+        if self.cause.is_some() || !aborted.is_connection_fatal() {
+            return false;
+        }
+        self.cause = Some(aborted.to_string());
+        true
+    }
+
+    /// The first fatal cause, once latched.
+    fn cause(&self) -> Option<&str> {
+        self.cause.as_deref()
+    }
+
+    /// The error every request gets while latched, or `None` when the wire is
+    /// still believed good.
+    ///
+    /// Two properties are load-bearing:
+    ///
+    /// * It is `Backend` carrying the literal "not connected", so
+    ///   [`EngineError::is_connection_fatal`] answers `true` — fatality stays
+    ///   observable to any supervisor plumbing added later. It must never be
+    ///   [`EngineError::BatchAborted`], which is structurally non-fatal. The
+    ///   phrase is written here rather than inherited from `cause`, because the
+    ///   stored text need not match the classifier at all (a latch armed by the
+    ///   structural [`EngineError::NotConnected`] displays as "not YET
+    ///   connected", which no substring rule catches).
+    /// * It quotes the original cause, so the operator and the SSE client both
+    ///   learn what actually killed the link, not just that it is gone.
+    fn fail_fast_error(&self) -> Option<EngineError> {
+        self.cause.as_deref().map(|cause| {
+            EngineError::Backend(format!(
+                "packed downstream link is not connected: this stage latched a dead wire and \
+                 fails every request until the process is restarted (first cause: {cause})"
+            ))
+        })
+    }
+}
+
 /// The relay failed to answer its upstream. When the step it was answering
 /// for ALSO failed, the send error on its own hides why the batch died — and
 /// those two failures are correlated, not independent: a dead upstream is
@@ -937,6 +1024,11 @@ pub struct OvRuntimeEngine {
     /// Reload source for a parked prefill model.
     prefill_reload: Option<PrefillReload>,
     step_warn: StepWarnLimiter,
+    /// Packed path only: armed the first time a packed batch dies of this
+    /// stage's own dead downstream socket. Once armed, `submit` and
+    /// `step_first_packed` refuse work immediately instead of serving
+    /// guaranteed failures for the life of the process. See [`WireDeadLatch`].
+    wire_dead: WireDeadLatch,
 }
 
 impl OvRuntimeEngine {
@@ -1580,6 +1672,28 @@ impl OvRuntimeEngine {
     /// several tasks at once — which is exactly what the runner's per-task
     /// chunk buffers were built to demultiplex.
     fn step_first_packed(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        // ---- dead-wire latch ----
+        // The downstream socket is poisoned for the life of this process, so
+        // every exchange below can only fail — after tokenizing, admitting and
+        // running a shared local inference first. Short-circuit ahead of all of
+        // it. Whatever the engine still holds is retired through the SAME abort
+        // machinery a live failure uses, so per-task attribution and slot
+        // release happen exactly once; queued-but-unadmitted tasks are folded
+        // into the same answer instead of sitting in the queue until the runner
+        // gives up on their streams.
+        if let Some(fatal) = self.wire_dead.fail_fast_error() {
+            if self.pending.is_empty() && self.packed.as_ref().unwrap().occupied() == 0 {
+                return Ok(Vec::new());
+            }
+            let msg = packed_abort_message(&fatal);
+            let out = self
+                .pending
+                .drain(..)
+                .map(|t| (t.task_id.clone(), Chunk::error(t.task_id, msg.clone())))
+                .collect();
+            return self.abort_packed_batch(fatal, out);
+        }
+
         let mut out = Vec::new();
         // ---- admission ----
         while !self.pending.is_empty() {
@@ -1659,10 +1773,12 @@ impl OvRuntimeEngine {
 
     /// A packed step failed in a way that loses the in-flight batch: retire
     /// every active slot (freeing its KV region) and hand each task its own
-    /// final error chunk. The single-task recovery in `step_first_body`
-    /// cannot express a multi-task failure. Slot state downstream is stale
-    /// but harmless — the next admission resets its slot in-band (a row
-    /// whose position equals its reuse length starts that slot fresh).
+    /// final error chunk. The single-task recovery in `step_first` (the
+    /// wrapper around `step_first_body`, which the packed path returns before
+    /// ever reaching) cannot express a multi-task failure. Slot state
+    /// downstream is stale but harmless — the next admission resets its slot
+    /// in-band (a row whose position equals its reuse length starts that slot
+    /// fresh).
     fn abort_packed_batch(
         &mut self,
         e: EngineError,
@@ -1670,13 +1786,20 @@ impl OvRuntimeEngine {
     ) -> EngineResult<Vec<(TaskId, Chunk)>> {
         warn!(error = %e, "packed step failed; aborting the in-flight packed batch");
         let aborted = packed_abort_error(e);
-        // A `BatchAborted` already says "batch aborted: …" in its Display;
-        // a cause left connection-fatal keeps its own wording, so name the
-        // abort for the client here rather than prefixing it twice.
-        let msg = match &aborted {
-            EngineError::BatchAborted(_) => aborted.to_string(),
-            fatal => format!("packed batch aborted: {fatal}"),
-        };
+        // The cause is typed, and `packed_abort_error` has already decided
+        // whether it is this stage's own dead socket or merely a lost batch —
+        // hand the VALUE to the latch, which asks `is_connection_fatal()`
+        // rather than re-reading these words. `observe` answers true exactly
+        // once, so this is a transition log, not per-batch noise.
+        if self.wire_dead.observe(&aborted) {
+            error!(
+                cause = %aborted,
+                "packed downstream link is dead and cannot be reconnected in-process; this \
+                 stage now fails every request immediately — restart the process to rebuild \
+                 the pipeline connection"
+            );
+        }
+        let msg = packed_abort_message(&aborted);
         let packed = self.packed.as_mut().unwrap();
         for slot in 0..packed.slots.len() {
             if let Some(ps) = packed.retire(slot) {
@@ -2825,6 +2948,22 @@ impl Engine for OvRuntimeEngine {
                 "non-first stage does not accept tasks directly".into(),
             ));
         }
+        // Dead-wire latch: refuse before the request costs anything. This is
+        // synchronous with the HTTP request, so the non-streaming path answers
+        // 5xx (and the API's readiness tracker sees a failure) rather than
+        // committing a 200 and delivering the same error inside a stream, and a
+        // streaming client gets an attributed error immediately instead of
+        // after a full local prefill. Connection-fatal by construction — see
+        // `WireDeadLatch::fail_fast_error`.
+        // DEBUG, not WARN: the latching `error!` is the operator signal, and it
+        // is emitted once on purpose — a per-request WARN would flood exactly
+        // the log the operator has to read it out of, at the request rate. Each
+        // refusal is already visible to the caller as an attributed 5xx.
+        if let Some(fatal) = self.wire_dead.fail_fast_error() {
+            debug!(task = %task.task_id, cause = self.wire_dead.cause().unwrap_or_default(),
+                   "refusing task: packed downstream link is dead");
+            return Err(fatal);
+        }
         if self.pending.iter().any(|t| t.task_id == task.task_id)
             || self
                 .active
@@ -3959,6 +4098,7 @@ impl Builder for OvRuntimeBuilder {
             park_prefill: self.park_prefill,
             prefill_reload: self.prefill_reload,
             step_warn: StepWarnLimiter::default(),
+            wire_dead: WireDeadLatch::default(),
         }))
     }
 }
@@ -4250,6 +4390,112 @@ mod tests {
             alone.to_string(),
             "backend error: packed token send: broken pipe"
         );
+    }
+
+    /// The dead-wire latch arms on this stage's own dead socket and on
+    /// nothing else. A lost batch (a downstream NACK, a bad plan, a failed
+    /// inference) leaves a working link and MUST leave the engine serving —
+    /// arming there would take a healthy rank 0 permanently offline on one
+    /// unlucky batch.
+    #[test]
+    fn wire_dead_latch_arms_only_on_a_connection_fatal_cause() {
+        let mut latch = WireDeadLatch::default();
+        assert!(latch.cause().is_none());
+        assert!(latch.fail_fast_error().is_none());
+
+        // A downstream NACK: structurally non-fatal, whatever it says.
+        assert!(!latch.observe(&EngineError::BatchAborted(
+            "downstream stage failed its packed step and NACKed this batch".into()
+        )));
+        // Even one quoting words the substring classifier hunts for — the
+        // dead socket in that text belongs to some OTHER rank.
+        assert!(!latch.observe(&EngineError::BatchAborted(
+            "the packed step failed: backend error: packed token recv: broken pipe".into()
+        )));
+        // A plain local step failure.
+        assert!(!latch.observe(&EngineError::Backend(
+            "packed plan decode: slot 9 beyond 4 slots".into()
+        )));
+        assert!(latch.cause().is_none(), "{:?}", latch.cause());
+        assert!(latch.fail_fast_error().is_none());
+
+        // This stage's own poisoned socket, as `packed_abort_error` passes it
+        // through: fatal, and it arms the latch.
+        let dead = packed_abort_error(EngineError::Backend(
+            "packed token recv: recv_exact timed out after 60s".into(),
+        ));
+        assert!(latch.observe(&dead));
+        let cause = latch.cause().expect("latched");
+        assert!(cause.contains("recv_exact timed out after 60s"), "{cause}");
+    }
+
+    /// Once latched, every request is refused with an error that is (a)
+    /// connection-fatal, so the failure stays visible to the API's readiness
+    /// tracker and to any supervisor plumbing added later, (b) never
+    /// `BatchAborted`, which is fatality-false by construction, and (c)
+    /// carrying the original cause so the operator learns what killed the wire.
+    #[test]
+    fn latched_wire_fails_fast_with_a_connection_fatal_error() {
+        let mut latch = WireDeadLatch::default();
+        latch.observe(&EngineError::Backend(
+            "packed token recv: recv_exact timed out after 60s".into(),
+        ));
+        let err = latch.fail_fast_error().expect("latched");
+        assert!(matches!(err, EngineError::Backend(_)), "{err:?}");
+        assert!(err.is_connection_fatal(), "{err}");
+        let msg = err.to_string();
+        assert!(msg.contains("recv_exact timed out after 60s"), "{msg}");
+        assert!(msg.contains("restart"), "{msg}");
+
+        // Fatality must not depend on the stored cause's wording. `NotConnected`
+        // is fatal STRUCTURALLY and displays as "not YET connected", which no
+        // substring rule matches — a fail-fast error that merely echoed the
+        // cause would silently become non-fatal here.
+        let mut latch = WireDeadLatch::default();
+        assert!(EngineError::NotConnected.is_connection_fatal());
+        assert!(!EngineError::NotConnected.to_string().contains(
+            // the classifier's substring, absent from this Display
+            "not connected"
+        ));
+        latch.observe(&EngineError::NotConnected);
+        let err = latch.fail_fast_error().expect("latched");
+        assert!(err.is_connection_fatal(), "{err}");
+        // And the chunk text a retired task receives names the abort once.
+        let chunk_msg = packed_abort_message(&err);
+        assert!(
+            chunk_msg.starts_with("packed batch aborted: "),
+            "{chunk_msg}"
+        );
+        assert!(
+            !chunk_msg.contains("batch aborted: batch aborted"),
+            "{chunk_msg}"
+        );
+    }
+
+    /// The operator-facing `error!` fires on the LATCHING TRANSITION only —
+    /// `observe` returns true exactly once, so a stage that keeps aborting
+    /// batches does not re-log the same dead link per batch. The first cause
+    /// is also the one kept: it is the failure that actually killed the wire,
+    /// every later one is a consequence.
+    #[test]
+    fn wire_dead_latch_transition_reports_once_and_keeps_the_first_cause() {
+        let mut latch = WireDeadLatch::default();
+        assert!(latch.observe(&EngineError::Backend(
+            "packed token recv: recv_exact timed out after 60s".into()
+        )));
+        // Every later fatal cause: no transition, no overwrite.
+        for _ in 0..3 {
+            assert!(!latch.observe(&EngineError::NotConnected));
+            assert!(!latch.observe(&EngineError::Backend(
+                "packed plan send: not connected".into()
+            )));
+        }
+        let cause = latch.cause().expect("latched");
+        assert!(cause.contains("recv_exact timed out after 60s"), "{cause}");
+        assert!(!cause.contains("packed plan send"), "{cause}");
+        // A benign cause after latching cannot disarm it either.
+        assert!(!latch.observe(&EngineError::BatchAborted("lost batch".into())));
+        assert!(latch.fail_fast_error().is_some());
     }
 
     /// Prefill chunks (several rows for one slot) get the widened reply

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -433,6 +433,19 @@ fn decode_wire_plan(
     Ok(out)
 }
 
+/// True when a packed plan carries a prefill chunk: some slot owns more than
+/// one row (decode frames have at most one row per slot). Picks the token
+/// reply's deadline budget — a prefill reply waits on multi-token compute
+/// across every remaining stage. A single-row prefill chunk is
+/// indistinguishable from a decode row here and gets the strict decode
+/// deadline, which a one-row tail inference fits comfortably.
+fn plan_has_prefill_rows(rows: &[Option<(usize, i64, usize)>]) -> bool {
+    let mut seen = std::collections::HashSet::new();
+    rows.iter()
+        .flatten()
+        .any(|(slot, _, _)| !seen.insert(*slot))
+}
+
 /// Encode the head stage's per-row sampled tokens as I64 `[1, 1, S]`. The
 /// non-packed path returns one token; packed returns one per active row, in
 /// row order, with 0 for idle rows (never read).
@@ -1540,14 +1553,19 @@ impl OvRuntimeEngine {
                 .tokenizer
                 .clone()
                 .ok_or_else(|| EngineError::Backend("first stage requires tokenizer".into()))?;
-            let enc = tok
-                .encode(task.prompt.clone(), false)
-                .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
+            // Admission failures are attributed to the failed task so the
+            // runner routes them to its stream — a bare Err here would kill
+            // whichever concurrent stream happened to be polling.
+            let enc = tok.encode(task.prompt.clone(), false).map_err(|e| {
+                EngineError::Backend(format!("tokenizer encode: {e}"))
+                    .for_task(task.task_id.clone())
+            })?;
             let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
             if prompt_ids.is_empty() {
-                return Err(EngineError::Backend(
-                    "empty prompt: no tokens to prefill".into(),
-                ));
+                return Err(
+                    EngineError::Backend("empty prompt: no tokens to prefill".into())
+                        .for_task(task.task_id),
+                );
             }
             info!(
                 task = %task.task_id,
@@ -1565,23 +1583,61 @@ impl OvRuntimeEngine {
         // exactly as the single-task static path already does.
         let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
         for _ in 0..Self::PACKED_MAX_INFERS_PER_STEP {
-            let Some((odt, oshape, obytes, kind)) = self.packed.as_mut().unwrap().step()? else {
+            // Any failure past admission loses the whole in-flight packed
+            // batch (a shared inference, or a shared downstream exchange) —
+            // route it through `abort_packed_batch` so every affected stream
+            // gets its own attributed error and every slot is retired. A
+            // bare `?` would kill whichever stream happened to be polling
+            // and leave the other slots wedged-active forever.
+            let stepped = match self.packed.as_mut().unwrap().step() {
+                Ok(s) => s,
+                Err(e) => return self.abort_packed_batch(e, out),
+            };
+            let Some((odt, oshape, obytes, kind)) = stepped else {
                 break;
             };
-            if single_stage {
-                self.emit_packed_rows(odt, &oshape, &obytes, kind, &mut out)?;
+            let emitted = if single_stage {
+                self.emit_packed_rows(odt, &oshape, &obytes, kind, &mut out)
             } else {
                 // Pipeline: this stage produced hidden rows. Ship the plan (so
                 // every downstream stage can rebuild the same mask and route
                 // rows to the same slots) plus the hidden block, then take back
                 // one sampled token per row from the tail.
-                let hidden = bytes_to_f32(odt, &obytes)?;
-                let plan_rows = self.packed.as_ref().unwrap().last_plan_rows();
-                let tokens = self.exchange_packed_downstream(&hidden, &oshape, &plan_rows)?;
-                self.emit_packed_tokens(&tokens, kind, &mut out)?;
+                bytes_to_f32(odt, &obytes).and_then(|hidden| {
+                    let plan_rows = self.packed.as_ref().unwrap().last_plan_rows();
+                    let tokens = self.exchange_packed_downstream(&hidden, &oshape, &plan_rows)?;
+                    self.emit_packed_tokens(&tokens, kind, &mut out)
+                })
+            };
+            if let Err(e) = emitted {
+                return self.abort_packed_batch(e, out);
             }
             if !out.is_empty() {
                 break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// A packed step failed in a way that loses the in-flight batch: retire
+    /// every active slot (freeing its KV region) and hand each task its own
+    /// final error chunk. The single-task recovery in `step_first_body`
+    /// cannot express a multi-task failure. Slot state downstream is stale
+    /// but harmless — the next admission resets its slot in-band (a row
+    /// whose position equals its reuse length starts that slot fresh).
+    fn abort_packed_batch(
+        &mut self,
+        e: EngineError,
+        mut out: Vec<(TaskId, Chunk)>,
+    ) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        warn!(error = %e, "packed step failed; aborting the in-flight packed batch");
+        let packed = self.packed.as_mut().unwrap();
+        for slot in 0..packed.slots.len() {
+            if let Some(ps) = packed.retire(slot) {
+                out.push((
+                    ps.task.task_id.clone(),
+                    Chunk::error(ps.task.task_id, format!("packed batch aborted: {e}")),
+                ));
             }
         }
         Ok(out)
@@ -1608,6 +1664,9 @@ impl OvRuntimeEngine {
             [s3[0] as u32, s3[1] as u32, s3[2] as u32],
             f32_to_f16_bytes(hidden),
         );
+        // A prefill reply waits on multi-token compute across every remaining
+        // stage — widen its deadline like the non-packed path does.
+        let prefill = plan_has_prefill_rows(plan_rows);
         self.block_on(async {
             let mut guard = down.lock().await;
             guard
@@ -1618,29 +1677,35 @@ impl OvRuntimeEngine {
                 .send(&hidden_frame)
                 .await
                 .map_err(|e| EngineError::Backend(format!("packed hidden send: {e}")))?;
-            // Bound the reply wait. Having just sent both frames this stage is
-            // OWED a token frame, so a downstream that never answers must not
-            // pin the thread forever — the same reasoning as `reply_bounded` on
-            // the qwen36 path, and the same configured activation timeout. This
-            // is what turns a dropped token frame from a silent permanent wedge
-            // into a reportable error; it does not prevent the drop.
-            let (reply, _) = match tokio::time::timeout(
-                cascadia_transport::recv_timeout(),
-                guard.recv(),
-            )
-            .await
-            {
-                Ok(r) => r.map_err(|e| EngineError::Backend(format!("packed token recv: {e}")))?,
-                Err(_) => {
-                    return Err(EngineError::Backend(
-                        "packed token recv timed out: the downstream stage did not answer a \
-                             plan+hidden pair. Multi-stage packed is known to drop a token frame \
-                             under load (issue #122); run the packed worker \
-                             single-stage (--total 1)"
-                            .into(),
-                    ))
-                }
-            };
+            // Having just sent both frames this stage is OWED a token frame.
+            // `recv_reply*`, NOT plain `recv` under an external
+            // `tokio::time::timeout` (#122): the deadline lives inside the
+            // transport, so a miss surfaces as an error instead of a dropped
+            // future (which silently discarded any partially-read bytes and
+            // left the stream misaligned), and a failed reply POISONS the
+            // connection — the socket is dropped so a late token frame can
+            // never be read into the next exchange as fresh data. The
+            // poisoned-socket errors ("recv_exact timed out" / "not
+            // connected") are connection-fatal, so a middle rank's relay
+            // loop exits for a supervisor rebuild rather than grinding on a
+            // desynced stream.
+            let (reply, _) = if prefill {
+                guard.recv_reply_prefill().await
+            } else {
+                guard.recv_reply().await
+            }
+            .map_err(|e| EngineError::Backend(format!("packed token recv: {e}")))?;
+            // An EMPTY token frame is the downstream's NACK (see
+            // `step_relay_packed`): its step failed AFTER it consumed our
+            // pair, so the batch is lost but the link is still
+            // frame-aligned. Abort the batch; do not poison the connection.
+            if reply.elements() == Some(0) {
+                return Err(EngineError::Backend(
+                    "downstream stage failed its packed step and NACKed this batch \
+                     (empty token frame); the pipeline link stays aligned"
+                        .into(),
+                ));
+            }
             decode_wire_tokens(&reply)
         })
     }
@@ -1689,17 +1754,27 @@ impl OvRuntimeEngine {
             .clone()
             .ok_or_else(|| EngineError::Backend("packed relay stage has no upstream".into()))?;
         let slots = self.packed.as_ref().unwrap().kv.slots;
-        let (plan_rows, hidden, hshape) = self.block_on(async {
+        let (plan_res, hidden, hshape) = self.block_on(async {
             let mut guard = up.lock().await;
+            // The plan frame is this stage's idle wait for the next unit of
+            // work — idle-tolerant `recv`. Once it arrives the upstream owes
+            // the hidden frame promptly, so the SECOND frame of the pair is
+            // a deadlined `recv_reply` (same rule as the non-packed
+            // `recv_hidden_from_upstream`): a half-sent pair must fail fast
+            // and poison the socket, not park this stage for the whole
+            // frame-idle ceiling. The plan is decoded only AFTER the hidden
+            // frame is consumed — bailing between the two frames would
+            // leave the hidden frame in the socket and permanently desync
+            // every later frame (#122).
             let (pf, _) = guard
                 .recv()
                 .await
                 .map_err(|e| EngineError::Backend(format!("packed plan recv: {e}")))?;
-            let plan_rows = decode_wire_plan(&pf, slots)?;
             let (hf, _) = guard
-                .recv()
+                .recv_reply()
                 .await
                 .map_err(|e| EngineError::Backend(format!("packed hidden recv: {e}")))?;
+            let plan_res = decode_wire_plan(&pf, slots);
             let hidden: Vec<f32> = match hf.dtype {
                 WireDType::F16 => f16_bytes_to_f32(&hf.data),
                 _ => hf
@@ -1708,9 +1783,41 @@ impl OvRuntimeEngine {
                     .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                     .collect(),
             };
-            Ok::<_, EngineError>((plan_rows, hidden, hf.shape))
+            Ok::<_, EngineError>((plan_res, hidden, hf.shape))
         })?;
 
+        // The pair is consumed. From here on, any failure MUST still answer
+        // the upstream — otherwise it blocks awaiting a token frame that
+        // never comes while this loop swallows the error and moves on: the
+        // silent-deadlock half of issue #122. The NACK is an EMPTY token
+        // frame ([1,1,0]): wire-aligned, unambiguous (a real reply always
+        // has one token per row), and it tells the upstream "batch lost,
+        // link healthy".
+        let step = self.relay_packed_body(plan_res, hidden, hshape);
+        let frame = match &step {
+            Ok(tokens) => encode_wire_tokens(tokens),
+            Err(_) => encode_wire_tokens(&[]),
+        };
+        self.block_on(async {
+            let mut guard = up.lock().await;
+            guard
+                .send(&frame)
+                .await
+                .map_err(|e| EngineError::Backend(format!("packed token send: {e}")))
+        })?;
+        step.map(|_| ())
+    }
+
+    /// Everything `step_relay_packed` does between consuming the (plan,
+    /// hidden) pair and answering the upstream. Split out so the caller can
+    /// turn any failure into an on-wire NACK instead of a swallowed error.
+    fn relay_packed_body(
+        &mut self,
+        plan_res: EngineResult<Vec<Option<(usize, i64, usize)>>>,
+        hidden: Vec<f32>,
+        hshape: [u32; MAX_RANK],
+    ) -> EngineResult<Vec<i32>> {
+        let plan_rows = plan_res?;
         let hidden_size = hshape[2] as usize;
         let plan = crate::packed::PackedPlan {
             rows: plan_rows
@@ -1752,27 +1859,14 @@ impl OvRuntimeEngine {
                     0
                 });
             }
-            let frame = encode_wire_tokens(&tokens);
-            self.block_on(async {
-                let mut guard = up.lock().await;
-                guard
-                    .send(&frame)
-                    .await
-                    .map_err(|e| EngineError::Backend(format!("packed token send: {e}")))
-            })?;
+            Ok(tokens)
         } else {
             let hidden_out = bytes_to_f32(odt, &obytes)?;
-            let tokens = self.exchange_packed_downstream(&hidden_out, &oshape, &plan_rows)?;
-            let frame = encode_wire_tokens(&tokens);
-            self.block_on(async {
-                let mut guard = up.lock().await;
-                guard
-                    .send(&frame)
-                    .await
-                    .map_err(|e| EngineError::Backend(format!("packed token send: {e}")))
-            })?;
+            // A downstream failure (including its NACK) propagates as Err —
+            // the caller NACKs our own upstream in turn, so the abort
+            // reaches rank 0 no matter how deep the pipeline is.
+            self.exchange_packed_downstream(&hidden_out, &oshape, &plan_rows)
         }
-        Ok(())
     }
 
     /// Sample the rows one packed inference produced and append their chunks.
@@ -4019,6 +4113,47 @@ mod tests {
         // a hidden (F32) frame where tokens were expected is a hard error
         let wrong = WireTensor::new(WireDType::F32, [1, 1, 2], vec![0u8; 8]);
         assert!(decode_wire_tokens(&wrong).is_err());
+    }
+
+    /// The relay's NACK is an EMPTY token frame — it must be wire-valid
+    /// (shape/payload consistent so the transport delivers it), detectable
+    /// via `elements() == 0` BEFORE `decode_wire_tokens` (which rejects
+    /// empties as malformed), and impossible to confuse with a real reply
+    /// (a real reply always carries one token per row, S >= 1).
+    #[test]
+    fn packed_nack_frame_is_empty_and_detectable() {
+        let nack = encode_wire_tokens(&[]);
+        assert_eq!(nack.shape, [1, 1, 0]);
+        assert!(nack.data.is_empty());
+        assert_eq!(nack.elements(), Some(0));
+        assert!(decode_wire_tokens(&nack).is_err()); // NACK check must come first
+        let real = encode_wire_tokens(&[7]);
+        assert_ne!(real.elements(), Some(0));
+    }
+
+    /// Prefill chunks (several rows for one slot) get the widened reply
+    /// budget; decode frames (at most one row per slot) keep the strict
+    /// deadline. Idle rows never count.
+    #[test]
+    fn plan_prefill_detection_by_duplicate_slot() {
+        // decode: three distinct slots + an idle row
+        assert!(!plan_has_prefill_rows(&[
+            Some((0, 5, 0)),
+            Some((1, 9, 0)),
+            None,
+            Some((3, 2, 0)),
+        ]));
+        // prefill chunk: slot 2 owns several rows
+        assert!(plan_has_prefill_rows(&[
+            Some((2, 0, 0)),
+            Some((2, 1, 0)),
+            Some((2, 2, 0)),
+            None,
+        ]));
+        // single-row prefill is indistinguishable from decode — strict
+        // deadline by design
+        assert!(!plan_has_prefill_rows(&[Some((0, 0, 0))]));
+        assert!(!plan_has_prefill_rows(&[]));
     }
 
     /// Which token sits in each ring slot, recovered by matching the

--- a/crates/cascadia-engine/src/lib.rs
+++ b/crates/cascadia-engine/src/lib.rs
@@ -53,6 +53,24 @@ pub enum EngineError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// The in-flight batch was abandoned, but the engine and its peer links
+    /// are healthy. A pipeline stage that fails its packed step NACKs its
+    /// upstream (an empty token frame) instead of going silent; the batch is
+    /// lost, the wire stays frame-aligned, and the next batch can proceed.
+    ///
+    /// Its own variant on purpose. This is the one failure that MUST NOT be
+    /// [connection-fatal](EngineError::is_connection_fatal): a NACK has to
+    /// make the relay loop back off and continue, not exit for a supervisor
+    /// rebuild. Left as a [`EngineError::Backend`] string that correctness
+    /// hung on a substring classifier never matching the message — one
+    /// reworded message mentioning a dropped or unreachable peer and every
+    /// NACK would start tearing stages down. The variant makes that
+    /// structural: `is_connection_fatal` answers `false` here before it looks
+    /// at any text, so the message is free to say whatever an operator (and
+    /// the SSE client that receives it) needs to read.
+    #[error("batch aborted: {0}")]
+    BatchAborted(String),
+
     /// A `step()` failure attributed to a specific task. Engines wrap their
     /// underlying error in this at the failure site when the active task is
     /// known, so the runner can route the failure to that task's stream
@@ -104,9 +122,19 @@ impl EngineError {
     /// dead-peer case), and a mid-frame stall ("recv_exact timed out"). A
     /// connected-but-misbehaving peer (bad frame kind, stray response) is
     /// NOT fatal — that link can still deliver a good frame next.
+    ///
+    /// [`EngineError::BatchAborted`] is answered structurally, ahead of any
+    /// string inspection: an aborted batch leaves a healthy link, so the
+    /// relay loop must back off and continue. Because the check never reads
+    /// its message, no rewording of an abort text can turn a NACK into a
+    /// stage teardown.
     pub fn is_connection_fatal(&self) -> bool {
         match self {
             EngineError::NotConnected => true,
+            // Structural, and BEFORE any substring matching: the batch is
+            // gone, the link is not. Its message is operator/SSE-facing text
+            // and must never be able to reclassify the error.
+            EngineError::BatchAborted(_) => false,
             EngineError::Task { source, .. } => source.is_connection_fatal(),
             EngineError::Backend(msg) => {
                 let msg = msg.to_ascii_lowercase();
@@ -272,5 +300,53 @@ mod tests {
         // A task-attributed fatal error unwraps to its source.
         let wrapped = EngineError::Backend("socket closed".into()).for_task(TaskId::from("t1"));
         assert!(wrapped.is_connection_fatal());
+    }
+
+    /// An aborted batch is never a dead link. The relay loop must back off
+    /// and keep driving on a NACK — exiting would hand the supervisor a
+    /// rebuild for a stage whose socket is perfectly fine.
+    ///
+    /// The point of the variant is that this holds for ANY message: the abort
+    /// text is operator- and SSE-facing prose that names the underlying cause,
+    /// and that cause is frequently a transport failure on the *other* side of
+    /// the pipeline, so it quotes exactly the substrings the classifier hunts
+    /// for. As a `Backend` string every one of these would have been
+    /// misclassified as fatal.
+    #[test]
+    fn batch_aborted_is_never_connection_fatal() {
+        for msg in [
+            "downstream stage failed its packed step and NACKed this batch \
+             (empty token frame); the pipeline link stays aligned",
+            // Abort messages that quote a peer's transport failure — the
+            // exact fragility a substring classifier could not survive.
+            "the packed step failed: backend error: packed token recv: recv_exact timed out",
+            "the packed step failed: backend error: not connected; call connect() first",
+            "the packed step failed: backend error: socket closed during recv",
+            "the packed step failed: backend error: io error: broken pipe",
+            "the packed step failed: backend error: connection reset by peer",
+            "",
+        ] {
+            let e = EngineError::BatchAborted(msg.into());
+            assert!(!e.is_connection_fatal(), "must not be fatal: {msg}");
+            // And attribution must not resurrect fatality either.
+            assert!(
+                !e.for_task(TaskId::from("t1")).is_connection_fatal(),
+                "{msg}"
+            );
+        }
+        // The same texts as genuine transport failures ARE still fatal — the
+        // variant narrows the classifier, it does not blunt it.
+        for msg in [
+            "packed token recv: recv_exact timed out",
+            "not connected; call connect() first",
+            "socket closed during recv",
+            "io error: broken pipe",
+            "connection reset by peer",
+        ] {
+            assert!(
+                EngineError::Backend(msg.into()).is_connection_fatal(),
+                "must stay fatal: {msg}"
+            );
+        }
     }
 }

--- a/crates/cascadia-runner/Cargo.toml
+++ b/crates/cascadia-runner/Cargo.toml
@@ -22,3 +22,4 @@ async-trait = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true }
 cascadia-engine-mock = { workspace = true }
+cascadia-transport = { workspace = true }

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -3184,4 +3184,107 @@ mod tests {
             0
         );
     }
+
+    // -----------------------------------------------------------------
+    // M7(b): `close()` while a stream is parked Pending.
+    //
+    // A stream that parked on engine contention is woken by exactly one
+    // thing: an engine-lock RELEASE (`EngineGuard::drop` drains
+    // `step_wakers`). Teardown is the release with nobody coming after it —
+    // if `close()` ever empties the slot without paying that drain, every
+    // parked stream waits `Pending` forever with no error, no log and no
+    // later holder to rescue it, and its client hangs until it gives up.
+    // Every wait below is bounded, so that regression FAILS the test
+    // instead of hanging the suite.
+    // -----------------------------------------------------------------
+
+    /// Stream A pins the engine inside a gated `step()`; stream B parks on
+    /// the contention; `close()` starts while B is parked. B must wake and
+    /// terminate on the teardown outcome — an error chunk saying the server
+    /// is going away, not a bare end-of-stream (which the API layer would
+    /// turn into a truncated 200) and not silence.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn close_wakes_a_stream_parked_on_engine_contention() {
+        let gate = Gate::closed();
+        let (runner, _log) = recording_runner(gate.clone()).await;
+
+        // Both tasks are submitted up front: `generate_async` takes the
+        // engine lock only for the submit itself, never for a step, so this
+        // runs before anyone is holding it.
+        let mut a = runner
+            .generate_async(GenerationTask::new("parked-holder", "x").with_max_tokens(2))
+            .await
+            .unwrap();
+        let mut b = runner
+            // Far more tokens than this test will ever let it produce: B
+            // cannot reach a normal final chunk, so the ONLY terminal
+            // outcome available to it is the teardown one.
+            .generate_async(GenerationTask::new("parked-waiter", "x").with_max_tokens(1_000_000))
+            .await
+            .unwrap();
+
+        // A takes the engine lock and parks inside `step()`, holding it.
+        let holder = tokio::spawn(async move {
+            let mut n = 0usize;
+            while a.next().await.is_some() {
+                n += 1;
+            }
+            n
+        });
+        await_until("the holder to enter step() with the engine locked", || {
+            gate.steps_entered() >= 1
+        })
+        .await;
+
+        // B polls, fails its `try_lock`, registers a waker and parks. From
+        // here nothing but a release can move it.
+        let waiter = tokio::spawn(async move {
+            let mut last = None;
+            while let Some(c) = b.next().await {
+                last = Some(c);
+            }
+            last
+        });
+        await_until("the waiter to park on engine contention", || {
+            !runner.slot.buffers.lock().step_wakers.is_empty()
+        })
+        .await;
+
+        // Teardown begins WHILE B is parked. `close()` blocks on the engine
+        // lock until the gate opens, so it needs its own thread; the
+        // `closing` flag it sets first (before it reaches for the lock) is
+        // the handshake that it is really in flight.
+        let closer = {
+            let runner = runner.clone();
+            tokio::task::spawn_blocking(move || runner.close())
+        };
+        await_until("close() to start tearing the runner down", || {
+            runner.closing.load(Ordering::SeqCst)
+        })
+        .await;
+
+        // Released LAST, so B spends the whole window parked with a
+        // teardown already underway. Two releases follow — A's and
+        // `close()`'s — and B must be woken by one of them.
+        gate.release();
+
+        let last = tokio::time::timeout(std::time::Duration::from_secs(10), waiter)
+            .await
+            .expect("the parked stream never woke: teardown stranded it Pending")
+            .unwrap()
+            .expect("the parked stream ended with no chunk at all (a truncated success)");
+        assert_eq!(
+            last.error.as_deref(),
+            Some("server is shutting down"),
+            "a stream parked across teardown must end on the teardown error: {last:?}"
+        );
+        assert!(last.is_final, "{last:?}");
+
+        closer.await.unwrap();
+        // The holder must not be stranded by the teardown either.
+        tokio::time::timeout(std::time::Duration::from_secs(10), holder)
+            .await
+            .expect("the lock holder never finished after teardown")
+            .unwrap();
+    }
 }

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -117,11 +117,12 @@ pub fn run_async<F: std::future::Future>(handle: &tokio::runtime::Handle, fut: F
 struct Buffers {
     chunks: HashMap<TaskId, VecDeque<Chunk>>,
     cancelled: std::collections::HashSet<TaskId>,
-    /// Streams parked because another caller held the engine (#122). Every
-    /// engine-lock release drains + wakes these, so a parked stream re-polls
-    /// as soon as the engine may be free. Registration happens ONLY after a
-    /// failed `try_lock`, and the registrant re-checks the lock afterwards,
-    /// so a release can't slip between the check and the registration.
+    /// Streams parked because another caller held the engine (#122).
+    /// [`EngineGuard`] drains + wakes these on every engine-lock release,
+    /// so a parked stream re-polls as soon as the engine may be free.
+    /// Registration happens ONLY after a failed `try_lock`, and the
+    /// registrant re-checks the lock afterwards, so a release can't slip
+    /// between the check and the registration.
     step_wakers: Vec<std::task::Waker>,
     /// Cancels that could not take the engine lock without blocking a
     /// worker thread (#122). Applied by the next engine-lock holder before
@@ -130,51 +131,132 @@ struct Buffers {
     deferred_cancels: Vec<TaskId>,
 }
 
-/// Drains + wakes [`Buffers::step_wakers`] when it leaves scope — including
-/// when a panic unwinds out of that scope.
+/// The engine, plus the state every release of it has to service: the
+/// wakers of the streams parked on contention, and the cancels deferred
+/// while it was busy (#122).
 ///
-/// The drain after an engine-lock release is straight-line code, so an
-/// unwind skips it: a panic inside `step()` (or anything else run under the
-/// engine guard) leaves every parked stream `Pending` forever with nothing
-/// in the log to say why. `parking_lot` does not poison, so the engine
-/// itself is released and perfectly usable — there is simply no one left to
-/// poll it. Running the drain from a destructor covers the unwind path too.
-///
-/// DECLARE THIS BEFORE the engine guard it protects: locals drop in reverse
-/// declaration order, so the engine lock is released first and the wake runs
-/// with the engine free. Waking while the lock is still held lets a woken
-/// stream re-park behind it and be stranded exactly as before.
-struct WakeParkedOnDrop<'a> {
-    buffers: &'a Mutex<Buffers>,
-    /// Armed only once the engine lock is actually held. A contended
-    /// `poll_next` that gives up and returns `Pending` has just registered
-    /// its OWN waker; draining from there would wake it straight back and
-    /// spin the worker for the whole of the holder's step.
-    armed: bool,
+/// One `Arc<EngineSlot>` is shared by the [`Runner`] and every
+/// [`ChunkStream`] it hands out. They used to hold loose `Arc` clones of an
+/// engine mutex and a buffers mutex, which is why the release protocol
+/// ("drop the engine lock, THEN drain + wake") could only be a convention,
+/// re-implemented by hand at six sites and silently skippable at a seventh.
+/// Going through [`EngineSlot::lock`] / [`EngineSlot::try_lock`] makes it a
+/// property of the type instead: there is no way to hold the engine without
+/// holding an [`EngineGuard`], and no way to drop that guard without waking.
+struct EngineSlot {
+    /// `Mutex<Option<...>>` so `close()` can drop the engine while other
+    /// callers hold references to the runner; subsequent calls fail
+    /// cleanly with [`EngineError::NotLoaded`].
+    ///
+    /// Deliberately a SYNC `parking_lot` mutex: `run_relay_loop` takes it
+    /// from a `spawn_blocking` thread and `submit` from the blocking pool,
+    /// neither of which can await. Contended async callers must park on a
+    /// failed `try_lock` rather than block a tokio worker here (#122).
+    engine: Mutex<Option<Box<dyn Engine>>>,
+    buffers: Mutex<Buffers>,
 }
 
-impl<'a> WakeParkedOnDrop<'a> {
-    /// Inert until [`arm`](Self::arm) is called.
-    fn disarmed(buffers: &'a Mutex<Buffers>) -> Self {
-        Self {
-            buffers,
-            armed: false,
+/// An engine lock that cannot be released without paying what the release
+/// owes: draining [`Buffers::step_wakers`] and waking every parked stream.
+///
+/// Two orderings this encodes, both of which were load-bearing bugs when
+/// left to hand-written call sites:
+///
+/// * **Release, THEN wake.** Waking while the engine lock is still held
+///   lets a woken stream re-poll, fail its `try_lock`, and re-park —
+///   stranded again, and this time with no one left to wake it. Rust drops
+///   struct fields AFTER `Drop::drop` returns, so the inner `parking_lot`
+///   guard lives in an `Option` that `drop` explicitly takes and releases
+///   first; making it a plain field would reintroduce exactly this bug.
+/// * **Wake on unwind too.** A panic inside `step()` unwinds past any
+///   straight-line drain. `parking_lot` doesn't poison, so the engine comes
+///   out of it usable — but every parked stream waits `Pending` forever,
+///   with nothing in the log. A destructor covers that path by
+///   construction.
+///
+/// A failed `try_lock` never produces a guard, so the contended
+/// `poll_next` path still returns `Pending` without waking the waker it
+/// just registered (which would spin the worker for the holder's step).
+struct EngineGuard<'a> {
+    slot: &'a EngineSlot,
+    /// `Some` for the guard's whole life; taken by `drop` to release the
+    /// engine lock before the wake. See the ordering note above.
+    guard: Option<parking_lot::MutexGuard<'a, Option<Box<dyn Engine>>>>,
+}
+
+impl EngineGuard<'_> {
+    /// The engine, or `None` once `close()` has emptied the slot.
+    fn engine(&mut self) -> Option<&mut Box<dyn Engine>> {
+        self.guard.as_mut().and_then(|g| g.as_mut())
+    }
+
+    /// Fill the slot (`start`) or empty it (`close`). An emptied slot makes
+    /// every later lock holder fail cleanly with [`EngineError::NotLoaded`];
+    /// the outgoing engine is dropped under the lock.
+    fn set(&mut self, engine: Option<Box<dyn Engine>>) {
+        if let Some(g) = self.guard.as_mut() {
+            **g = engine;
         }
     }
-
-    fn arm(&mut self) {
-        self.armed = true;
-    }
 }
 
-impl Drop for WakeParkedOnDrop<'_> {
+impl Drop for EngineGuard<'_> {
     fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        let wakers = std::mem::take(&mut self.buffers.lock().step_wakers);
+        // Release the engine FIRST: `Option::take` + drop, because struct
+        // fields would otherwise drop after this body has already woken.
+        drop(self.guard.take());
+        let wakers = std::mem::take(&mut self.slot.buffers.lock().step_wakers);
         for w in wakers {
             w.wake();
+        }
+    }
+}
+
+impl EngineSlot {
+    fn new(engine: Option<Box<dyn Engine>>) -> Self {
+        Self {
+            engine: Mutex::new(engine),
+            buffers: Mutex::new(Buffers::default()),
+        }
+    }
+
+    /// Take the engine lock, blocking the calling thread until it is free.
+    /// Sync callers only — see the mutex's note on #122.
+    fn lock(&self) -> EngineGuard<'_> {
+        EngineGuard {
+            slot: self,
+            guard: Some(self.engine.lock()),
+        }
+    }
+
+    /// Take the engine lock only if it is free right now. `None` means
+    /// someone is mid-step and the caller must park (`poll_next`) or defer
+    /// (`cancel_or_defer`) instead of blocking a tokio worker (#122).
+    fn try_lock(&self) -> Option<EngineGuard<'_>> {
+        self.engine.try_lock().map(|g| EngineGuard {
+            slot: self,
+            guard: Some(g),
+        })
+    }
+
+    /// Cancel `task_id` on the engine, or queue it for the next lock holder
+    /// when a step is in flight.
+    ///
+    /// Shared by [`Runner::cancel`] and [`ChunkStream::drop`], which have
+    /// the same constraint: both run on whatever (often tokio worker)
+    /// thread calls them, and a hard `lock()` during another stream's step
+    /// counts toward the worker starvation that wedges the pipeline (#122).
+    /// Deferring costs nothing — a running step can't be interrupted
+    /// anyway, so the next holder applies it at the same effective time a
+    /// blocking cancel would have.
+    fn cancel_or_defer(&self, task_id: &TaskId) {
+        match self.try_lock() {
+            Some(mut guard) => {
+                if let Some(engine) = guard.engine() {
+                    engine.cancel(task_id);
+                }
+            }
+            None => self.buffers.lock().deferred_cancels.push(task_id.clone()),
         }
     }
 }
@@ -183,11 +265,9 @@ pub struct Runner {
     /// Mutex so the Runner is `Sync` even with a `dyn Builder` inside;
     /// taken once during `start()` and dropped.
     builder: Mutex<Option<Box<dyn Builder>>>,
-    /// `Mutex<Option<...>>` so `close()` can drop the engine while other
-    /// callers hold references to the runner; subsequent calls fail
-    /// cleanly with [`EngineError::NotLoaded`].
-    engine: Arc<Mutex<Option<Box<dyn Engine>>>>,
-    buffers: Arc<Mutex<Buffers>>,
+    /// Engine + parked-stream bookkeeping, shared with every
+    /// [`ChunkStream`] this runner hands out.
+    slot: Arc<EngineSlot>,
     /// Model id captured from the [`ShardSpec`] at `start()`, used as the
     /// `model` label on generation metrics (#16). `None` until started.
     model: Mutex<Option<Arc<str>>>,
@@ -203,8 +283,7 @@ impl Runner {
     pub fn new(builder: Box<dyn Builder>) -> Self {
         Self {
             builder: Mutex::new(Some(builder)),
-            engine: Arc::new(Mutex::new(None)),
-            buffers: Arc::new(Mutex::new(Buffers::default())),
+            slot: Arc::new(EngineSlot::new(None)),
             model: Mutex::new(None),
             closing: Arc::new(AtomicBool::new(false)),
         }
@@ -264,7 +343,7 @@ impl Runner {
         info!("runner ready");
 
         *self.model.lock() = Some(Arc::from(model));
-        *self.engine.lock() = Some(engine);
+        self.slot.lock().set(Some(engine));
         Ok(())
     }
 
@@ -282,28 +361,14 @@ impl Runner {
         // async submit path (or their own `spawn_blocking`) — a worker
         // thread blocked here counts toward the driver starvation that
         // wedges the pipeline (#122).
-        let res = {
-            let mut guard = self.engine.lock();
-            // Route the empty slot through `res` rather than `?`: an early
-            // return here released the engine lock and skipped the wake
-            // below, and an empty slot means `close()` already ran — no
-            // later lock holder is coming to wake them instead.
-            match guard.as_mut() {
-                Some(engine) => engine.submit(task),
-                None => Err(EngineError::NotLoaded),
-            }
-        };
-        self.wake_parked_streams();
-        res
-    }
-
-    /// Drain + wake every stream that parked on engine-lock contention.
-    /// Called after every engine-lock release (#122): a parked stream is
-    /// only ever woken from here, so skipping a release site would strand it.
-    fn wake_parked_streams(&self) {
-        let wakers = std::mem::take(&mut self.buffers.lock().step_wakers);
-        for w in wakers {
-            w.wake();
+        // Releasing the guard wakes the streams parked on contention, on
+        // the empty-slot path as much as the submitting one — an empty slot
+        // means `close()` already ran, so no later lock holder is coming to
+        // wake them instead.
+        let mut guard = self.slot.lock();
+        match guard.engine() {
+            Some(engine) => engine.submit(task),
+            None => Err(EngineError::NotLoaded),
         }
     }
 
@@ -316,27 +381,11 @@ impl Runner {
         // chunk that lands in between is dropped by the cancelled-check on the
         // distribution path, which is the behaviour either way.
         {
-            let mut bufs = self.buffers.lock();
+            let mut bufs = self.slot.buffers.lock();
             bufs.cancelled.insert(task_id.clone());
             bufs.chunks.remove(task_id);
         }
-        // Never block a (possibly async) caller on the engine mutex — a
-        // worker thread parked here counts toward the driver starvation
-        // that wedges the pipeline (#122). If a step is in flight, defer:
-        // the next engine-lock holder applies it before stepping, which is
-        // when a blocking cancel would have run anyway.
-        match self.engine.try_lock() {
-            Some(mut guard) => {
-                if let Some(engine) = guard.as_mut() {
-                    engine.cancel(task_id);
-                }
-                drop(guard);
-                self.wake_parked_streams();
-            }
-            None => {
-                self.buffers.lock().deferred_cancels.push(task_id.clone());
-            }
-        }
+        self.slot.cancel_or_defer(task_id);
     }
 
     /// Submit a task and return a stream of chunks. Stops on the final
@@ -368,8 +417,7 @@ impl Runner {
     fn stream_for(&self, task_id: TaskId) -> ChunkStream {
         ChunkStream {
             task_id,
-            engine: self.engine.clone(),
-            buffers: self.buffers.clone(),
+            slot: self.slot.clone(),
             consecutive_empty: 0,
             last_errored_task: None,
             consecutive_foreign_err: 0,
@@ -404,8 +452,13 @@ impl Runner {
     pub fn run_relay_loop(&self) -> RelayExit {
         let _blocking = BlockingContextGuard::enter();
         loop {
-            let mut guard = self.engine.lock();
-            let Some(engine) = guard.as_mut() else {
+            // Through the guard like every other holder: a relay-stage
+            // runner serves no streams today, so it has nothing to wake —
+            // but a runner that both relays and generates would strand
+            // every parked stream behind this loop, and the guard makes
+            // that impossible for free.
+            let mut guard = self.slot.lock();
+            let Some(engine) = guard.engine() else {
                 drop(guard);
                 info!("relay loop exited: engine slot empty");
                 return RelayExit::SlotEmpty;
@@ -447,13 +500,21 @@ impl Runner {
         // whole point: set it after, and a stream that polls in between books
         // a client cancellation for a server restart.
         self.closing.store(true, Ordering::SeqCst);
-        if let Some(engine) = self.engine.lock().as_mut() {
-            engine.close();
+        {
+            // Tear down and empty the slot under ONE guard, where this used
+            // to take the lock twice. Releasing in between now means waking,
+            // and a stream woken there would find the engine closed but
+            // still present, step a torn-down transport, and book a failure
+            // instead of the teardown outcome. One acquisition closes that
+            // window; the single release still wakes the streams parked on
+            // contention, which must re-poll to observe the emptied slot or
+            // a teardown would strand them Pending forever.
+            let mut guard = self.slot.lock();
+            if let Some(engine) = guard.engine() {
+                engine.close();
+            }
+            guard.set(None);
         }
-        *self.engine.lock() = None;
-        // Streams parked on engine-lock contention must re-poll to observe
-        // the emptied slot, or a teardown would strand them Pending forever.
-        self.wake_parked_streams();
         if let Some(builder) = self.builder.lock().as_mut() {
             builder.close();
         }
@@ -462,8 +523,12 @@ impl Runner {
 
 pub struct ChunkStream {
     task_id: TaskId,
-    engine: Arc<Mutex<Option<Box<dyn Engine>>>>,
-    buffers: Arc<Mutex<Buffers>>,
+    /// The engine slot, shared with the [`Runner`] that made this stream and
+    /// with every sibling stream. One `Arc` rather than loose clones of the
+    /// engine and buffer handles, so a stream reaches the engine through the
+    /// same [`EngineGuard`] every other holder uses and cannot re-implement
+    /// the release protocol by hand.
+    slot: Arc<EngineSlot>,
     consecutive_empty: usize,
     /// Foreign-task hot-spin guard: the last foreign task-id an engine `step()`
     /// failed, and how many times in a row it has failed *that same* id. A
@@ -565,7 +630,7 @@ impl ChunkStream {
     /// site in `poll_next` gets terminal accounting by construction.
     fn fail_stream(&mut self, reason: String) -> Poll<Option<Chunk>> {
         self.done = true;
-        self.buffers.lock().chunks.remove(&self.task_id);
+        self.slot.buffers.lock().chunks.remove(&self.task_id);
         let chunk = Chunk::error(self.task_id.clone(), reason);
         self.record_chunk_metrics(&chunk);
         Poll::Ready(Some(chunk))
@@ -584,7 +649,7 @@ impl ChunkStream {
     /// a planned restart must not land on the primary failure SLO.
     fn fail_teardown(&mut self) -> Poll<Option<Chunk>> {
         self.done = true;
-        self.buffers.lock().chunks.remove(&self.task_id);
+        self.slot.buffers.lock().chunks.remove(&self.task_id);
         warn!(
             task = %self.task_id,
             "engine slot emptied mid-generation (server teardown); failing the \
@@ -654,7 +719,7 @@ impl Stream for ChunkStream {
 
             // 1) Drain anything already buffered for us.
             {
-                let mut bufs = this.buffers.lock();
+                let mut bufs = this.slot.buffers.lock();
                 if bufs.cancelled.contains(&this.task_id) {
                     this.done = true;
                     bufs.chunks.remove(&this.task_id);
@@ -699,48 +764,46 @@ impl Stream for ChunkStream {
             //    someone else is stepping; park with a registered waker and
             //    let their release wake us.
             let step_result = {
-                // Wake-on-release, unwind included: `step()` runs arbitrary
-                // engine code under this lock, and a panic there must not
-                // strand the streams parked behind it (see
-                // `WakeParkedOnDrop`). Declared BEFORE the engine guard so
-                // reverse-declaration drop order releases the engine first
-                // and wakes second, on the normal path and on the unwind.
-                let mut wake_on_release = WakeParkedOnDrop::disarmed(&this.buffers);
-                let mut guard = match this.engine.try_lock() {
+                let mut guard = match this.slot.try_lock() {
                     Some(g) => g,
                     None => {
-                        this.buffers.lock().step_wakers.push(cx.waker().clone());
+                        this.slot
+                            .buffers
+                            .lock()
+                            .step_wakers
+                            .push(cx.waker().clone());
                         // Re-check after registering: the holder may have
                         // released (and drained wakers) between the failed
                         // try_lock and the registration. A stale registration
                         // from the success arm only costs a spurious wake.
-                        match this.engine.try_lock() {
+                        // No guard exists on this path, so returning Pending
+                        // does NOT wake — waking the waker just registered
+                        // would spin this worker for the holder's whole step.
+                        match this.slot.try_lock() {
                             Some(g) => g,
                             None => return Poll::Pending,
                         }
                     }
                 };
-                // The engine is ours: every exit from here — value, early
-                // return, or panic — owes the parked streams a wake.
-                wake_on_release.arm();
-                let result = match guard.as_mut() {
+                let result = match guard.engine() {
                     // Slot empty: `Runner::close` took the engine, i.e. server
                     // teardown. Handled below rather than here because
                     // `fail_teardown` needs `&mut *this` and this guard still
-                    // borrows `this.engine`.
+                    // borrows `this.slot`.
                     None => None,
                     Some(engine) => {
                         // Apply cancels that arrived while the engine was
                         // busy (Runner::cancel / stream Drop never block on
                         // the engine mutex — see deferred_cancels).
-                        let deferred = std::mem::take(&mut this.buffers.lock().deferred_cancels);
+                        let deferred =
+                            std::mem::take(&mut this.slot.buffers.lock().deferred_cancels);
                         for tid in &deferred {
                             engine.cancel(tid);
                         }
                         Some(match engine.step() {
                             Ok(produced) => {
                                 let empty = produced.is_empty();
-                                let mut bufs = this.buffers.lock();
+                                let mut bufs = this.slot.buffers.lock();
                                 for (tid, chunk) in produced {
                                     if bufs.cancelled.contains(&tid) {
                                         continue;
@@ -753,8 +816,9 @@ impl Stream for ChunkStream {
                         })
                     }
                 };
-                // Engine released here; `wake_on_release` drains + wakes
-                // every stream parked on contention right after.
+                // Releasing the guard is what drains + wakes every stream
+                // parked on contention — engine first, wake second, and on
+                // an unwind out of `step()` just the same.
                 drop(guard);
                 result
             };
@@ -780,7 +844,7 @@ impl Stream for ChunkStream {
                             error = %e,
                             "engine step failed for another task; routing failure to it"
                         );
-                        let mut bufs = this.buffers.lock();
+                        let mut bufs = this.slot.buffers.lock();
                         // Cancelled task = no consumer left; recreating its
                         // buffer entry would leak until close() (mirror the
                         // cancelled-check on the distribution path below).
@@ -899,29 +963,11 @@ impl Drop for ChunkStream {
         // (often tokio worker) thread drops the stream, and a hard lock()
         // during another stream's step counts toward the worker starvation
         // that wedges the pipeline (#122). Busy engine = defer; the next
-        // engine-lock holder applies it before stepping.
-        {
-            // Same wake-on-release protocol as `poll_next`, unwind
-            // included: `engine.cancel()` is engine code too, and a panic
-            // here would otherwise strand every parked stream. Declared
-            // BEFORE the guard so the engine lock is released first.
-            let mut wake_on_release = WakeParkedOnDrop::disarmed(&self.buffers);
-            match self.engine.try_lock() {
-                Some(mut guard) => {
-                    wake_on_release.arm();
-                    if let Some(engine) = guard.as_mut() {
-                        engine.cancel(&self.task_id);
-                    }
-                }
-                None => {
-                    self.buffers
-                        .lock()
-                        .deferred_cancels
-                        .push(self.task_id.clone());
-                }
-            }
-        }
-        let mut bufs = self.buffers.lock();
+        // engine-lock holder applies it before stepping. Same helper
+        // `Runner::cancel` uses, and the guard inside it handles the
+        // release-then-wake ordering for both.
+        self.slot.cancel_or_defer(&self.task_id);
+        let mut bufs = self.slot.buffers.lock();
         bufs.chunks.remove(&self.task_id);
         // Tombstone rather than remove: an engine that defers its final
         // chunk past cancel would re-buffer it for this dead stream via
@@ -1087,8 +1133,7 @@ mod tests {
         let engine: Box<dyn Engine> = Box::new(CountingFailingEngine(calls.clone()));
         let runner = Arc::new(Runner {
             builder: Mutex::new(None),
-            engine: Arc::new(Mutex::new(Some(engine))),
-            buffers: Arc::new(Mutex::new(Buffers::default())),
+            slot: Arc::new(EngineSlot::new(Some(engine))),
             model: Mutex::new(None),
             closing: Arc::new(AtomicBool::new(false)),
         });
@@ -1139,8 +1184,7 @@ mod tests {
         let engine: Box<dyn Engine> = Box::new(DeadLinkEngine(calls.clone()));
         let runner = Arc::new(Runner {
             builder: Mutex::new(None),
-            engine: Arc::new(Mutex::new(Some(engine))),
-            buffers: Arc::new(Mutex::new(Buffers::default())),
+            slot: Arc::new(EngineSlot::new(Some(engine))),
             model: Mutex::new(None),
             closing: Arc::new(AtomicBool::new(false)),
         });
@@ -1188,8 +1232,7 @@ mod tests {
             let engine: Box<dyn Engine> = Box::new(RstStepEngine(EngineError::Backend(msg.into())));
             let runner = Arc::new(Runner {
                 builder: Mutex::new(None),
-                engine: Arc::new(Mutex::new(Some(engine))),
-                buffers: Arc::new(Mutex::new(Buffers::default())),
+                slot: Arc::new(EngineSlot::new(Some(engine))),
                 model: Mutex::new(None),
                 closing: Arc::new(AtomicBool::new(false)),
             });
@@ -1469,7 +1512,7 @@ mod tests {
         // Drive until our stream closes (the engine never serves us).
         while stream.next().await.is_some() {}
         assert!(
-            !runner.buffers.lock().chunks.contains_key("dead"),
+            !runner.slot.buffers.lock().chunks.contains_key("dead"),
             "routing a failure to a cancelled task must not recreate its buffer entry"
         );
     }
@@ -1595,7 +1638,7 @@ mod tests {
         // B polls, finds the engine contended, and parks with a waker.
         let b = tokio::spawn(async move { stream_b.next().await });
         let start = Instant::now();
-        while runner.buffers.lock().step_wakers.is_empty() {
+        while runner.slot.buffers.lock().step_wakers.is_empty() {
             assert!(
                 start.elapsed() < std::time::Duration::from_secs(10),
                 "stream B never parked on the engine lock"

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -284,8 +284,14 @@ impl Runner {
         // wedges the pipeline (#122).
         let res = {
             let mut guard = self.engine.lock();
-            let engine = guard.as_mut().ok_or(EngineError::NotLoaded)?;
-            engine.submit(task)
+            // Route the empty slot through `res` rather than `?`: an early
+            // return here released the engine lock and skipped the wake
+            // below, and an empty slot means `close()` already ran — no
+            // later lock holder is coming to wake them instead.
+            match guard.as_mut() {
+                Some(engine) => engine.submit(task),
+                None => Err(EngineError::NotLoaded),
+            }
         };
         self.wake_parked_streams();
         res

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -432,6 +432,10 @@ impl Runner {
         self.start_with_listen(peers, shard, None).await
     }
 
+    /// Enqueue a task with the engine.
+    ///
+    /// Refuses (as a benign no-op `Ok(())`) any task whose id already carries
+    /// a `cancelled` tombstone — see the comment in the lock region below.
     pub fn submit(&self, task: GenerationTask) -> Result<(), EngineError> {
         // NOTE: blocks the calling thread for up to one engine step if a
         // step is in flight. Async callers must use [`Runner::generate`]'s
@@ -445,9 +449,37 @@ impl Runner {
         // while the engine was busy, freeing their slots before this task
         // asks for one.
         let mut guard = self.slot.lock_applying_cancels();
-        match guard.engine() {
-            Some(engine) => engine.submit(task),
-            None => Err(EngineError::NotLoaded),
+        // ==== BEGIN cancellation-safety check — keep INSIDE the lock ====
+        // NEVER hand the engine a task that is already tombstoned
+        // cancelled. `generate_async` arms a cancel guard BEFORE it
+        // dispatches this submit, so a caller future dropped at that
+        // await (axum drops handler futures on client disconnect) writes
+        // the tombstone while the detached submit closure is still queued
+        // or parked on this very mutex. Admitting the task then creates a
+        // ghost: no `ChunkStream` was ever constructed for it, so nothing
+        // drains its chunks and nothing cancels it — it occupies a packed
+        // slot and grinds through max_tokens driven by other streams'
+        // polls, buffering under an id nobody reads, until process exit.
+        //
+        // Task ids are per-request UUIDs at the API layer, so a
+        // tombstoned id can only mean "this exact request was already
+        // cancelled" — refusing is a no-op, not a lost request. Read
+        // while holding the engine mutex so it cannot interleave with a
+        // concurrent step's distribution pass; buffers-under-engine is
+        // the lock order used everywhere else (see `Runner::cancel`).
+        //
+        // "Inside the lock" now means inside `guard`'s scope: the refusal
+        // is an arm of this expression rather than an early `return`, so
+        // the guard is still live and still owes — and on drop pays — the
+        // drain + wake every engine-lock release owes its parked streams.
+        if self.slot.buffers.lock().cancelled.contains(&task.task_id) {
+            Ok(())
+        } else {
+            // ==== END; the branch below is the original submit path ====
+            match guard.engine() {
+                Some(engine) => engine.submit(task),
+                None => Err(EngineError::NotLoaded),
+            }
         }
     }
 
@@ -481,16 +513,62 @@ impl Runner {
     /// the engine mutex for up to a full engine step, and enough worker
     /// threads parked there starve the tokio I/O + timer drivers, which is
     /// the #122 pipeline wedge.
+    ///
+    /// **Cancellation-safe**: this future may be dropped at any await point
+    /// (axum drops handler futures on client disconnect, and disconnects
+    /// cluster exactly when the submit wait is longest) without leaking a
+    /// task. Dropping the `JoinHandle` detaches rather than cancels, so the
+    /// submit closure still runs and may admit the task with no `ChunkStream`
+    /// to own it — a ghost that would occupy an engine slot and grind through
+    /// `max_tokens` with nobody draining its chunks. Two mechanisms close
+    /// that, both required:
+    ///
+    /// * A cancel guard armed BEFORE the submit is dispatched. Unless the
+    ///   stream is successfully constructed (which disarms it), the guard's
+    ///   `Drop` calls [`Runner::cancel`] — non-blocking by construction, so
+    ///   it is safe on any thread a dropped future lands on.
+    /// * [`Runner::submit`] refuses tombstoned ids, for the reverse ordering
+    ///   where the guard's cancel runs BEFORE the queued/parked submit does.
+    ///
+    /// Guarantee: on return of this future, either the caller owns a
+    /// [`ChunkStream`] for the task, or the task is cancelled — never
+    /// submitted-and-unowned.
     pub async fn generate_async(
         self: &Arc<Self>,
         task: GenerationTask,
     ) -> Result<ChunkStream, EngineError> {
+        let task_id = task.task_id.clone();
+        // Armed BEFORE the dispatch below: from here until `disarm()`, every
+        // exit path — `?`, a panic, or the caller's future being dropped at
+        // the await — cancels the task.
+        let mut guard = SubmitCancelGuard {
+            runner: self.clone(),
+            task_id: task_id.clone(),
+            armed: true,
+        };
         let this = self.clone();
-        let submitted = task.clone();
-        tokio::task::spawn_blocking(move || this.submit(submitted))
-            .await
-            .map_err(|e| EngineError::Backend(format!("submit task join: {e}")))??;
-        Ok(self.stream_for(task.task_id))
+        let joined = tokio::task::spawn_blocking(move || this.submit(task)).await;
+        match joined {
+            // The engine rejected the task (QueueFull, NotLoaded, …). Per the
+            // `Engine::submit` contract nothing was enqueued, so there is
+            // nothing to cancel — disarm rather than write a tombstone for a
+            // task that never existed (an overload burst would otherwise grow
+            // the tombstone set with ids no stream will ever consume).
+            Ok(Err(e)) => {
+                guard.disarm();
+                return Err(e);
+            }
+            // Join error: the submit panicked (or was cancelled). Whether it
+            // landed is unknowable from here, so leave the guard ARMED and
+            // let it cancel — cancelling an id the engine never admitted is a
+            // documented no-op for every `Engine` impl.
+            Err(e) => return Err(EngineError::Backend(format!("submit task join: {e}"))),
+            Ok(Ok(())) => {}
+        }
+        // The task now has an owner: from here its `Drop` handles cancellation.
+        let stream = self.stream_for(task_id);
+        guard.disarm();
+        Ok(stream)
     }
 
     fn stream_for(&self, task_id: TaskId) -> ChunkStream {
@@ -598,6 +676,44 @@ impl Runner {
         }
         if let Some(builder) = self.builder.lock().as_mut() {
             builder.close();
+        }
+    }
+}
+
+/// Cancels a task on drop unless disarmed — the ownership hand-off between
+/// "submitted" and "a [`ChunkStream`] exists to own it".
+///
+/// [`Runner::generate_async`] arms one before dispatching its submit, so the
+/// window in which a task is submitted but unowned is covered by an RAII
+/// cancel rather than by hoping the caller's future is never dropped. It is
+/// disarmed the instant a `ChunkStream` exists, because from then on that
+/// stream's own `Drop` is the cancel path.
+///
+/// `Drop` may run on any thread (a dropped axum handler future lands on
+/// whichever worker polled it last), so it must never block: it goes through
+/// [`Runner::cancel`], which try_locks the engine and defers when a step is
+/// in flight (#122).
+struct SubmitCancelGuard {
+    runner: Arc<Runner>,
+    task_id: TaskId,
+    armed: bool,
+}
+
+impl SubmitCancelGuard {
+    /// The task found an owner (or was never admitted): stand down.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SubmitCancelGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // Writes the `cancelled` tombstone and cancels the engine-side
+            // task (or defers the engine half). The tombstone is what makes a
+            // submit that has not run yet refuse the task — see the check in
+            // `Runner::submit`.
+            self.runner.cancel(&self.task_id);
         }
     }
 }
@@ -2644,6 +2760,388 @@ mod tests {
                 .get_sample_count(),
             1
         );
+    }
+
+    // -----------------------------------------------------------------
+    // H1: `generate_async` cancellation-safety.
+    //
+    // `spawn_blocking(...).await` is a cancellation point that can pend for
+    // a full engine step. Dropping the caller's future there DETACHES the
+    // closure rather than cancelling it, so the submit still runs — and
+    // before the fix no `ChunkStream` was ever constructed for the task, so
+    // nothing cancelled it and nothing drained it.
+    // -----------------------------------------------------------------
+
+    /// What the engine was actually asked to do. Enough to tell "never
+    /// admitted" from "admitted and ground through tokens nobody read".
+    #[derive(Default, Debug)]
+    struct EngineLog {
+        submitted: Vec<TaskId>,
+        cancelled: Vec<TaskId>,
+        produced: Vec<TaskId>,
+    }
+
+    /// Lets a test pin the engine mutex down for a deterministic window:
+    /// `step()` parks inside the lock until the gate opens.
+    #[derive(Default)]
+    struct Gate {
+        open: AtomicBool,
+        entered: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Gate {
+        fn opened() -> Arc<Self> {
+            let g = Arc::new(Gate::default());
+            g.open.store(true, Ordering::SeqCst);
+            g
+        }
+        fn closed() -> Arc<Self> {
+            Arc::new(Gate::default())
+        }
+        fn release(&self) {
+            self.open.store(true, Ordering::SeqCst);
+        }
+        fn steps_entered(&self) -> usize {
+            self.entered.load(Ordering::SeqCst)
+        }
+    }
+
+    /// Recording engine: one token per active task per `step()`, final marker
+    /// at `max_tokens`, and a log of every submit / cancel / emission.
+    struct RecordingEngine {
+        log: Arc<Mutex<EngineLog>>,
+        gate: Arc<Gate>,
+        active: Vec<(GenerationTask, u32)>,
+    }
+
+    impl Engine for RecordingEngine {
+        fn warmup(&mut self) {}
+
+        fn submit(&mut self, task: GenerationTask) -> Result<(), EngineError> {
+            self.log.lock().submitted.push(task.task_id.clone());
+            self.active.push((task, 0));
+            Ok(())
+        }
+
+        fn cancel(&mut self, task_id: &TaskId) {
+            self.log.lock().cancelled.push(task_id.clone());
+            // An id the engine never admitted is a harmless no-op here, as
+            // the `Engine::cancel` contract requires and every real impl
+            // (ov-runtime, genai, dist_spec, sparse-moe) implements via
+            // `retain` / an id-matched conditional.
+            self.active.retain(|(t, _)| &t.task_id != task_id);
+        }
+
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            self.gate.entered.fetch_add(1, Ordering::SeqCst);
+            while !self.gate.open.load(Ordering::SeqCst) {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+            if self.active.is_empty() {
+                return Ok(Vec::new());
+            }
+            let mut out = Vec::new();
+            let mut still = Vec::new();
+            let mut produced = Vec::new();
+            for (task, emitted) in self.active.drain(..) {
+                let n = emitted + 1;
+                produced.push(task.task_id.clone());
+                out.push((
+                    task.task_id.clone(),
+                    Chunk::token(&task.task_id, n as i64, "x "),
+                ));
+                if n >= task.max_tokens {
+                    out.push((task.task_id.clone(), Chunk::final_marker(&task.task_id, "")));
+                } else {
+                    still.push((task, n));
+                }
+            }
+            self.active = still;
+            self.log.lock().produced.extend(produced);
+            Ok(out)
+        }
+    }
+
+    struct RecordingBuilder {
+        log: Arc<Mutex<EngineLog>>,
+        gate: Arc<Gate>,
+    }
+
+    #[async_trait::async_trait]
+    impl Builder for RecordingBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(RecordingEngine {
+                log: self.log,
+                gate: self.gate,
+                active: Vec::new(),
+            }))
+        }
+    }
+
+    async fn recording_runner(gate: Arc<Gate>) -> (Arc<Runner>, Arc<Mutex<EngineLog>>) {
+        let log = Arc::new(Mutex::new(EngineLog::default()));
+        let runner = Arc::new(Runner::new(Box::new(RecordingBuilder {
+            log: log.clone(),
+            gate,
+        })));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+        (runner, log)
+    }
+
+    /// Poll `cond` until it holds, or fail the test. Used instead of a fixed
+    /// sleep so the blocking-pool hand-offs below are waited on, not guessed.
+    async fn await_until(label: &str, mut cond: impl FnMut() -> bool) {
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        while !cond() {
+            assert!(Instant::now() < deadline, "timed out waiting for {label}");
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
+
+    /// (a) The caller's future is dropped while its submit is parked on the
+    /// engine mutex behind another stream's in-flight step — the axum
+    /// client-disconnect shape, hitting at the moment the wait is longest.
+    ///
+    /// The detached submit runs anyway. It must not leave a ghost: no engine
+    /// admission, no chunks accreting under an id nobody drains, once the
+    /// lock churns.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn dropped_generate_async_leaves_no_ghost_task() {
+        let gate = Gate::closed();
+        let (runner, log) = recording_runner(gate.clone()).await;
+
+        // A holder stream takes the engine mutex and parks inside `step()`.
+        let holder_runner = runner.clone();
+        let holder = tokio::spawn(async move {
+            let mut s = holder_runner
+                .generate_async(GenerationTask::new("holder", "x").with_max_tokens(4))
+                .await
+                .unwrap();
+            let mut n = 0usize;
+            while let Some(c) = s.next().await {
+                assert!(c.error.is_none(), "holder failed: {:?}", c.error);
+                n += 1;
+            }
+            n
+        });
+        await_until("the holder to enter step() with the engine locked", || {
+            gate.steps_entered() >= 1
+        })
+        .await;
+
+        // The engine mutex is held for the whole of this window, so the
+        // ghost's submit cannot complete and the caller goes away first.
+        let dropped = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            runner.generate_async(GenerationTask::new("ghost", "x").with_max_tokens(64)),
+        )
+        .await;
+        assert!(
+            dropped.is_err(),
+            "the submit must still be in flight when the caller's future is dropped"
+        );
+        // Release BEFORE asserting: the holder is parked inside `step()` with
+        // the engine mutex held, so a panic here would wedge the runtime's
+        // teardown instead of reporting the failure. `timeout` has already
+        // dropped the inner future (and run the guard) by the time it returns
+        // Err, so the window under test is closed either way.
+        gate.release();
+        assert!(
+            runner.slot.buffers.lock().cancelled.contains("ghost"),
+            "the drop guard must have tombstoned the abandoned task"
+        );
+
+        // Churn the lock: the holder finishes, then two more full generations
+        // run. Every one of those polls would step a ghost that got admitted.
+        assert!(holder.await.unwrap() > 0);
+        for i in 0..2 {
+            let mut s = runner
+                .generate_async(GenerationTask::new(format!("after-{i}"), "x").with_max_tokens(2))
+                .await
+                .unwrap();
+            while s.next().await.is_some() {}
+        }
+
+        let log = log.lock();
+        assert!(
+            !log.produced.iter().any(|t| t == "ghost"),
+            "abandoned task was admitted and generated tokens nobody reads: {log:?}"
+        );
+        assert!(
+            !log.submitted.iter().any(|t| t == "ghost")
+                || log.cancelled.iter().any(|t| t == "ghost"),
+            "abandoned task was neither refused at submit nor cancelled: {log:?}"
+        );
+        drop(log);
+        assert!(
+            !runner.slot.buffers.lock().chunks.contains_key("ghost"),
+            "chunks accreted for a task with no owner"
+        );
+    }
+
+    /// The other half of (a): the submit LANDS, and only then is the caller's
+    /// future dropped. Nothing refuses it, so the drop guard is the only
+    /// thing that can retire the task — it must cancel it at the engine.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn generate_async_dropped_after_submit_landed_cancels_the_task() {
+        let (runner, log) = recording_runner(Gate::opened()).await;
+
+        {
+            let fut = runner.generate_async(GenerationTask::new("ghost", "x").with_max_tokens(64));
+            futures::pin_mut!(fut);
+            // First poll dispatches the submit; the join is still pending.
+            assert!(futures::poll!(fut.as_mut()).is_pending());
+            await_until("the detached submit to reach the engine", || {
+                log.lock().submitted.iter().any(|t| t == "ghost")
+            })
+            .await;
+            // Dropped without ever being polled again — no stream is built.
+        }
+
+        assert!(
+            log.lock().cancelled.iter().any(|t| t == "ghost"),
+            "an admitted-but-unowned task must be cancelled at the engine: {:?}",
+            log.lock()
+        );
+        // Churn the engine: a still-admitted ghost would generate here.
+        let mut s = runner
+            .generate_async(GenerationTask::new("after", "x").with_max_tokens(2))
+            .await
+            .unwrap();
+        while s.next().await.is_some() {}
+        assert!(
+            !log.lock().produced.iter().any(|t| t == "ghost"),
+            "cancelled ghost still generated: {:?}",
+            log.lock()
+        );
+    }
+
+    /// (b), unit form: a tombstoned id is refused inside `submit` — a benign
+    /// no-op `Ok(())`, and the engine never sees the task. A fresh id still
+    /// lands, so the check refuses exactly one thing.
+    #[tokio::test]
+    async fn submit_refuses_an_already_tombstoned_id() {
+        let (runner, log) = recording_runner(Gate::opened()).await;
+        runner.cancel(&"ghost".to_string());
+        runner
+            .submit(GenerationTask::new("ghost", "x").with_max_tokens(8))
+            .expect("a refused submit is a no-op Ok, not an error");
+        runner
+            .submit(GenerationTask::new("live", "x").with_max_tokens(8))
+            .unwrap();
+        let log = log.lock();
+        assert!(
+            !log.submitted.iter().any(|t| t == "ghost"),
+            "a cancelled task must never reach the engine: {log:?}"
+        );
+        assert!(
+            log.submitted.iter().any(|t| t == "live"),
+            "the tombstone check must not refuse healthy submits: {log:?}"
+        );
+    }
+
+    /// (b), the real ordering race: the caller's future is dropped BEFORE the
+    /// submit closure has run at all, so the guard's cancel executes FIRST
+    /// and the submit would admit the task afterwards. Forced deterministic
+    /// by capping the blocking pool at one thread and occupying it, which is
+    /// exactly the production shape (every worker busy) that makes the race
+    /// reachable.
+    #[test]
+    fn submit_queued_behind_a_drop_is_refused_when_it_finally_runs() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (runner, log) = recording_runner(Gate::opened()).await;
+
+            // Occupy the pool's only blocking thread.
+            let (release, blocked) = std::sync::mpsc::channel::<()>();
+            let started = Arc::new(AtomicBool::new(false));
+            let started_in = started.clone();
+            let occupier = tokio::task::spawn_blocking(move || {
+                started_in.store(true, Ordering::SeqCst);
+                let _ = blocked.recv();
+            });
+            await_until("the blocking pool's only thread to be occupied", || {
+                started.load(Ordering::SeqCst)
+            })
+            .await;
+
+            // Dispatch + drop. The submit closure is queued, never run.
+            let dropped = tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                runner.generate_async(GenerationTask::new("ghost", "x").with_max_tokens(64)),
+            )
+            .await;
+            assert!(dropped.is_err());
+            assert!(
+                log.lock().submitted.is_empty(),
+                "the submit closure must still be queued behind the occupier"
+            );
+            assert!(runner.slot.buffers.lock().cancelled.contains("ghost"));
+
+            // Release the pool. The blocking queue is FIFO, so the barrier
+            // below can only run once the ghost's submit closure has finished.
+            drop(release);
+            occupier.await.unwrap();
+            tokio::task::spawn_blocking(|| {}).await.unwrap();
+
+            assert!(
+                !log.lock().submitted.iter().any(|t| t == "ghost"),
+                "a submit that runs after its caller cancelled must be refused: {:?}",
+                log.lock()
+            );
+
+            // And the runner is still usable for real work afterwards.
+            let mut s = runner
+                .generate_async(GenerationTask::new("fresh", "x").with_max_tokens(2))
+                .await
+                .unwrap();
+            let mut n = 0usize;
+            while let Some(c) = s.next().await {
+                assert!(c.error.is_none(), "{:?}", c.error);
+                n += 1;
+            }
+            assert!(n > 0, "a fresh request must still stream");
+        });
+    }
+
+    /// (c) The normal path is untouched: polled to completion,
+    /// `generate_async` streams exactly what it always did.
+    #[tokio::test]
+    async fn generate_async_polled_to_completion_is_unaffected() {
+        let runner = Arc::new(make_runner().await);
+        let task = GenerationTask::new("t-ga", "the quick brown fox").with_max_tokens(2);
+        let mut stream = runner.generate_async(task).await.unwrap();
+        let mut chunks = Vec::new();
+        while let Some(c) = stream.next().await {
+            chunks.push(c);
+        }
+        // Two tokens then a final marker — same as the sync `generate()`.
+        // A guard that failed to disarm would have cancelled us to zero.
+        assert_eq!(chunks.len(), 3, "{chunks:?}");
+        assert_eq!(chunks[0].text, "the ");
+        assert_eq!(chunks[1].text, "quick ");
+        assert!(chunks.last().unwrap().is_final);
+        assert!(chunks.iter().all(|c| c.error.is_none()));
     }
 
     #[tokio::test]

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -130,6 +130,55 @@ struct Buffers {
     deferred_cancels: Vec<TaskId>,
 }
 
+/// Drains + wakes [`Buffers::step_wakers`] when it leaves scope — including
+/// when a panic unwinds out of that scope.
+///
+/// The drain after an engine-lock release is straight-line code, so an
+/// unwind skips it: a panic inside `step()` (or anything else run under the
+/// engine guard) leaves every parked stream `Pending` forever with nothing
+/// in the log to say why. `parking_lot` does not poison, so the engine
+/// itself is released and perfectly usable — there is simply no one left to
+/// poll it. Running the drain from a destructor covers the unwind path too.
+///
+/// DECLARE THIS BEFORE the engine guard it protects: locals drop in reverse
+/// declaration order, so the engine lock is released first and the wake runs
+/// with the engine free. Waking while the lock is still held lets a woken
+/// stream re-park behind it and be stranded exactly as before.
+struct WakeParkedOnDrop<'a> {
+    buffers: &'a Mutex<Buffers>,
+    /// Armed only once the engine lock is actually held. A contended
+    /// `poll_next` that gives up and returns `Pending` has just registered
+    /// its OWN waker; draining from there would wake it straight back and
+    /// spin the worker for the whole of the holder's step.
+    armed: bool,
+}
+
+impl<'a> WakeParkedOnDrop<'a> {
+    /// Inert until [`arm`](Self::arm) is called.
+    fn disarmed(buffers: &'a Mutex<Buffers>) -> Self {
+        Self {
+            buffers,
+            armed: false,
+        }
+    }
+
+    fn arm(&mut self) {
+        self.armed = true;
+    }
+}
+
+impl Drop for WakeParkedOnDrop<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let wakers = std::mem::take(&mut self.buffers.lock().step_wakers);
+        for w in wakers {
+            w.wake();
+        }
+    }
+}
+
 pub struct Runner {
     /// Mutex so the Runner is `Sync` even with a `dyn Builder` inside;
     /// taken once during `start()` and dropped.
@@ -644,6 +693,13 @@ impl Stream for ChunkStream {
             //    someone else is stepping; park with a registered waker and
             //    let their release wake us.
             let step_result = {
+                // Wake-on-release, unwind included: `step()` runs arbitrary
+                // engine code under this lock, and a panic there must not
+                // strand the streams parked behind it (see
+                // `WakeParkedOnDrop`). Declared BEFORE the engine guard so
+                // reverse-declaration drop order releases the engine first
+                // and wakes second, on the normal path and on the unwind.
+                let mut wake_on_release = WakeParkedOnDrop::disarmed(&this.buffers);
                 let mut guard = match this.engine.try_lock() {
                     Some(g) => g,
                     None => {
@@ -658,6 +714,9 @@ impl Stream for ChunkStream {
                         }
                     }
                 };
+                // The engine is ours: every exit from here — value, early
+                // return, or panic — owes the parked streams a wake.
+                wake_on_release.arm();
                 let result = match guard.as_mut() {
                     // Slot empty: `Runner::close` took the engine, i.e. server
                     // teardown. Handled below rather than here because
@@ -688,12 +747,9 @@ impl Stream for ChunkStream {
                         })
                     }
                 };
+                // Engine released here; `wake_on_release` drains + wakes
+                // every stream parked on contention right after.
                 drop(guard);
-                // Engine released: wake every stream parked on contention.
-                let wakers = std::mem::take(&mut this.buffers.lock().step_wakers);
-                for w in wakers {
-                    w.wake();
-                }
                 result
             };
             let Some(step_result) = step_result else {
@@ -838,22 +894,25 @@ impl Drop for ChunkStream {
         // during another stream's step counts toward the worker starvation
         // that wedges the pipeline (#122). Busy engine = defer; the next
         // engine-lock holder applies it before stepping.
-        match self.engine.try_lock() {
-            Some(mut guard) => {
-                if let Some(engine) = guard.as_mut() {
-                    engine.cancel(&self.task_id);
+        {
+            // Same wake-on-release protocol as `poll_next`, unwind
+            // included: `engine.cancel()` is engine code too, and a panic
+            // here would otherwise strand every parked stream. Declared
+            // BEFORE the guard so the engine lock is released first.
+            let mut wake_on_release = WakeParkedOnDrop::disarmed(&self.buffers);
+            match self.engine.try_lock() {
+                Some(mut guard) => {
+                    wake_on_release.arm();
+                    if let Some(engine) = guard.as_mut() {
+                        engine.cancel(&self.task_id);
+                    }
                 }
-                drop(guard);
-                let wakers = std::mem::take(&mut self.buffers.lock().step_wakers);
-                for w in wakers {
-                    w.wake();
+                None => {
+                    self.buffers
+                        .lock()
+                        .deferred_cancels
+                        .push(self.task_id.clone());
                 }
-            }
-            None => {
-                self.buffers
-                    .lock()
-                    .deferred_cancels
-                    .push(self.task_id.clone());
             }
         }
         let mut bufs = self.buffers.lock();
@@ -1407,6 +1466,153 @@ mod tests {
             !runner.buffers.lock().chunks.contains_key("dead"),
             "routing a failure to a cancelled task must not recreate its buffer entry"
         );
+    }
+
+    /// Engine whose first `step()` panics while holding the engine lock —
+    /// an engine bug, but one whose unwind passes straight through
+    /// `ChunkStream::poll_next`. It blocks in `step()` until the test has a
+    /// second stream parked behind the lock, then panics. Later steps fail
+    /// cleanly so a woken stream can terminate instead of panicking in turn.
+    struct PanicStepEngine {
+        entered: Arc<AtomicBool>,
+        release: Arc<AtomicBool>,
+        panicked: Arc<AtomicBool>,
+    }
+
+    impl Engine for PanicStepEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            if self.panicked.load(Ordering::SeqCst) {
+                return Err(EngineError::Backend("engine panicked earlier".into()));
+            }
+            self.entered.store(true, Ordering::SeqCst);
+            // Bounded, so a broken test fails rather than hangs.
+            let start = Instant::now();
+            while !self.release.load(Ordering::SeqCst)
+                && start.elapsed() < std::time::Duration::from_secs(10)
+            {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            self.panicked.store(true, Ordering::SeqCst);
+            panic!("engine step blew up");
+        }
+    }
+
+    struct PanicStepBuilder {
+        entered: Arc<AtomicBool>,
+        release: Arc<AtomicBool>,
+        panicked: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Builder for PanicStepBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(PanicStepEngine {
+                entered: self.entered,
+                release: self.release,
+                panicked: self.panicked,
+            }))
+        }
+    }
+
+    /// A panic inside `step()` must still wake the streams parked on the
+    /// engine lock.
+    ///
+    /// `parking_lot` doesn't poison, so the unwind releases the engine and
+    /// the next poller could drive it fine — but the drain + wake used to be
+    /// straight-line code after the release, which an unwind skips. Every
+    /// parked stream then waited `Pending` forever, with no log line and a
+    /// perfectly healthy-looking engine.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn step_panic_still_wakes_parked_streams() {
+        let entered = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+        let panicked = Arc::new(AtomicBool::new(false));
+        let runner = Arc::new(Runner::new(Box::new(PanicStepBuilder {
+            entered: entered.clone(),
+            release: release.clone(),
+            panicked: panicked.clone(),
+        })));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+
+        let stream_a = runner
+            .generate(GenerationTask::new("panic-a", "x").with_max_tokens(4))
+            .unwrap();
+        let mut stream_b = runner
+            .generate(GenerationTask::new("panic-b", "y").with_max_tokens(4))
+            .unwrap();
+
+        // Poll A on a blocking thread and catch the panic THERE, keeping A's
+        // ChunkStream alive across the unwind: dropping it would run
+        // `ChunkStream::drop`, whose own release wakes B and would mask the
+        // bug under test.
+        let (hold_tx, hold_rx) = std::sync::mpsc::channel::<()>();
+        let a = tokio::task::spawn_blocking(move || {
+            let mut sa = stream_a;
+            let waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&waker);
+            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = Pin::new(&mut sa).poll_next(&mut cx);
+            }));
+            let _ = hold_rx.recv(); // hold A's stream until the test is done
+            caught.is_err()
+        });
+
+        // Wait until A is inside step(), holding the engine lock.
+        let start = Instant::now();
+        while !entered.load(Ordering::SeqCst) {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(10),
+                "stream A never entered step()"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        // B polls, finds the engine contended, and parks with a waker.
+        let b = tokio::spawn(async move { stream_b.next().await });
+        let start = Instant::now();
+        while runner.buffers.lock().step_wakers.is_empty() {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(10),
+                "stream B never parked on the engine lock"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        // Blow up the step with B parked behind the lock.
+        release.store(true, Ordering::SeqCst);
+
+        let chunk = tokio::time::timeout(std::time::Duration::from_secs(10), b)
+            .await
+            .expect("parked stream was never woken after a panicking step()")
+            .unwrap();
+        let chunk = chunk.expect("woken stream must terminate loud, not silently");
+        assert!(chunk.is_final);
+        assert!(
+            chunk.error.is_some(),
+            "woken stream must surface the broken engine: {chunk:?}"
+        );
+
+        let _ = hold_tx.send(());
+        assert!(a.await.unwrap(), "step() was expected to panic");
     }
 
     /// Engine that never errors and never produces: every step is Ok(empty).

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -434,14 +434,19 @@ impl Runner {
 
     /// Enqueue a task with the engine.
     ///
+    /// **Blocks the calling thread** for up to a full engine step when one is
+    /// in flight. Async contexts must not call this directly — use
+    /// [`Runner::generate_async`], which dispatches it via `spawn_blocking`.
+    ///
     /// Refuses (as a benign no-op `Ok(())`) any task whose id already carries
     /// a `cancelled` tombstone — see the comment in the lock region below.
     pub fn submit(&self, task: GenerationTask) -> Result<(), EngineError> {
-        // NOTE: blocks the calling thread for up to one engine step if a
-        // step is in flight. Async callers must use [`Runner::generate`]'s
-        // async submit path (or their own `spawn_blocking`) — a worker
-        // thread blocked here counts toward the driver starvation that
-        // wedges the pipeline (#122).
+        // NOTE: the lock below is a hard `lock()`, not a `try_lock()` — this
+        // is the one engine-lock caller that must not give up, since there is
+        // nowhere to park a submit. A tokio worker thread blocked here counts
+        // toward the driver starvation that wedges the pipeline (#122), which
+        // is why the async entry point (`Runner::generate_async`) keeps this
+        // call off the runtime.
         // Releasing the guard wakes the streams parked on contention, on
         // the empty-slot path as much as the submitting one — an empty slot
         // means `close()` already ran, so no later lock holder is coming to
@@ -503,6 +508,10 @@ impl Runner {
     /// chunk, on cancellation, on an engine step error, or after
     /// MAX_CONSECUTIVE_EMPTY_STEPS empty engine polls (engine appears
     /// stuck).
+    ///
+    /// **Blocks the calling thread** for up to a full engine step: the submit
+    /// runs inline via [`Runner::submit`], and only the returned stream is
+    /// async. Async contexts must use [`Runner::generate_async`] instead.
     pub fn generate(&self, task: GenerationTask) -> Result<ChunkStream, EngineError> {
         self.submit(task.clone())?;
         Ok(self.stream_for(task.task_id))

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -36,6 +36,13 @@ const MAX_CONSECUTIVE_EMPTY_STEPS: usize = 3;
 /// situation (`WORKER_BACKOFF`).
 const RELAY_ERR_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
 
+/// Ceiling on [`Buffers::deferred_cancels`]. Matches the `cancelled`
+/// tombstone bound: every engine-lock acquisition drains the queue, so
+/// reaching this means the engine is not being locked at all and the
+/// cancels are moot anyway — but an unbounded vec on that path would grow
+/// for the life of the process.
+const MAX_DEFERRED_CANCELS: usize = 4096;
+
 /// Why [`Runner::run_relay_loop`] returned.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RelayExit {
@@ -125,9 +132,21 @@ struct Buffers {
     /// between the check and the registration.
     step_wakers: Vec<std::task::Waker>,
     /// Cancels that could not take the engine lock without blocking a
-    /// worker thread (#122). Applied by the next engine-lock holder before
-    /// it steps — the same effective timing a blocking cancel had, since a
-    /// running step can't be interrupted anyway.
+    /// worker thread (#122). Applied by the next holder to ACQUIRE the
+    /// engine lock — `submit`, `poll_next`, another `cancel`, or a relay
+    /// round — before it does anything else with the engine. That is the
+    /// same effective timing a blocking cancel had, since a running step
+    /// can't be interrupted anyway.
+    ///
+    /// Draining only from `poll_next` was not enough: cancelling the one
+    /// in-flight request leaves nobody polling, so its engine-side slot and
+    /// KV region stayed occupied until some later request happened along —
+    /// hours, on an idle server. A relay-stage runner takes `cancel()`
+    /// calls and never polls a stream at all, so the queue there only grew.
+    ///
+    /// Deduped on push, and capped at [`MAX_DEFERRED_CANCELS`] like the
+    /// `cancelled` tombstone set, so a queue that is somehow not being
+    /// drained cannot grow without bound.
     deferred_cancels: Vec<TaskId>,
 }
 
@@ -198,6 +217,22 @@ impl EngineGuard<'_> {
             **g = engine;
         }
     }
+
+    /// Hand the engine the cancels that arrived while it was busy, before
+    /// this holder does anything else with it (see
+    /// [`Buffers::deferred_cancels`]). Draining an emptied slot's queue is
+    /// still correct: `close()` has run, so there is nothing left to cancel.
+    fn apply_deferred_cancels(&mut self) {
+        let deferred = std::mem::take(&mut self.slot.buffers.lock().deferred_cancels);
+        if deferred.is_empty() {
+            return;
+        }
+        if let Some(engine) = self.engine() {
+            for tid in &deferred {
+                engine.cancel(tid);
+            }
+        }
+    }
 }
 
 impl Drop for EngineGuard<'_> {
@@ -239,6 +274,24 @@ impl EngineSlot {
         })
     }
 
+    /// [`lock`](Self::lock), then hand the engine everything queued in
+    /// [`Buffers::deferred_cancels`]. Every acquisition that can act on
+    /// that queue goes through this or its `try_` twin, which is what makes
+    /// the queue's contract ("applied by the next engine-lock holder") true
+    /// rather than "applied by the next stream poll, if one ever comes".
+    fn lock_applying_cancels(&self) -> EngineGuard<'_> {
+        let mut guard = self.lock();
+        guard.apply_deferred_cancels();
+        guard
+    }
+
+    /// [`try_lock`](Self::try_lock) + [`lock_applying_cancels`] semantics.
+    fn try_lock_applying_cancels(&self) -> Option<EngineGuard<'_>> {
+        let mut guard = self.try_lock()?;
+        guard.apply_deferred_cancels();
+        Some(guard)
+    }
+
     /// Cancel `task_id` on the engine, or queue it for the next lock holder
     /// when a step is in flight.
     ///
@@ -250,14 +303,38 @@ impl EngineSlot {
     /// anyway, so the next holder applies it at the same effective time a
     /// blocking cancel would have.
     fn cancel_or_defer(&self, task_id: &TaskId) {
-        match self.try_lock() {
+        match self.try_lock_applying_cancels() {
             Some(mut guard) => {
                 if let Some(engine) = guard.engine() {
                     engine.cancel(task_id);
                 }
             }
-            None => self.buffers.lock().deferred_cancels.push(task_id.clone()),
+            None => self.defer_cancel(task_id),
         }
+    }
+
+    /// Queue a cancel for the next engine-lock holder.
+    ///
+    /// Deduped: the queue is a to-do list, and cancelling the same task
+    /// twice buys nothing. Capped at [`MAX_DEFERRED_CANCELS`], dropping the
+    /// newest with a warning rather than clearing the queue wholesale — the
+    /// tombstone set can afford a wholesale clear because re-buffering one
+    /// late chunk is the whole cost, whereas dropping queued cancels leaves
+    /// that many engine-side slots occupied.
+    fn defer_cancel(&self, task_id: &TaskId) {
+        let mut bufs = self.buffers.lock();
+        if bufs.deferred_cancels.iter().any(|t| t == task_id) {
+            return;
+        }
+        if bufs.deferred_cancels.len() >= MAX_DEFERRED_CANCELS {
+            warn!(
+                task = %task_id,
+                "deferred cancel queue is full ({MAX_DEFERRED_CANCELS}); dropping this cancel — \
+                 the engine keeps the task until it finishes on its own"
+            );
+            return;
+        }
+        bufs.deferred_cancels.push(task_id.clone());
     }
 }
 
@@ -364,8 +441,10 @@ impl Runner {
         // Releasing the guard wakes the streams parked on contention, on
         // the empty-slot path as much as the submitting one — an empty slot
         // means `close()` already ran, so no later lock holder is coming to
-        // wake them instead.
-        let mut guard = self.slot.lock();
+        // wake them instead. Taking the lock also flushes cancels deferred
+        // while the engine was busy, freeing their slots before this task
+        // asks for one.
+        let mut guard = self.slot.lock_applying_cancels();
         match guard.engine() {
             Some(engine) => engine.submit(task),
             None => Err(EngineError::NotLoaded),
@@ -456,8 +535,10 @@ impl Runner {
             // runner serves no streams today, so it has nothing to wake —
             // but a runner that both relays and generates would strand
             // every parked stream behind this loop, and the guard makes
-            // that impossible for free.
-            let mut guard = self.slot.lock();
+            // that impossible for free. It is also the only thing that ever
+            // drains a relay-stage runner's deferred cancels: nobody polls a
+            // stream here, so without this round the queue only grows.
+            let mut guard = self.slot.lock_applying_cancels();
             let Some(engine) = guard.engine() else {
                 drop(guard);
                 info!("relay loop exited: engine slot empty");
@@ -764,7 +845,11 @@ impl Stream for ChunkStream {
             //    someone else is stepping; park with a registered waker and
             //    let their release wake us.
             let step_result = {
-                let mut guard = match this.slot.try_lock() {
+                //    Acquiring also applies the cancels deferred while the
+                //    engine was busy (Runner::cancel / stream Drop never
+                //    block on the engine mutex — see deferred_cancels), so
+                //    this step doesn't spend a round on abandoned tasks.
+                let mut guard = match this.slot.try_lock_applying_cancels() {
                     Some(g) => g,
                     None => {
                         this.slot
@@ -779,7 +864,7 @@ impl Stream for ChunkStream {
                         // No guard exists on this path, so returning Pending
                         // does NOT wake — waking the waker just registered
                         // would spin this worker for the holder's whole step.
-                        match this.slot.try_lock() {
+                        match this.slot.try_lock_applying_cancels() {
                             Some(g) => g,
                             None => return Poll::Pending,
                         }
@@ -791,30 +876,20 @@ impl Stream for ChunkStream {
                     // `fail_teardown` needs `&mut *this` and this guard still
                     // borrows `this.slot`.
                     None => None,
-                    Some(engine) => {
-                        // Apply cancels that arrived while the engine was
-                        // busy (Runner::cancel / stream Drop never block on
-                        // the engine mutex — see deferred_cancels).
-                        let deferred =
-                            std::mem::take(&mut this.slot.buffers.lock().deferred_cancels);
-                        for tid in &deferred {
-                            engine.cancel(tid);
-                        }
-                        Some(match engine.step() {
-                            Ok(produced) => {
-                                let empty = produced.is_empty();
-                                let mut bufs = this.slot.buffers.lock();
-                                for (tid, chunk) in produced {
-                                    if bufs.cancelled.contains(&tid) {
-                                        continue;
-                                    }
-                                    bufs.chunks.entry(tid).or_default().push_back(chunk);
+                    Some(engine) => Some(match engine.step() {
+                        Ok(produced) => {
+                            let empty = produced.is_empty();
+                            let mut bufs = this.slot.buffers.lock();
+                            for (tid, chunk) in produced {
+                                if bufs.cancelled.contains(&tid) {
+                                    continue;
                                 }
-                                Ok(empty)
+                                bufs.chunks.entry(tid).or_default().push_back(chunk);
                             }
-                            Err(e) => Err(e),
-                        })
-                    }
+                            Ok(empty)
+                        }
+                        Err(e) => Err(e),
+                    }),
                 };
                 // Releasing the guard is what drains + wakes every stream
                 // parked on contention — engine first, wake second, and on
@@ -1662,6 +1737,197 @@ mod tests {
 
         let _ = hold_tx.send(());
         assert!(a.await.unwrap(), "step() was expected to panic");
+    }
+
+    /// Engine that blocks inside `step()` until the test releases it and
+    /// records every `cancel()` it is handed. Lets a test hold the engine
+    /// lock at a chosen moment, then observe exactly which later lock
+    /// acquisition delivered a deferred cancel.
+    struct GatedCancelEngine {
+        serve: TaskId,
+        entered: Arc<AtomicBool>,
+        release: Arc<AtomicBool>,
+        cancels: Arc<Mutex<Vec<TaskId>>>,
+    }
+
+    impl Engine for GatedCancelEngine {
+        fn warmup(&mut self) {}
+        fn submit(&mut self, _task: GenerationTask) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn cancel(&mut self, task_id: &TaskId) {
+            self.cancels.lock().push(task_id.clone());
+        }
+        fn step(&mut self) -> Result<Vec<(TaskId, Chunk)>, EngineError> {
+            self.entered.store(true, Ordering::SeqCst);
+            // Bounded, so a broken test fails rather than hangs.
+            let start = Instant::now();
+            while !self.release.load(Ordering::SeqCst)
+                && start.elapsed() < std::time::Duration::from_secs(10)
+            {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            Ok(vec![(
+                self.serve.clone(),
+                Chunk::token(self.serve.clone(), 0, "x"),
+            )])
+        }
+    }
+
+    struct GatedCancelBuilder {
+        serve: TaskId,
+        entered: Arc<AtomicBool>,
+        release: Arc<AtomicBool>,
+        cancels: Arc<Mutex<Vec<TaskId>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Builder for GatedCancelBuilder {
+        async fn connect(&mut self, _peers: PeerLayout) -> Result<(), EngineError> {
+            Ok(())
+        }
+        async fn load(
+            &mut self,
+            _shard: ShardSpec,
+        ) -> Result<cascadia_engine::LoadStream, EngineError> {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+        fn build(self: Box<Self>) -> Result<Box<dyn Engine>, EngineError> {
+            Ok(Box::new(GatedCancelEngine {
+                serve: self.serve,
+                entered: self.entered,
+                release: self.release,
+                cancels: self.cancels,
+            }))
+        }
+    }
+
+    /// A cancel deferred past a busy engine must be applied by the next
+    /// engine-lock ACQUISITION, not only by the next stream poll.
+    ///
+    /// Cancelling the sole in-flight request leaves nobody polling, so a
+    /// poll-only drain kept the task's engine-side slot and KV region
+    /// occupied until some unrelated request happened along — hours, on an
+    /// idle server — while the queue's own contract said "the next
+    /// engine-lock holder". A plain `submit` is such a holder.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deferred_cancel_is_applied_by_the_next_lock_acquisition() {
+        let entered = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+        let polled = Arc::new(AtomicBool::new(false));
+        let cancels = Arc::new(Mutex::new(Vec::new()));
+        let runner = Arc::new(Runner::new(Box::new(GatedCancelBuilder {
+            serve: "holder".to_string(),
+            entered: entered.clone(),
+            release: release.clone(),
+            cancels: cancels.clone(),
+        })));
+        runner
+            .start(
+                PeerLayout::single_stage(),
+                ShardSpec::single_stage("m", "CPU"),
+            )
+            .await
+            .unwrap();
+
+        let holder = runner
+            .generate(GenerationTask::new("holder", "x").with_max_tokens(64))
+            .unwrap();
+        // Exactly ONE manual poll, on a blocking thread: one engine-lock
+        // acquisition, and the stream is kept alive afterwards so its Drop
+        // (which also takes the lock) can't be what applies the cancel.
+        let (hold_tx, hold_rx) = std::sync::mpsc::channel::<()>();
+        let polled_by_task = polled.clone();
+        let poll = tokio::task::spawn_blocking(move || {
+            let mut s = holder;
+            let waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&waker);
+            let out = Pin::new(&mut s).poll_next(&mut cx);
+            polled_by_task.store(true, Ordering::SeqCst);
+            let _ = hold_rx.recv();
+            out.is_ready()
+        });
+
+        // Wait until the poll is inside step(), holding the engine lock.
+        let start = Instant::now();
+        while !entered.load(Ordering::SeqCst) {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(10),
+                "the holding stream never entered step()"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+
+        // Mid-step: this cancel cannot take the lock, so it is deferred.
+        // Twice, because the queue is a to-do list, not a log.
+        runner.cancel(&"victim".to_string());
+        runner.cancel(&"victim".to_string());
+        assert_eq!(
+            runner.slot.buffers.lock().deferred_cancels,
+            vec!["victim".to_string()],
+            "a cancel behind a busy engine must be deferred, and deduped"
+        );
+        assert!(
+            cancels.lock().is_empty(),
+            "the engine was mid-step; no cancel could have reached it yet"
+        );
+
+        // Let the step finish. The poll returns, releasing the engine.
+        release.store(true, Ordering::SeqCst);
+        let start = Instant::now();
+        while !polled.load(Ordering::SeqCst) {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(10),
+                "the holding stream's poll never returned"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        assert!(
+            cancels.lock().is_empty(),
+            "nothing has taken the engine lock since the cancel was deferred"
+        );
+
+        // A plain submit — no stream polled anywhere — is the next holder.
+        runner
+            .submit(GenerationTask::new("later", "y").with_max_tokens(1))
+            .unwrap();
+        assert_eq!(
+            &*cancels.lock(),
+            &["victim".to_string()],
+            "the next engine-lock acquisition must apply the deferred cancel"
+        );
+        assert!(
+            runner.slot.buffers.lock().deferred_cancels.is_empty(),
+            "applying the queue must clear it"
+        );
+
+        let _ = hold_tx.send(());
+        assert!(poll.await.unwrap(), "the gated poll should have produced");
+    }
+
+    /// The deferred-cancel queue is a bounded to-do list. A runner whose
+    /// engine nobody locks (a relay stage taking cancel() calls) would
+    /// otherwise accrete one entry per cancelled request for the life of
+    /// the process.
+    #[test]
+    fn deferred_cancel_queue_dedups_and_is_bounded() {
+        let slot = EngineSlot::new(None);
+        for _ in 0..8 {
+            slot.defer_cancel(&"same".to_string());
+        }
+        assert_eq!(
+            slot.buffers.lock().deferred_cancels,
+            vec!["same".to_string()],
+            "re-cancelling one task must not queue it twice"
+        );
+        for i in 0..MAX_DEFERRED_CANCELS + 16 {
+            slot.defer_cancel(&format!("t{i}"));
+        }
+        assert_eq!(
+            slot.buffers.lock().deferred_cancels.len(),
+            MAX_DEFERRED_CANCELS,
+            "the queue must stop growing at its cap"
+        );
     }
 
     /// Engine that never errors and never produces: every step is Ok(empty).

--- a/crates/cascadia-runner/src/lib.rs
+++ b/crates/cascadia-runner/src/lib.rs
@@ -117,6 +117,17 @@ pub fn run_async<F: std::future::Future>(handle: &tokio::runtime::Handle, fut: F
 struct Buffers {
     chunks: HashMap<TaskId, VecDeque<Chunk>>,
     cancelled: std::collections::HashSet<TaskId>,
+    /// Streams parked because another caller held the engine (#122). Every
+    /// engine-lock release drains + wakes these, so a parked stream re-polls
+    /// as soon as the engine may be free. Registration happens ONLY after a
+    /// failed `try_lock`, and the registrant re-checks the lock afterwards,
+    /// so a release can't slip between the check and the registration.
+    step_wakers: Vec<std::task::Waker>,
+    /// Cancels that could not take the engine lock without blocking a
+    /// worker thread (#122). Applied by the next engine-lock holder before
+    /// it steps — the same effective timing a blocking cancel had, since a
+    /// running step can't be interrupted anyway.
+    deferred_cancels: Vec<TaskId>,
 }
 
 pub struct Runner {
@@ -217,9 +228,28 @@ impl Runner {
     }
 
     pub fn submit(&self, task: GenerationTask) -> Result<(), EngineError> {
-        let mut guard = self.engine.lock();
-        let engine = guard.as_mut().ok_or(EngineError::NotLoaded)?;
-        engine.submit(task)
+        // NOTE: blocks the calling thread for up to one engine step if a
+        // step is in flight. Async callers must use [`Runner::generate`]'s
+        // async submit path (or their own `spawn_blocking`) — a worker
+        // thread blocked here counts toward the driver starvation that
+        // wedges the pipeline (#122).
+        let res = {
+            let mut guard = self.engine.lock();
+            let engine = guard.as_mut().ok_or(EngineError::NotLoaded)?;
+            engine.submit(task)
+        };
+        self.wake_parked_streams();
+        res
+    }
+
+    /// Drain + wake every stream that parked on engine-lock contention.
+    /// Called after every engine-lock release (#122): a parked stream is
+    /// only ever woken from here, so skipping a release site would strand it.
+    fn wake_parked_streams(&self) {
+        let wakers = std::mem::take(&mut self.buffers.lock().step_wakers);
+        for w in wakers {
+            w.wake();
+        }
     }
 
     /// Cooperatively cancel a task.
@@ -235,8 +265,22 @@ impl Runner {
             bufs.cancelled.insert(task_id.clone());
             bufs.chunks.remove(task_id);
         }
-        if let Some(engine) = self.engine.lock().as_mut() {
-            engine.cancel(task_id);
+        // Never block a (possibly async) caller on the engine mutex — a
+        // worker thread parked here counts toward the driver starvation
+        // that wedges the pipeline (#122). If a step is in flight, defer:
+        // the next engine-lock holder applies it before stepping, which is
+        // when a blocking cancel would have run anyway.
+        match self.engine.try_lock() {
+            Some(mut guard) => {
+                if let Some(engine) = guard.as_mut() {
+                    engine.cancel(task_id);
+                }
+                drop(guard);
+                self.wake_parked_streams();
+            }
+            None => {
+                self.buffers.lock().deferred_cancels.push(task_id.clone());
+            }
         }
     }
 
@@ -246,8 +290,29 @@ impl Runner {
     /// stuck).
     pub fn generate(&self, task: GenerationTask) -> Result<ChunkStream, EngineError> {
         self.submit(task.clone())?;
-        Ok(ChunkStream {
-            task_id: task.task_id,
+        Ok(self.stream_for(task.task_id))
+    }
+
+    /// Async [`Runner::generate`]: submits off the runtime via
+    /// `spawn_blocking`. Async servers must use this — `submit` blocks on
+    /// the engine mutex for up to a full engine step, and enough worker
+    /// threads parked there starve the tokio I/O + timer drivers, which is
+    /// the #122 pipeline wedge.
+    pub async fn generate_async(
+        self: &Arc<Self>,
+        task: GenerationTask,
+    ) -> Result<ChunkStream, EngineError> {
+        let this = self.clone();
+        let submitted = task.clone();
+        tokio::task::spawn_blocking(move || this.submit(submitted))
+            .await
+            .map_err(|e| EngineError::Backend(format!("submit task join: {e}")))??;
+        Ok(self.stream_for(task.task_id))
+    }
+
+    fn stream_for(&self, task_id: TaskId) -> ChunkStream {
+        ChunkStream {
+            task_id,
             engine: self.engine.clone(),
             buffers: self.buffers.clone(),
             consecutive_empty: 0,
@@ -259,7 +324,7 @@ impl Runner {
             last_chunk_at: None,
             metrics_finalized: false,
             closing: self.closing.clone(),
-        })
+        }
     }
 
     /// Step the engine forever; exits when the engine slot empties (clean
@@ -331,6 +396,9 @@ impl Runner {
             engine.close();
         }
         *self.engine.lock() = None;
+        // Streams parked on engine-lock contention must re-poll to observe
+        // the emptied slot, or a teardown would strand them Pending forever.
+        self.wake_parked_streams();
         if let Some(builder) = self.builder.lock().as_mut() {
             builder.close();
         }
@@ -522,7 +590,7 @@ impl ChunkStream {
 impl Stream for ChunkStream {
     type Item = Chunk;
 
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Chunk>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Chunk>> {
         let this = self.get_mut();
         loop {
             if this.done {
@@ -566,29 +634,67 @@ impl Stream for ChunkStream {
             //    which another stream completes a LATER step and buffers its
             //    round before this one lands — reordering a single request's
             //    own text. Step and distribute have to be one critical section.
+            //    The engine mutex is a sync lock and `step()` spans real
+            //    network round trips, so NEVER block this worker thread on
+            //    it: enough streams parked in a hard `lock()` here (plus one
+            //    stepping) can pin every tokio worker, and with no worker
+            //    left to poll the I/O + timer drivers the step-holder's
+            //    `recv()` never wakes — no bytes delivered, no timeout fired,
+            //    the whole pipeline permanently wedged (#122). Contended =
+            //    someone else is stepping; park with a registered waker and
+            //    let their release wake us.
             let step_result = {
-                let mut guard = this.engine.lock();
-                match guard.as_mut() {
+                let mut guard = match this.engine.try_lock() {
+                    Some(g) => g,
+                    None => {
+                        this.buffers.lock().step_wakers.push(cx.waker().clone());
+                        // Re-check after registering: the holder may have
+                        // released (and drained wakers) between the failed
+                        // try_lock and the registration. A stale registration
+                        // from the success arm only costs a spurious wake.
+                        match this.engine.try_lock() {
+                            Some(g) => g,
+                            None => return Poll::Pending,
+                        }
+                    }
+                };
+                let result = match guard.as_mut() {
                     // Slot empty: `Runner::close` took the engine, i.e. server
                     // teardown. Handled below rather than here because
                     // `fail_teardown` needs `&mut *this` and this guard still
                     // borrows `this.engine`.
                     None => None,
-                    Some(engine) => Some(match engine.step() {
-                        Ok(produced) => {
-                            let empty = produced.is_empty();
-                            let mut bufs = this.buffers.lock();
-                            for (tid, chunk) in produced {
-                                if bufs.cancelled.contains(&tid) {
-                                    continue;
-                                }
-                                bufs.chunks.entry(tid).or_default().push_back(chunk);
-                            }
-                            Ok(empty)
+                    Some(engine) => {
+                        // Apply cancels that arrived while the engine was
+                        // busy (Runner::cancel / stream Drop never block on
+                        // the engine mutex — see deferred_cancels).
+                        let deferred = std::mem::take(&mut this.buffers.lock().deferred_cancels);
+                        for tid in &deferred {
+                            engine.cancel(tid);
                         }
-                        Err(e) => Err(e),
-                    }),
+                        Some(match engine.step() {
+                            Ok(produced) => {
+                                let empty = produced.is_empty();
+                                let mut bufs = this.buffers.lock();
+                                for (tid, chunk) in produced {
+                                    if bufs.cancelled.contains(&tid) {
+                                        continue;
+                                    }
+                                    bufs.chunks.entry(tid).or_default().push_back(chunk);
+                                }
+                                Ok(empty)
+                            }
+                            Err(e) => Err(e),
+                        })
+                    }
+                };
+                drop(guard);
+                // Engine released: wake every stream parked on contention.
+                let wakers = std::mem::take(&mut this.buffers.lock().step_wakers);
+                for w in wakers {
+                    w.wake();
                 }
+                result
             };
             let Some(step_result) = step_result else {
                 return this.fail_teardown();
@@ -726,8 +832,29 @@ impl Drop for ChunkStream {
         // grinding through max_tokens worth of chunks that no one
         // will ever drain — the chunk buffer for this task accretes
         // until close() and the engine slot stays busy.
-        if let Some(engine) = self.engine.lock().as_mut() {
-            engine.cancel(&self.task_id);
+        //
+        // Never block on the engine mutex here: Drop runs on whatever
+        // (often tokio worker) thread drops the stream, and a hard lock()
+        // during another stream's step counts toward the worker starvation
+        // that wedges the pipeline (#122). Busy engine = defer; the next
+        // engine-lock holder applies it before stepping.
+        match self.engine.try_lock() {
+            Some(mut guard) => {
+                if let Some(engine) = guard.as_mut() {
+                    engine.cancel(&self.task_id);
+                }
+                drop(guard);
+                let wakers = std::mem::take(&mut self.buffers.lock().step_wakers);
+                for w in wakers {
+                    w.wake();
+                }
+            }
+            None => {
+                self.buffers
+                    .lock()
+                    .deferred_cancels
+                    .push(self.task_id.clone());
+            }
         }
         let mut bufs = self.buffers.lock();
         bufs.chunks.remove(&self.task_id);

--- a/crates/cascadia-runner/tests/packed_wire_stress.rs
+++ b/crates/cascadia-runner/tests/packed_wire_stress.rs
@@ -17,8 +17,13 @@
 //! The load mirrors `packed_accuracy.py`: solo requests, then a concurrent
 //! batch, repeated. A wedge shows up as the watchdog firing with requests
 //! stuck mid-generation.
+//!
+//! The last scenario drives the OTHER half of that wire contract over the
+//! same pipeline: a relay whose step fails still OWES its upstream a reply,
+//! so it answers with the empty-token-frame NACK, and the driver has to
+//! retire the in-flight batch per task while leaving the link alive.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,8 +38,52 @@ use tokio::sync::Mutex as TokioMutex;
 const HIDDEN: usize = 64;
 const SLOTS: usize = 4;
 
+/// What a NACKed batch tells its tasks. Same words the runtime's
+/// `exchange_packed_downstream` uses, so an abort here is recognisable as
+/// THE NACK path and not as a teardown, a no-progress close or a dead link.
+const NACK_ABORT_REASON: &str = "downstream stage failed its packed step and NACKed this batch \
+     (empty token frame); the pipeline link stays aligned";
+
 fn backend(e: impl std::fmt::Display) -> EngineError {
     EngineError::Backend(e.to_string())
+}
+
+/// The relay's NACK frame, byte-for-byte what
+/// `cascadia_engine_openvino::runtime::packed_nack_frame()` puts on the wire:
+/// an EMPTY I64 `[1, 1, 0]` token frame.
+///
+/// Rebuilt from the same `cascadia-transport` primitives rather than
+/// imported: the encoder is a private fn, and `cascadia-engine-openvino`
+/// depends on `cascadia-runner`, so it cannot be pulled in here without
+/// dragging the whole OpenVINO stack (tokenizers, the genai shim) into this
+/// crate's test build. The shape is pinned by
+/// `nack_frame_is_the_empty_token_frame` below and by the engine crate's own
+/// `packed_nack_frame_is_empty_and_detectable`; a drift in either direction
+/// fails one of them.
+fn packed_nack_frame() -> Tensor {
+    Tensor::new(DType::I64, [1, 1, 0], Vec::new())
+}
+
+/// The driver-side NACK predicate, mirroring `is_packed_nack` in the runtime:
+/// a reply that carries NO tokens is the downstream saying "batch lost, link
+/// fine". Checked before the reply is read as tokens.
+fn is_packed_nack(reply: &Tensor) -> bool {
+    reply.elements() == Some(0)
+}
+
+/// The NACK is empty, wire-consistent (or the transport would refuse to
+/// deliver it) and never confusable with a real per-row token reply.
+#[test]
+fn nack_frame_is_the_empty_token_frame() {
+    let nack = packed_nack_frame();
+    assert_eq!(nack.shape, [1, 1, 0]);
+    assert_eq!(nack.dtype, DType::I64);
+    assert!(nack.data.is_empty());
+    assert!(is_packed_nack(&nack));
+    for rows in 1..=SLOTS as u32 {
+        let real = Tensor::new(DType::I64, [1, 1, rows], vec![0u8; rows as usize * 8]);
+        assert!(!is_packed_nack(&real), "{rows}-row reply read as a NACK");
+    }
 }
 
 /// Rank 0 packed engine: admit → fake inference (hard-blocks the polling
@@ -47,6 +96,34 @@ struct DriverEngine {
     active: Vec<(GenerationTask, u32)>,
     infer: Duration,
     seq: Arc<AtomicU64>,
+}
+
+impl DriverEngine {
+    /// Mirror of the runtime's `abort_packed_batch`: a failure that loses the
+    /// in-flight packed batch retires EVERY active slot and hands each task
+    /// its own final error chunk, so no stream is left wedged-active waiting
+    /// for tokens that will never come. The downstream link is untouched —
+    /// this engine keeps serving and the next step admits whatever is still
+    /// pending.
+    fn abort_packed_batch(&mut self, aborted: EngineError) -> Vec<(TaskId, Chunk)> {
+        // The whole point of the typed variant: a lost batch must never be
+        // read as a dead link (which would exit a relay loop and, on rank 0,
+        // arm the dead-wire latch).
+        assert!(
+            !aborted.is_connection_fatal(),
+            "a NACKed batch must not classify as a dead link: {aborted}"
+        );
+        let msg = aborted.to_string();
+        self.active
+            .drain(..)
+            .map(|(task, _)| {
+                (
+                    task.task_id.clone(),
+                    Chunk::error(task.task_id, msg.clone()),
+                )
+            })
+            .collect()
+    }
 }
 
 impl Engine for DriverEngine {
@@ -87,8 +164,9 @@ impl Engine for DriverEngine {
 
         // Mirrors exchange_packed_downstream: one lock over send(plan) +
         // send(hidden) + a deadlined, poisoning recv_reply for the owed
-        // token frame.
-        let reply_rows: usize = run_async(&self.handle, async move {
+        // token frame, and the NACK check that runs BEFORE the reply is
+        // read as tokens.
+        let exchanged = run_async(&self.handle, async move {
             let mut guard = down.lock().await;
             guard.send(&plan).await.map_err(backend)?;
             guard.send(&hidden).await.map_err(backend)?;
@@ -96,8 +174,25 @@ impl Engine for DriverEngine {
                 .recv_reply()
                 .await
                 .map_err(|e| EngineError::Backend(format!("token recv (seq={seq}): {e}")))?;
+            // An EMPTY token frame is the downstream's NACK: its step failed
+            // AFTER it consumed our pair, so the batch is lost while the link
+            // stays frame-aligned. Typed `BatchAborted` exactly as the runtime
+            // types it, so nothing downstream can classify a lost batch as a
+            // dead link.
+            if is_packed_nack(&reply) {
+                return Err(EngineError::BatchAborted(NACK_ABORT_REASON.into()));
+            }
             Ok::<usize, EngineError>(reply.shape[2] as usize)
-        })?;
+        });
+        let reply_rows = match exchanged {
+            Ok(rows) => rows,
+            // The runtime's `abort_packed_batch`: retire every active slot
+            // with its own final error chunk and keep serving.
+            Err(aborted @ EngineError::BatchAborted(_)) => {
+                return Ok(self.abort_packed_batch(aborted))
+            }
+            Err(e) => return Err(e),
+        };
         if reply_rows != rows {
             return Err(EngineError::Backend(format!(
                 "reply rows {reply_rows} != sent rows {rows}"
@@ -531,5 +626,544 @@ fn packed_multistage_survives_mid_generation_disconnects() {
                 seq.load(Ordering::Relaxed)
             );
         }
+    }
+}
+
+// =====================================================================
+// Scenario 4 (review finding M7a): relay failure → NACK → driver-side
+// batch abort, under concurrency.
+//
+// The engine-side hardening (a relay that always answers, an empty token
+// frame as the NACK, `abort_packed_batch` retiring every slot with its own
+// error chunk, `BatchAborted` keeping the link alive) had no end-to-end
+// coverage: the real `exchange_packed_downstream` / `abort_packed_batch`
+// live on `OvRuntimeEngine`, which cannot be constructed without an
+// OpenVINO runtime. What IS reachable is the protocol and the runner
+// behaviour around it — the mock engines below speak the real wire format
+// over a real loopback socket, so everything from "the relay's step failed"
+// to "each affected client gets its own error chunk and the next request
+// still works" is exercised for real.
+//
+// The pipeline setup is deliberately duplicated from `run_stress` rather
+// than factored out of it: the three scenarios above are the #122
+// regression guard and stay untouched.
+// =====================================================================
+
+/// What the relay should do with the exchanges it is about to answer.
+/// Flipped by the load thread between phases, read by the relay engine.
+#[derive(Default)]
+struct NackPlan {
+    /// NACK every Nth exchange; 0 = injection off.
+    every: AtomicU64,
+    /// NACK the very next exchange, once. Used for the deterministic
+    /// full-slate abort: arm, submit a whole batch, only then poll.
+    once: AtomicBool,
+    /// Exchanges answered so far.
+    seen: AtomicU64,
+    /// NACKs actually put on the wire.
+    sent: AtomicU64,
+}
+
+impl NackPlan {
+    /// Decide — and record — whether this exchange is answered with a NACK.
+    /// `Some(n)` is the 1-based index of the NACK, for the error text.
+    fn should_nack(&self) -> Option<u64> {
+        let n = self.seen.fetch_add(1, Ordering::SeqCst) + 1;
+        let every = self.every.load(Ordering::SeqCst);
+        let nack =
+            self.once.swap(false, Ordering::SeqCst) || (every != 0 && n.is_multiple_of(every));
+        nack.then(|| self.sent.fetch_add(1, Ordering::SeqCst) + 1)
+    }
+
+    fn arm_every(&self, every: u64) {
+        self.every.store(every, Ordering::SeqCst);
+    }
+
+    fn arm_once(&self) {
+        self.once.store(true, Ordering::SeqCst);
+    }
+
+    fn nacks_sent(&self) -> u64 {
+        self.sent.load(Ordering::SeqCst)
+    }
+}
+
+/// Rank 1 packed relay that can fail its tail inference and NACK, exactly
+/// the way `step_relay_packed` does: it consumes the (plan, hidden) pair,
+/// the body fails, and it STILL answers — with the empty token frame —
+/// before reporting the failure to its own relay loop.
+///
+/// The invariant the whole scenario rests on: one pair consumed, one reply
+/// sent, always, so the link stays frame-aligned across any number of
+/// failures.
+struct NackingRelayEngine {
+    handle: tokio::runtime::Handle,
+    up: Arc<TokioMutex<ActivationServer>>,
+    infer: Duration,
+    plan: Arc<NackPlan>,
+}
+
+impl Engine for NackingRelayEngine {
+    fn warmup(&mut self) {}
+
+    fn submit(&mut self, _task: GenerationTask) -> EngineResult<()> {
+        Ok(())
+    }
+
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        let up = self.up.clone();
+        let rows: usize = run_async(&self.handle, async move {
+            let mut guard = up.lock().await;
+            let (_pf, _) = guard.recv().await.map_err(backend)?;
+            let (hf, _) = guard.recv_reply().await.map_err(backend)?;
+            Ok::<usize, EngineError>(hf.shape[1] as usize)
+        })?;
+
+        std::thread::sleep(self.infer); // fake tail inference, lock released
+
+        // The pair is consumed, so from here EVERY path has to answer the
+        // upstream — a swallowed failure leaves it awaiting a token frame
+        // that never comes (the silent-deadlock half of #122).
+        let failure = self.plan.should_nack().map(|n| {
+            EngineError::Backend(format!(
+                "injected relay tail-inference failure #{n} ({rows} rows)"
+            ))
+        });
+        let frame = match &failure {
+            None => Tensor::new(DType::I64, [1, 1, rows as u32], vec![0u8; rows * 8]),
+            Some(_) => packed_nack_frame(),
+        };
+        let up = self.up.clone();
+        run_async(&self.handle, async move {
+            let mut guard = up.lock().await;
+            guard.send(&frame).await.map_err(backend)?;
+            Ok::<(), EngineError>(())
+        })?;
+
+        match failure {
+            // What `step_relay_packed` returns once the NACK is out: the
+            // body error. Non-fatal, so `run_relay_loop` backs off and keeps
+            // driving instead of exiting for a supervisor rebuild — the
+            // injected text must never trip the fatal-substring classifier.
+            Some(e) => {
+                assert!(
+                    !e.is_connection_fatal(),
+                    "an injected step failure must stay non-fatal: {e}"
+                );
+                Err(e)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+}
+
+/// How one request ended. An aborted batch is an OUTCOME here, not a test
+/// failure — the point of the scenario is that aborts get DELIVERED rather
+/// than hung.
+enum Outcome {
+    Completed(usize),
+    Aborted(String),
+}
+
+#[derive(Default)]
+struct Tally {
+    completed: usize,
+    aborted: usize,
+    chunks: usize,
+    aborts: Vec<String>,
+}
+
+impl Tally {
+    fn record(&mut self, o: Outcome) {
+        match o {
+            Outcome::Completed(n) => {
+                self.completed += 1;
+                self.chunks += n;
+            }
+            Outcome::Aborted(msg) => {
+                self.aborted += 1;
+                self.aborts.push(msg);
+            }
+        }
+    }
+
+    fn merge(&mut self, other: Tally) {
+        self.completed += other.completed;
+        self.aborted += other.aborted;
+        self.chunks += other.chunks;
+        self.aborts.extend(other.aborts);
+    }
+
+    fn total(&self) -> usize {
+        self.completed + self.aborted
+    }
+
+    /// Every abort must be THE NACK abort: a lost batch, naming the
+    /// downstream NACK. A teardown, a no-progress close or a dead-link error
+    /// would all satisfy "ended with an error chunk" while meaning the
+    /// opposite of what this scenario claims.
+    fn check_aborts_are_nacks(&self, phase: &str) -> Result<(), String> {
+        for msg in &self.aborts {
+            if !msg.starts_with("batch aborted: ") || !msg.contains("NACKed this batch") {
+                return Err(format!(
+                    "{phase}: a request ended on something other than the NACK abort: {msg}"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Drain a stream to its terminal chunk. The error chunk is final, so this
+/// returns as soon as one arrives — a hang can only show up as the watchdog
+/// firing, never as a silent pass.
+async fn drain_outcome(mut stream: cascadia_runner::ChunkStream) -> Outcome {
+    let mut n = 0usize;
+    while let Some(chunk) = stream.next().await {
+        if let Some(err) = chunk.error {
+            return Outcome::Aborted(err);
+        }
+        n += 1;
+    }
+    Outcome::Completed(n)
+}
+
+async fn run_one_outcome(
+    runner: Arc<Runner>,
+    id: String,
+    max_tokens: u32,
+) -> Result<Outcome, String> {
+    let task = GenerationTask::new(id, "stress prompt").with_max_tokens(max_tokens);
+    let stream = runner
+        .generate_async(task)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(drain_outcome(stream).await)
+}
+
+/// One phase of the NACK load, shaped like a `run_stress` round: `solo`
+/// sequential requests, then one concurrent batch of `batch`.
+fn nack_phase(
+    handle: &tokio::runtime::Handle,
+    runner: &Arc<Runner>,
+    label: &str,
+    solo: usize,
+    batch: usize,
+    max_tokens: u32,
+) -> Result<Tally, String> {
+    let mut tally = Tally::default();
+    for i in 0..solo {
+        let id = format!("{label}-solo-{i}");
+        let jh = handle.spawn(run_one_outcome(runner.clone(), id.clone(), max_tokens));
+        let out = handle.block_on(jh).map_err(|e| format!("join {id}: {e}"))?;
+        tally.record(out.map_err(|e| format!("{id}: {e}"))?);
+    }
+    let mut joins = Vec::new();
+    for i in 0..batch {
+        let id = format!("{label}-batch-{i}");
+        joins.push((
+            id.clone(),
+            handle.spawn(run_one_outcome(runner.clone(), id, max_tokens)),
+        ));
+    }
+    for (id, jh) in joins {
+        let out = handle.block_on(jh).map_err(|e| format!("join {id}: {e}"))?;
+        tally.record(out.map_err(|e| format!("{id}: {e}"))?);
+    }
+    Ok(tally)
+}
+
+/// Submit a FULL slate before anything polls, so the driver admits every row
+/// in one admission pass and the very next exchange carries all of them.
+/// That makes the concurrent abort deterministic: one NACK, one exchange,
+/// every in-flight task retired together.
+///
+/// `generate_async` returns only once its submit has landed, so awaiting all
+/// of them puts every task in the engine's queue with no step yet run.
+fn nack_full_slate(
+    handle: &tokio::runtime::Handle,
+    runner: &Arc<Runner>,
+    label: &str,
+    slate: usize,
+    max_tokens: u32,
+) -> Result<Tally, String> {
+    let mut streams = Vec::new();
+    for i in 0..slate {
+        let id = format!("{label}-{i}");
+        let runner = runner.clone();
+        let task = GenerationTask::new(id.clone(), "stress prompt").with_max_tokens(max_tokens);
+        let stream = handle
+            .block_on(async move { runner.generate_async(task).await })
+            .map_err(|e| format!("{id}: submit: {e}"))?;
+        streams.push((id, stream));
+    }
+    let joins: Vec<_> = streams
+        .into_iter()
+        .map(|(id, s)| (id, handle.spawn(drain_outcome(s))))
+        .collect();
+    let mut tally = Tally::default();
+    for (id, jh) in joins {
+        tally.record(handle.block_on(jh).map_err(|e| format!("join {id}: {e}"))?);
+    }
+    Ok(tally)
+}
+
+struct NackParams {
+    workers: usize,
+    batch: usize,
+    rounds: usize,
+    solo_per_round: usize,
+    max_tokens: u32,
+    /// NACK every Nth exchange during the sustained phase. Kept ABOVE
+    /// `max_tokens` on purpose: a solo request spans at most `max_tokens`
+    /// consecutive exchanges, so no two consecutive solos can both be hit
+    /// and the phase is guaranteed to contain completions as well as aborts.
+    every: u64,
+    /// Fewest NACKs the sustained phase must actually deliver, so "the link
+    /// survives N failures" means something.
+    min_nacks: u64,
+    watchdog: Duration,
+}
+
+/// Build the pipeline with a NACK-injecting relay and run the four phases.
+fn run_nack_stress(p: NackParams) -> Result<(), String> {
+    assert!(
+        p.every > p.max_tokens as u64,
+        "every ({}) must exceed max_tokens ({}) — see NackParams::every",
+        p.every,
+        p.max_tokens
+    );
+    let driver_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(p.workers)
+        .enable_all()
+        .build()
+        .unwrap();
+    let relay_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (server, port) = relay_rt.block_on(async {
+        let mut s = ActivationServer::new("127.0.0.1", 0);
+        s.start().await.unwrap();
+        let port = s.port();
+        (s, port)
+    });
+    let accept = relay_rt.spawn(async move {
+        let mut s = server;
+        s.accept().await.unwrap();
+        s
+    });
+    let client = driver_rt.block_on(async {
+        let mut c = ActivationClient::new("127.0.0.1", port);
+        c.connect().await.unwrap();
+        c
+    });
+    let server = relay_rt.block_on(accept).unwrap();
+
+    let seq = Arc::new(AtomicU64::new(0));
+    let plan = Arc::new(NackPlan::default());
+    let driver_runner = Arc::new(Runner::new(Box::new(PrebuiltBuilder {
+        engine: Some(Box::new(DriverEngine {
+            handle: driver_rt.handle().clone(),
+            down: Arc::new(TokioMutex::new(client)),
+            pending: Vec::new(),
+            active: Vec::new(),
+            infer: Duration::from_micros(300),
+            seq: seq.clone(),
+        })),
+    })));
+    let relay_runner = Arc::new(Runner::new(Box::new(PrebuiltBuilder {
+        engine: Some(Box::new(NackingRelayEngine {
+            handle: relay_rt.handle().clone(),
+            up: Arc::new(TokioMutex::new(server)),
+            infer: Duration::from_micros(500),
+            plan: plan.clone(),
+        })),
+    })));
+    driver_rt
+        .block_on(driver_runner.start(PeerLayout::default(), spec(true)))
+        .unwrap();
+    relay_rt
+        .block_on(relay_runner.start(PeerLayout::default(), spec(false)))
+        .unwrap();
+
+    let relay_for_loop = relay_runner.clone();
+    let relay_join = relay_rt.spawn_blocking(move || relay_for_loop.run_relay_loop());
+
+    let (done_tx, done_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let load_runner = driver_runner.clone();
+    let handle = driver_rt.handle().clone();
+    let load_plan = plan.clone();
+    let batch = p.batch;
+    let rounds = p.rounds;
+    let solo = p.solo_per_round;
+    let max_tokens = p.max_tokens;
+    let every = p.every;
+    let min_nacks = p.min_nacks;
+    std::thread::spawn(move || {
+        let result = (|| -> Result<(), String> {
+            // ---- A. baseline, injection off ----------------------------
+            // Establishes that any abort later can only have come from an
+            // injected NACK, not from the harness being flaky.
+            let warm = nack_phase(&handle, &load_runner, "warm", solo, batch, max_tokens)?;
+            if warm.aborted != 0 {
+                return Err(format!(
+                    "baseline: {} of {} requests aborted with injection OFF: {:?}",
+                    warm.aborted,
+                    warm.total(),
+                    warm.aborts
+                ));
+            }
+            if load_plan.nacks_sent() != 0 {
+                return Err("baseline: the relay NACKed with injection OFF".into());
+            }
+
+            // ---- B. ONE NACK onto a full slate -------------------------
+            // The concurrent case, made deterministic: `SLOTS` requests are
+            // submitted before anything polls, so the first exchange carries
+            // every row and the single NACK has to retire the whole batch —
+            // each task with its own error chunk, none left wedged-active.
+            load_plan.arm_once();
+            let slate = nack_full_slate(&handle, &load_runner, "slate", SLOTS, max_tokens)?;
+            slate.check_aborts_are_nacks("full slate")?;
+            if load_plan.nacks_sent() != 1 {
+                return Err(format!(
+                    "full slate: expected exactly 1 NACK, the relay sent {}",
+                    load_plan.nacks_sent()
+                ));
+            }
+            if slate.aborted != SLOTS {
+                return Err(format!(
+                    "full slate: one NACK retired {} of {SLOTS} in-flight requests (the whole \
+                     batch is lost, so every one of them owes its client an error chunk): {:?}",
+                    slate.aborted, slate.aborts
+                ));
+            }
+
+            // ---- C. sustained: NACK every Nth exchange -----------------
+            load_plan.arm_every(every);
+            let mut hot = Tally::default();
+            for round in 0..rounds {
+                let label = format!("nack-{round}");
+                hot.merge(nack_phase(
+                    &handle,
+                    &load_runner,
+                    &label,
+                    solo,
+                    batch,
+                    max_tokens,
+                )?);
+            }
+            load_plan.arm_every(0);
+            hot.check_aborts_are_nacks("under load")?;
+            let nacks = load_plan.nacks_sent() - 1; // minus the full-slate one
+            if nacks < min_nacks {
+                return Err(format!(
+                    "under load: only {nacks} NACKs were injected (wanted >= {min_nacks}); the \
+                     scenario did not exercise what it claims"
+                ));
+            }
+            // Each NACK retires every row of the exchange it answered, and a
+            // retired task cannot be retired twice — so aborts must at least
+            // keep pace with NACKs. Fewer means a task was silently dropped
+            // instead of being handed its error chunk.
+            if (hot.aborted as u64) < nacks {
+                return Err(format!(
+                    "under load: {nacks} NACKs retired only {} requests — every NACKed batch \
+                     owes each of its tasks a final error chunk",
+                    hot.aborted
+                ));
+            }
+            if hot.completed == 0 || hot.chunks == 0 {
+                return Err(format!(
+                    "under load: no request completed while NACKs were being injected \
+                     ({} aborted, {} chunks) — progress stopped instead of continuing",
+                    hot.aborted, hot.chunks
+                ));
+            }
+
+            // ---- D. the link survived ----------------------------------
+            // Injection off again: after N aborted batches the socket must
+            // still be frame-aligned and every request must complete
+            // normally. A torn-down or desynced link fails here.
+            let after = nack_phase(&handle, &load_runner, "after", solo, batch, max_tokens)?;
+            if after.aborted != 0 {
+                return Err(format!(
+                    "the link did not survive {nacks} NACKs: {} of {} later requests aborted: {:?}",
+                    after.aborted,
+                    after.total(),
+                    after.aborts
+                ));
+            }
+            if after.chunks == 0 {
+                return Err("no tokens were produced after injection stopped".into());
+            }
+            Ok(())
+        })();
+        let _ = done_tx.send(result);
+    });
+
+    let verdict = match done_rx.recv_timeout(p.watchdog) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(e),
+        Err(_) => {
+            let done = seq.load(Ordering::Relaxed);
+            match done_rx.recv_timeout(Duration::from_secs(10)) {
+                Ok(Ok(())) => Err("SLOW: finished only in the grace period".into()),
+                Ok(Err(e)) => Err(format!("failed late: {e}")),
+                Err(_) => {
+                    let now = seq.load(Ordering::Relaxed);
+                    Err(format!(
+                        "WEDGED: NACK load incomplete after {:?}+10s; exchanges {done} -> {now} \
+                         ({} in grace period), NACKs sent {}",
+                        p.watchdog,
+                        now - done,
+                        plan.nacks_sent()
+                    ))
+                }
+            }
+        }
+    };
+
+    if verdict.is_ok() {
+        driver_runner.close();
+        relay_runner.close();
+        drop(relay_join);
+        driver_rt.shutdown_background();
+        relay_rt.shutdown_background();
+    } else {
+        // Same rule as `run_stress`: a wedged engine holds its mutex, so
+        // close()/Drop would deadlock this thread. Leak deliberately and let
+        // the panic end the process.
+        std::mem::forget(driver_rt);
+        std::mem::forget(relay_rt);
+        std::mem::forget(driver_runner);
+        std::mem::forget(relay_runner);
+        std::mem::forget(relay_join);
+    }
+    verdict
+}
+
+/// A relay that fails its step NACKs the driver instead of going silent, and
+/// the driver retires the lost batch per task without losing the link:
+/// affected requests end on an error chunk (never a hang, never a truncated
+/// success), unaffected and subsequent ones complete normally, and the
+/// pipeline keeps making progress across a run of failures.
+#[test]
+fn packed_multistage_nack_aborts_the_batch_without_killing_the_link() {
+    let p = NackParams {
+        workers: 4,
+        batch: 6,
+        rounds: 3,
+        solo_per_round: 4,
+        max_tokens: 4,
+        every: 8,
+        min_nacks: 3,
+        watchdog: Duration::from_secs(120),
+    };
+    if let Err(e) = run_nack_stress(p) {
+        panic!("{e}");
     }
 }

--- a/crates/cascadia-runner/tests/packed_wire_stress.rs
+++ b/crates/cascadia-runner/tests/packed_wire_stress.rs
@@ -1,0 +1,535 @@
+//! Issue #122: multi-stage packed decode wedges under sustained concurrent
+//! load — rank 1 writes the token-frame reply, rank 0's `recv()` never wakes.
+//!
+//! This harness reproduces the production concurrency shape without OpenVINO:
+//!
+//! * A DRIVER runtime (rank 0): requests are spawned as tasks (like axum
+//!   handlers), each polling a `ChunkStream` whose `poll_next` locks the
+//!   sync engine mutex and runs `step()` — fake inference hard-blocks the
+//!   polling thread (like `packed.step()`), then the packed wire exchange
+//!   runs through `cascadia_runner::run_async` (`block_in_place` +
+//!   `block_on`, exactly like `exchange_packed_downstream`).
+//! * A RELAY runtime (rank 1): its own tokio runtime (a separate process in
+//!   production), driving `Runner::run_relay_loop` on a `spawn_blocking`
+//!   thread (`BlockingContextGuard` → naked `block_on`), recv-pair /
+//!   infer / send-reply like `step_relay_packed`.
+//!
+//! The load mirrors `packed_accuracy.py`: solo requests, then a concurrent
+//! batch, repeated. A wedge shows up as the watchdog firing with requests
+//! stuck mid-generation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
+use cascadia_runner::{run_async, RelayExit, Runner};
+use cascadia_transport::{ActivationClient, ActivationServer, DType, Tensor};
+use cascadia_types::{Chunk, GenerationTask, PeerLayout, ShardSpec, TaskId};
+use futures::{stream, StreamExt};
+use tokio::sync::Mutex as TokioMutex;
+
+const HIDDEN: usize = 64;
+const SLOTS: usize = 4;
+
+fn backend(e: impl std::fmt::Display) -> EngineError {
+    EngineError::Backend(e.to_string())
+}
+
+/// Rank 0 packed engine: admit → fake inference (hard-blocks the polling
+/// thread) → plan+hidden/token exchange, one decode token per active task
+/// per step. Wire calls mirror `exchange_packed_downstream` on main.
+struct DriverEngine {
+    handle: tokio::runtime::Handle,
+    down: Arc<TokioMutex<ActivationClient>>,
+    pending: Vec<GenerationTask>,
+    active: Vec<(GenerationTask, u32)>,
+    infer: Duration,
+    seq: Arc<AtomicU64>,
+}
+
+impl Engine for DriverEngine {
+    fn warmup(&mut self) {}
+
+    fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
+        self.pending.push(task);
+        Ok(())
+    }
+
+    fn cancel(&mut self, task_id: &TaskId) {
+        self.pending.retain(|t| &t.task_id != task_id);
+        self.active.retain(|(t, _)| &t.task_id != task_id);
+    }
+
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        while self.active.len() < SLOTS && !self.pending.is_empty() {
+            let t = self.pending.remove(0);
+            self.active.push((t, 0));
+        }
+        if self.active.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Fake stage-0 packed inference: hard-blocks the polling thread the
+        // same way `packed.step()` (OV infer) does — no block_in_place.
+        std::thread::sleep(self.infer);
+
+        let rows = self.active.len();
+        let plan = Tensor::new(DType::I64, [1, 3, rows as u32], vec![0u8; 3 * rows * 8]);
+        let hidden = Tensor::new(
+            DType::F16,
+            [1, rows as u32, HIDDEN as u32],
+            vec![0u8; rows * HIDDEN * 2],
+        );
+        let down = self.down.clone();
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+
+        // Mirrors exchange_packed_downstream: one lock over send(plan) +
+        // send(hidden) + a deadlined, poisoning recv_reply for the owed
+        // token frame.
+        let reply_rows: usize = run_async(&self.handle, async move {
+            let mut guard = down.lock().await;
+            guard.send(&plan).await.map_err(backend)?;
+            guard.send(&hidden).await.map_err(backend)?;
+            let (reply, _) = guard
+                .recv_reply()
+                .await
+                .map_err(|e| EngineError::Backend(format!("token recv (seq={seq}): {e}")))?;
+            Ok::<usize, EngineError>(reply.shape[2] as usize)
+        })?;
+        if reply_rows != rows {
+            return Err(EngineError::Backend(format!(
+                "reply rows {reply_rows} != sent rows {rows}"
+            )));
+        }
+
+        let mut out = Vec::new();
+        let mut still = Vec::new();
+        for (task, emitted) in self.active.drain(..) {
+            let n = emitted + 1;
+            out.push((
+                task.task_id.clone(),
+                Chunk::token(&task.task_id, n as i64, "x "),
+            ));
+            if n >= task.max_tokens {
+                out.push((task.task_id.clone(), Chunk::final_marker(&task.task_id, "")));
+            } else {
+                still.push((task, n));
+            }
+        }
+        self.active = still;
+        Ok(out)
+    }
+}
+
+/// Rank 1 packed relay: recv plan+hidden under the upstream lock, release,
+/// fake tail inference, re-lock, send one token per row. Mirrors
+/// `step_relay_packed` on main.
+struct RelayEngine {
+    handle: tokio::runtime::Handle,
+    up: Arc<TokioMutex<ActivationServer>>,
+    infer: Duration,
+}
+
+impl Engine for RelayEngine {
+    fn warmup(&mut self) {}
+
+    fn submit(&mut self, _task: GenerationTask) -> EngineResult<()> {
+        Ok(())
+    }
+
+    fn step(&mut self) -> EngineResult<Vec<(TaskId, Chunk)>> {
+        let up = self.up.clone();
+        let rows: usize = run_async(&self.handle, async move {
+            let mut guard = up.lock().await;
+            let (_pf, _) = guard.recv().await.map_err(backend)?;
+            // The owed second frame of the pair: deadlined recv_reply,
+            // mirroring the fixed step_relay_packed.
+            let (hf, _) = guard.recv_reply().await.map_err(backend)?;
+            Ok::<usize, EngineError>(hf.shape[1] as usize)
+        })?;
+
+        std::thread::sleep(self.infer); // fake tail inference, lock released
+
+        let frame = Tensor::new(DType::I64, [1, 1, rows as u32], vec![0u8; rows * 8]);
+        let up = self.up.clone();
+        run_async(&self.handle, async move {
+            let mut guard = up.lock().await;
+            guard.send(&frame).await.map_err(backend)?;
+            Ok::<(), EngineError>(())
+        })?;
+        Ok(Vec::new())
+    }
+}
+
+/// Builder that hands out a pre-built engine (sockets already connected).
+struct PrebuiltBuilder {
+    engine: Option<Box<dyn Engine>>,
+}
+
+#[async_trait]
+impl Builder for PrebuiltBuilder {
+    async fn connect(&mut self, _peers: PeerLayout) -> EngineResult<()> {
+        Ok(())
+    }
+
+    async fn load(&mut self, _shard: ShardSpec) -> EngineResult<LoadStream> {
+        Ok(Box::pin(stream::iter(Vec::new())))
+    }
+
+    fn build(mut self: Box<Self>) -> EngineResult<Box<dyn Engine>> {
+        self.engine.take().ok_or(EngineError::NotLoaded)
+    }
+}
+
+fn spec(first: bool) -> ShardSpec {
+    ShardSpec {
+        model_id: "stress".into(),
+        layer_start: 0,
+        layer_end: 1,
+        total_layers: 2,
+        device: "CPU".into(),
+        is_first_stage: first,
+        is_last_stage: !first,
+        tp_size: 1,
+        tp_rank: 0,
+    }
+}
+
+async fn run_one(runner: Arc<Runner>, id: String, max_tokens: u32) -> Result<usize, String> {
+    let task = GenerationTask::new(id, "stress prompt").with_max_tokens(max_tokens);
+    // The async submit path, like the API layer: sync `generate()` from a
+    // worker task blocks the worker on the engine mutex behind an in-flight
+    // step — enough simultaneous submits starve the I/O driver (#122).
+    let mut stream = runner
+        .generate_async(task)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut n = 0usize;
+    while let Some(chunk) = stream.next().await {
+        if let Some(err) = chunk.error {
+            return Err(err);
+        }
+        n += 1;
+    }
+    Ok(n)
+}
+
+struct Params {
+    workers: usize,
+    batch: usize,
+    rounds: usize,
+    solo_per_round: usize,
+    max_tokens: u32,
+    watchdog: Duration,
+}
+
+/// Build the two-runtime pipeline, run the load, return Ok(()) or a
+/// description of what wedged/failed.
+fn run_stress(p: Params) -> Result<(), String> {
+    let driver_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(p.workers)
+        .enable_all()
+        .build()
+        .unwrap();
+    let relay_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Wire the single duplex TCP connection: server socket lives on the
+    // relay runtime's driver, client socket on the driver runtime's driver —
+    // exactly the two-process registration split production has.
+    let (server, port) = relay_rt.block_on(async {
+        let mut s = ActivationServer::new("127.0.0.1", 0);
+        s.start().await.unwrap();
+        let port = s.port();
+        (s, port)
+    });
+    let accept = relay_rt.spawn(async move {
+        let mut s = server;
+        s.accept().await.unwrap();
+        s
+    });
+    let client = driver_rt.block_on(async {
+        let mut c = ActivationClient::new("127.0.0.1", port);
+        c.connect().await.unwrap();
+        c
+    });
+    let server = relay_rt.block_on(accept).unwrap();
+
+    let seq = Arc::new(AtomicU64::new(0));
+    let driver_engine = DriverEngine {
+        handle: driver_rt.handle().clone(),
+        down: Arc::new(TokioMutex::new(client)),
+        pending: Vec::new(),
+        active: Vec::new(),
+        infer: Duration::from_micros(300),
+        seq: seq.clone(),
+    };
+    let relay_engine = RelayEngine {
+        handle: relay_rt.handle().clone(),
+        up: Arc::new(TokioMutex::new(server)),
+        infer: Duration::from_micros(500),
+    };
+
+    let driver_runner = Arc::new(Runner::new(Box::new(PrebuiltBuilder {
+        engine: Some(Box::new(driver_engine)),
+    })));
+    let relay_runner = Arc::new(Runner::new(Box::new(PrebuiltBuilder {
+        engine: Some(Box::new(relay_engine)),
+    })));
+    driver_rt
+        .block_on(driver_runner.start(PeerLayout::default(), spec(true)))
+        .unwrap();
+    relay_rt
+        .block_on(relay_runner.start(PeerLayout::default(), spec(false)))
+        .unwrap();
+
+    let relay_for_loop = relay_runner.clone();
+    let relay_join = relay_rt.spawn_blocking(move || relay_for_loop.run_relay_loop());
+
+    // The load, in its own thread so the test thread can watchdog it.
+    let (done_tx, done_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let load_runner = driver_runner.clone();
+    let handle = driver_rt.handle().clone();
+    let batch = p.batch;
+    let rounds = p.rounds;
+    let solo = p.solo_per_round;
+    let max_tokens = p.max_tokens;
+    std::thread::spawn(move || {
+        let result = (|| -> Result<(), String> {
+            for round in 0..rounds {
+                for i in 0..solo {
+                    let r = load_runner.clone();
+                    let id = format!("solo-{round}-{i}");
+                    let jh = handle.spawn(run_one(r, id.clone(), max_tokens));
+                    let out = handle.block_on(jh).map_err(|e| format!("join {id}: {e}"))?;
+                    out.map_err(|e| format!("{id}: {e}"))?;
+                }
+                let mut joins = Vec::new();
+                for i in 0..batch {
+                    let r = load_runner.clone();
+                    let id = format!("batch-{round}-{i}");
+                    joins.push((id.clone(), handle.spawn(run_one(r, id, max_tokens))));
+                }
+                for (id, jh) in joins {
+                    let out = handle.block_on(jh).map_err(|e| format!("join {id}: {e}"))?;
+                    out.map_err(|e| format!("{id}: {e}"))?;
+                }
+            }
+            Ok(())
+        })();
+        let _ = done_tx.send(result);
+    });
+
+    let verdict = match done_rx.recv_timeout(p.watchdog) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(format!("request failed: {e}")),
+        Err(_) => {
+            let done = seq.load(Ordering::Relaxed);
+            // Grace period: distinguish a permanent wedge from a slow run.
+            match done_rx.recv_timeout(Duration::from_secs(10)) {
+                Ok(Ok(())) => Err("SLOW: finished only in the grace period".into()),
+                Ok(Err(e)) => Err(format!("request failed late: {e}")),
+                Err(_) => {
+                    let now = seq.load(Ordering::Relaxed);
+                    Err(format!(
+                        "WEDGED: load incomplete after {:?}+10s; exchanges {done} -> {now} \
+                         ({} in grace period)",
+                        p.watchdog,
+                        now - done
+                    ))
+                }
+            }
+        }
+    };
+
+    if verdict.is_ok() {
+        // Clean teardown only on success: a wedged engine holds its mutex
+        // forever, so close()/Drop would deadlock this thread. On failure we
+        // leak the runtimes deliberately and let the panic end the process.
+        driver_runner.close();
+        relay_runner.close();
+        drop(relay_join); // exits via ConnectionFatal/SlotEmpty once sockets drop
+        driver_rt.shutdown_background();
+        relay_rt.shutdown_background();
+    } else {
+        std::mem::forget(driver_rt);
+        std::mem::forget(relay_rt);
+        std::mem::forget(driver_runner);
+        std::mem::forget(relay_runner);
+        std::mem::forget(relay_join);
+    }
+    let _ = RelayExit::SlotEmpty; // silence unused import when cfg varies
+    verdict
+}
+
+/// Production-like shape: 8 workers, batch of 4 — the packed_accuracy load.
+#[test]
+fn packed_multistage_survives_sustained_concurrency() {
+    let p = Params {
+        workers: 8,
+        batch: 4,
+        rounds: 4,
+        solo_per_round: 12,
+        max_tokens: 16,
+        watchdog: Duration::from_secs(120),
+    };
+    if let Err(e) = run_stress(p) {
+        panic!("{e}");
+    }
+}
+
+/// Small box / higher admission: more concurrent streams than worker
+/// threads. Pre-fix this wedged deterministically on the first concurrent
+/// batch: every submit and every stream poll hard-blocked a worker on the
+/// sync engine mutex behind the in-flight step; with all workers blocked
+/// nothing could poll the tokio I/O + timer drivers, so the token frame sat
+/// unread in the socket buffer and no recv deadline could fire either —
+/// issue #122's exact signature (reply written, recv never woke, no WARN or
+/// ERROR, never recovered).
+#[test]
+fn packed_multistage_survives_more_streams_than_workers() {
+    let p = Params {
+        workers: 4,
+        batch: 6,
+        rounds: 3,
+        solo_per_round: 8,
+        max_tokens: 16,
+        watchdog: Duration::from_secs(120),
+    };
+    if let Err(e) = run_stress(p) {
+        panic!("{e}");
+    }
+}
+
+/// Clients hanging up mid-generation must not wedge the survivors: stream
+/// Drop and Runner::cancel no longer block on the engine mutex (deferred
+/// cancels), so a disconnect burst during a concurrent batch cannot eat
+/// worker threads either.
+#[test]
+fn packed_multistage_survives_mid_generation_disconnects() {
+    let driver_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+    let relay_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (server, port) = relay_rt.block_on(async {
+        let mut s = ActivationServer::new("127.0.0.1", 0);
+        s.start().await.unwrap();
+        let port = s.port();
+        (s, port)
+    });
+    let accept = relay_rt.spawn(async move {
+        let mut s = server;
+        s.accept().await.unwrap();
+        s
+    });
+    let client = driver_rt.block_on(async {
+        let mut c = ActivationClient::new("127.0.0.1", port);
+        c.connect().await.unwrap();
+        c
+    });
+    let server = relay_rt.block_on(accept).unwrap();
+
+    let seq = Arc::new(AtomicU64::new(0));
+    let driver_runner = Arc::new(Runner::new(Box::new(PrebuiltBuilder {
+        engine: Some(Box::new(DriverEngine {
+            handle: driver_rt.handle().clone(),
+            down: Arc::new(TokioMutex::new(client)),
+            pending: Vec::new(),
+            active: Vec::new(),
+            infer: Duration::from_micros(300),
+            seq: seq.clone(),
+        })),
+    })));
+    let relay_runner = Arc::new(Runner::new(Box::new(PrebuiltBuilder {
+        engine: Some(Box::new(RelayEngine {
+            handle: relay_rt.handle().clone(),
+            up: Arc::new(TokioMutex::new(server)),
+            infer: Duration::from_micros(500),
+        })),
+    })));
+    driver_rt
+        .block_on(driver_runner.start(PeerLayout::default(), spec(true)))
+        .unwrap();
+    relay_rt
+        .block_on(relay_runner.start(PeerLayout::default(), spec(false)))
+        .unwrap();
+    let relay_for_loop = relay_runner.clone();
+    let _relay_join = relay_rt.spawn_blocking(move || relay_for_loop.run_relay_loop());
+
+    let (done_tx, done_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let handle = driver_rt.handle().clone();
+    let load_runner = driver_runner.clone();
+    std::thread::spawn(move || {
+        let result = (|| -> Result<(), String> {
+            for round in 0..3 {
+                let mut joins = Vec::new();
+                for i in 0..6 {
+                    let r = load_runner.clone();
+                    let id = format!("dc-{round}-{i}");
+                    // Odd streams are abandoned after the first chunk (client
+                    // disconnect → ChunkStream::drop on a worker thread).
+                    let abandon = i % 2 == 1;
+                    joins.push((
+                        id.clone(),
+                        handle.spawn(async move {
+                            let task = GenerationTask::new(id, "stress prompt").with_max_tokens(24);
+                            let mut stream =
+                                r.generate_async(task).await.map_err(|e| e.to_string())?;
+                            let mut n = 0usize;
+                            while let Some(chunk) = stream.next().await {
+                                if let Some(err) = chunk.error {
+                                    return Err(err);
+                                }
+                                n += 1;
+                                if abandon && n >= 1 {
+                                    return Ok(n); // drops the stream mid-generation
+                                }
+                            }
+                            Ok(n)
+                        }),
+                    ));
+                }
+                for (id, jh) in joins {
+                    let out = handle.block_on(jh).map_err(|e| format!("join {id}: {e}"))?;
+                    out.map_err(|e| format!("{id}: {e}"))?;
+                }
+            }
+            Ok(())
+        })();
+        let _ = done_tx.send(result);
+    });
+
+    match done_rx.recv_timeout(Duration::from_secs(120)) {
+        Ok(Ok(())) => {
+            driver_runner.close();
+            relay_runner.close();
+            driver_rt.shutdown_background();
+            relay_rt.shutdown_background();
+        }
+        Ok(Err(e)) => {
+            std::mem::forget(driver_rt);
+            std::mem::forget(relay_rt);
+            panic!("request failed: {e}");
+        }
+        Err(_) => {
+            std::mem::forget(driver_rt);
+            std::mem::forget(relay_rt);
+            panic!(
+                "WEDGED with disconnect load (exchanges: {})",
+                seq.load(Ordering::Relaxed)
+            );
+        }
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -173,7 +173,7 @@ dropped, with a warning in the log.
 | `--cb-dynamic-split-fuse <BOOL>` | ov-genai default (on) | Dynamic-split-fuse scheduler toggle for `--cb`. |
 | `--cb-prefix-caching <BOOL>` | ov-genai default (off) | KV-block prefix reuse across requests for `--cb`. |
 | `--packed-slots <N>` | `0` | Continuous batching on the **NPU** (`--engine ov-runtime`, static `--target npu` exports): serve N concurrent requests in ONE inference by packing them into the sequence dimension with a per-row mask. Needs a packed variant beside the decode IR (`tools/packed_variant.py --slots N`). A different mechanism to `--cb` — the NPU has no paged attention. Works single- and multi-stage; every stage must run the same `--packed-slots` value (baked into the packed IR shape). See [docs/perf/NPU_PACKED_SLOTS.md](perf/NPU_PACKED_SLOTS.md). |
-| `--packed-prefix <N>` | `0` | Reserve N KV slots as a read-only shared prefix every packed slot may attend to — prefix caching without paging. Costs per-slot context. Requires `--packed-slots`. |
+| `--packed-prefix <N>` | `0` | Reserve N KV slots as a read-only shared prefix every packed slot may attend to — prefix caching without paging. Costs per-slot context. Requires `--packed-slots`. Single-stage only (`--total 1`): only the first stage admits requests, so a relay stage never populates the shared prefix. |
 
 For distributed speculative decode, every rank needs `--engine ov-dist-spec` —
 they share a wire protocol. See [engines/ov-dist-spec.md](engines/ov-dist-spec.md).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -172,7 +172,7 @@ dropped, with a warning in the log.
 | `--cb-max-batched-tokens <N>` | `0` | Max tokens per batch iteration (0 = ov-genai default 256). |
 | `--cb-dynamic-split-fuse <BOOL>` | ov-genai default (on) | Dynamic-split-fuse scheduler toggle for `--cb`. |
 | `--cb-prefix-caching <BOOL>` | ov-genai default (off) | KV-block prefix reuse across requests for `--cb`. |
-| `--packed-slots <N>` | `0` | Continuous batching on the **NPU** (`--engine ov-runtime`, static `--target npu` exports): serve N concurrent requests in ONE inference by packing them into the sequence dimension with a per-row mask. Needs a packed variant beside the decode IR (`tools/packed_variant.py --slots N`). A different mechanism to `--cb` — the NPU has no paged attention. **Single-stage only (`--total 1`)**; multi-stage packed is withheld pending a wire fault. See [docs/perf/NPU_PACKED_SLOTS.md](perf/NPU_PACKED_SLOTS.md). |
+| `--packed-slots <N>` | `0` | Continuous batching on the **NPU** (`--engine ov-runtime`, static `--target npu` exports): serve N concurrent requests in ONE inference by packing them into the sequence dimension with a per-row mask. Needs a packed variant beside the decode IR (`tools/packed_variant.py --slots N`). A different mechanism to `--cb` — the NPU has no paged attention. Works single- and multi-stage; every stage must run the same `--packed-slots` value (baked into the packed IR shape). See [docs/perf/NPU_PACKED_SLOTS.md](perf/NPU_PACKED_SLOTS.md). |
 | `--packed-prefix <N>` | `0` | Reserve N KV slots as a read-only shared prefix every packed slot may attend to — prefix caching without paging. Costs per-slot context. Requires `--packed-slots`. |
 
 For distributed speculative decode, every rank needs `--engine ov-dist-spec` —

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -237,6 +237,10 @@ populated by whichever request arrives first; no block-level dedup between
 partially-overlapping prompts beyond that single shared run; and the cached
 prefix persists for the worker's lifetime rather than being evicted by pressure.
 
+Single-stage only for now (`--total 1`, enforced by the CLI): the prefix is
+populated at admission, which only the first stage does, so a relay stage would
+open zero shared columns for the tokens rank 0 skipped prefilling.
+
 ### Accuracy parity
 
 Harness and method: [tests-e2e/accuracy](../../tests-e2e/accuracy). Full-text

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -172,10 +172,13 @@ saving a full NPU compile and a second resident weight copy.
 > timer driver — the runner's sync engine mutex was hard-locked from enough
 > worker-thread tasks (stream polls, submits, drops) that no worker remained
 > to poll the driver, so the readable event could never be dispatched and no
-> recv deadline could fire either. Fixed in `cascadia-runner` (non-blocking
-> poll/submit/cancel/drop) with the packed wire hardened alongside
-> (deadlined + poisoning reply recvs, an on-wire NACK from a failed relay
-> step, whole-batch abort with per-task attribution).
+> recv deadline could fire either. Fixed in `cascadia-runner` — no tokio
+> worker blocks on the engine mutex any more: stream polls park on a failed
+> `try_lock`, cancels and drops defer to the next lock holder, and submits
+> (which do still block for up to a step) run off-worker via
+> `spawn_blocking`. The packed wire was hardened alongside (deadlined +
+> poisoning reply recvs, an on-wire NACK from a failed relay step,
+> whole-batch abort with per-task attribution).
 
 Packing works across a pipeline. Stage 0 ships an I64 `[1, 3, S]` **plan frame**
 (per row: slot id with `-1` for idle, absolute position, and shared-prefix reuse
@@ -296,9 +299,12 @@ diverged on 2/10 prompts, TinyLlama on 5/10.
 ### Per-slot cancel
 
 A disconnecting client's slot is retired and its KV region returned to the free
-pool immediately, leaving the other in-flight slots untouched — the single-task
-path can only drop *queued* tasks, never reclaim a running one. Observed in the
-2-stage run: four disconnects released slots one at a time
+pool at the next engine-lock acquisition — a cancel arriving mid-step is
+deferred rather than blocking on the mutex, so the retire lands as soon as the
+in-flight step ends, which is the same effective moment a blocking cancel would
+have reached the engine. Other in-flight slots are untouched; the single-task
+path, by contrast, can only drop *queued* tasks, never reclaim a running one.
+Observed in the 2-stage run: four disconnects released slots one at a time
 (`in_flight=3, 2, 1, 0`).
 
 Side benefit worth remembering: at ~0.21-0.29 ms marginal per row, speculative

--- a/docs/perf/NPU_PACKED_SLOTS.md
+++ b/docs/perf/NPU_PACKED_SLOTS.md
@@ -160,19 +160,22 @@ Note also that packed mode skips compiling the chunked-prefill variant
 entirely — a packed plan whose rows all belong to one slot IS a causal chunk —
 saving a full NPU compile and a second resident weight copy.
 
-### Multi-stage — WITHHELD (`--total 1` enforced)
+### Multi-stage
 
-> **Not currently available.** The CLI rejects `--packed-slots` with `--total > 1`.
-> The packing mechanism below is correct and the pipeline serves requests, but a
-> token frame intermittently goes missing between ranks and rank 0 then blocks
-> forever on a reply that never arrives. Instrumented on NPU with a shared
-> sequence counter: rank 1 logged `replying with tokens seq=1119` and advanced to
-> the next frame, rank 0 logged `awaiting tokens seq=1119` and never saw it, with
-> no error on either side. It surfaces after sustained load — roughly two runs in
-> three, and adding the instrumentation masked it once — so it reads as a race in
-> `cascadia-transport` rather than in the packing. Single-stage packed is
-> unaffected and verified across 5 models. Evidence, what is ruled out and a
-> reproduction: **issue #122**.
+> **Available.** Historical note: multi-stage packed was withheld for a while
+> because the pipeline intermittently wedged under sustained concurrent load —
+> rank 1 wrote the token-frame reply and advanced, rank 0 never saw it, no
+> error on either side (issue #122). The frame was never lost on the wire: the
+> reply sat unread in rank 0's kernel receive buffer (observed directly:
+> `Recv-Q` = exactly one token frame, every tokio worker parked in a futex,
+> no thread in `ep_poll`). Rank 0's process had starved its own tokio I/O +
+> timer driver — the runner's sync engine mutex was hard-locked from enough
+> worker-thread tasks (stream polls, submits, drops) that no worker remained
+> to poll the driver, so the readable event could never be dispatched and no
+> recv deadline could fire either. Fixed in `cascadia-runner` (non-blocking
+> poll/submit/cancel/drop) with the packed wire hardened alongside
+> (deadlined + poisoning reply recvs, an on-wire NACK from a failed relay
+> step, whole-batch abort with per-task attribution).
 
 Packing works across a pipeline. Stage 0 ships an I64 `[1, 3, S]` **plan frame**
 (per row: slot id with `-1` for idle, absolute position, and shared-prefix reuse

--- a/docs/perf/NPU_TTFT_TIERS.md
+++ b/docs/perf/NPU_TTFT_TIERS.md
@@ -124,10 +124,12 @@ The *mechanism* is prior art; the *measurement direction* is not:
    slow for bulk (~1–5 MB/s/stream); parallel part-streams aggregate.
 6. **A pipeline stage that prefills tokenwise starves its downstream links**:
    the transport's data-frame recv timeout (60 s) fires while a big stage
-   grinds seq=1 steps, collapsing the pipeline. Graceful degradation
-   (`--no-chunked-prefill`, missing prefill variants) is therefore only safe
-   for stages small/fast enough to emit within the timeout — or the
-   transport needs progress keep-alives (follow-up).
+   grinds seq=1 steps, collapsing the pipeline. This is a recv-budget
+   problem, distinct from the #122 driver starvation (tokio workers blocked
+   on the runner's engine mutex, fixed in `cascadia-runner`). Graceful
+   degradation (`--no-chunked-prefill`, missing prefill variants) is
+   therefore only safe for stages small/fast enough to emit within the
+   timeout — or the transport needs progress keep-alives (follow-up).
 7. **Mixed Windows shell defaults make inline ssh commands non-portable**
    (cmd vs PowerShell hosts parse quoting differently; `-File` arg parsing
    treats single quotes as literal). The only robust remote-orchestration


### PR DESCRIPTION
# Fix #122: multi-stage packed decode wedge — driver starvation, not a lost frame

Closes #122.

## Root cause

The token frame was never lost and never late — **rank 0's process starved its own tokio I/O + timer driver**, so the frame sat unread in the socket buffer while the `recv()` future's readable event was never dispatched and no recv deadline could fire either (timers ride the same driver). That is exactly the reported signature: rank 1 wrote the reply and moved on, rank 0's `recv()` never woke, no WARN or ERROR on either side, wedged forever.

The starvation is structural, in `cascadia-runner`: the engine sits behind a **sync** `parking_lot::Mutex`, `step()` holds it across OV inference plus a full plan+hidden/token network round trip, and four different async-context callers took that mutex with a **hard blocking `lock()` on tokio worker threads**:

- `ChunkStream::poll_next` (every concurrent stream's SSE task)
- `Runner::submit` via the API's `generate()` call sites (every arriving request)
- `Runner::cancel` (DELETE handler)
- `ChunkStream::drop` (every client disconnect / completed stream)

A blocked worker is invisible to the scheduler — no core handoff. Once (streams polling) + (requests arriving) + (streams dropping) ≥ worker threads while a step is in flight, **every** worker is pinned, nobody can poll the shared I/O + timer driver, and the step-holder's `recv()` — parked via `block_in_place` + `block_on` — can never be woken. The engine mutex then never releases, so the blocked workers never unblock: permanent, silent, and it needs sustained load plus a concurrent burst to line up, which is why a fresh pipeline served 4 concurrent requests fine and the wedge showed up "after ~10–20 solo requests, on the first concurrent batch", roughly two runs in three.

## Reproduction

`crates/cascadia-runner/tests/packed_wire_stress.rs` rebuilds the production shape with no OpenVINO: a driver runtime and a relay runtime (two processes in prod), real loopback TCP through `cascadia-transport`, identical lock structure and `block_in_place`/`block_on` dispatch on each side, and the issue's load pattern (solo requests, then a concurrent batch).

- **Pre-fix**: wedges deterministically on the first concurrent batch once streams+submits reach the worker count — stuck at exchange 129 with zero progress through a 130 s watchdog, no error surfaced (timers starved too).
- **Post-fix**: all three scenarios (prod-like 8×4, small-box 4×6, disconnect burst) pass in ~1.2 s, 10/10 consecutive runs.

Real-engine A/B on miner (Xeon, OV 2026.2, real `cascadia worker` binaries, 2-stage Llama-3.2-1B packed export per the issue's repro command, rank 0 pinned to 4 cores):

- **baseline** (= `origin/main` 1a9c147f + the CLI gate bypassed): 15 solo requests fine (1–4 s each), then **wedged on the first 6-concurrent batch** — all six hung, `PROBE_FAILED: TimeoutError`. Forensics captured live at the wedge:
  - `ss -tinm`: rank 0's data socket showed **`Recv-Q = 52` for minutes** — exactly one I64 `[1,1,4]` token frame (20 B header + 32 B payload, a 4-row prefill chunk — the same frame shape the issue logged as `active=[0,0,0,0]`) delivered, acked, and **never read**. Rank 1's side: `Send-Q = 0`, all bytes acked. The frame was not lost.
  - `/proc/<rank0>/task/*/wchan`: **all 5 `tokio-rt-worker` threads in `futex_do_wait`; not one tokio thread in `ep_poll`** (the only epoll waiter was the unrelated mDNS daemon). Nobody could poll the I/O + timer driver.
  - Bonus: the wedged rank 0 **survived SIGTERM** (signal handling is a task on the starved runtime) and had to be SIGKILLed — a wedged node also resists orderly supervision.
- **fixed** (= this branch, same load, same 4-core rank 0): the first concurrent batch — the exact point the baseline died — completed in 2.9–7.4 s per request, and the full probe ran **`ALL_OK requests=84 wall=174.2s`** (4 rounds of 15 solo + 6 concurrent, zero errors, zero hangs). Server logs across the whole fixed run (probe + all accuracy captures, 134 requests): **zero WARN/ERROR, zero aborts, zero NACKs** — the new recovery paths exist but never needed to fire.

## The fix

**`cascadia-runner` — never hard-block a worker on the engine mutex (the wedge fix):**

- `poll_next`: `try_lock`; on contention, register a waker and return `Pending`. Every engine-lock release (step, submit, cancel, close) wakes the parked streams; registration re-checks the lock so a release can't slip through the gap.
- `generate_async`: submit dispatched via `spawn_blocking`; the API's four call sites use it. (`generate`/`submit` remain for sync callers, documented as blocking.)
- `cancel` and stream `Drop`: `try_lock`, deferring the engine-side cancel to the next lock holder — the same effective timing a blocking cancel had, since a running step can't be interrupted anyway.
- `close()` wakes parked streams so teardown can't strand them.

**`cascadia-engine-openvino` — harden the packed wire (so a genuinely lost/unanswerable frame degrades cleanly, plus the latent deadlock the issue called out):**

- `exchange_packed_downstream`: the owed token reply now uses `recv_reply` / `recv_reply_prefill` (prefill chunks get the widened budget) instead of idle-tolerant `recv()` under an external `tokio::time::timeout`. The deadline lives inside the transport: a miss can't cancel the recv future mid-frame (which silently discarded partially-read bytes), and a failed reply poisons the connection so a late frame can never be read into the next exchange. Poisoned-socket errors are connection-fatal → a middle rank exits for supervisor rebuild.
- `step_relay_packed`: the hidden frame (owed second half of the pair) is a deadlined `recv_reply`, and the plan is decoded only after the hidden frame is consumed, so a bad plan can't desync the stream. Any failure after the pair is consumed **answers the upstream with a NACK** (an empty `[1,1,0]` token frame) before surfacing the error — previously the relay loop swallowed the error and looped while rank 0 blocked forever. Middle stages propagate the NACK.
- `step_first_packed`: a failed shared inference or exchange **aborts the whole in-flight batch** — every active slot retired (KV region freed), every affected task gets its own attributed error chunk. Previously a bare `Err` killed whichever stream happened to be polling and left the other slots wedged-active. Admission failures are attributed to the failing task. Downstream slot state after an abort is stale but harmless — the next admission resets its slot in-band.

**`cascadia-cli`:** the `--packed-slots` + `--total > 1` gate is removed.

## Multi-stage packed accuracy (the blocked deliverable)

`packed_accuracy.py` now runs to completion multi-stage (it wedged before). 2-stage packed vs 2-stage plain on the same shards, Llama-3.2-1B, CPU device, 128 tokens, exact full-text match:

| check | result |
|---|---|
| packed determinism (solo vs solo-repeat) | **10/10** |
| packed batch-composition invariance | **9/10** (one `can't`→`cannot` flip at char 207 of 477) |
| plain determinism | 10/10 |
| packed vs plain parity (solo / batched) | 5/10 / 5/10 |

Every parity diff diverges **late** (char 93–471 into 277–563-char outputs) into semantically equivalent phrasing — the packed graph's known numeric-drift envelope (issue #122's own single-stage control was 8/10 with the same class of benign late single-token diffs; the multi-stage batch-invariance 9/10 here is actually better than that control). This drift is packed-vs-plain computation difference by construction (block-diagonal mask, region-local KV), not a wire/scheduling artifact: within-packed determinism is 10/10, and no error path fired during any capture.

## Testing

- `cargo test` across the workspace: green (one pre-existing failure on pristine `main`, `cascadia-tests-e2e::binary_serves_health_then_models_then_chat` — `/metrics` 404 — unrelated, fails identically without this branch).
- New: 3 stress scenarios (above), NACK/prefill-detection unit tests in the engine, CLI gate test updated.
- fmt + clippy clean on touched code.

## Notes

- E2E substrate: miner (Linux/CPU) rather than the 2-box NPU rig — the defect and fix live in the tokio/runner/transport layers, which are device-independent (the CPU repro reproduced the issue's NPU signature down to the identical 4-row frame size), and the Lunar Lake boxes host live demos. A confirmation run on the NPU rig is a cheap follow-up if wanted: the exact export + commands from the issue now work gate-free.

- Open PR #95 (bounded token recv + seq echo on the **non-packed** head path) attacks an adjacent failure class at the transport layer; this PR deliberately doesn't touch those call sites, and the two compose.
- The `docs/perf/NPU_TTFT_TIERS.md` "tokenwise stage starves its downstream links" note describes recv-timeout expiry under long compute — a different mechanism (budget, not starvation) — unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
