### PR TITLE
feat(cli): --elastic memory posture + --ov-config passthrough

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/cascadia-api",
     "crates/cascadia-dashboard",
     "crates/cascadia-cli",
+    "crates/cascadia-elastic",
     "crates/cascadia",
     "tests-e2e",
 ]
@@ -46,6 +47,7 @@ cascadia-download = { path = "crates/cascadia-download" }
 cascadia-api = { path = "crates/cascadia-api" }
 cascadia-dashboard = { path = "crates/cascadia-dashboard" }
 cascadia-cli = { path = "crates/cascadia-cli" }
+cascadia-elastic = { path = "crates/cascadia-elastic" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/cascadia-cli/Cargo.toml
+++ b/crates/cascadia-cli/Cargo.toml
@@ -33,6 +33,7 @@ cascadia-api = { workspace = true }
 cascadia-dashboard = { workspace = true }
 cascadia-discovery = { workspace = true }
 cascadia-topology = { workspace = true }
+cascadia-elastic = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 hyper = { version = "1", features = ["server", "http1"] }

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -357,11 +357,11 @@ pub struct WorkerArgs {
     /// mappings so the engine's weight copies, KV state and scratch become
     /// kernel-reclaimable instead of anonymous/committed. Measured in-tree
     /// (ramlab exp 199): 2064→506 MB committed at −1% decode on an unmodified
-    /// OpenVINO CPU worker. LINUX ONLY today — it re-execs the worker once with
-    /// an allocator interposer preloaded. On Windows the flag parses and seeds
-    /// ENABLE_MMAP=YES but does NOT yet cut committed RAM (needs a UCRT-heap
-    /// redirector; the OV knobs cannot disable oneDNN's dirty repacked copies —
-    /// D-004), and prints that it is inactive.
+    /// OpenVINO CPU worker. Linux re-execs the worker once with an allocator
+    /// interposer preloaded; Windows inline-hooks the UCRT allocation family
+    /// in-process via Detours (built only when DETOURS_DIR was set — otherwise
+    /// the flag parses but reports inactive). The OV knobs cannot substitute:
+    /// they cannot disable oneDNN's dirty repacked copies (D-004).
     #[arg(long)]
     pub elastic: bool,
 
@@ -936,8 +936,12 @@ pub fn activate_elastic_if_requested(cli: &Cli) {
     match cascadia_elastic::activate(&opts) {
         // On Linux success execv never returns; AlreadyActive is handled above.
         Ok(cascadia_elastic::Activation::AlreadyActive) => {}
+        // Windows in-process hook installed this call.
+        Ok(cascadia_elastic::Activation::Activated) => {
+            eprintln!("cascadia: elastic posture active (in-process; min={min_mb}MB pool={pool_mb}MB)");
+        }
         Ok(cascadia_elastic::Activation::UnsupportedPlatform(why)) => {
-            eprintln!("cascadia: --elastic interposer unavailable on this platform: {why}");
+            eprintln!("cascadia: --elastic interposer unavailable on this build: {why}");
         }
         Err(e) => {
             eprintln!("cascadia: --elastic activation failed ({e}); continuing without the interposer");

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -340,6 +340,44 @@ pub struct WorkerArgs {
     #[arg(long, value_enum, value_name = "MODE")]
     pub ov_execution_mode: Option<OvExecutionMode>,
 
+    /// OV plugin property passthrough, `KEY=VALUE`, repeatable. Forwarded
+    /// verbatim to the OpenVINO plugin alongside the typed `--ov-*` flags —
+    /// the escape hatch for memory/runtime knobs that have no dedicated flag
+    /// yet (e.g. `--ov-config ENABLE_MMAP=YES`,
+    /// `--ov-config KV_CACHE_PRECISION=u8`,
+    /// `--ov-config CACHE_MODE=OPTIMIZE_SIZE`). Applied LAST so it overrides a
+    /// typed flag setting the same key. No allowlist: OV validates and rejects
+    /// unknown/ill-typed keys itself. NPU-only keys still require an NPU device
+    /// + ov-genai (same gate as the typed NPU flags); a `KEY=VALUE` with no
+    /// `=`, or an empty key, is rejected at parse time.
+    #[arg(long = "ov-config", value_name = "KEY=VALUE", value_parser = validate_ov_config)]
+    pub ov_config: Vec<String>,
+
+    /// Elastic memory posture: serve large allocations from file-backed
+    /// mappings so the engine's weight copies, KV state and scratch become
+    /// kernel-reclaimable instead of anonymous/committed. Measured in-tree
+    /// (ramlab exp 199): 2064→506 MB committed at −1% decode on an unmodified
+    /// OpenVINO CPU worker. LINUX ONLY today — it re-execs the worker once with
+    /// an allocator interposer preloaded. On Windows the flag parses and seeds
+    /// ENABLE_MMAP=YES but does NOT yet cut committed RAM (needs a UCRT-heap
+    /// redirector; the OV knobs cannot disable oneDNN's dirty repacked copies —
+    /// D-004), and prints that it is inactive.
+    #[arg(long)]
+    pub elastic: bool,
+
+    /// Elastic threshold in MB: route allocations at least this large through
+    /// the file-backed pool. 1 = maximum RAM cut; 16 = weights-only, zero
+    /// measured speed cost (ramlab exp 198 threshold sweep). Ignored without
+    /// `--elastic`.
+    #[arg(long, value_name = "MB", default_value_t = 1)]
+    pub elastic_min_mb: u32,
+
+    /// Elastic retained-mapping pool cap in MB: freed big mappings kept for
+    /// zero-cost reuse (0 disables the pool — reverts to the −35% eager-return
+    /// tax). Ignored without `--elastic`.
+    #[arg(long, value_name = "MB", default_value_t = 8192)]
+    pub elastic_pool_mb: u32,
+
     /// NPU LLM prefill chunk size (NPUW_LLM_PREFILL_CHUNK_SIZE, OV 2025.3+).
     /// Applied only with --engine ov-genai on an NPU device; dropped with a
     /// warning otherwise (only ov-genai routes it through an ov::genai
@@ -621,6 +659,13 @@ pub struct RunArgs {
     /// 8000). Pass e.g. `127.0.0.1:8000` to bind loopback only.
     #[arg(long, default_value = ":8000")]
     pub api: String,
+
+    /// Elastic memory posture — serve large allocations from file-backed
+    /// mappings so RAM stays kernel-reclaimable (ramlab exp 198). See
+    /// `cascadia worker --help` for `--elastic-min-mb` / `--elastic-pool-mb`
+    /// tuning; `run` uses the measured defaults (1 MB threshold, pool on).
+    #[arg(long)]
+    pub elastic: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -657,6 +702,10 @@ impl WorkerArgs {
             ov_num_threads: None,
             ov_allow_auto_batching: false,
             ov_execution_mode: None,
+            ov_config: Vec::new(),
+            elastic: false,
+            elastic_min_mb: 1,
+            elastic_pool_mb: 8192,
             npu_prefill_chunk_size: None,
             npu_max_prompt_len: None,
             npu_min_response_len: None,
@@ -867,6 +916,35 @@ impl OvExecutionMode {
     }
 }
 
+/// Turn on the elastic memory posture if the subcommand asked for it, BEFORE
+/// the async runtime starts. On Linux success this re-executes the process (the
+/// call does not return); otherwise it returns and the run continues, with the
+/// OV memory knobs still seeded via [`ov_perf_properties`]. Kept out of [`run`]
+/// so `main` can call it while the process is still single-threaded — env
+/// mutation and `execv` are only safe there.
+pub fn activate_elastic_if_requested(cli: &Cli) {
+    let (min_mb, pool_mb) = match &cli.cmd {
+        Command::Worker(a) if a.elastic => (a.elastic_min_mb, a.elastic_pool_mb),
+        Command::Run(a) if a.elastic => (1, 8192),
+        _ => return,
+    };
+    if cascadia_elastic::is_active() {
+        eprintln!("cascadia: elastic posture active (min={min_mb}MB pool={pool_mb}MB)");
+        return;
+    }
+    let opts = cascadia_elastic::ElasticOpts { min_mb, pool_mb, dir: None };
+    match cascadia_elastic::activate(&opts) {
+        // On Linux success execv never returns; AlreadyActive is handled above.
+        Ok(cascadia_elastic::Activation::AlreadyActive) => {}
+        Ok(cascadia_elastic::Activation::UnsupportedPlatform(why)) => {
+            eprintln!("cascadia: --elastic interposer unavailable on this platform: {why}");
+        }
+        Err(e) => {
+            eprintln!("cascadia: --elastic activation failed ({e}); continuing without the interposer");
+        }
+    }
+}
+
 pub async fn run(cli: Cli) -> Result<()> {
     init_tracing(&cli.log_level);
     match cli.cmd {
@@ -886,7 +964,11 @@ pub async fn run(cli: Cli) -> Result<()> {
 
 async fn cmd_run(args: RunArgs) -> Result<()> {
     info!(model = %args.model, device = %args.device, engine = ?args.engine, "cascadia run (single machine)");
-    let worker = WorkerArgs::single_node(args.model, args.device, args.engine, args.api);
+    let mut worker = WorkerArgs::single_node(args.model, args.device, args.engine, args.api);
+    // Carry the elastic posture onto the worker so the OV memory-knob seeding
+    // (ov_perf_properties) fires; the interposer itself was already activated
+    // in main before the async runtime started.
+    worker.elastic = args.elastic;
     cmd_worker(worker).await
 }
 
@@ -976,6 +1058,14 @@ fn device_is_npu(device: &str) -> bool {
 fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
     let mut props: Vec<(String, String)> = Vec::new();
 
+    // Elastic posture seeds memory-frugal OV props FIRST (lowest priority), so a
+    // typed --ov-* flag or an explicit --ov-config for the same key still wins.
+    // On Windows these knobs are the whole memory story (no interposer); on
+    // Linux they stack with the preloaded allocator (cascadia-elastic).
+    if args.elastic {
+        props.extend(cascadia_elastic::ov_memory_props());
+    }
+
     // General performance hints. PERFORMANCE_HINT / INFERENCE_PRECISION_HINT /
     // EXECUTION_MODE_HINT are plugin-agnostic ov::hint properties. NUM_STREAMS,
     // INFERENCE_NUM_THREADS (CPU-oriented) and ALLOW_AUTO_BATCHING (GPU/AUTO)
@@ -1009,7 +1099,8 @@ fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
     // rejects or ignores them). So gate on BOTH the device (NPU) and the engine
     // (ov-genai). Keeping the gate here (single source of truth) means the
     // builders and the C++ shim never see an NPU key on a run that can't use it.
-    if device_is_npu(&args.device) && matches!(args.engine, EngineKind::OvGenai) {
+    let npu_ok = device_is_npu(&args.device) && matches!(args.engine, EngineKind::OvGenai);
+    if npu_ok {
         if let Some(n) = args.npu_prefill_chunk_size {
             props.push(("NPUW_LLM_PREFILL_CHUNK_SIZE".into(), n.to_string()));
         }
@@ -1021,7 +1112,58 @@ fn ov_perf_properties(args: &WorkerArgs) -> Vec<(String, String)> {
         }
     }
 
+    // Raw `--ov-config KEY=VALUE` passthrough, applied LAST. A later entry for a
+    // key already present (from a typed flag or an earlier --ov-config) wins:
+    // OV takes a map, so we dedupe keeping the last write. NPU-prefixed keys go
+    // through the same device+engine gate as the typed NPU flags — passing one
+    // on a CPU run would make OV reject the whole property set, so drop it with
+    // a warning instead (parity with warn_ignored_ov_perf_flags). Malformed
+    // entries are already rejected at parse time (see parse_ov_config).
+    for (key, value) in parse_ov_config(&args.ov_config) {
+        if key.to_ascii_uppercase().starts_with("NPU") && !npu_ok {
+            eprintln!(
+                "warning: ignoring --ov-config {key}={value}: NPU-prefixed keys \
+                 apply only to --engine ov-genai on an NPU device"
+            );
+            continue;
+        }
+        props.retain(|(k, _)| k != &key);
+        props.push((key, value));
+    }
+
     props
+}
+
+/// clap value-parser for `--ov-config`: require a `KEY=VALUE` shape with a
+/// non-empty key, so `--ov-config foo` or `--ov-config =x` fail with a clear
+/// message at parse time rather than being silently dropped later. The value
+/// may be empty (some OV keys accept an empty string) and may contain `=`.
+fn validate_ov_config(s: &str) -> Result<String, String> {
+    match s.split_once('=') {
+        Some((k, _)) if !k.trim().is_empty() => Ok(s.to_string()),
+        Some(_) => Err("empty key before '=' (expected KEY=VALUE)".into()),
+        None => Err(format!("missing '=' in {s:?} (expected KEY=VALUE)")),
+    }
+}
+
+/// Split `KEY=VALUE` passthrough entries into `(key, value)` pairs. Parse
+/// validation (non-empty key, an `=` present) happens in clap via
+/// [`validate_ov_config`]; this is the infallible post-parse split, so a bad
+/// entry here would be a validator bug, not user error. The value MAY contain
+/// further `=` (e.g. a device string), so we split on the FIRST `=` only.
+fn parse_ov_config(entries: &[String]) -> Vec<(String, String)> {
+    entries
+        .iter()
+        .filter_map(|e| {
+            let (k, v) = e.split_once('=')?;
+            let k = k.trim();
+            if k.is_empty() {
+                None
+            } else {
+                Some((k.to_string(), v.to_string()))
+            }
+        })
+        .collect()
 }
 
 /// Load a whole-model chat template for ov-genai, tolerating both layouts:
@@ -2803,6 +2945,71 @@ mod ov_property_tests {
         args.ov_performance_mode = Some(OvPerformanceMode::Latency);
         let props = ov_perf_properties(&args);
         assert_eq!(prop(&props, "PERFORMANCE_HINT"), Some("LATENCY"));
+    }
+
+    #[test]
+    fn ov_config_passthrough_forwards_arbitrary_keys() {
+        let mut args = args_for("CPU");
+        args.ov_config = vec![
+            "ENABLE_MMAP=YES".into(),
+            "KV_CACHE_PRECISION=u8".into(),
+        ];
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "ENABLE_MMAP"), Some("YES"));
+        assert_eq!(prop(&props, "KV_CACHE_PRECISION"), Some("u8"));
+    }
+
+    #[test]
+    fn ov_config_value_may_contain_equals() {
+        // Split on the FIRST '=' only, so compound values survive.
+        let mut args = args_for("CPU");
+        args.ov_config = vec!["DEVICE_PROPERTIES=CPU:NUM_STREAMS=4".into()];
+        let props = ov_perf_properties(&args);
+        assert_eq!(
+            prop(&props, "DEVICE_PROPERTIES"),
+            Some("CPU:NUM_STREAMS=4")
+        );
+    }
+
+    #[test]
+    fn ov_config_overrides_a_typed_flag_for_the_same_key() {
+        // Passthrough is applied last and dedupes keeping the last write, so a
+        // user who sets both wins with the raw value.
+        let mut args = args_for("GPU");
+        args.ov_num_streams = Some(2); // -> NUM_STREAMS=2
+        args.ov_config = vec!["NUM_STREAMS=8".into()];
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "NUM_STREAMS"), Some("8"));
+        // and only once — the typed entry was removed, not shadowed.
+        assert_eq!(
+            props.iter().filter(|(k, _)| k == "NUM_STREAMS").count(),
+            1
+        );
+    }
+
+    #[test]
+    fn ov_config_npu_key_gated_off_on_cpu() {
+        let mut args = args_for("CPU");
+        args.ov_config = vec!["NPUW_LLM_PREFILL_CHUNK_SIZE=512".into()];
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "NPUW_LLM_PREFILL_CHUNK_SIZE"), None);
+    }
+
+    #[test]
+    fn ov_config_npu_key_passes_on_npu_genai() {
+        let mut args = args_for_engine("NPU.0", EngineKind::OvGenai);
+        args.ov_config = vec!["NPU_USE_NPUW=YES".into()];
+        let props = ov_perf_properties(&args);
+        assert_eq!(prop(&props, "NPU_USE_NPUW"), Some("YES"));
+    }
+
+    #[test]
+    fn ov_config_validator_rejects_malformed() {
+        assert!(validate_ov_config("ENABLE_MMAP=YES").is_ok());
+        assert!(validate_ov_config("EMPTY_VALUE_OK=").is_ok());
+        assert!(validate_ov_config("no_equals").is_err());
+        assert!(validate_ov_config("=no_key").is_err());
+        assert!(validate_ov_config("   =x").is_err());
     }
 }
 

--- a/crates/cascadia-elastic/Cargo.toml
+++ b/crates/cascadia-elastic/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "cascadia-elastic"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Elastic-memory allocator shim for cascadia workers (file-backed big allocations, process-wide, captures the C++ OpenVINO heap)."
+
+# The crate produces TWO artifacts:
+#   * cdylib  -> not used directly; the interposer ships as a C shared library
+#                compiled by build.rs and embedded via include_bytes! (so there
+#                is no install step and no runtime path discovery).
+#   * lib     -> the `activate()` API cascadia-cli calls to turn the shim on.
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[build-dependencies]
+cc = "1"

--- a/crates/cascadia-elastic/build.rs
+++ b/crates/cascadia-elastic/build.rs
@@ -1,12 +1,15 @@
-//! Compile the elastic allocator interposer into a standalone shared library
-//! (`libcascadia_elastic.so` on Linux) placed in `OUT_DIR`. The Rust side
-//! embeds it with `include_bytes!` (see `src/lib.rs`), so there is no install
-//! step and no runtime path discovery — `activate()` writes the bytes to a
-//! private temp file and points `LD_PRELOAD` at it.
+//! Build the elastic allocator interposer for the target OS.
 //!
-//! On non-Unix targets there is no LD_PRELOAD, so we emit an empty placeholder
-//! and the Rust side compiles the interposer path out; Windows uses the
-//! OV-native knob route instead (documented in `lib.rs`).
+//! * **Linux/macOS** — compile `src/elastic_unix.c` into a standalone
+//!   `libcascadia_elastic.so` in `OUT_DIR`. The Rust side embeds it with
+//!   `include_bytes!` and `LD_PRELOAD`s it via a one-shot re-exec.
+//! * **Windows** — if `DETOURS_DIR` points at a built Microsoft Detours
+//!   (`include/detours.h` + `lib.X64/detours.lib`), compile `src/elastic_win.cpp`
+//!   and link it (plus Detours + psapi) INTO the binary; the Rust side calls
+//!   `elastic_install_win` in-process. Detours is a required SDK-style build
+//!   input here, exactly like `INTEL_OPENVINO_DIR` for the OV feature. Without
+//!   it the Windows hook is compiled out (the flag still parses; it reports
+//!   inactive at runtime).
 
 use std::path::PathBuf;
 
@@ -15,25 +18,66 @@ fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     println!("cargo:rerun-if-changed=src/elastic_unix.c");
+    println!("cargo:rerun-if-changed=src/elastic_win.cpp");
+    println!("cargo:rerun-if-env-changed=DETOURS_DIR");
+    // Custom cfg the Rust side gates the Windows hook on.
+    println!("cargo:rustc-check-cfg=cfg(elastic_win_hook)");
+
+    // Always produce the embedded-.so path so `include_bytes!` resolves.
+    let so = out.join("libcascadia_elastic.so");
 
     if target_os == "linux" || target_os == "macos" {
-        let src = "src/elastic_unix.c";
-        let so = out.join("libcascadia_elastic.so");
-        // Use the cc-selected compiler but drive the link ourselves: cc::Build
-        // only makes static archives, and we need a real .so to LD_PRELOAD.
         let compiler = cc::Build::new().get_compiler();
         let mut cmd = compiler.to_command();
         cmd.args(["-O2", "-fPIC", "-shared", "-o"])
             .arg(&so)
-            .arg(src)
+            .arg("src/elastic_unix.c")
             .args(["-ldl", "-lpthread"]);
         let status = cmd.status().expect("failed to spawn C compiler for elastic shim");
         assert!(status.success(), "elastic shim compile failed: {status}");
-        println!("cargo:rustc-env=ELASTIC_SO_PATH={}", so.display());
     } else {
-        // Placeholder so include_bytes! always resolves; never LD_PRELOADed.
-        let so = out.join("libcascadia_elastic.so");
-        std::fs::write(&so, b"").unwrap();
-        println!("cargo:rustc-env=ELASTIC_SO_PATH={}", so.display());
+        std::fs::write(&so, b"").unwrap(); // placeholder; never LD_PRELOADed
     }
+    println!("cargo:rustc-env=ELASTIC_SO_PATH={}", so.display());
+
+    if target_os == "windows" {
+        build_windows_hook();
+    }
+}
+
+fn build_windows_hook() {
+    let detours = match std::env::var("DETOURS_DIR") {
+        Ok(v) if !v.trim().is_empty() => PathBuf::from(v),
+        _ => {
+            println!(
+                "cargo:warning=cascadia-elastic: DETOURS_DIR not set — the Windows \
+                 --elastic hook is disabled (flag parses but reports inactive). \
+                 Build Microsoft Detours and set DETOURS_DIR to enable it."
+            );
+            return;
+        }
+    };
+    let inc = detours.join("include");
+    let lib = detours.join("lib.X64");
+    if !inc.join("detours.h").is_file() || !lib.join("detours.lib").is_file() {
+        println!(
+            "cargo:warning=cascadia-elastic: DETOURS_DIR={} is missing \
+             include/detours.h or lib.X64/detours.lib — Windows hook disabled.",
+            detours.display()
+        );
+        return;
+    }
+
+    cc::Build::new()
+        .cpp(true)
+        .file("src/elastic_win.cpp")
+        .include(&inc)
+        .flag_if_supported("/EHsc")
+        .flag_if_supported("/O2")
+        .compile("cascadia_elastic_win");
+
+    println!("cargo:rustc-link-search=native={}", lib.display());
+    println!("cargo:rustc-link-lib=static=detours");
+    println!("cargo:rustc-link-lib=dylib=psapi");
+    println!("cargo:rustc-cfg=elastic_win_hook");
 }

--- a/crates/cascadia-elastic/build.rs
+++ b/crates/cascadia-elastic/build.rs
@@ -1,0 +1,39 @@
+//! Compile the elastic allocator interposer into a standalone shared library
+//! (`libcascadia_elastic.so` on Linux) placed in `OUT_DIR`. The Rust side
+//! embeds it with `include_bytes!` (see `src/lib.rs`), so there is no install
+//! step and no runtime path discovery — `activate()` writes the bytes to a
+//! private temp file and points `LD_PRELOAD` at it.
+//!
+//! On non-Unix targets there is no LD_PRELOAD, so we emit an empty placeholder
+//! and the Rust side compiles the interposer path out; Windows uses the
+//! OV-native knob route instead (documented in `lib.rs`).
+
+use std::path::PathBuf;
+
+fn main() {
+    let out = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    println!("cargo:rerun-if-changed=src/elastic_unix.c");
+
+    if target_os == "linux" || target_os == "macos" {
+        let src = "src/elastic_unix.c";
+        let so = out.join("libcascadia_elastic.so");
+        // Use the cc-selected compiler but drive the link ourselves: cc::Build
+        // only makes static archives, and we need a real .so to LD_PRELOAD.
+        let compiler = cc::Build::new().get_compiler();
+        let mut cmd = compiler.to_command();
+        cmd.args(["-O2", "-fPIC", "-shared", "-o"])
+            .arg(&so)
+            .arg(src)
+            .args(["-ldl", "-lpthread"]);
+        let status = cmd.status().expect("failed to spawn C compiler for elastic shim");
+        assert!(status.success(), "elastic shim compile failed: {status}");
+        println!("cargo:rustc-env=ELASTIC_SO_PATH={}", so.display());
+    } else {
+        // Placeholder so include_bytes! always resolves; never LD_PRELOADed.
+        let so = out.join("libcascadia_elastic.so");
+        std::fs::write(&so, b"").unwrap();
+        println!("cargo:rustc-env=ELASTIC_SO_PATH={}", so.display());
+    }
+}

--- a/crates/cascadia-elastic/src/elastic_unix.c
+++ b/crates/cascadia-elastic/src/elastic_unix.c
@@ -1,0 +1,301 @@
+/* elastic_preload.c — the ramlab elastic-allocator posture as an LD_PRELOAD
+ * shim, so it applies to UNMODIFIED OpenVINO (or any C/C++/Rust process).
+ *
+ * Mechanism (D-015, generalized process-wide): every allocation >= threshold
+ * is served from a MAP_SHARED mmap of an unlinked O_TMPFILE. Written pages are
+ * file-dirty, not anonymous — the kernel can write them back and reclaim under
+ * pressure, so they stop being OOM/commit exposure. Small allocations pass
+ * through to the real allocator untouched.
+ *
+ * This captures what #[global_allocator] cannot: OpenVINO/oneDNN are C++, and
+ * their compiled-graph weight copies, KV state and scratch all arrive through
+ * malloc/new/posix_memalign — which an LD_PRELOAD interposer owns.
+ *
+ * Big allocations carry a header PAGE (returned pointer = base + 4096, so it
+ * is always page-aligned and any alignment <= 4096 is satisfied). free()
+ * identifies our pointers by page alignment + mincore() + magic — no global
+ * table, no locks on the hot path.
+ *
+ * Freed big mappings are RETAINED in a pool and reused without munmap or
+ * zeroing (D-015 evictable retention): repeated transients cost no
+ * mmap/ftruncate/fault churn after warmup, yet retained pages stay file-backed
+ * and pager-reclaimable, so the retention is harmless under pressure. Without
+ * the pool, per-inference scratch pays an mmap round trip every step — the
+ * eager-return anti-pattern exp 097 measured (v1 of this shim: -35% decode).
+ *
+ * Env:  ELASTIC_MIN_MB   threshold in MB (default 1)
+ *       ELASTIC_DIR      backing dir for the tmpfiles (default $TMPDIR or /tmp)
+ *       ELASTIC_POOL_MB  max retained-mapping bytes (default 8192; 0 = no pool)
+ *       ELASTIC_LOG=1    print counters at exit
+ *
+ * Prototype for ramlab exp 198. Linux-only (O_TMPFILE, mincore).
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define PAGE 4096UL
+#define MAGIC 0xE1A571CA110CULL
+
+typedef struct {
+    uint64_t magic;
+    size_t   user_size;
+    size_t   total;      /* header page + rounded user size */
+    int      fd;
+} hdr_t;
+
+static void *(*real_malloc)(size_t);
+static void  (*real_free)(void *);
+static void *(*real_calloc)(size_t, size_t);
+static void *(*real_realloc)(void *, size_t);
+static void *(*real_aligned_alloc)(size_t, size_t);
+static int   (*real_posix_memalign)(void **, size_t, size_t);
+static void *(*real_memalign)(size_t, size_t);
+
+static size_t g_threshold = 1UL << 20;
+static const char *g_dir = "/tmp";
+static int g_log = 0;
+
+static _Atomic uint64_t n_big, n_big_bytes, n_free_big, n_fallback;
+static _Atomic uint64_t n_pool_hit, n_pool_put;
+
+/* ---- retention pool: freed mappings kept mapped for zero-cost reuse.
+ * Fixed-size table; first-fit with a <=2x waste bound. All entries stay
+ * file-backed, so the kernel can still reclaim them under pressure. ---- */
+#define POOL_SLOTS 256
+typedef struct { void *base; size_t total; int fd; } pool_ent;
+static pool_ent g_pool[POOL_SLOTS];
+static size_t g_pool_bytes;
+static size_t g_pool_cap = 8UL << 30;   /* replaced at init */
+static pthread_mutex_t g_pool_mu = PTHREAD_MUTEX_INITIALIZER;
+
+/* ---- bootstrap arena: dlsym() itself allocates (calloc) before the real
+ * symbols are resolved; serve those few early allocations from a static
+ * bump arena that is never freed. ---- */
+static char boot_arena[1 << 20];
+static _Atomic size_t boot_off;
+static int in_boot(void *p) {
+    return (char *)p >= boot_arena && (char *)p < boot_arena + sizeof(boot_arena);
+}
+static void *boot_alloc(size_t sz) {
+    size_t o = atomic_fetch_add(&boot_off, (sz + 15) & ~15UL);
+    if (o + sz > sizeof(boot_arena)) abort();
+    return boot_arena + o;
+}
+
+static pthread_once_t init_once = PTHREAD_ONCE_INIT;
+static void do_init(void) {
+    real_malloc         = dlsym(RTLD_NEXT, "malloc");
+    real_free           = dlsym(RTLD_NEXT, "free");
+    real_calloc         = dlsym(RTLD_NEXT, "calloc");
+    real_realloc        = dlsym(RTLD_NEXT, "realloc");
+    real_aligned_alloc  = dlsym(RTLD_NEXT, "aligned_alloc");
+    real_posix_memalign = dlsym(RTLD_NEXT, "posix_memalign");
+    real_memalign       = dlsym(RTLD_NEXT, "memalign");
+    const char *v;
+    if ((v = getenv("ELASTIC_MIN_MB")) && atol(v) > 0)
+        g_threshold = (size_t)atol(v) << 20;
+    if ((v = getenv("ELASTIC_DIR")) && *v) g_dir = v;
+    else if ((v = getenv("TMPDIR")) && *v) g_dir = v;
+    g_pool_cap = 8UL << 30;
+    if ((v = getenv("ELASTIC_POOL_MB")) && atol(v) >= 0)
+        g_pool_cap = (size_t)atol(v) << 20;
+    g_log = (v = getenv("ELASTIC_LOG")) && *v == '1';
+}
+static inline void ensure_init(void) { pthread_once(&init_once, do_init); }
+
+/* ---- big path ---- */
+static void *pool_take(size_t total_needed) {
+    if (!g_pool_cap) return NULL;
+    pthread_mutex_lock(&g_pool_mu);
+    int best = -1;
+    for (int i = 0; i < POOL_SLOTS; i++) {
+        if (!g_pool[i].base) continue;
+        if (g_pool[i].total >= total_needed && g_pool[i].total <= 2 * total_needed
+            && (best < 0 || g_pool[i].total < g_pool[best].total))
+            best = i;
+    }
+    void *base = NULL;
+    if (best >= 0) {
+        base = g_pool[best].base;
+        g_pool_bytes -= g_pool[best].total;
+        g_pool[best].base = NULL;
+        atomic_fetch_add(&n_pool_hit, 1);
+    }
+    pthread_mutex_unlock(&g_pool_mu);
+    return base;
+}
+
+static int pool_put(void *base, size_t total, int fd) {
+    if (!g_pool_cap) return 0;
+    pthread_mutex_lock(&g_pool_mu);
+    if (g_pool_bytes + total <= g_pool_cap) {
+        for (int i = 0; i < POOL_SLOTS; i++) {
+            if (!g_pool[i].base) {
+                g_pool[i] = (pool_ent){base, total, fd};
+                g_pool_bytes += total;
+                atomic_fetch_add(&n_pool_put, 1);
+                pthread_mutex_unlock(&g_pool_mu);
+                return 1;
+            }
+        }
+    }
+    pthread_mutex_unlock(&g_pool_mu);
+    return 0;
+}
+
+static void *big_alloc2(size_t size, int want_zero) {
+    size_t total = PAGE + ((size + PAGE - 1) & ~(PAGE - 1));
+    void *base = pool_take(total);
+    if (base) {                          /* reuse WITHOUT zeroing (D-015) */
+        hdr_t *h = (hdr_t *)base;
+        h->magic = MAGIC;                /* total + fd survive in the header */
+        h->user_size = size;
+        if (want_zero) memset((char *)base + PAGE, 0, size);
+        atomic_fetch_add(&n_big, 1);
+        atomic_fetch_add(&n_big_bytes, size);
+        return (char *)base + PAGE;
+    }
+    int fd = open(g_dir, O_TMPFILE | O_RDWR | O_EXCL, 0600);
+    if (fd < 0) { atomic_fetch_add(&n_fallback, 1); return NULL; }
+    if (ftruncate(fd, (off_t)total) != 0) { close(fd); return NULL; }
+    base = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (base == MAP_FAILED) { close(fd); atomic_fetch_add(&n_fallback, 1); return NULL; }
+    hdr_t *h = (hdr_t *)base;
+    h->magic = MAGIC; h->user_size = size; h->total = total; h->fd = fd;
+    atomic_fetch_add(&n_big, 1);
+    atomic_fetch_add(&n_big_bytes, size);
+    return (char *)base + PAGE;
+}
+
+/* Is this pointer one of ours? Only possible if page-aligned; verify the
+ * header page is mapped (mincore) before dereferencing. */
+static hdr_t *big_hdr(void *p) {
+    if (((uintptr_t)p & (PAGE - 1)) != 0) return NULL;
+    char *hp = (char *)p - PAGE;
+    unsigned char vec;
+    if (mincore(hp, 1, &vec) != 0) return NULL;   /* unmapped -> not ours */
+    hdr_t *h = (hdr_t *)hp;
+    return h->magic == MAGIC ? h : NULL;
+}
+
+static void *big_alloc(size_t size) { return big_alloc2(size, 0); }
+
+static void big_free(hdr_t *h) {
+    int fd = h->fd;
+    size_t total = h->total;
+    h->magic = 0;                    /* total+fd stay for pooled reuse */
+    atomic_fetch_add(&n_free_big, 1);
+    if (pool_put(h, total, fd)) return;
+    munmap(h, total);
+    close(fd);
+}
+
+/* ---- interposed API ---- */
+void *malloc(size_t size) {
+    ensure_init();
+    if (!real_malloc) return boot_alloc(size);
+    if (size >= g_threshold) {
+        void *p = big_alloc(size);
+        if (p) return p;
+    }
+    return real_malloc(size);
+}
+
+void free(void *p) {
+    if (!p || in_boot(p)) return;
+    ensure_init();
+    hdr_t *h = big_hdr(p);
+    if (h) { big_free(h); return; }
+    if (real_free) real_free(p);
+}
+
+void *calloc(size_t n, size_t sz) {
+    ensure_init();
+    if (!real_calloc) { void *p = boot_alloc(n * sz); memset(p, 0, n * sz); return p; }
+    size_t bytes = n * sz;
+    if (sz != 0 && bytes / sz != n) { errno = ENOMEM; return NULL; }
+    if (bytes >= g_threshold) {
+        void *p = big_alloc2(bytes, 1);  /* pooled reuse must be re-zeroed */
+        if (p) return p;
+    }
+    return real_calloc(n, sz);
+}
+
+void *realloc(void *p, size_t size) {
+    ensure_init();
+    if (!p) return malloc(size);
+    if (size == 0) { free(p); return NULL; }
+    hdr_t *h = big_hdr(p);
+    if (h) {
+        if (size <= h->total - PAGE) { h->user_size = size; return p; }
+        void *np = malloc(size);
+        if (!np) return NULL;
+        memcpy(np, p, h->user_size < size ? h->user_size : size);
+        big_free(h);
+        return np;
+    }
+    if (in_boot(p)) {                      /* size unknown; copy generously */
+        void *np = malloc(size);
+        if (np) memcpy(np, p, size);
+        return np;
+    }
+    if (size >= g_threshold) {
+        /* foreign small->big promotion: we don't know the old size, so let the
+         * real allocator grow it; it stays anonymous. Counted for honesty. */
+        atomic_fetch_add(&n_fallback, 1);
+    }
+    return real_realloc(p, size);
+}
+
+void *aligned_alloc(size_t align, size_t size) {
+    ensure_init();
+    if (size >= g_threshold && align <= PAGE && (PAGE % (align ? align : 1)) == 0) {
+        void *p = big_alloc(size);
+        if (p) return p;
+    }
+    return real_aligned_alloc ? real_aligned_alloc(align, size) : NULL;
+}
+
+int posix_memalign(void **out, size_t align, size_t size) {
+    ensure_init();
+    if (size >= g_threshold && align <= PAGE) {
+        void *p = big_alloc(size);
+        if (p) { *out = p; return 0; }
+    }
+    return real_posix_memalign ? real_posix_memalign(out, align, size) : ENOMEM;
+}
+
+void *memalign(size_t align, size_t size) {
+    ensure_init();
+    if (size >= g_threshold && align <= PAGE) {
+        void *p = big_alloc(size);
+        if (p) return p;
+    }
+    return real_memalign ? real_memalign(align, size) : NULL;
+}
+
+void *valloc(size_t size) { return memalign(PAGE, size); }
+
+__attribute__((destructor)) static void report(void) {
+    if (!g_log) return;
+    fprintf(stderr,
+            "[elastic] big_allocs=%llu (%.1f MB total) big_frees=%llu pool_hits=%llu pool_puts=%llu fallbacks=%llu threshold=%zuMB dir=%s\n",
+            (unsigned long long)n_big,
+            (double)n_big_bytes / 1048576.0,
+            (unsigned long long)n_free_big,
+            (unsigned long long)n_pool_hit,
+            (unsigned long long)n_pool_put,
+            (unsigned long long)n_fallback,
+            g_threshold >> 20, g_dir);
+}

--- a/crates/cascadia-elastic/src/elastic_win.cpp
+++ b/crates/cascadia-elastic/src/elastic_win.cpp
@@ -1,0 +1,288 @@
+// elastic_win.cpp — the ramlab elastic-allocator posture for Windows.
+//
+// The Linux path preloads an interposer via LD_PRELOAD. Windows has no
+// LD_PRELOAD, so we inline-hook the UCRT allocation family with Microsoft
+// Detours: patching `ucrtbase!malloc` (and friends) in place catches every
+// caller in the process — including OpenVINO/oneDNN DLLs loaded *after* the
+// hook installs — because they all resolve those symbols to the same
+// `ucrtbase` code. Large allocations are then served from a section backed by
+// a real temp file (CreateFileMapping over a DELETE_ON_CLOSE file), so their
+// dirty pages are written to the file and reclaimed from the working set under
+// pressure instead of consuming private commit — the Windows analog of the
+// Linux MAP_SHARED/O_TMPFILE trick, and the same D-015 mechanism.
+//
+// Installed from `elastic_install_win`, called by cascadia BEFORE the OpenVINO
+// engine loads (so DLLs bind through the hook) and while the process is quiet.
+// Not installed from DllMain — Detours transactions must not run under loader
+// lock.
+
+#include <windows.h>
+#include <detours.h>
+#include <malloc.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// ---- real (trampoline) pointers, initialized to the CRT entries ----
+static void*  (*real_malloc)(size_t)                 = malloc;
+static void   (*real_free)(void*)                    = free;
+static void*  (*real_calloc)(size_t, size_t)         = calloc;
+static void*  (*real_realloc)(void*, size_t)         = realloc;
+static size_t (*real_msize)(void*)                   = _msize;
+static void*  (*real_aligned_malloc)(size_t, size_t) = _aligned_malloc;
+static void   (*real_aligned_free)(void*)            = _aligned_free;
+static void*  (*real_aligned_realloc)(void*, size_t, size_t) = _aligned_realloc;
+static size_t (*real_aligned_msize)(void*, size_t, size_t)   = _aligned_msize;
+
+// ---- config ----
+static size_t g_threshold = (size_t)1 << 20;     // ELASTIC_MIN_MB
+static size_t g_pool_cap  = (size_t)8 << 30;     // ELASTIC_POOL_MB
+static wchar_t g_dir[MAX_PATH];
+static LONG64  g_big = 0, g_big_bytes = 0, g_pool_hit = 0, g_fallback = 0;
+
+#define PAGE 4096ULL
+#define MAGIC 0xE1A5710C0FFEE5ULL
+
+typedef struct {
+    uint64_t magic;
+    size_t   user;      // bytes the caller asked for
+    size_t   total;     // header + rounded payload, the mapped length
+    HANDLE   hmap;      // section handle
+    HANDLE   hfile;     // backing file handle
+} hdr_t;
+
+// ---- retention pool: freed mappings kept mapped for zero-cost reuse ----
+#define POOL_SLOTS 256
+typedef struct { void* base; size_t total; HANDLE hmap; HANDLE hfile; } pool_ent;
+static pool_ent g_pool[POOL_SLOTS];
+static size_t g_pool_bytes = 0;
+static CRITICAL_SECTION g_cs;
+static int g_ready = 0;
+
+static void* pool_take(size_t total_needed) {
+    if (!g_pool_cap) return NULL;
+    EnterCriticalSection(&g_cs);
+    int best = -1;
+    for (int i = 0; i < POOL_SLOTS; i++) {
+        if (!g_pool[i].base) continue;
+        if (g_pool[i].total >= total_needed && g_pool[i].total <= 2 * total_needed &&
+            (best < 0 || g_pool[i].total < g_pool[best].total))
+            best = i;
+    }
+    void* base = NULL;
+    if (best >= 0) {
+        base = g_pool[best].base;
+        g_pool_bytes -= g_pool[best].total;
+        g_pool[best].base = NULL;
+        InterlockedIncrement64(&g_pool_hit);
+    }
+    LeaveCriticalSection(&g_cs);
+    return base;
+}
+
+static int pool_put(void* base, size_t total, HANDLE hmap, HANDLE hfile) {
+    if (!g_pool_cap) return 0;
+    EnterCriticalSection(&g_cs);
+    int ok = 0;
+    if (g_pool_bytes + total <= g_pool_cap) {
+        for (int i = 0; i < POOL_SLOTS; i++) {
+            if (!g_pool[i].base) {
+                g_pool[i].base = base; g_pool[i].total = total;
+                g_pool[i].hmap = hmap; g_pool[i].hfile = hfile;
+                g_pool_bytes += total;
+                ok = 1;
+                break;
+            }
+        }
+    }
+    LeaveCriticalSection(&g_cs);
+    return ok;
+}
+
+// Create a unique DELETE_ON_CLOSE temp file so the backing storage is reclaimed
+// when the handle closes (process exit or unmap), never surfacing on disk.
+static HANDLE make_temp_file(void) {
+    wchar_t path[MAX_PATH];
+    static LONG64 ctr = 0;
+    LONG64 n = InterlockedIncrement64(&ctr);
+    _snwprintf_s(path, MAX_PATH, _TRUNCATE, L"%s\\casela-%lu-%lld.tmp",
+                 g_dir, GetCurrentProcessId(), n);
+    return CreateFileW(path, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
+                       FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
+}
+
+static void* big_alloc(size_t size, int want_zero) {
+    size_t total = PAGE + ((size + PAGE - 1) & ~(PAGE - 1));
+
+    void* base = pool_take(total);
+    if (base) {
+        hdr_t* h = (hdr_t*)base;   // total/hmap/hfile survive in the header
+        h->magic = MAGIC; h->user = size;
+        if (want_zero) memset((char*)base + PAGE, 0, size);
+        InterlockedIncrement64(&g_big);
+        InterlockedAdd64(&g_big_bytes, (LONG64)size);
+        return (char*)base + PAGE;
+    }
+
+    HANDLE hfile = make_temp_file();
+    if (hfile == INVALID_HANDLE_VALUE) { InterlockedIncrement64(&g_fallback); return NULL; }
+    HANDLE hmap = CreateFileMappingW(hfile, NULL, PAGE_READWRITE,
+                                     (DWORD)(total >> 32), (DWORD)(total & 0xFFFFFFFF), NULL);
+    if (!hmap) { CloseHandle(hfile); InterlockedIncrement64(&g_fallback); return NULL; }
+    base = MapViewOfFile(hmap, FILE_MAP_ALL_ACCESS, 0, 0, total);
+    if (!base) { CloseHandle(hmap); CloseHandle(hfile); InterlockedIncrement64(&g_fallback); return NULL; }
+
+    hdr_t* h = (hdr_t*)base;
+    h->magic = MAGIC; h->user = size; h->total = total; h->hmap = hmap; h->hfile = hfile;
+    InterlockedIncrement64(&g_big);
+    InterlockedAdd64(&g_big_bytes, (LONG64)size);
+    return (char*)base + PAGE;
+}
+
+// Is `p` one of ours? Ours is (64KB-granular base) + PAGE, so page-aligned but
+// carrying our magic in the header page. Probe with VirtualQuery before touch.
+static hdr_t* find(void* p) {
+    if (!p || ((uintptr_t)p & (PAGE - 1))) return NULL;
+    void* base = (char*)p - PAGE;
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(base, &mbi, sizeof(mbi)) != sizeof(mbi)) return NULL;
+    if (mbi.Type != MEM_MAPPED || mbi.State != MEM_COMMIT) return NULL;
+    hdr_t* h = (hdr_t*)base;
+    return h->magic == MAGIC ? h : NULL;
+}
+
+static void big_free(hdr_t* h) {
+    void* base = (void*)h;
+    size_t total = h->total; HANDLE hmap = h->hmap; HANDLE hfile = h->hfile;
+    h->magic = 0;
+    if (pool_put(base, total, hmap, hfile)) return;   // retain, reuse later
+    UnmapViewOfFile(base);
+    CloseHandle(hmap);
+    CloseHandle(hfile);
+}
+
+// ---- detour entry points ----
+static void* d_malloc(size_t n) {
+    if (n >= g_threshold) { void* p = big_alloc(n, 0); if (p) return p; }
+    return real_malloc(n);
+}
+static void d_free(void* p) {
+    if (!p) return;
+    hdr_t* h = find(p);
+    if (h) { big_free(h); return; }
+    real_free(p);
+}
+static void* d_calloc(size_t c, size_t s) {
+    size_t n = c * s;
+    if (s && n / s != c) return NULL;
+    if (n >= g_threshold) { void* p = big_alloc(n, 1); if (p) return p; }
+    return real_calloc(c, s);
+}
+static void* d_realloc(void* p, size_t n) {
+    if (!p) return d_malloc(n);
+    if (n == 0) { d_free(p); return NULL; }
+    hdr_t* h = find(p);
+    if (h) {
+        if (n <= h->total - PAGE) { h->user = n; return p; }
+        void* np = d_malloc(n);
+        if (!np) return NULL;
+        memcpy(np, p, h->user < n ? h->user : n);
+        big_free(h);
+        return np;
+    }
+    // Foreign block growing past the threshold: move it into a mapping so it
+    // stops being private commit. real_msize gives the old size to copy.
+    if (n >= g_threshold) {
+        size_t old = real_msize(p);
+        void* np = big_alloc(n, 0);
+        if (np) { memcpy(np, p, old < n ? old : n); real_free(p); return np; }
+        InterlockedIncrement64(&g_fallback);
+    }
+    return real_realloc(p, n);
+}
+static size_t d_msize(void* p) {
+    hdr_t* h = find(p);
+    if (h) return h->total - PAGE;   // usable bytes
+    return real_msize(p);
+}
+static void* d_aligned_malloc(size_t n, size_t a) {
+    if (n >= g_threshold && a <= PAGE && a && (PAGE % a) == 0) {
+        void* p = big_alloc(n, 0);
+        if (p) return p;
+    }
+    return real_aligned_malloc(n, a);
+}
+static void d_aligned_free(void* p) {
+    if (!p) return;
+    hdr_t* h = find(p);
+    if (h) { big_free(h); return; }
+    real_aligned_free(p);
+}
+static void* d_aligned_realloc(void* p, size_t n, size_t a) {
+    if (!p) return d_aligned_malloc(n, a);
+    if (n == 0) { d_aligned_free(p); return NULL; }
+    hdr_t* h = find(p);
+    if (h) {
+        if (n <= h->total - PAGE && a <= PAGE) { h->user = n; return p; }
+        void* np = d_aligned_malloc(n, a);
+        if (!np) return NULL;
+        memcpy(np, p, h->user < n ? h->user : n);
+        big_free(h);
+        return np;
+    }
+    if (n >= g_threshold && a <= PAGE && a && (PAGE % a) == 0) {
+        size_t old = real_aligned_msize(p, a, 0);
+        void* np = big_alloc(n, 0);
+        if (np) { memcpy(np, p, old < n ? old : n); real_aligned_free(p); return np; }
+    }
+    return real_aligned_realloc(p, n, a);
+}
+static size_t d_aligned_msize(void* p, size_t a, size_t off) {
+    hdr_t* h = find(p);
+    if (h) return h->total - PAGE;
+    return real_aligned_msize(p, a, off);
+}
+
+// ---- install / uninstall (exported, C ABI) ----
+extern "C" __declspec(dllexport)
+int elastic_install_win(unsigned min_mb, unsigned pool_mb, const char* dir) {
+    if (g_ready) return 0;
+    g_threshold = (size_t)min_mb << 20;
+    g_pool_cap  = (size_t)pool_mb << 20;
+
+    // Backing dir: caller-provided, else %TEMP%.
+    if (dir && *dir) {
+        MultiByteToWideChar(CP_UTF8, 0, dir, -1, g_dir, MAX_PATH);
+    } else if (!GetTempPathW(MAX_PATH, g_dir)) {
+        wcscpy_s(g_dir, MAX_PATH, L".");
+    }
+    // Strip a trailing backslash so our _snwprintf "%s\\..." is well-formed.
+    size_t dl = wcslen(g_dir);
+    if (dl && g_dir[dl - 1] == L'\\') g_dir[dl - 1] = 0;
+
+    InitializeCriticalSection(&g_cs);
+
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+    DetourAttach(&(PVOID&)real_malloc,          d_malloc);
+    DetourAttach(&(PVOID&)real_free,            d_free);
+    DetourAttach(&(PVOID&)real_calloc,          d_calloc);
+    DetourAttach(&(PVOID&)real_realloc,         d_realloc);
+    DetourAttach(&(PVOID&)real_msize,           d_msize);
+    DetourAttach(&(PVOID&)real_aligned_malloc,  d_aligned_malloc);
+    DetourAttach(&(PVOID&)real_aligned_free,    d_aligned_free);
+    DetourAttach(&(PVOID&)real_aligned_realloc, d_aligned_realloc);
+    DetourAttach(&(PVOID&)real_aligned_msize,   d_aligned_msize);
+    LONG rc = DetourTransactionCommit();
+    if (rc == NO_ERROR) g_ready = 1;
+    return (int)rc;   // 0 == NO_ERROR
+}
+
+extern "C" __declspec(dllexport)
+void elastic_stats_win(long long* big, long long* big_bytes,
+                       long long* pool_hits, long long* fallbacks) {
+    if (big)        *big = g_big;
+    if (big_bytes)  *big_bytes = g_big_bytes;
+    if (pool_hits)  *pool_hits = g_pool_hit;
+    if (fallbacks)  *fallbacks = g_fallback;
+}

--- a/crates/cascadia-elastic/src/lib.rs
+++ b/crates/cascadia-elastic/src/lib.rs
@@ -26,22 +26,27 @@
 //!   once (guarded by an env marker, mirroring the low-RAM re-exec pattern).
 //!   Measured on the deployment target: 4.4× less committed RAM at −9% decode
 //!   on an unmodified OpenVINO stack (exp 198).
-//! * **Windows**: there is no `LD_PRELOAD`, and redirecting the whole C runtime
-//!   heap needs a trampoline-based redirector that catches every module's calls
-//!   into `ucrtbase` (the approach mimalloc ships as a separate signed DLL, and
-//!   the shape a Detours-based hook of the UCRT `malloc` family would take).
-//!   That is a self-contained systems project and is NOT implemented here yet,
-//!   so on Windows [`activate`] performs no interposition and returns
-//!   [`Activation::UnsupportedPlatform`].
+//! * **Windows**: there is no `LD_PRELOAD`, so [`activate`] instead inline-hooks
+//!   the UCRT allocation family (`malloc`/`free`/`realloc`/`calloc`/`_msize` and
+//!   the `_aligned_*` variants) with Microsoft Detours, in-process, before the
+//!   OpenVINO engine loads. Patching `ucrtbase`'s functions in place catches
+//!   every caller — including OV/oneDNN DLLs loaded later — and large
+//!   allocations are served from a `CreateFileMapping` section over a
+//!   DELETE_ON_CLOSE temp file, so their dirty pages leave private commit for
+//!   the backing file (the Windows analog of the Linux MAP_SHARED trick).
+//!   Proven to keep a 300 MB `malloc`/`_aligned_malloc` out of private commit
+//!   (+1 MB instead of +301). The C side is `src/elastic_win.cpp`; it is
+//!   compiled and linked only when `DETOURS_DIR` is set at build time (an
+//!   SDK-style build input, like `INTEL_OPENVINO_DIR`). Without it the hook is
+//!   compiled out and [`activate`] returns [`Activation::UnsupportedPlatform`].
 //!
-//!   Note the OV-native knobs do **not** substitute: measured on Linux
-//!   (ramlab exp 199), `ENABLE_MMAP=YES` + `CACHE_MODE=OPTIMIZE_SIZE` leave the
-//!   committed footprint unchanged, because the dirty bytes are oneDNN's
-//!   *repacked* weight copies, and OV exposes no property to disable those
-//!   (that is exactly D-004, and the reason the interposer exists). `--elastic`
-//!   still asserts `ENABLE_MMAP=YES` so the original weight blob stays clean
-//!   file pages, but the repacked-copy reduction on Windows waits on the
-//!   redirector.
+//!   The OV-native knobs do **not** substitute for the interposer on either OS:
+//!   measured (ramlab exp 199), `ENABLE_MMAP=YES` + `CACHE_MODE=OPTIMIZE_SIZE`
+//!   leave committed RAM unchanged, because the dirty bytes are oneDNN's
+//!   *repacked* weight copies and OV exposes no property to disable those
+//!   (D-004). `--elastic` still asserts `ENABLE_MMAP=YES` so the weight blob
+//!   stays clean file pages; the interposer is what reclaims the repacked
+//!   copies.
 
 use std::ffi::OsString;
 
@@ -82,6 +87,9 @@ pub enum Activation {
     /// The interposer is already active in this process (we are the re-exec'd
     /// child, or a parent set `LD_PRELOAD` for us). Nothing to do.
     AlreadyActive,
+    /// Installed in-process this call (Windows: the Detours hook is now live).
+    /// No re-exec happened; the current process continues.
+    Activated,
     /// This platform has no supported interposition path. The caller should
     /// fall back to engine-level knobs. Carries a human-readable reason.
     UnsupportedPlatform(&'static str),
@@ -193,16 +201,46 @@ fn activate_impl(opts: &ElasticOpts) -> Result<Activation, ActivateError> {
     Err(ActivateError::Exec(std::io::Error::last_os_error()))
 }
 
-#[cfg(not(unix))]
+// Windows WITH the Detours hook compiled in (DETOURS_DIR was set at build): the
+// interposer installs IN-PROCESS — no re-exec. Called first in `main`, before
+// the OpenVINO engine loads, so DLLs bind their `malloc` through the hook.
+#[cfg(all(windows, elastic_win_hook))]
+fn activate_impl(opts: &ElasticOpts) -> Result<Activation, ActivateError> {
+    let _ = ELASTIC_SO;
+    let dir_c = match &opts.dir {
+        Some(d) => std::ffi::CString::new(d.to_string_lossy().as_bytes()).ok(),
+        None => None,
+    };
+    let dir_ptr = dir_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr());
+    // SAFETY: single-threaded at this point (called before the tokio runtime);
+    // the C side suspends no other threads because none exist yet.
+    let rc = unsafe { elastic_install_win(opts.min_mb, opts.pool_mb, dir_ptr) };
+    if rc == 0 {
+        Ok(Activation::Activated)
+    } else {
+        Err(ActivateError::Exec(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("DetourTransactionCommit failed (rc={rc})"),
+        )))
+    }
+}
+
+// Windows WITHOUT the hook (DETOURS_DIR unset at build).
+#[cfg(all(not(unix), not(all(windows, elastic_win_hook))))]
 fn activate_impl(_opts: &ElasticOpts) -> Result<Activation, ActivateError> {
-    let _ = ELASTIC_SO; // silence unused on non-unix
+    let _ = ELASTIC_SO;
     Ok(Activation::UnsupportedPlatform(
-        "no allocator interposer on this platform yet — the committed-RAM cut \
-         needs a UCRT-heap redirector (Detours/mimalloc-redirect class), which \
-         is not implemented. OV-native knobs do NOT substitute (they cannot \
-         disable oneDNN's dirty repacked weight copies — D-004); ENABLE_MMAP is \
+        "no allocator interposer compiled in — on Windows, build cascadia-elastic \
+         with DETOURS_DIR pointing at a built Microsoft Detours to enable the \
+         in-process UCRT-heap hook. OV-native knobs do NOT substitute (they \
+         cannot disable oneDNN's dirty repacked copies — D-004); ENABLE_MMAP is \
          still seeded so the weight blob stays clean file pages",
     ))
+}
+
+#[cfg(all(windows, elastic_win_hook))]
+extern "C" {
+    fn elastic_install_win(min_mb: u32, pool_mb: u32, dir: *const std::os::raw::c_char) -> i32;
 }
 
 /// The OpenVINO plugin properties `--elastic` seeds so the engine's own memory

--- a/crates/cascadia-elastic/src/lib.rs
+++ b/crates/cascadia-elastic/src/lib.rs
@@ -1,0 +1,254 @@
+//! Elastic-memory posture for cascadia workers — the ramlab exp 198 result
+//! packaged as a first-class flag.
+//!
+//! # What it does
+//!
+//! An LLM server's dirty RAM is dominated by large, evictable buffers: the
+//! engine's weight copies, KV state and per-inference scratch. The elastic
+//! posture serves every allocation at or above a threshold from a file-backed
+//! mapping (an unlinked temp file) instead of anonymous memory, so those pages
+//! become clean/file-dirty and the kernel can write them back and reclaim them
+//! under pressure. Freed big mappings are retained in a pool and reused without
+//! unmap/zero, so the churn is a warm-up cost, not a per-inference tax
+//! (ramlab D-012/D-013/D-015; the process-wide generalization is exp 198).
+//!
+//! # Why an interposer, not a Rust `#[global_allocator]`
+//!
+//! In an OpenVINO worker the bytes that matter are allocated by C++ (oneDNN
+//! weight repacks, the GenAI KV cache). A Rust global allocator never sees
+//! them. An allocator **interposer** loaded ahead of the C runtime does, which
+//! is why this ships as a preloaded shared library rather than a Rust type.
+//!
+//! # Platform support
+//!
+//! * **Linux**: [`activate`] embeds the compiled interposer, writes it to a
+//!   private temp file, sets `LD_PRELOAD`, and re-executes the current process
+//!   once (guarded by an env marker, mirroring the low-RAM re-exec pattern).
+//!   Measured on the deployment target: 4.4× less committed RAM at −9% decode
+//!   on an unmodified OpenVINO stack (exp 198).
+//! * **Windows**: there is no `LD_PRELOAD`, and redirecting the whole C runtime
+//!   heap needs a trampoline-based redirector that catches every module's calls
+//!   into `ucrtbase` (the approach mimalloc ships as a separate signed DLL, and
+//!   the shape a Detours-based hook of the UCRT `malloc` family would take).
+//!   That is a self-contained systems project and is NOT implemented here yet,
+//!   so on Windows [`activate`] performs no interposition and returns
+//!   [`Activation::UnsupportedPlatform`].
+//!
+//!   Note the OV-native knobs do **not** substitute: measured on Linux
+//!   (ramlab exp 199), `ENABLE_MMAP=YES` + `CACHE_MODE=OPTIMIZE_SIZE` leave the
+//!   committed footprint unchanged, because the dirty bytes are oneDNN's
+//!   *repacked* weight copies, and OV exposes no property to disable those
+//!   (that is exactly D-004, and the reason the interposer exists). `--elastic`
+//!   still asserts `ENABLE_MMAP=YES` so the original weight blob stays clean
+//!   file pages, but the repacked-copy reduction on Windows waits on the
+//!   redirector.
+
+use std::ffi::OsString;
+
+/// Env marker set on the child so the re-exec happens at most once.
+const GUARD: &str = "CASCADIA_ELASTIC_ACTIVE";
+/// Env var the interposer reads for its threshold, in MB.
+const MIN_MB: &str = "ELASTIC_MIN_MB";
+/// Env var the interposer reads for the retained-mapping pool cap, in MB.
+const POOL_MB: &str = "ELASTIC_POOL_MB";
+/// Env var the interposer reads for the backing directory.
+const DIR: &str = "ELASTIC_DIR";
+
+/// The interposer shared library, embedded at build time (empty on non-Unix).
+const ELASTIC_SO: &[u8] = include_bytes!(env!("ELASTIC_SO_PATH"));
+
+/// Tunables for the elastic posture. Defaults mirror the exp 198 sweet spot
+/// (1 MB threshold with the retention pool on).
+#[derive(Debug, Clone)]
+pub struct ElasticOpts {
+    /// Route allocations at least this many MB through the file-backed pool.
+    /// 1 = maximum RAM cut; 16 = weights-only, zero measured speed cost.
+    pub min_mb: u32,
+    /// Cap on retained (freed-but-mapped) bytes, in MB. 0 disables the pool.
+    pub pool_mb: u32,
+    /// Backing directory for the temp files. `None` = `$TMPDIR` or `/tmp`.
+    pub dir: Option<OsString>,
+}
+
+impl Default for ElasticOpts {
+    fn default() -> Self {
+        Self { min_mb: 1, pool_mb: 8192, dir: None }
+    }
+}
+
+/// Outcome of [`activate`].
+#[derive(Debug)]
+pub enum Activation {
+    /// The interposer is already active in this process (we are the re-exec'd
+    /// child, or a parent set `LD_PRELOAD` for us). Nothing to do.
+    AlreadyActive,
+    /// This platform has no supported interposition path. The caller should
+    /// fall back to engine-level knobs. Carries a human-readable reason.
+    UnsupportedPlatform(&'static str),
+}
+
+/// Errors that abort activation before the process is re-executed. A failure
+/// here is non-fatal to the caller: run without the posture rather than not at
+/// all.
+#[derive(Debug)]
+pub enum ActivateError {
+    /// Writing the embedded interposer to a temp file failed.
+    Io(std::io::Error),
+    /// `execv` returned, i.e. the re-exec itself failed.
+    Exec(std::io::Error),
+}
+
+impl std::fmt::Display for ActivateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActivateError::Io(e) => write!(f, "writing elastic interposer: {e}"),
+            ActivateError::Exec(e) => write!(f, "re-exec with elastic interposer: {e}"),
+        }
+    }
+}
+impl std::error::Error for ActivateError {}
+
+/// Turn the elastic posture on for this process.
+///
+/// On Linux, on success this **does not return**: the process is replaced by a
+/// copy of itself with the interposer preloaded. It returns `Ok(_)` only when
+/// no re-exec was needed (already active) or the platform is unsupported, and
+/// `Err(_)` if activation was attempted but failed (caller should continue
+/// without the posture).
+pub fn activate(opts: &ElasticOpts) -> Result<Activation, ActivateError> {
+    if std::env::var_os(GUARD).is_some() {
+        return Ok(Activation::AlreadyActive);
+    }
+    activate_impl(opts)
+}
+
+/// True when running inside an already-activated (re-exec'd) process. Lets the
+/// CLI log "elastic: on" without attempting a second activation.
+pub fn is_active() -> bool {
+    std::env::var_os(GUARD).is_some()
+}
+
+#[cfg(unix)]
+fn activate_impl(opts: &ElasticOpts) -> Result<Activation, ActivateError> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // Write the interposer to a private temp file (0700). Keep it on disk for
+    // the child's lifetime; the OS reclaims it when the process exits and the
+    // fd/mapping close. We deliberately do not unlink before exec so the
+    // dynamic loader can open it by path.
+    let mut path = std::env::temp_dir();
+    let unique = format!("libcascadia_elastic.{}.so", std::process::id());
+    path.push(unique);
+    {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o700)
+            .open(&path)
+            .map_err(ActivateError::Io)?;
+        f.write_all(ELASTIC_SO).map_err(ActivateError::Io)?;
+    }
+
+    // Prepend to any existing LD_PRELOAD rather than clobbering it.
+    let mut preload = OsString::from(&path);
+    if let Some(existing) = std::env::var_os("LD_PRELOAD") {
+        if !existing.is_empty() {
+            preload.push(":");
+            preload.push(existing);
+        }
+    }
+
+    let exe = std::env::current_exe().map_err(ActivateError::Io)?;
+    let args: Vec<OsString> = std::env::args_os().collect();
+
+    // SAFETY: execv replaces the image; on success nothing after it runs. We
+    // set env with std (process still single-threaded intent aside — this is
+    // called first thing in main, before tokio/rayon spin up).
+    std::env::set_var("LD_PRELOAD", &preload);
+    std::env::set_var(GUARD, "1");
+    std::env::set_var(MIN_MB, opts.min_mb.to_string());
+    std::env::set_var(POOL_MB, opts.pool_mb.to_string());
+    if let Some(dir) = &opts.dir {
+        std::env::set_var(DIR, dir);
+    }
+
+    // Build argv as C strings.
+    let c_exe = std::ffi::CString::new(exe.as_os_str().as_bytes())
+        .map_err(|e| ActivateError::Exec(std::io::Error::new(std::io::ErrorKind::InvalidInput, e)))?;
+    let c_args: Vec<std::ffi::CString> = args
+        .iter()
+        .map(|a| std::ffi::CString::new(a.as_bytes()).unwrap_or_default())
+        .collect();
+    let mut ptrs: Vec<*const libc::c_char> = c_args.iter().map(|a| a.as_ptr()).collect();
+    ptrs.push(std::ptr::null());
+
+    // SAFETY: c_exe/ptrs outlive the call; on success execv never returns.
+    unsafe {
+        libc::execv(c_exe.as_ptr(), ptrs.as_ptr());
+    }
+    // Only reached if execv failed.
+    Err(ActivateError::Exec(std::io::Error::last_os_error()))
+}
+
+#[cfg(not(unix))]
+fn activate_impl(_opts: &ElasticOpts) -> Result<Activation, ActivateError> {
+    let _ = ELASTIC_SO; // silence unused on non-unix
+    Ok(Activation::UnsupportedPlatform(
+        "no allocator interposer on this platform yet — the committed-RAM cut \
+         needs a UCRT-heap redirector (Detours/mimalloc-redirect class), which \
+         is not implemented. OV-native knobs do NOT substitute (they cannot \
+         disable oneDNN's dirty repacked weight copies — D-004); ENABLE_MMAP is \
+         still seeded so the weight blob stays clean file pages",
+    ))
+}
+
+/// The OpenVINO plugin properties `--elastic` seeds so the engine's own memory
+/// is frugal too — used on every platform, and the ONLY memory lever on
+/// Windows. Returned as `(key, value)` pairs the CLI merges into the property
+/// set BEFORE user `--ov-config` (so the user can still override any of them).
+///
+/// * `ENABLE_MMAP=YES` — keep the weight blob memory-mapped (clean pages)
+///   rather than copied into the compiled model. OV default is already YES for
+///   reading, but we assert it so a stale cache mode cannot flip it.
+/// * `CACHE_MODE=OPTIMIZE_SIZE` — when a compile cache is used, store a
+///   weightless blob and re-read weights from the mmap'd IR, avoiding a second
+///   resident copy.
+pub fn ov_memory_props() -> Vec<(String, String)> {
+    vec![
+        ("ENABLE_MMAP".to_string(), "YES".to_string()),
+        ("CACHE_MODE".to_string(), "OPTIMIZE_SIZE".to_string()),
+    ]
+}
+
+#[cfg(all(unix, test))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_shim_is_nonempty_on_unix() {
+        // build.rs must have compiled a real .so, not the placeholder.
+        assert!(
+            ELASTIC_SO.len() > 1024,
+            "embedded interposer looks empty ({} bytes) — build.rs compile failed",
+            ELASTIC_SO.len()
+        );
+        // ELF magic.
+        assert_eq!(&ELASTIC_SO[..4], b"\x7fELF");
+    }
+
+    #[test]
+    fn default_opts_match_exp198_sweet_spot() {
+        let o = ElasticOpts::default();
+        assert_eq!(o.min_mb, 1);
+        assert!(o.pool_mb > 0, "pool on by default");
+    }
+
+    #[test]
+    fn ov_memory_props_assert_mmap() {
+        let p = ov_memory_props();
+        assert!(p.iter().any(|(k, v)| k == "ENABLE_MMAP" && v == "YES"));
+    }
+}

--- a/crates/cascadia/src/main.rs
+++ b/crates/cascadia/src/main.rs
@@ -4,8 +4,19 @@ use anyhow::Result;
 use cascadia_cli::Cli;
 use clap::Parser;
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
-    cascadia_cli::run(cli).await
+
+    // The elastic memory posture (`--elastic`) may re-execute this process with
+    // an allocator interposer preloaded. That must happen BEFORE the async
+    // runtime spins up worker threads: `execv` and the `LD_PRELOAD`/env setup
+    // are only safe while the process is single-threaded. On Linux success the
+    // call replaces the image and never returns; otherwise it falls through and
+    // the run continues (with OV memory knobs still seeded).
+    cascadia_cli::activate_elastic_if_requested(&cli);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(cascadia_cli::run(cli))
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -148,15 +148,19 @@ device + `--engine ov-genai`, like the typed NPU flags. Cross-platform.
 
 **`--elastic`** serves large allocations from file-backed mappings so the
 worker's weight copies, KV state and scratch are kernel-reclaimable rather than
-anonymous/committed (ramlab exp 198/199: 2064→506 MB committed at −1% decode on
-an unmodified OpenVINO CPU worker; `--elastic-min-mb 16` gives 2064→1549 MB at
-speed parity). **Linux only today**: it re-execs the worker once with an
-allocator interposer preloaded — the serving PID is unchanged (execv), and the
-log prints `elastic posture active`. On **Windows** the flag parses and asserts
-`ENABLE_MMAP=YES`, but does **not** yet cut committed RAM: OV exposes no property
-to disable oneDNN's dirty repacked weight copies (that is D-004, and why the
-interposer exists), so the Windows reduction waits on a UCRT-heap redirector.
-The flag prints that it is inactive on Windows rather than implying a win.
+committed. Measured on unmodified OpenVINO CPU workers (ramlab exp 199): Linux
+2064→506 MB committed at −1% decode (`--elastic-min-mb 16` → 1549 MB at parity);
+Windows 1329→223 MB private commit at −6% decode. Same file-backed mechanism,
+different injection vector: **Linux** re-execs the worker once with an allocator
+interposer `LD_PRELOAD`ed (serving PID unchanged via execv; logs `elastic
+posture active`); **Windows** inline-hooks the UCRT allocation family
+(`malloc`/`free`/`realloc`/`calloc`/`_msize` + `_aligned_*`) in-process with
+Microsoft Detours before the OV engine loads (logs `elastic posture active
+(in-process)`). The OV-native knobs cannot substitute — they cannot disable
+oneDNN's dirty repacked copies (D-004) — so `--elastic` still asserts
+`ENABLE_MMAP=YES` to keep the weight blob clean but relies on the interposer for
+the cut. The Windows hook is compiled in only when `cascadia-elastic` was built
+with `DETOURS_DIR` set; otherwise `--elastic` reports inactive there.
 
 **`--ov-cache-dir` is on by default and matters.** For `ov-genai`, `ov-runtime`,
 `gemma4` and `sparse-moe`, leaving it unset defaults to

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -132,6 +132,31 @@ a few each. MiniMax-M2 `sparse-moe` only.
 | `--ov-num-threads <N>` | — | Host CPU thread cap (`INFERENCE_NUM_THREADS`). CPU plugin only. |
 | `--ov-allow-auto-batching` | off | Allow GPU-plugin internal auto-batching. |
 | `--ov-execution-mode <MODE>` | — | `ACCURACY` / `PERFORMANCE`. |
+| `--ov-config <KEY=VALUE>` | — | Raw OV plugin property passthrough, repeatable. See below. |
+| `--elastic` | off | Elastic memory posture (Linux; file-backed big allocations). See below. |
+| `--elastic-min-mb <MB>` | 1 | Elastic threshold; 16 = weights-only, zero speed cost. |
+| `--elastic-pool-mb <MB>` | 8192 | Elastic retained-mapping pool cap (0 = off). |
+
+**`--ov-config KEY=VALUE`** forwards any plugin property to OpenVINO verbatim,
+alongside the typed `--ov-*` flags — the escape hatch for knobs without a
+dedicated flag (`--ov-config KV_CACHE_PRECISION=u8`,
+`--ov-config DYNAMIC_QUANTIZATION_GROUP_SIZE=0`). Repeatable; applied last, so it
+overrides a typed flag setting the same key. The value may contain `=` (split on
+the first only). Malformed entries (no `=`, empty key) are rejected at parse
+time; OV itself validates the key/value. NPU-prefixed keys are gated to an NPU
+device + `--engine ov-genai`, like the typed NPU flags. Cross-platform.
+
+**`--elastic`** serves large allocations from file-backed mappings so the
+worker's weight copies, KV state and scratch are kernel-reclaimable rather than
+anonymous/committed (ramlab exp 198/199: 2064→506 MB committed at −1% decode on
+an unmodified OpenVINO CPU worker; `--elastic-min-mb 16` gives 2064→1549 MB at
+speed parity). **Linux only today**: it re-execs the worker once with an
+allocator interposer preloaded — the serving PID is unchanged (execv), and the
+log prints `elastic posture active`. On **Windows** the flag parses and asserts
+`ENABLE_MMAP=YES`, but does **not** yet cut committed RAM: OV exposes no property
+to disable oneDNN's dirty repacked weight copies (that is D-004, and why the
+interposer exists), so the Windows reduction waits on a UCRT-heap redirector.
+The flag prints that it is inactive on Windows rather than implying a win.
 
 **`--ov-cache-dir` is on by default and matters.** For `ov-genai`, `ov-runtime`,
 `gemma4` and `sparse-moe`, leaving it unset defaults to


### PR DESCRIPTION
## Summary

Two memory-oriented `worker` flags for the OpenVINO path.

**`--ov-config KEY=VALUE`** (repeatable) — raw OpenVINO plugin-property passthrough, merged into the property set alongside the typed `--ov-*` flags and applied **last** (override-wins). Parse-validated (`KEY=VALUE`, non-empty key); NPU-prefixed keys reuse the existing NPU device + `ov-genai` gate. The escape hatch for plugin knobs without a dedicated flag — e.g. `--ov-config ENABLE_MMAP=YES`, `--ov-config KV_CACHE_PRECISION=u8`. Cross-platform.

**`--elastic`** (+ `--elastic-min-mb` / `--elastic-pool-mb`) — serve large allocations from file-backed mappings so the worker's weight copies, KV and scratch become kernel-reclaimable instead of private/committed. New `cascadia-elastic` crate:

- **Linux** — embeds a compiled interposer, writes it to a private temp file, and `LD_PRELOAD`s it via a one-shot guarded re-exec (serving PID unchanged via `execv`).
- **Windows** — inline-hooks the UCRT allocation family (`malloc`/`free`/`realloc`/`calloc`/`_msize` + the `_aligned_*` variants) with Microsoft Detours, in-process, before the OV engine loads. Compiled + linked only when `DETOURS_DIR` is set at build time (an SDK-style input, like `INTEL_OPENVINO_DIR`); without it the hook is compiled out and `--elastic` reports inactive.

Activation runs in `main` before the async runtime starts (env mutation + `execv` are only safe single-threaded).

## Measured — unmodified OpenVINO CPU worker

| platform | engine / model | stock | `--elastic` | delta |
|---|---|---|---|---|
| Linux (Cascade Lake) | ov-runtime, 8B-class int4 | 2064 MB anon | 506 MB | 4.1×, −1% decode |
| Windows (Lunar Lake) | ov-genai, Qwen3-1.7B-int4 | 1329 MB private | 223 MB | 5.95×, −6% decode |

Output byte-identical; working set unchanged (the weight pages stay resident, now file-backed). `--elastic-min-mb 16` (weights-only threshold) gives 2064→1549 MB at speed parity. Standalone Windows microbench: 300 MB `malloc` + 300 MB `_aligned_malloc` kept out of private commit (+1 MB vs +301).

## Scope / caveats (for review)

- The interposer reduces **committed / private** memory (the multi-tenancy + OOM-exposure metric), **not** physical residency — it file-backs the engine's weight copy, it does not prevent the copy. OpenVINO exposes no property to disable oneDNN's repack, and a warm model-cache import does not mmap it clean either. Collapsing to a single clean copy would need a targeted plugin change.
- CPU-plugin serving; GPU/NPU device memory (USM) bypasses the CRT heap.
- Windows requires a pre-built Detours via `DETOURS_DIR`. **Vendoring Detours vs. keeping the env-var build input is an open decision — feedback welcome.**

## Build / test

- Builds with `--features openvino` on Linux (miner) and Windows/MSVC (Lunar Lake).
- Tests: `cascadia-elastic` (3), `cascadia-cli --ov-config` (6). Linux release build verified unchanged after the Windows additions.
- `docs/CLI.md` updated for both flags.

---

Opening as **draft** for early feedback on the approach — in particular the Windows Detours build input (vendor vs `DETOURS_DIR`) and the commit-vs-physical scope.
