### PR TITLE
docs: alpha status; ci: manual dispatch for release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,16 +1,23 @@
 # release-please — versioning + changelog + release orchestration for cascadia.
 #
-# Driven by Conventional Commits. Two things happen here:
+# Driven by Conventional Commits. Two things happen here, split by trigger:
 #
-#   * Every push to main → release-please opens/updates ONE release PR that
-#     bumps the workspace version (Cargo.toml marker + manifest), refreshes
-#     Cargo.lock, and rewrites CHANGELOG.md. Merging feature PRs does NOT
-#     release; changes accumulate in that PR.
-#   * When the release PR is merged, release-please creates the tag `vX.Y.Z`
-#     and a GitHub Release marked PRE-RELEASE, then the build job (the reusable
-#     release.yml, same run) builds the binary bundles, attaches them, and
-#     promotes the release to a full release. A release only loses its
-#     pre-release badge once both bundles are attached.
+#   * MANUAL (Actions → release-please → Run workflow) → release-please
+#     opens/updates ONE release PR that bumps the workspace version
+#     (Cargo.toml marker + manifest), refreshes Cargo.lock, and rewrites
+#     CHANGELOG.md. Pushes to main never open that PR on their own; you decide
+#     when to cut a release and commits just accumulate until you dispatch.
+#   * AUTOMATIC (push to main) → release-please only looks for an already-merged
+#     release PR. When it finds one it creates the tag `vX.Y.Z` and a GitHub
+#     Release marked PRE-RELEASE, then the build job (the reusable release.yml,
+#     same run) builds the binary bundles, attaches them, and promotes the
+#     release to a full release. A release only loses its pre-release badge
+#     once both bundles are attached. So merging the release PR still ships
+#     with no further clicks; ordinary pushes to main are a no-op here.
+#
+# The split is the action's own `skip-github-pull-request` / `skip-github-release`
+# switches, keyed off `github.event_name` — one job, one of the two halves
+# enabled per run.
 #
 # Chosen over release-plz: release-please never touches cargo registries or
 # runs `cargo package`, so it works for this never-published workspace
@@ -22,6 +29,9 @@
 name: release-please
 
 on:
+  # Cut (or refresh) the release PR — on demand only.
+  workflow_dispatch:
+  # Tag + release the merged release PR, and nothing else.
   push:
     branches: [main]
 
@@ -53,6 +63,10 @@ jobs:
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Manual dispatch does the PR half; push-to-main does the tag/release
+          # half. Never both in one run, so a push can't sneak a release PR open.
+          skip-github-release: ${{ github.event_name == 'workflow_dispatch' }}
+          skip-github-pull-request: ${{ github.event_name != 'workflow_dispatch' }}
 
       # release-please edits manifests as text, so it can't refresh Cargo.lock
       # (which records every workspace member's version). Do it here whenever
@@ -86,8 +100,10 @@ jobs:
           fi
 
   # Build + attach the binary bundles in the SAME run (reusable workflow), then
-  # promote the release. No dispatch needed, so the GITHUB_TOKEN retrigger
-  # restriction never comes into play.
+  # promote the release. Nothing is dispatched between tag and build, so the
+  # GITHUB_TOKEN retrigger restriction never comes into play. Only reachable
+  # from the push-to-main half: a workflow_dispatch run skips the release, so
+  # release_created is empty and this job is skipped.
   build:
     name: build bundles
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,9 @@
 name: release-please
 
 on:
-  # Cut (or refresh) the release PR — on demand only.
+  # Cut (or refresh) the release PR — on demand only. `on:` has no branch
+  # filter for workflow_dispatch, so main-only is enforced by the guard step
+  # below; the run still starts, it just fails immediately elsewhere.
   workflow_dispatch:
   # Tag + release the merged release PR, and nothing else.
   push:
@@ -52,6 +54,17 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      # release-please always targets the repository's default branch, so a
+      # dispatch from a feature branch would silently run that branch's
+      # workflow file against main. Refuse it instead.
+      - name: Enforce dispatch from main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::release-please can only be dispatched from main (got $REF)"
+          exit 1
+
       # Actions pinned to full commit SHAs (supply-chain hardening); trailing
       # comment records the tag, matching ci.yml / release.yml.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,14 @@ These are **non-negotiable** for this repo:
 
 ## Releases (maintainers)
 
-Releases are automated by release-please from the Conventional Commits
-above — another reason they're non-negotiable. On every push to `main` it
-maintains a `chore(main): release X.Y.Z` PR carrying the version bump,
-`CHANGELOG.md`, and `Cargo.lock`. **Merging that PR is the release**: the same run tags
+Releases are cut by release-please from the Conventional Commits
+above — another reason they're non-negotiable. **Starting a release is manual**:
+run the `release-please` workflow from Actions → *Run workflow* on `main`, and
+it opens (or refreshes) a `chore(main): release X.Y.Z` PR carrying the version
+bump, `CHANGELOG.md`, and `Cargo.lock`. Pushes to `main` don't open that PR, so
+commits just accumulate until you dispatch.
+
+From there it's hands-off: **merging that PR is the release**: the same run tags
 `vX.Y.Z`, publishes a pre-release, builds the Linux + Windows OpenVINO
 bundles, attaches them, and promotes to a full release. Wrong version
 proposed? Edit the release PR. Hotfix path: push a `v*` tag by hand and

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/labscommunity/cascadia/actions/workflows/ci.yml"><img src="https://github.com/labscommunity/cascadia/actions/workflows/ci.yml/badge.svg" alt="ci"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="license"></a>
   <img src="https://img.shields.io/badge/rust-1.89%2B-orange.svg" alt="rust 1.89+">
-  <img src="https://img.shields.io/badge/status-pre--alpha-red.svg" alt="pre-alpha">
+  <img src="https://img.shields.io/badge/status-alpha-orange.svg" alt="alpha">
 </p>
 
 ---
@@ -28,7 +28,7 @@ Frontier models don't fit on a single laptop. Cloud APIs are expensive, opaque, 
 - **`cascadia doctor`**: diagnoses the one failure everyone hits: OpenVINO silently not seeing your GPU
 
 > [!NOTE]
-> Cascadia is in **pre-alpha status**. It works on Intel AI PCs (Lunar Lake / Arrow Lake / Panther Lake) and Arc B-series (Battlemage) discrete GPUs. Intel Arc A-series discrete GPUs and Xeon CPU-only servers are on the roadmap.
+> Cascadia is in **alpha status**. It works on Intel AI PCs (Lunar Lake / Arrow Lake / Panther Lake) and Arc B-series (Battlemage) discrete GPUs. Intel Arc A-series discrete GPUs and Xeon CPU-only servers are on the roadmap.
 
 ## Quick start
 


### PR DESCRIPTION
## What

- README: project status `pre-alpha` → `alpha` (badge + NOTE block).
- `release-please.yml`: the release PR is now cut on demand instead of on every push to `main`. Everything after the merge stays automatic.
- CONTRIBUTING: Releases section updated to match.

## Release flow after this

| Trigger | What runs |
| --- | --- |
| Actions → **release-please** → *Run workflow* | Opens/refreshes the `chore(main): release X.Y.Z` PR (version bump, `CHANGELOG.md`, `Cargo.lock`). No tag, no release. |
| Push to `main` | Only looks for an already-merged release PR. Finds one → tag `vX.Y.Z`, pre-release, build bundles, promote. Ordinary pushes are a no-op. |

Implemented with the action's own switches, keyed off `github.event_name`, so exactly one half runs per invocation:

```yaml
skip-github-release:      ${{ github.event_name == 'workflow_dispatch' }}
skip-github-pull-request: ${{ github.event_name != 'workflow_dispatch' }}
```

Both inputs verified against `action.yml` at the pinned SHA (`45996ed1`, v5.0.0) — see [Action Inputs](https://github.com/googleapis/release-please-action#action-inputs) for the full list and semantics. The upstream docs describe this pair as exactly this use case ("useful if splitting release tagging from PR creation"), and the v3 → v4 migration table maps the retired `github-release` command to `skip-github-pull-request: true` and `release-pr` to `skip-github-release: true`.

Nothing is dispatched between tag and build, so the `GITHUB_TOKEN` retrigger restriction still doesn't apply.

Dispatch is restricted to `main`. `on:` has no branch filter for `workflow_dispatch`, so this is a guard step — the run still starts from another branch, it just fails on the first step with a clear error. Without it, a dispatch from a feature branch would run that branch's workflow file but still cut the PR against the default branch, since release-please always targets `github.repository.defaultBranch`.

## Post-OSS security checklist

Not part of this diff — parking it here so it's next to the workflow it touches. Most of these are blocked while the repo is private on a free plan (branch protection currently 403s with *"Upgrade to GitHub Pro or make this repository public"*), so going public is what unlocks them. Do them in this order.

- [x] **1. Lock down Actions** — biggest new exposure, since public repo + self-hosted AI-PC runners is the classic compromise path.
  Settings → Actions → General:
  - *Fork pull request workflows from outside collaborators* → **Require approval for all outside collaborators**
  - *Workflow permissions* → **Read repository contents and packages permissions**
  - ⚠️ **Leave "Allow GitHub Actions to create and approve pull requests" CHECKED.** release-please opens the release PR with `GITHUB_TOKEN`; unchecking it breaks this workflow. The read-only default is safe because every workflow here declares its own `permissions:` block.

  `ai-pc-tests.yml:62` already blocks fork PRs from the self-hosted pool; this is the repo-level backstop for any future job that forgets the guard.

- [x] **2. Secret scanning + push protection** — Settings → Code security → enable **Secret scanning** and **Push protection**.
  Do the history sweep **before** flipping, not after: the entire git history becomes public in one step, and anything ever committed and later deleted is still in the objects.
  ```bash
  docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest detect -s /repo --redact
  ```
  A hit means rewriting history or rotating the credential — not something you can fix with a setting afterwards.

- [x] **3. Branch protection on `main`** — `CONTRIBUTING.md` says "never push to `main`" and nothing currently enforces it.
  Settings → Rules → Rulesets → New branch ruleset, target `main`:
  - Require a pull request before merging (1 approval, dismiss stale approvals)
  - Require status checks to pass — add both by exact name:
    - `cargo test (stub)`
    - `cargo-deny (advisories, licenses, bans, sources)`
  - Block force pushes; restrict deletions

  Then a second ruleset targeting tag `v*` with *Restrict updates* + *Restrict deletions*, so the tags release-please creates can't be force-moved.

- [x] **4. Private vulnerability reporting** — Settings → Code security → **Private vulnerability reporting** → Enable.
  `SECURITY.md` already sends reporters to `/security/advisories/new`, which outsiders **cannot use on a private repo**. Until this is on, the documented disclosure path doesn't work for anyone outside the org.

- [x] **5. Dependabot** — Settings → Code security → enable **Dependabot alerts** and **Dependabot security updates**.
  Complements `security.yml`: `cargo-deny` fails the build on a RUSTSEC advisory, Dependabot opens the PR that fixes it.

- [ ] **6. Prune branches before the flip** — going public exposes **every branch**, not just `main`. Currently 137: 32 merged, 104 unmerged.

  Merged branches are safe to delete and remove no content (all their commits are reachable from `main`) — that half is pure hygiene. The unmerged ones are the real exposure: 71 `perf/*` from May, 4 `autolab/*`, 1 `bench/*`, `infra/matias-2box-revival-029`. Those carry files that never landed on `main` — autolab experiment logs, `bench/start_rank0_tunnel.ps1`, `.autolab/state.json`, and campaign names that identify people and specific hardware.

  List candidates (read-only, deletes nothing):
  ```bash
  # merged, excluding main and release-please branches
  git branch -r --merged origin/main --format='%(refname:short)' \
    | grep -vE '^origin/(HEAD|main)$|release-please' | sed 's|origin/||'

  # unmerged, oldest first — review before deleting, these hold unique content
  git branch -r --no-merged origin/main --format='%(committerdate:short) %(refname:short)' \
    | grep -v 'origin/HEAD' | sort
  ```
  Keep: any branch with an open PR, `release-please--*`, and `pin/enterprise-staging-76ed77b1`.

  ⚠️ Deleting a branch on GitHub does **not** purge the objects — commits stay fetchable by full SHA for a while and can surface via the fork network. Deletion reduces what people browse and clone; it is not a scrub. Anything genuinely sensitive needs rotation or history rewrite, done **before** the repo goes public.

- [ ] **7. README "not for untrusted networks" banner** — no TLS and no auth on either the HTTP API or the inter-stage relay. That's documented in `SECURITY.md`, but people who download an alpha bundle and run it don't read `SECURITY.md`. One line above the fold.

## Worth knowing

- The release PR no longer refreshes itself as commits land on `main`. Commits added after you dispatch need a re-dispatch before merging, or the PR ships a stale changelog.
- The currently open `release-please--branches--main--components--cascadia` branch goes stale until the next dispatch.
