### PR TITLE
fix(deps): upgrade lru to 0.18 (RUSTSEC-2026-0253)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,9 +1138,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1142,6 +1146,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1582,11 +1591,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]

--- a/crates/cascadia-engine-sparse-moe/Cargo.toml
+++ b/crates/cascadia-engine-sparse-moe/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokenizers = { workspace = true }
 half = "2"
-lru = "0.12"
+lru = "0.18"
 memmap2 = "0.9"
 rayon = "1"
 

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,6 @@
 # or `unmaintained` (there are no open `vulnerability`-class advisories). Each
 # entry states its actual blocker; remove the entry when the blocker clears.
 ignore = [
-    "RUSTSEC-2026-0002", # lru 0.12.5 — IterMut Stacked-Borrows unsoundness. Patched in 0.16.3+, but 0.12 → 0.16+ is a breaking upgrade of a direct dep (cascadia-engine-sparse-moe); ignore until that crate migrates.
     "RUSTSEC-2025-0119", # number_prefix 0.4.0 (unmaintained) — transitive via indicatif → hf-hub → cascadia-download; no safe upgrade.
     "RUSTSEC-2024-0436", # paste 1.0.15 (unmaintained) — transitive via tokenizers; no safe upgrade.
 ]


### PR DESCRIPTION
## Summary

[RUSTSEC-2026-0253](https://rustsec.org/advisories/RUSTSEC-2026-0253) marks `lru < 0.18.2` unsound: `LruCache::pop()` is not panic-safe, so a panicking key `Drop` skips `detach()` and leaves dangling nodes in the intrusive list, which a later eviction can write through (use-after-free / double-free). This turned the release `cargo-deny (advisories, licenses, bans, sources)` job red — see the [failed run](https://github.com/labscommunity/cascadia/actions/runs/31485396344). `lru` is a direct dependency of `cascadia-engine-sparse-moe` and the only path into the workspace, so this bumps it `0.12` → `0.18` (lockfile lands `0.18.2`); the crate is API-compatible with the surface used here (`new`/`unbounded`/`get`/`put`/`pop`/`len`), so no code changes were needed.

Worth noting for review: the unsound path is unreachable in this tree regardless of version — every `LruCache` in the workspace is keyed by `(u32, u32)`, which is `Copy` and has no `Drop` impl that could panic. This is a compliance fix to clear the gate, not a live memory-safety bug.

This also drops the `RUSTSEC-2026-0002` ignore from `deny.toml`. That entry's own comment scoped it to "ignore until that crate migrates" — the advisory is patched in `0.16.3+`, so `0.18.2` satisfies it and the stated blocker is now cleared. Verified locally with `cargo-deny 0.20.2`: the pre-change tree reproduces `advisories FAILED` on RUSTSEC-2026-0253, and the post-change tree reports `advisories ok, bans ok, licenses ok, sources ok` with no remaining advisories beyond the two documented unmaintained ignores (`number_prefix`, `paste`). The bump also unifies `hashbrown` in the host build graph, removing one pre-existing duplicate-version warning; the one new lockfile crate, `foldhash 0.2.0`, is `Zlib`, already in the allow-list.

## Checklist

- [x] `just check` passes locally (see [CONTRIBUTING.md](https://github.com/labscommunity/cascadia/blob/main/CONTRIBUTING.md) for the by-hand equivalent)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …), one logical change per commit
- [ ] If this touches an OV engine: tested on real Intel hardware (say which, and which OpenVINO version) — CI only covers stub mode — n/a: dependency-only bump, no OV engine code touched; covered by stub CI