### PR TITLE
fix(dashboard): honest / + embed the SPA in release bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,24 @@ jobs:
         # clean runtime error. Runs every unit test plus the binary
         # e2e tests against the mock engine.
         run: cargo test --workspace --all-targets
+
+      # Everything above builds default features, and `dashboard-embed` is
+      # default-off — so without these steps the whole embedded-SPA path
+      # (spa.rs, rust-embed, mime_guess, and build.rs's success branch) is
+      # first compiled by the release workflow, at tag time. That workflow
+      # only runs once release-please has already created the tag and the
+      # GitHub pre-release, so a break there strands a published release
+      # with no binaries attached. Compile it on every PR instead.
+      #
+      # Runner-preinstalled Node (>= 20 on all hosted images); the JS deps
+      # are pinned by package-lock.json via `npm ci`.
+      - name: Build dashboard SPA
+        working-directory: crates/cascadia-dashboard/web
+        run: npm ci && npm run build
+
+      - name: Lint + test (dashboard embed path)
+        # Also the only lint spa.rs ever gets: the clippy run above is
+        # default-features, so the file is invisible to it.
+        run: |
+          cargo clippy -p cascadia-dashboard --features embed-spa --all-targets
+          cargo test -p cascadia-dashboard --features embed-spa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,13 @@
 # The final job promotes the release (drops the pre-release badge) once both
 # bundles are attached — a release is never "full" without its binaries.
 #
-# Flavor : `--features openvino` (real inference). Each bundle ships the cascadia
+# Flavor : `--features openvino,dashboard-embed` (real inference + the web
+#          dashboard embedded in the binary). Each bundle ships the cascadia
 #          binary PLUS the OpenVINO GenAI runtime libraries it dynamically links.
-#          The binary does NOT work standalone — see INSTALL.md.
+#          The binary does NOT work standalone — see INSTALL.md. The dashboard
+#          SPA is built with npm right before the cargo build (web/dist is
+#          generated, not checked in); the cascadia-dashboard build script
+#          fails the job with instructions if that step is ever dropped.
 # Targets: linux-x86_64, windows-x86_64 (both Intel). macOS has no Intel GPU
 #          runtime — it is stub-only (dev) and intentionally not released here.
 # Runner : GitHub-hosted. The OpenVINO *build* only links against the SDK
@@ -139,7 +143,17 @@ jobs:
           tar -xzf "$RUNNER_TEMP/ov.tgz" -C "$RUNNER_TEMP/ov" --strip-components=1
           echo "INTEL_OPENVINO_DIR=$RUNNER_TEMP/ov" >> "$GITHUB_ENV"
 
-      - name: Build cascadia (openvino)
+      # Runner-preinstalled Node (>= 20 on all hosted images) — the JS deps
+      # are pinned by package-lock.json via `npm ci`, and a Vite build has
+      # no native-addon sensitivity to the Node minor, so a setup-node
+      # action would only add a supply-chain pin to maintain.
+      - name: Build dashboard SPA
+        working-directory: crates/cascadia-dashboard/web
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build cascadia (openvino + dashboard)
         env:
           CXX: g++-12
           # Load the bundled .so's at runtime from a lib/ dir beside the binary.
@@ -150,7 +164,7 @@ jobs:
           # (which carries no runpath) must still resolve libtbb.so.12 from
           # the same lib/ dir. RPATH applies to those transitive lookups too.
           RUSTFLAGS: "-C link-arg=-Wl,-rpath,$ORIGIN/lib -C link-arg=-Wl,--disable-new-dtags"
-        run: cargo build --release -p cascadia --features openvino
+        run: cargo build --release -p cascadia --features openvino,dashboard-embed
 
       - name: Package bundle
         id: pkg
@@ -205,6 +219,14 @@ jobs:
         with:
           shared-key: release-windows-openvino
 
+      # See the linux job for why preinstalled Node rather than setup-node.
+      - name: Build dashboard SPA
+        working-directory: crates/cascadia-dashboard/web
+        shell: pwsh
+        run: |
+          npm ci
+          npm run build
+
       # MSVC (VS 2022 Build Tools) is preinstalled on windows-latest; cc-rs
       # locates it via vswhere, so no Developer Command Prompt is needed here.
       - name: Download + extract OpenVINO GenAI SDK
@@ -217,9 +239,9 @@ jobs:
           $root = (Get-ChildItem -Directory "$tmp/ov_raw")[0].FullName
           "INTEL_OPENVINO_DIR=$root" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Build cascadia (openvino)
+      - name: Build cascadia (openvino + dashboard)
         shell: pwsh
-        run: cargo build --release -p cascadia --features openvino
+        run: cargo build --release -p cascadia --features openvino,dashboard-embed
 
       - name: Package bundle
         id: pkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,10 @@
 #          dashboard embedded in the binary). Each bundle ships the cascadia
 #          binary PLUS the OpenVINO GenAI runtime libraries it dynamically links.
 #          The binary does NOT work standalone — see INSTALL.md. The dashboard
-#          SPA is built with npm right before the cargo build (web/dist is
-#          generated, not checked in); the cascadia-dashboard build script
-#          fails the job with instructions if that step is ever dropped.
+#          SPA (web/dist is generated, not checked in) is built once in its
+#          own read-only job and downloaded by both build jobs; the
+#          cascadia-dashboard build script fails the job with instructions
+#          if that download is ever dropped.
 # Targets: linux-x86_64, windows-x86_64 (both Intel). macOS has no Intel GPU
 #          runtime — it is stub-only (dev) and intentionally not released here.
 # Runner : GitHub-hosted. The OpenVINO *build* only links against the SDK
@@ -102,9 +103,44 @@ jobs:
               --title "cascadia $TAG" --generate-notes
           fi
 
+  # ── The dashboard SPA is platform-independent, so it is built once here
+  #    and both bundles embed the same dist. Keeping npm out of the build
+  #    jobs matters beyond deduplication: those jobs hold `contents: write`
+  #    and upload the release assets, and `npm ci` runs ~190 third-party
+  #    packages' lifecycle scripts. This job can only read the repo.
+  build-spa:
+    name: dashboard SPA
+    needs: ensure-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Same ref as the build jobs, or a workflow_call run would embed
+          # the SPA from the wrong commit.
+          ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
+
+      # Runner-preinstalled Node (>= 20 on all hosted images) — the JS deps
+      # are pinned by package-lock.json via `npm ci`, and a Vite build has
+      # no native-addon sensitivity to the Node minor, so a setup-node
+      # action would only add a supply-chain pin to maintain.
+      - name: Build dashboard SPA
+        working-directory: crates/cascadia-dashboard/web
+        run: npm ci && npm run build
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-dist
+          path: crates/cascadia-dashboard/web/dist
+          if-no-files-found: error
+          retention-days: 1
+
   build-linux:
     name: linux-x86_64 (openvino)
-    needs: ensure-release
+    needs: [ensure-release, build-spa]
     # ubuntu-22.04 → glibc 2.35 floor, and matches the ubuntu22 OV archive.
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -143,15 +179,13 @@ jobs:
           tar -xzf "$RUNNER_TEMP/ov.tgz" -C "$RUNNER_TEMP/ov" --strip-components=1
           echo "INTEL_OPENVINO_DIR=$RUNNER_TEMP/ov" >> "$GITHUB_ENV"
 
-      # Runner-preinstalled Node (>= 20 on all hosted images) — the JS deps
-      # are pinned by package-lock.json via `npm ci`, and a Vite build has
-      # no native-addon sensitivity to the Node minor, so a setup-node
-      # action would only add a supply-chain pin to maintain.
-      - name: Build dashboard SPA
-        working-directory: crates/cascadia-dashboard/web
-        run: |
-          npm ci
-          npm run build
+      # Built by the build-spa job; web/dist is generated, not checked in.
+      # If this step is ever dropped, cascadia-dashboard's build script fails
+      # the job with instructions rather than silently shipping without a UI.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dashboard-dist
+          path: crates/cascadia-dashboard/web/dist
 
       - name: Build cascadia (openvino + dashboard)
         env:
@@ -198,7 +232,7 @@ jobs:
 
   build-windows:
     name: windows-x86_64 (openvino)
-    needs: ensure-release
+    needs: [ensure-release, build-spa]
     runs-on: windows-latest
     timeout-minutes: 60
     permissions:
@@ -219,13 +253,11 @@ jobs:
         with:
           shared-key: release-windows-openvino
 
-      # See the linux job for why preinstalled Node rather than setup-node.
-      - name: Build dashboard SPA
-        working-directory: crates/cascadia-dashboard/web
-        shell: pwsh
-        run: |
-          npm ci
-          npm run build
+      # See the linux job — same artifact, same build-script backstop.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dashboard-dist
+          path: crates/cascadia-dashboard/web/dist
 
       # MSVC (VS 2022 Build Tools) is preinstalled on windows-latest; cc-rs
       # locates it via vswhere, so no Developer Command Prompt is needed here.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,6 +113,18 @@ INTEL_OPENVINO_DIR=/opt/intel/openvino_genai_2026.2.0.0 \
 
 The binary is statically linked apart from the OpenVINO dynamic libraries. To run it elsewhere, copy the binary plus `INTEL_OPENVINO_DIR/runtime/lib/intel64/` **and** `runtime/3rdparty/tbb/lib/` (Linux), or `runtime/bin/intel64/Release/` + `runtime/3rdparty/tbb/bin/` (Windows), onto the target's library path. TBB ships beside the runtime, not inside it, and `libopenvino` imports it.
 
+### Web dashboard (optional, either mode)
+
+The browser dashboard served at `/` by `--api` workers is compiled into the binary behind the `dashboard-embed` feature. It needs the SPA built first (Node 20+); without the feature, `/` serves a pointer page and only the JSON/API endpoints are live. Release bundles ship with it embedded.
+
+```bash
+cd crates/cascadia-dashboard/web && npm ci && npm run build && cd -
+cargo build --release -p cascadia --features dashboard-embed        # stub mode
+# or: --features openvino,dashboard-embed                           # real inference
+```
+
+If cargo stops with "`embed-spa` is enabled, but the dashboard SPA has not been built", run the npm step above — `web/dist/` is generated, not checked in.
+
 ---
 
 ## Export-time Python (only for `cascadia shard`)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -115,7 +115,7 @@ The binary is statically linked apart from the OpenVINO dynamic libraries. To ru
 
 ### Web dashboard (optional, either mode)
 
-The browser dashboard served at `/` by `--api` workers is compiled into the binary behind the `dashboard-embed` feature. It needs the SPA built first (Node 20+); without the feature, `/` serves a pointer page and only the JSON/API endpoints are live. Release bundles ship with it embedded.
+The browser dashboard served at `/` by `--api` workers is compiled into the binary behind the `dashboard-embed` feature. It needs the SPA built first (Node 20+); without the feature, `/` serves a pointer page and only the JSON/API endpoints are live. Release bundles newer than v0.1.8 ship with it embedded.
 
 ```bash
 cd crates/cascadia-dashboard/web && npm ci && npm run build && cd -

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -123,6 +123,10 @@ cargo build --release -p cascadia --features dashboard-embed        # stub mode
 # or: --features openvino,dashboard-embed                           # real inference
 ```
 
+`--release` is what actually embeds the assets: `rust-embed` reads `web/dist`
+from disk at request time in debug builds, so a debug binary serves the UI
+only while that directory is present and current.
+
 If cargo stops with "`embed-spa` is enabled, but the dashboard SPA has not been built", run the npm step above — `web/dist/` is generated, not checked in.
 
 ---

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -44,6 +44,11 @@ curl http://localhost:8000/v1/chat/completions \
 You should get a JSON chat-completion response back. That's the whole
 request path working end to end. ✅
 
+Opening <http://localhost:8000/> in a browser shows a pointer page: the web
+dashboard is embedded in the binary only when built with
+`--features dashboard-embed` (release bundles have it; the page and the
+[README](README.md#web-dashboard) show the two-step source build).
+
 ---
 
 ## 2. Real inference on one Intel machine

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -46,8 +46,9 @@ request path working end to end. ✅
 
 Opening <http://localhost:8000/> in a browser shows a pointer page: the web
 dashboard is embedded in the binary only when built with
-`--features dashboard-embed` (release bundles have it; the page and the
-[README](README.md#web-dashboard) show the two-step source build).
+`--features dashboard-embed` (release bundles newer than v0.1.8 have it;
+the page and the [README](README.md#web-dashboard) show the two-step
+source build).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ cd ../../..
 cargo build --release -p cascadia --features dashboard-embed   # add openvino for real inference
 ```
 
+Use `--release` if you want the single-static-binary property: `rust-embed`
+bakes the assets in for release builds, but reads `web/dist` from disk at
+request time in debug ones, so a debug binary stops serving the UI if that
+directory moves or is rebuilt.
+
 Either way the JSON endpoints the UI reads (`/api/topology`, `/api/stats`) are always served, so during UI development `npm run dev` in `crates/cascadia-dashboard/web` hosts the SPA on :5173 and proxies API calls to a running worker (`VITE_API_PROXY` points it at a non-default host).
 
 ### Engines

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ For distributed speculative decoding, run **every** rank with `--engine ov-dist-
 
 ### Web dashboard
 
-Workers started with `--api` also serve a browser dashboard at `/` — cluster topology with per-link latency/bandwidth, live request/token counters, and a chat surface. **Release bundles include it.** Source builds don't by default: the UI is a Vite SPA embedded into the binary behind the `dashboard-embed` cargo feature, and cargo can't run npm for you, so a plain `cargo build` serves the API plus a pointer page at `/` instead. To embed it (needs Node 20+):
+Workers started with `--api` also serve a browser dashboard at `/` — cluster topology with per-link latency/bandwidth, live request/token counters, and a chat surface. **Release bundles newer than v0.1.8 include it.** Source builds don't by default: the UI is a Vite SPA embedded into the binary behind the `dashboard-embed` cargo feature, and cargo can't run npm for you, so a plain `cargo build` serves the API plus a pointer page at `/` instead. To embed it (needs Node 20+):
 
 ```bash
 cd crates/cascadia-dashboard/web

--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ Not sure of a node's address? `cascadia discover` lists Cascadia peers on the LA
 
 For distributed speculative decoding, run **every** rank with `--engine ov-dist-spec` (they share a wire protocol) and give rank 0 `--draft-model ~/models/llama-3.2-1b-int4-ov --spec-k 4` — the draft is a local OpenVINO IR directory, not an HF id. See ([docs/engines/ov-dist-spec.md](docs/engines/ov-dist-spec.md)).
 
+### Web dashboard
+
+Workers started with `--api` also serve a browser dashboard at `/` — cluster topology with per-link latency/bandwidth, live request/token counters, and a chat surface. **Release bundles include it.** Source builds don't by default: the UI is a Vite SPA embedded into the binary behind the `dashboard-embed` cargo feature, and cargo can't run npm for you, so a plain `cargo build` serves the API plus a pointer page at `/` instead. To embed it (needs Node 20+):
+
+```bash
+cd crates/cascadia-dashboard/web
+npm ci && npm run build
+cd ../../..
+cargo build --release -p cascadia --features dashboard-embed   # add openvino for real inference
+```
+
+Either way the JSON endpoints the UI reads (`/api/topology`, `/api/stats`) are always served, so during UI development `npm run dev` in `crates/cascadia-dashboard/web` hosts the SPA on :5173 and proxies API calls to a running worker (`VITE_API_PROXY` points it at a non-default host).
+
 ### Engines
 
 ```console

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -1922,7 +1922,20 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
         // fallback, so it must be merged second.
         let app = api_router.merge(cascadia_dashboard::make_router(dash_state));
         let listener = tokio::net::TcpListener::bind((api_host.as_str(), api_port)).await?;
-        info!(host = %api_host, port = api_port, "API + dashboard serving");
+        // Only claim a dashboard when this build actually embeds one — the
+        // unconditional "API + dashboard serving" line sent the first
+        // source-build user to a bare 404 on `/`. `SPA_EMBEDDED` comes from
+        // the dashboard crate (the feature owner), not a local cfg!, so
+        // feature unification can't make the log disagree with the router.
+        if cascadia_dashboard::SPA_EMBEDDED {
+            info!(host = %api_host, port = api_port, "API + dashboard serving");
+        } else {
+            info!(
+                host = %api_host,
+                port = api_port,
+                "API serving (dashboard UI not embedded in this build; GET / explains how to enable it)"
+            );
+        }
         // NODELAY-on-accept wrapper. tokio's TcpStream defaults to
         // NODELAY=false (Nagle on); for SSE streaming small per-token
         // chunks, Nagle aggregates them into ~3500 B bursts every

--- a/crates/cascadia-dashboard/Cargo.toml
+++ b/crates/cascadia-dashboard/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Dashboard HTTP routes (topology, stats, SSE events) and embedded SPA for visualizing a Cascadia cluster."
+description = "Dashboard HTTP routes (topology, stats) and embedded SPA for visualizing a Cascadia cluster."
 
 [dependencies]
 cascadia-topology = { workspace = true }
@@ -26,8 +26,8 @@ default = []
 # Embed the built SPA (web/dist) into the binary so a single static binary
 # ships with the UI. Requires `npm run build` to have been run in `web/`
 # before `cargo build --features embed-spa`. Without the feature, the
-# crate exposes only the JSON + SSE endpoints; an external SPA host (e.g.
-# `vite dev` during local development) supplies the UI.
+# crate serves the JSON endpoints plus a pointer page at `/`; an external
+# SPA host (e.g. `vite dev` during local development) supplies the UI.
 embed-spa = ["dep:rust-embed", "dep:mime_guess"]
 
 [dev-dependencies]

--- a/crates/cascadia-dashboard/build.rs
+++ b/crates/cascadia-dashboard/build.rs
@@ -1,0 +1,29 @@
+//! Fail `--features embed-spa` builds with instructions when the SPA
+//! hasn't been built, instead of the three cryptic E0599 errors the
+//! `#[derive(Embed)]` on a missing `web/dist/` folder produces.
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    // Set by cargo iff the `embed-spa` feature is enabled for this build.
+    if env::var_os("CARGO_FEATURE_EMBED_SPA").is_some() {
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let index = Path::new(&manifest_dir)
+            .join("web")
+            .join("dist")
+            .join("index.html");
+        if !index.exists() {
+            panic!(
+                "\n\nthe `embed-spa` / `dashboard-embed` feature is enabled, but the dashboard \
+                 SPA has not been built (crates/cascadia-dashboard/web/dist/ is missing — it is \
+                 generated, not checked in).\n\nBuild it first:\n\n    cd crates/cascadia-dashboard/web\n    \
+                 npm ci && npm run build\n\nthen re-run the cargo build.\n"
+            );
+        }
+        // Re-run this check (and rust-embed's re-embed) when the built SPA
+        // appears or changes; without the feature the crate doesn't touch
+        // web/dist, so no dependency is registered.
+        println!("cargo:rerun-if-changed=web/dist");
+    }
+}

--- a/crates/cascadia-dashboard/src/lib.rs
+++ b/crates/cascadia-dashboard/src/lib.rs
@@ -6,8 +6,6 @@
 //! * `GET /api/stats` — coarse runtime counters (in-flight requests,
 //!   tokens generated). Read from the shared [`cascadia_types::ApiStats`]
 //!   the OpenAI server bumps on the chat hot path.
-//! * `GET /api/events` — server-sent events for live updates (added in a
-//!   follow-up; the placeholder route returns a one-shot welcome event).
 //! * `embed-spa` feature — when on, serves the built Vite SPA from
 //!   `crates/cascadia-dashboard/web/dist` at `/`, including a fallback to
 //!   `index.html` for client-side routes. When off, `/` serves a small

--- a/crates/cascadia-dashboard/src/lib.rs
+++ b/crates/cascadia-dashboard/src/lib.rs
@@ -237,4 +237,57 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    // The embedded build's half of the same contract. A missing asset used to
+    // come back as 200 + the SPA shell, so a browser asking for a hashed
+    // `.js` got `text/html`, refused it on MIME grounds, and rendered a blank
+    // dashboard — with every response a 200 and nothing in the log.
+
+    #[cfg(feature = "embed-spa")]
+    #[tokio::test]
+    async fn missing_asset_404s_instead_of_serving_the_shell() {
+        let app = make_router(state_with_two_nodes());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/bogus.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[cfg(feature = "embed-spa")]
+    #[tokio::test]
+    async fn client_routes_still_resolve_to_the_shell() {
+        let app = make_router(state_with_two_nodes());
+        let response = app
+            .oneshot(Request::builder().uri("/chat").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        // `/chat` is a client-side route with no file behind it: the SPA
+        // router resolves it, so the shell is the correct answer.
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = &response.headers()[axum::http::header::CONTENT_TYPE];
+        assert!(ct.to_str().unwrap().starts_with("text/html"));
+    }
+
+    #[cfg(feature = "embed-spa")]
+    #[tokio::test]
+    async fn reserved_api_paths_404_rather_than_masking_as_the_shell() {
+        for uri in ["/v1/nope", "/api/nope", "/health"] {
+            let app = make_router(state_with_two_nodes());
+            let response = app
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{uri} must 404, not return the SPA shell"
+            );
+        }
+    }
 }

--- a/crates/cascadia-dashboard/src/lib.rs
+++ b/crates/cascadia-dashboard/src/lib.rs
@@ -10,7 +10,11 @@
 //!   follow-up; the placeholder route returns a one-shot welcome event).
 //! * `embed-spa` feature — when on, serves the built Vite SPA from
 //!   `crates/cascadia-dashboard/web/dist` at `/`, including a fallback to
-//!   `index.html` for client-side routes.
+//!   `index.html` for client-side routes. When off, `/` serves a small
+//!   built-in pointer page saying the UI isn't in this build and how to
+//!   get it — a bare 404 on `/` reads as "the server is broken" when the
+//!   startup log just advertised a dashboard (that's exactly how the
+//!   first source-build user experienced it).
 //!
 //! Why a separate crate rather than expanding `cascadia-api`:
 //! `cascadia-api` is the OpenAI-compatible surface and shouldn't grow a
@@ -30,6 +34,12 @@ use serde::Serialize;
 
 #[cfg(feature = "embed-spa")]
 mod spa;
+
+/// Whether this build carries the SPA. Exported so the host process can
+/// log what `/` will actually serve — evaluated HERE, in the crate that
+/// owns the feature, so the answer stays correct even if a dependency
+/// other than the host enabled `embed-spa` through feature unification.
+pub const SPA_EMBEDDED: bool = cfg!(feature = "embed-spa");
 
 /// Shared state for the dashboard routes.
 ///
@@ -60,7 +70,23 @@ pub fn make_router(state: DashboardState) -> Router {
     #[cfg(feature = "embed-spa")]
     let r = r.merge(spa::router());
 
+    // No SPA in this build: `/` gets a pointer page instead of axum's
+    // empty-body 404. Only `/` — other unknown paths keep 404ing, since
+    // there are no client-side routes to resolve without the SPA.
+    #[cfg(not(feature = "embed-spa"))]
+    let r = r.route("/", get(placeholder_index));
+
     r.with_state(state)
+}
+
+/// Served at `/` when the SPA is not embedded. Self-contained (inline
+/// CSS, no assets) so it renders from any build with zero extra routes.
+#[cfg(not(feature = "embed-spa"))]
+const PLACEHOLDER_HTML: &str = include_str!("placeholder.html");
+
+#[cfg(not(feature = "embed-spa"))]
+async fn placeholder_index() -> axum::response::Html<&'static str> {
+    axum::response::Html(PLACEHOLDER_HTML)
 }
 
 #[derive(Serialize)]
@@ -176,5 +202,39 @@ mod tests {
         assert_eq!(v["requests_total"], 7);
         assert_eq!(v["tokens_total"], 2048);
         assert_eq!(v["max_concurrent"], 16);
+    }
+
+    // Regression tests for the "downloaded main, saw `API + dashboard
+    // serving`, got an empty 404 on /" report: a no-SPA build must say
+    // something useful at `/`, and must NOT grow an SPA-style fallback
+    // (unknown paths keep 404ing — there are no client routes to serve).
+
+    #[cfg(not(feature = "embed-spa"))]
+    #[tokio::test]
+    async fn root_serves_pointer_page_when_spa_not_embedded() {
+        let app = make_router(state_with_two_nodes());
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response.headers()[axum::http::header::CONTENT_TYPE].clone();
+        assert!(ct.to_str().unwrap().starts_with("text/html"));
+        let body = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+        let page = std::str::from_utf8(&body).unwrap();
+        // The page's whole job: name the feature and the SPA build step.
+        assert!(page.contains("dashboard-embed"));
+        assert!(page.contains("npm run build"));
+    }
+
+    #[cfg(not(feature = "embed-spa"))]
+    #[tokio::test]
+    async fn unknown_paths_still_404_without_the_spa() {
+        let app = make_router(state_with_two_nodes());
+        let response = app
+            .oneshot(Request::builder().uri("/nope").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/cascadia-dashboard/src/lib.rs
+++ b/crates/cascadia-dashboard/src/lib.rs
@@ -33,10 +33,16 @@ use serde::Serialize;
 #[cfg(feature = "embed-spa")]
 mod spa;
 
-/// Whether this build carries the SPA. Exported so the host process can
-/// log what `/` will actually serve — evaluated HERE, in the crate that
-/// owns the feature, so the answer stays correct even if a dependency
-/// other than the host enabled `embed-spa` through feature unification.
+/// Whether the SPA route is compiled into this build. Exported so the host
+/// process can log what `/` will actually serve — evaluated HERE, in the
+/// crate that owns the feature, so the answer stays correct even if a
+/// dependency other than the host enabled `embed-spa` through feature
+/// unification.
+///
+/// This is a build fact, not a promise that assets are readable right now:
+/// `rust-embed` only bakes them into the binary for release builds, and
+/// reads `web/dist` from disk per request in debug ones. `spa::shell` warns
+/// when that read comes up empty.
 pub const SPA_EMBEDDED: bool = cfg!(feature = "embed-spa");
 
 /// Shared state for the dashboard routes.

--- a/crates/cascadia-dashboard/src/placeholder.html
+++ b/crates/cascadia-dashboard/src/placeholder.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>cascadia</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background: #0d1117; color: #d8dee7;
+  }
+  main { max-width: 42rem; padding: 2.5rem 1.5rem; line-height: 1.6; }
+  h1 { font-size: 1.2rem; font-weight: 600; }
+  code, pre {
+    background: #1a212b; border-radius: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.9em;
+  }
+  code { padding: 0.1rem 0.35rem; }
+  pre { padding: 0.9rem 1rem; overflow-x: auto; }
+  ul { padding-left: 1.2rem; }
+  li { margin: 0.25rem 0; }
+  .dim { color: #8b98a9; }
+</style>
+</head>
+<body>
+<main>
+  <h1>cascadia is running &mdash; this build doesn&rsquo;t include the dashboard UI</h1>
+  <p>The API is live on this port:</p>
+  <ul>
+    <li><code>POST /v1/chat/completions</code>, <code>POST /v1/completions</code> &mdash; OpenAI-compatible inference</li>
+    <li><code>GET /v1/models</code>, <code>GET /health</code>, <code>GET /metrics</code></li>
+    <li><code>GET /api/topology</code>, <code>GET /api/stats</code> &mdash; cluster state as JSON</li>
+  </ul>
+  <p>The web dashboard is compiled in behind the <code>dashboard-embed</code> cargo
+  feature, which needs the SPA built first:</p>
+  <pre>cd crates/cascadia-dashboard/web
+npm ci &amp;&amp; npm run build
+cd ../../..
+cargo build --release -p cascadia --features dashboard-embed</pre>
+  <p class="dim">Add <code>openvino</code> to the feature list for real-inference
+  builds. Prebuilt release bundles ship with the dashboard included.</p>
+</main>
+</body>
+</html>

--- a/crates/cascadia-dashboard/src/placeholder.html
+++ b/crates/cascadia-dashboard/src/placeholder.html
@@ -41,7 +41,8 @@ npm ci &amp;&amp; npm run build
 cd ../../..
 cargo build --release -p cascadia --features dashboard-embed</pre>
   <p class="dim">Add <code>openvino</code> to the feature list for real-inference
-  builds. Prebuilt release bundles ship with the dashboard included.</p>
+  builds. Prebuilt release bundles newer than v0.1.8 ship with the dashboard
+  included.</p>
 </main>
 </body>
 </html>

--- a/crates/cascadia-dashboard/src/spa.rs
+++ b/crates/cascadia-dashboard/src/spa.rs
@@ -2,9 +2,9 @@
 //!
 //! `rust_embed::Embed` derives a virtual filesystem from the literal
 //! contents of `web/dist/` at compile time. The `serve` handler matches
-//! the request path against the embedded files; unknown paths fall back
-//! to `index.html` so client-side routes (e.g. `/chat`) resolve to the
-//! SPA shell rather than 404.
+//! the request path against the embedded files; unknown *extension-less*
+//! paths fall back to `index.html` so client-side routes (e.g. `/chat`)
+//! resolve to the SPA shell rather than 404.
 
 use axum::body::Body;
 use axum::http::{header, StatusCode, Uri};
@@ -12,6 +12,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use rust_embed::Embed;
+use tracing::warn;
 
 #[derive(Embed)]
 #[folder = "web/dist/"]
@@ -28,7 +29,7 @@ pub fn router() -> Router<crate::DashboardState> {
 }
 
 async fn index() -> Response {
-    serve_path("index.html")
+    shell()
 }
 
 async fn serve(uri: Uri) -> Response {
@@ -39,29 +40,58 @@ async fn serve(uri: Uri) -> Response {
     if path.starts_with("/v1/") || path.starts_with("/api/") || path == "/health" {
         return (StatusCode::NOT_FOUND, "not found").into_response();
     }
-    serve_path(path.trim_start_matches('/'))
+    let rel = path.trim_start_matches('/');
+    if let Some(response) = asset(rel) {
+        return response;
+    }
+    // A miss on a path whose last segment carries an extension is a missing
+    // *asset*, not a client route. Serving the shell there answers a
+    // `<script src="/assets/index-abc123.js">` with `text/html`; the browser
+    // refuses it on MIME grounds and the dashboard renders blank — while
+    // every response is a 200 and nothing is logged. 404 says what happened.
+    if rel.rsplit('/').next().is_some_and(|seg| seg.contains('.')) {
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    }
+    // Extension-less miss: a client-side route (e.g. `/chat`) that only the
+    // SPA router can resolve, so hand over the shell.
+    shell()
 }
 
-fn serve_path(path: &str) -> Response {
-    // Direct hit on a built asset (e.g. /assets/index-abc123.js).
-    if let Some(file) = SpaAssets::get(path) {
-        let mime = mime_guess::from_path(path).first_or_octet_stream();
-        return Response::builder()
+/// A built asset served under its own MIME type (e.g. `/assets/index-abc123.js`),
+/// or `None` when this build embeds no such file.
+fn asset(path: &str) -> Option<Response> {
+    let file = SpaAssets::get(path)?;
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    Some(
+        Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, mime.as_ref())
             .body(Body::from(file.data.into_owned()))
-            .unwrap();
-    }
-    // SPA fallback: anything that's not a real file becomes index.html so
-    // client-side router routes resolve. /api/* is already claimed by the
-    // JSON endpoints above this router in the merge order, so it never
-    // reaches this branch.
+            .unwrap(),
+    )
+}
+
+/// The SPA shell (`index.html`), served at `/` and for client-side routes.
+fn shell() -> Response {
     match SpaAssets::get("index.html") {
         Some(file) => Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
             .body(Body::from(file.data.into_owned()))
             .unwrap(),
-        None => (StatusCode::NOT_FOUND, "SPA assets missing").into_response(),
+        // Unreachable in a release build: build.rs refuses to compile the
+        // feature without `web/dist/index.html`, and the assets are baked in.
+        // Debug builds are the live case — `rust-embed` reads `web/dist` from
+        // disk per request there, so deleting or moving it after the build
+        // empties the dashboard while the startup log still advertises one.
+        // Say so, rather than 404ing in silence.
+        None => {
+            warn!(
+                "dashboard SPA assets are not readable — this is a debug build, which reads \
+                 crates/cascadia-dashboard/web/dist at request time; re-run `npm run build` \
+                 there, or build with --release to embed the assets in the binary"
+            );
+            (StatusCode::NOT_FOUND, "SPA assets missing").into_response()
+        }
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Hand-rolled AVX-512 INT4 GEMM kernels for the sparse-MoE expert path — group-3
 
 ## `cascadia-dashboard`
 
-Dashboard HTTP routes (`/api/topology`, `/api/stats`, `/api/events` SSE) and an embedded Vite SPA (behind the `embed-spa` feature) for visualizing a cluster; without the feature, `/` serves a built-in pointer page explaining how to enable the UI. Kept separate from `cascadia-api` so the OpenAI surface doesn't grow a topology dependency or bundled static assets.
+Dashboard HTTP routes (`/api/topology`, `/api/stats`) and an embedded Vite SPA (behind the `embed-spa` feature) for visualizing a cluster; without the feature, `/` serves a built-in pointer page explaining how to enable the UI. Kept separate from `cascadia-api` so the OpenAI surface doesn't grow a topology dependency or bundled static assets.
 
 ## `cascadia-ov-genai-shim`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,7 @@ Hand-rolled AVX-512 INT4 GEMM kernels for the sparse-MoE expert path — group-3
 
 ## `cascadia-dashboard`
 
-Dashboard HTTP routes (`/api/topology`, `/api/stats`, `/api/events` SSE) and an embedded Vite SPA (behind the `embed-spa` feature) for visualizing a cluster. Kept separate from `cascadia-api` so the OpenAI surface doesn't grow a topology dependency or bundled static assets.
+Dashboard HTTP routes (`/api/topology`, `/api/stats`, `/api/events` SSE) and an embedded Vite SPA (behind the `embed-spa` feature) for visualizing a cluster; without the feature, `/` serves a built-in pointer page explaining how to enable the UI. Kept separate from `cascadia-api` so the OpenAI surface doesn't grow a topology dependency or bundled static assets.
 
 ## `cascadia-ov-genai-shim`
 


### PR DESCRIPTION
## Problem

A user built main per the README (`cargo build --release -p cascadia`), started a worker with `--api`, saw `API + dashboard serving` in the log — and got an empty-body `404` on `/`:

```
< HTTP/1.1 404 Not Found
< content-length: 0
```

Root cause: the dashboard SPA is only compiled in behind the default-off `dashboard-embed` feature, and **no documented build path enables it** — not the README/QUICKSTART/INSTALL commands, and not the release workflow either, so even release bundles shipped without the UI. The startup log claimed a dashboard unconditionally, and the docs never mentioned one (the log line was the only hint it existed). Bonus trap: `web/dist/` is gitignored, so even `--features dashboard-embed` on a fresh checkout died in three cryptic `E0599` errors from `#[derive(Embed)]` unless you knew to run npm first.

## Fix (three parts)

1. **Honest serving** (`fix(dashboard)`): without the embed, `/` now serves a small built-in pointer page — live endpoints + the exact npm/cargo steps — instead of a bare 404; other unknown paths still 404 (no client routes to serve). The startup log only says "dashboard" when the build embeds one, keyed off the new `cascadia_dashboard::SPA_EMBEDDED` const (evaluated in the feature-owning crate, so feature unification can't make the log disagree with the router). A new build script turns the missing-`web/dist` compile errors into an actionable message.
2. **Release bundles get the dashboard** (`ci(release)`): both release jobs run `npm ci && npm run build` in `crates/cascadia-dashboard/web` (runner-preinstalled Node; JS deps pinned via `package-lock.json`) and build with `--features openvino,dashboard-embed`. If the npm step is ever dropped, the build script fails the job instead of silently shipping a dashboard-less bundle.
3. **Docs** (`docs`): README gains a "Web dashboard" section (what it is, why plain cargo builds serve a pointer page, the two-step embed build, the `vite dev` flow), QUICKSTART points at it from the first curl, INSTALL covers the feature for both build modes, ARCHITECTURE.md one-liner updated.

## Testing

Unit: two new router tests (pointer page served at `/` with the feature off; unknown paths still 404). `cargo test -p cascadia-dashboard` (4 passed), `cargo test -p cascadia-cli` (79 passed), `cargo fmt --check`, `cargo clippy --workspace --all-targets` clean for the touched crates.

E2E, macOS (debug) and the miner (Linux, release — fresh shallow clone of the repo, same environment class as the report):

- **Default build** (`cargo build --release -p cascadia`): log now reads `API serving (dashboard UI not embedded in this build; GET / explains how to enable it)`; `GET /` → 200 pointer page; `/nope` → 404; `/health`, `/api/stats`, `/api/topology` unchanged.
- **`--features dashboard-embed` without `web/dist`**: build stops with the instructions message (was: 3 × E0599).
- **`--features dashboard-embed` after `npm ci && npm run build`**: log reads `API + dashboard serving`; `GET /` serves the SPA; client route `/chat` → SPA shell; hashed `/assets/*.js` served with correct MIME; reserved `/v1/*` misses still 404. On the miner, `web/dist/` was then **deleted and the binary re-run**: the SPA still serves, proving the release binary truly embeds the assets (single-static-binary claim).

The workflow change itself can only fully run on the next `v*` tag; YAML validated, and the npm build step was exercised locally and on CI-equivalent inputs (`npm ci` from the committed lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
