### PR TITLE
feat(engines): forced-prefix resume + sparse-moe per-token streaming

### DIFF
--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1839,6 +1839,10 @@ async fn chat_completions(
         // client that could set it from request JSON could name another tenant's namespace and
         // resume off its prefix. The real value is assigned server-side from the admitted identity.
         tenant: String::new(),
+        // Never client-settable, same class as `tenant`: a client that could
+        // seed it from request JSON would inject arbitrary token-ids into the
+        // model's context PAST the rendered prompt. Only the scheduler's
+        // rescue path sets it, engine-side of this API.
         resume_token_ids: None,
     };
 
@@ -2056,6 +2060,7 @@ async fn completions(
         trust_remote_code: false,
         // H.1b: hardcoded server-side; see the note on the chat endpoint's task above.
         tenant: String::new(),
+        // Never client-settable; see the chat endpoint's note.
         resume_token_ids: None,
     };
 

--- a/crates/cascadia-api/src/lib.rs
+++ b/crates/cascadia-api/src/lib.rs
@@ -1839,6 +1839,7 @@ async fn chat_completions(
         // client that could set it from request JSON could name another tenant's namespace and
         // resume off its prefix. The real value is assigned server-side from the admitted identity.
         tenant: String::new(),
+        resume_token_ids: None,
     };
 
     // Acquire a request slot before touching the engine. Contended streams
@@ -2055,6 +2056,7 @@ async fn completions(
         trust_remote_code: false,
         // H.1b: hardcoded server-side; see the note on the chat endpoint's task above.
         tenant: String::new(),
+        resume_token_ids: None,
     };
 
     let permit = match state.permits.clone().try_acquire_owned() {

--- a/crates/cascadia-cli/src/lib.rs
+++ b/crates/cascadia-cli/src/lib.rs
@@ -2033,6 +2033,7 @@ async fn cmd_worker(args: WorkerArgs) -> Result<()> {
             enable_thinking: false,
             trust_remote_code: false,
             tenant: String::new(), // H.1b: single-tenant CLI path — LOCAL_NS
+            resume_token_ids: None,
         };
         // `generate_async`, not `generate`: this loop runs on the tokio
         // runtime, and the sync path would block a worker on the engine

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -92,7 +92,8 @@ impl Engine for MockEngine {
             )]);
         }
         let token = words[emitted].to_string();
-        let chunk = Chunk::token(&task.task_id, emitted as i64, token + " ");
+        let chunk =
+            Chunk::token(&task.task_id, emitted as i64, token + " ").with_token_ids(vec![emitted as i64]);
         let task_id = task.task_id.clone();
         self.pending.push((task, emitted + 1));
         Ok(vec![(task_id, chunk)])

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -42,8 +42,18 @@ impl Engine for MockEngine {
         }
         // Option B resume: the seed ids are already-emitted, so start the
         // echo cursor past them. They are never re-emitted by step().
-        let seed_len = cascadia_types::resume_generated_seed(task.resume_ids()).len();
-        self.pending.push((task, seed_len));
+        //
+        // Id-FIDELITY, not just length: the mock's own emitted id for position
+        // i is exactly `i` (see step()), so a resume seed claiming this stream
+        // must be [0..K). Length-only checking let a splicer that shuffled or
+        // corrupted ids pass every mock-based integration test (review).
+        let seed = task.resume_ids().map(<[i32]>::to_vec).unwrap_or_default();
+        if let Some((i, &bad)) = seed.iter().enumerate().find(|(i, &id)| id != *i as i32) {
+            return Err(EngineError::Backend(format!(
+                "mock resume seed id mismatch at {i}: got {bad}, this stream emitted {i}"
+            )));
+        }
+        self.pending.push((task, seed.len()));
         Ok(())
     }
 

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -92,8 +92,8 @@ impl Engine for MockEngine {
             )]);
         }
         let token = words[emitted].to_string();
-        let chunk =
-            Chunk::token(&task.task_id, emitted as i64, token + " ").with_token_ids(vec![emitted as i64]);
+        let chunk = Chunk::token(&task.task_id, emitted as i64, token + " ")
+            .with_token_ids(vec![emitted as i64]);
         let task_id = task.task_id.clone();
         self.pending.push((task, emitted + 1));
         Ok(vec![(task_id, chunk)])

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -256,6 +256,18 @@ mod tests {
     }
 
     #[test]
+    fn resume_with_wrong_ids_is_rejected() {
+        let mut e = MockEngine::new();
+        let mut task = GenerationTask::new("t1", "a b c d").with_max_tokens(64);
+        // Shuffled ids: right length, wrong content — a corrupted accumulator.
+        task.resume_token_ids = Some(vec![1, 0]);
+        assert!(
+            e.submit(task).is_err(),
+            "length-only consumption would have accepted a corrupt prefix"
+        );
+    }
+
+    #[test]
     fn resume_at_full_budget_emits_zero_new_tokens() {
         let mut e = MockEngine::new();
         // resume_token_ids covers the whole prompt and max_tokens equals

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -40,7 +40,11 @@ impl Engine for MockEngine {
         if self.pending.iter().any(|(t, _)| t.task_id == task.task_id) {
             return Ok(());
         }
-        self.pending.push((task, 0));
+        // Option B resume: the seed ids are already-emitted, so start the
+        // echo cursor past them. They are never re-emitted by step().
+        let seed_len =
+            cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref()).len();
+        self.pending.push((task, seed_len));
         Ok(())
     }
 
@@ -218,6 +222,43 @@ mod tests {
             .unwrap();
         // The very next step serves t2 — no draining of the abandoned t1.
         assert_eq!(e.step().unwrap()[0].0, "t2");
+    }
+
+    #[test]
+    fn resume_emits_only_tail_tokens() {
+        let mut e = MockEngine::new();
+        // Prompt echoes to [a b c d]; resume_token_ids covers [a b] (the
+        // mock's own ids for the first two positions), so only c/d are new.
+        let mut task = GenerationTask::new("t1", "a b c d").with_max_tokens(64);
+        task.resume_token_ids = Some(vec![0, 1]);
+        e.submit(task).unwrap();
+        let mut emitted = Vec::new();
+        for _ in 0..8 {
+            for (_, chunk) in e.step().unwrap() {
+                emitted.push(chunk);
+            }
+        }
+        // Exactly 2 new tokens (c, d) then a final marker — the prefix a/b
+        // is never re-emitted.
+        assert_eq!(emitted.len(), 3);
+        assert!(emitted[0].text.starts_with('c'));
+        assert!(emitted[1].text.starts_with('d'));
+        assert!(emitted[2].is_final);
+    }
+
+    #[test]
+    fn resume_at_full_budget_emits_zero_new_tokens() {
+        let mut e = MockEngine::new();
+        // resume_token_ids covers the whole prompt and max_tokens equals
+        // the prefix length, so the task finals immediately with no new
+        // tokens.
+        let mut task = GenerationTask::new("t1", "a b c d").with_max_tokens(4);
+        task.resume_token_ids = Some(vec![0, 1, 2, 3]);
+        e.submit(task).unwrap();
+        let emitted = e.step().unwrap();
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].1.is_final);
+        assert_eq!(emitted[0].1.token_id, 0);
     }
 
     #[test]

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -42,8 +42,7 @@ impl Engine for MockEngine {
         }
         // Option B resume: the seed ids are already-emitted, so start the
         // echo cursor past them. They are never re-emitted by step().
-        let seed_len =
-            cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref()).len();
+        let seed_len = cascadia_types::resume_generated_seed(task.resume_ids()).len();
         self.pending.push((task, seed_len));
         Ok(())
     }

--- a/crates/cascadia-engine-mock/src/lib.rs
+++ b/crates/cascadia-engine-mock/src/lib.rs
@@ -271,16 +271,22 @@ mod tests {
     #[test]
     fn resume_at_full_budget_emits_zero_new_tokens() {
         let mut e = MockEngine::new();
-        // resume_token_ids covers the whole prompt and max_tokens equals
-        // the prefix length, so the task finals immediately with no new
-        // tokens.
-        let mut task = GenerationTask::new("t1", "a b c d").with_max_tokens(4);
+        // The seed alone exhausts max_tokens, so the task finals immediately
+        // with no new tokens. The prompt has MORE words than the budget so the
+        // finish reason provably comes from the BUDGET branch (Length), not
+        // word exhaustion (Stop) — with a 4-word prompt both conditions were
+        // true and the tie-break masked which branch fired.
+        let mut task = GenerationTask::new("t1", "a b c d e f").with_max_tokens(4);
         task.resume_token_ids = Some(vec![0, 1, 2, 3]);
         e.submit(task).unwrap();
         let emitted = e.step().unwrap();
         assert_eq!(emitted.len(), 1);
         assert!(emitted[0].1.is_final);
-        assert_eq!(emitted[0].1.token_id, 0);
+        assert_eq!(
+            emitted[0].1.finish_reason,
+            Some(cascadia_types::FinishReason::Length),
+            "an exhausted resume budget is a Length stop, like every real engine"
+        );
     }
 
     #[test]

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1572,7 +1572,13 @@ impl Engine for OvDistSpecEngine {
             match self.do_one_round(max_tokens) {
                 Err(e) => {
                     warn!(task = %task_id, error = %e, "ov-dist-spec round failed");
-                    self.finish_task(task_id, String::new(), 0)
+                    // Surface, don't `finish_task`: finishing turns a dead-peer transport
+                    // error into a clean `[DONE]`, so the client gets a truncated answer
+                    // presented as complete and issue-34's splicer — which only triggers on
+                    // a surfaced error — never fires. Clearing `active` first (as runtime.rs
+                    // does) keeps a stale task from wedging the next `submit()`.
+                    self.active = None;
+                    return Err(e);
                 }
                 Ok(RoundResult {
                     delta,
@@ -1843,8 +1849,8 @@ impl OvDistSpecEngine {
         );
         // Multi-token final round (do_one_round's finished=true path): surface
         // every id this round appended, in order. Single/zero-token finals
-        // (first-chunk-hits-max/EOS, or the round-failed path) leave it empty —
-        // `token_id` alone already identifies the single accepted token.
+        // (first-chunk-hits-max/EOS) leave it empty — `token_id` alone already
+        // identifies the single accepted token.
         let token_ids = if n_tokens > 1 {
             let start = active.out.len().saturating_sub(n_tokens as usize);
             active.out[start..].to_vec()

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1869,11 +1869,12 @@ impl OvDistSpecEngine {
             accept = active.stats.accept_rate(),
             "ov-dist-spec done"
         );
-        // Multi-token final round (do_one_round's finished=true path): surface
-        // every id this round appended, in order. Single/zero-token finals
-        // (first-chunk-hits-max/EOS) leave it empty — `token_id` alone already
-        // identifies the single accepted token.
-        let token_ids = if n_tokens > 1 {
+        // Surface every id this round appended, in order — including a
+        // single-token final: `token_id == 0` with an empty `token_ids` reads
+        // as id-less, and token 0 is a legal sample. A ZERO-token final keeps
+        // it empty (this round appended nothing; `token_id` there is a prior
+        // round's last token, not this chunk's).
+        let token_ids = if n_tokens > 0 {
             let start = active.out.len().saturating_sub(n_tokens as usize);
             active.out[start..].to_vec()
         } else {

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1381,6 +1381,7 @@ struct ActiveSpec {
     /// not resuming). Unconditional (not `kv_coord`-gated) so both builds see
     /// the same `ActiveSpec` layout; used to keep the kv-capture key from
     /// double-counting the resume ids (they're already in `prompt_ids`).
+    #[cfg_attr(not(feature = "kv_coord"), allow(dead_code))]
     resume_seed_len: usize,
     /// Cumulative byte-length of the detokenized text emitted so far.
     /// Used to compute the streaming delta on each step.

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1509,8 +1509,27 @@ impl Engine for OvDistSpecEngine {
             // Option B forced-prefix resume: append the already-emitted assistant
             // tokens after the rendered prompt (concat, not replace) — flows into
             // BOTH the draft and target prefill via start_task's shared feed_ids.
-            // No-op when not resuming.
-            cascadia_types::append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
+            // No-op when not resuming (`resume_ids()` normalizes `Some([])` too).
+            let resume = task.resume_ids().map(<[i32]>::to_vec);
+            if let Some(r) = resume.as_deref() {
+                // Peer-supplied indices reach native OV prefill — bound them first.
+                let vocab = self.tokenizer.get_vocab_size(true) as u32;
+                if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                    let task_id = task.task_id.clone();
+                    let c = Chunk::error(task.task_id, format!("invalid resume prefix: {e}"));
+                    return Ok(vec![(task_id, c)]);
+                }
+                // Exhausted budget (prefix >= max_tokens): finish Length with ZERO
+                // new tokens BEFORE start_task — start_task unconditionally samples
+                // and pushes the first token, which would overshoot the budget.
+                if r.len() >= task.max_tokens.max(1) as usize {
+                    let mut c = Chunk::final_marker(task.task_id.clone(), "");
+                    c.n_tokens = Some(0);
+                    c.finish_reason = Some(cascadia_types::FinishReason::Length);
+                    return Ok(vec![(task.task_id.clone(), c)]);
+                }
+            }
+            cascadia_types::append_resume_ids(&mut prompt_ids, resume.as_deref());
             info!(
                 task = %task.task_id,
                 prompt_tokens = prompt_ids.len(),
@@ -1577,8 +1596,11 @@ impl Engine for OvDistSpecEngine {
                     // presented as complete and issue-34's splicer — which only triggers on
                     // a surfaced error — never fires. Clearing `active` first (as runtime.rs
                     // does) keeps a stale task from wedging the next `submit()`.
+                    // `for_task` is load-bearing: an unattributed Err from step() makes the
+                    // runner fail whichever queued stream happened to poll, while THIS
+                    // task's stream hangs with nothing further (review finding).
                     self.active = None;
-                    return Err(e);
+                    return Err(e.for_task(task_id));
                 }
                 Ok(RoundResult {
                     delta,
@@ -1680,7 +1702,7 @@ impl OvDistSpecEngine {
         // `emitted` with the seed's DECODED BYTES so `decode_delta` hands the client
         // only `full[emitted.len()..]` — the forced prefix is never re-emitted.
         // Empty on a normal turn ⇒ identical to today.
-        let mut out = cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref());
+        let mut out = cascadia_types::resume_generated_seed(task.resume_ids());
         // Captured BEFORE `out.push(first)`: the kv_coord capture key must count
         // only the resumed prefix, not the freshly sampled token.
         let resume_seed_len = out.len();

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1513,7 +1513,7 @@ impl Engine for OvDistSpecEngine {
             let resume = task.resume_ids().map(<[i32]>::to_vec);
             if let Some(r) = resume.as_deref() {
                 // Peer-supplied indices reach native OV prefill — bound them first.
-                let vocab = self.tokenizer.get_vocab_size(true) as u32;
+                let vocab = crate::resume_vocab_bound(&self.tokenizer);
                 if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
                     let task_id = task.task_id.clone();
                     let c = Chunk::error(task.task_id, format!("invalid resume prefix: {e}"));

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1547,6 +1547,7 @@ impl Engine for OvDistSpecEngine {
                         n_tokens: Some(1),
                         prompt_tokens: None,
                         error: None,
+                        token_ids: Vec::new(),
                         finish_reason: None,
                     },
                 )]
@@ -1579,6 +1580,7 @@ impl Engine for OvDistSpecEngine {
                                 n_tokens: Some(n_tokens),
                                 prompt_tokens: None,
                                 error: None,
+                                token_ids: Vec::new(),
                                 finish_reason: None,
                             },
                         )]
@@ -1798,6 +1800,7 @@ impl OvDistSpecEngine {
                 n_tokens: if n_tokens > 0 { Some(n_tokens) } else { None },
                 prompt_tokens: None,
                 error: None,
+                token_ids: Vec::new(),
                 finish_reason: None,
             },
         )]

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1375,7 +1375,8 @@ struct ActiveSpec {
     /// Issue-34: the prompt tokens (capture key = prompt ++ out). `kv_coord` only.
     #[cfg(feature = "kv_coord")]
     prompt_ids: Vec<i64>,
-    /// Accumulated accepted tokens (including the first sampled token).
+    /// Accumulated accepted tokens (including the first sampled token;
+    /// preceded by the resume seed on a resumed turn).
     out: Vec<i64>,
     /// Option B: length of the resume-seed prefix at the front of `out` (0 when
     /// not resuming). Unconditional (not `kv_coord`-gated) so both builds see

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1499,7 +1499,12 @@ impl Engine for OvDistSpecEngine {
                     return Ok(vec![(task_id, c)]);
                 }
             };
-            let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            let mut prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            // Option B forced-prefix resume: append the already-emitted assistant
+            // tokens after the rendered prompt (concat, not replace) — flows into
+            // BOTH the draft and target prefill via start_task's shared feed_ids.
+            // No-op when not resuming.
+            cascadia_types::append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
             info!(
                 task = %task.task_id,
                 prompt_tokens = prompt_ids.len(),
@@ -1529,7 +1534,11 @@ impl Engine for OvDistSpecEngine {
             // If the first token already hits max_tokens or EOS, finalize now.
             // Decided before decoding: it is what makes this the terminal read,
             // which tells decode_delta whether it may hold anything back.
-            let hit_eos = self.eos_token_ids.contains(&(active.out[0] as u32));
+            // Option B: resume seeds a prefix ahead of the freshly sampled token,
+            // so the newly sampled token is `out.last()`, not `out[0]` — checking
+            // `out[0]` would test a RESUMED token for EOS and finalize instantly.
+            let first_new = *active.out.last().unwrap_or(&0);
+            let hit_eos = self.eos_token_ids.contains(&(first_new as u32));
             let finished = active.out.len() >= max_tokens || hit_eos;
             let new_text =
                 decode_delta(&self.tokenizer, &active.out, &mut active.emitted, !finished);
@@ -1540,7 +1549,7 @@ impl Engine for OvDistSpecEngine {
                     task_id,
                     Chunk {
                         task_id: active.task.task_id.clone(),
-                        token_id: active.out[0],
+                        token_id: first_new,
                         text: new_text,
                         is_final: false,
                         logprobs: None,
@@ -1563,6 +1572,7 @@ impl Engine for OvDistSpecEngine {
                     delta,
                     finished,
                     n_tokens,
+                    token_ids,
                 }) => {
                     if finished {
                         self.finish_task(task_id, delta, n_tokens)
@@ -1580,7 +1590,7 @@ impl Engine for OvDistSpecEngine {
                                 n_tokens: Some(n_tokens),
                                 prompt_tokens: None,
                                 error: None,
-                                token_ids: Vec::new(),
+                                token_ids,
                                 finish_reason: None,
                             },
                         )]
@@ -1613,6 +1623,10 @@ struct RoundResult {
     /// Chunk::n_tokens so downstream tok/s metrics stay accurate when
     /// each chunk carries multiple tokens (1..=K+1).
     n_tokens: u32,
+    /// The token ids added to `out` this round, in order (accepted drafts
+    /// plus the correction). Surfaced via `Chunk::token_ids` so a dist-spec
+    /// multi-token chunk can serve as a resume source.
+    token_ids: Vec<i64>,
 }
 
 impl OvDistSpecEngine {
@@ -1649,12 +1663,29 @@ impl OvDistSpecEngine {
         let dv = d_shape[2];
         let d_last_logit = d_logits[d_logits.len() - dv..].to_vec();
 
+        // Option B: pre-seed `out` with the resumed tokens so `out.len()` bounds
+        // prefix+new against max_tokens (no separate subtraction needed), and seed
+        // `emitted` with the seed's DECODED BYTES so `decode_delta` hands the client
+        // only `full[emitted.len()..]` — the forced prefix is never re-emitted.
+        // Empty on a normal turn ⇒ identical to today.
+        let mut out = cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref());
+        let emitted: Vec<u8> = if out.is_empty() {
+            Vec::new()
+        } else {
+            let seed_u32: Vec<u32> = out.iter().map(|&t| t as u32).collect();
+            self.tokenizer
+                .decode(&seed_u32, true)
+                .unwrap_or_default()
+                .into_bytes()
+        };
+        out.push(first);
+
         Ok(ActiveSpec {
             task,
             #[cfg(feature = "kv_coord")]
             prompt_ids: prompt_ids.to_vec(),
-            out: vec![first],
-            emitted: Vec::new(),
+            out,
+            emitted,
             prev_correction: first,
             d_last_logit,
             stats: SpecDecodeStats::default(),
@@ -1729,6 +1760,9 @@ impl OvDistSpecEngine {
             active.out.push(t);
         }
         let n_tokens_added = (active.out.len() - out_len_before) as u32;
+        // Slice the ids this round actually appended to `out`, in order — the
+        // per-round accepted-ids source for `Chunk::token_ids`.
+        let token_ids_added: Vec<i64> = active.out[out_len_before..].to_vec();
 
         // Rewind any rejected drafts from the target's KV cache.
         self.target.rewind(drafts.len() - accepted);
@@ -1754,6 +1788,7 @@ impl OvDistSpecEngine {
             delta,
             finished: hit_eos || hit_max,
             n_tokens: n_tokens_added,
+            token_ids: token_ids_added,
         })
     }
 
@@ -1789,6 +1824,16 @@ impl OvDistSpecEngine {
             accept = active.stats.accept_rate(),
             "ov-dist-spec done"
         );
+        // Multi-token final round (do_one_round's finished=true path): surface
+        // every id this round appended, in order. Single/zero-token finals
+        // (first-chunk-hits-max/EOS, or the round-failed path) leave it empty —
+        // `token_id` alone already identifies the single accepted token.
+        let token_ids = if n_tokens > 1 {
+            let start = active.out.len().saturating_sub(n_tokens as usize);
+            active.out[start..].to_vec()
+        } else {
+            Vec::new()
+        };
         vec![(
             task_id.clone(),
             Chunk {
@@ -1800,7 +1845,7 @@ impl OvDistSpecEngine {
                 n_tokens: if n_tokens > 0 { Some(n_tokens) } else { None },
                 prompt_tokens: None,
                 error: None,
-                token_ids: Vec::new(),
+                token_ids,
                 finish_reason: None,
             },
         )]

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1562,7 +1562,10 @@ impl Engine for OvDistSpecEngine {
             // Option B: resume seeds a prefix ahead of the freshly sampled token,
             // so the newly sampled token is `out.last()`, not `out[0]` — checking
             // `out[0]` would test a RESUMED token for EOS and finalize instantly.
-            let first_new = *active.out.last().unwrap_or(&0);
+            // `out` is seeded + first-sample-pushed before this runs; an
+            // empty vec is a broken invariant, and silently reading token 0
+            // here would test a fabricated id for EOS.
+            let first_new = *active.out.last().expect("out seeded before init step");
             let hit_eos = self.eos_token_ids.contains(&(first_new as u32));
             let finished = active.out.len() >= max_tokens || hit_eos;
             let new_text =

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1682,9 +1682,12 @@ impl OvDistSpecEngine {
             Vec::new()
         } else {
             let seed_u32: Vec<u32> = out.iter().map(|&t| t as u32).collect();
+            // Propagate, never `unwrap_or_default()`: an empty seed here would make the
+            // first delta re-emit the entire forced prefix to the client. Failing the
+            // task is the honest outcome — same call as the qwen36 seed-decode fix.
             self.tokenizer
                 .decode(&seed_u32, true)
-                .unwrap_or_default()
+                .map_err(|e| EngineError::Backend(format!("resume seed decode failed: {e}")))?
                 .into_bytes()
         };
         out.push(first);

--- a/crates/cascadia-engine-openvino/src/dist_spec.rs
+++ b/crates/cascadia-engine-openvino/src/dist_spec.rs
@@ -1377,6 +1377,11 @@ struct ActiveSpec {
     prompt_ids: Vec<i64>,
     /// Accumulated accepted tokens (including the first sampled token).
     out: Vec<i64>,
+    /// Option B: length of the resume-seed prefix at the front of `out` (0 when
+    /// not resuming). Unconditional (not `kv_coord`-gated) so both builds see
+    /// the same `ActiveSpec` layout; used to keep the kv-capture key from
+    /// double-counting the resume ids (they're already in `prompt_ids`).
+    resume_seed_len: usize,
     /// Cumulative byte-length of the detokenized text emitted so far.
     /// Used to compute the streaming delta on each step.
     /// Bytes already handed to the client (see `decode_delta`).
@@ -1669,6 +1674,9 @@ impl OvDistSpecEngine {
         // only `full[emitted.len()..]` — the forced prefix is never re-emitted.
         // Empty on a normal turn ⇒ identical to today.
         let mut out = cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref());
+        // Captured BEFORE `out.push(first)`: the kv_coord capture key must count
+        // only the resumed prefix, not the freshly sampled token.
+        let resume_seed_len = out.len();
         let emitted: Vec<u8> = if out.is_empty() {
             Vec::new()
         } else {
@@ -1686,6 +1694,7 @@ impl OvDistSpecEngine {
             prompt_ids: prompt_ids.to_vec(),
             out,
             emitted,
+            resume_seed_len,
             prev_correction: first,
             d_last_logit,
             stats: SpecDecodeStats::default(),
@@ -1807,10 +1816,14 @@ impl OvDistSpecEngine {
         // resets. Best-effort + gated.
         #[cfg(feature = "kv_coord")]
         {
+            // `prompt_ids` already carries the resume ids (Option B appends them
+            // before start_task); `out` is seeded with the same ids so the fed
+            // sequence lines up round-to-round. Skip the seed here so the capture
+            // key matches the real fed depth instead of double-counting it.
             let tokens: Vec<i32> = active
                 .prompt_ids
                 .iter()
-                .chain(active.out.iter())
+                .chain(active.out.iter().skip(active.resume_seed_len))
                 .map(|&t| t as i32)
                 .collect();
             // H.1b R2: this turn's namespace, read off THIS task's own state — never off a

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1169,10 +1169,22 @@ impl Gemma4Engine {
         // emit a partial UTF-8 sequence on token N and complete the
         // glyph on token N+1, in which case the prefix bytes change).
         // Slicing past a UTF-8 boundary panics.
-        let delta = full_text
-            .strip_prefix(active.last_text.as_str())
-            .unwrap_or(&full_text)
-            .to_string();
+        //
+        // On divergence RE-ANCHOR (empty delta), never `unwrap_or(&full_text)`:
+        // that re-emits everything decoded so far, which under Option B resume is
+        // the whole forced prefix duplicated into the client stream. Same contract
+        // as the shim's `advance_emitted` — bounded loss at the seam, never
+        // duplication.
+        let delta = match full_text.strip_prefix(active.last_text.as_str()) {
+            Some(d) => d.to_string(),
+            None => {
+                warn!(
+                    task = %active.task.task_id,
+                    "decode diverged from the emitted prefix; re-anchoring (delta dropped)"
+                );
+                String::new()
+            }
+        };
         active.last_text = full_text;
 
         let max_tokens = active.task.max_tokens.max(1) as usize;

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -2253,6 +2253,7 @@ mod tests {
     /// at G_PREFILL_REPLY_CEILING regardless of how large the operator knob is.
     #[tokio::test]
     async fn prefill_reply_wait_is_ceilinged_on_a_silent_downstream() {
+        let _knob = crate::timeout_knob_lock();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let accept = tokio::spawn(async move { listener.accept().await.unwrap().0 });

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -886,7 +886,7 @@ impl Gemma4Engine {
             let resume = task.resume_ids().map(<[i32]>::to_vec);
             if let Some(r) = resume.as_deref() {
                 // Peer-supplied indices reach native OV prefill — bound them first.
-                let vocab = tok.get_vocab_size(true) as u32;
+                let vocab = crate::resume_vocab_bound(&tok);
                 if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
                     let id = task.task_id.clone();
                     return Ok(vec![(

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1261,6 +1261,7 @@ impl Gemma4Engine {
             }
         } else {
             Chunk::token(task_id.clone(), next_token as i64, delta)
+                .with_token_ids(vec![next_token as i64])
         };
 
         if is_final {

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -414,6 +414,19 @@ struct ActiveTask {
     t_wire: std::time::Duration,
 }
 
+/// One prefill span's end. Prompt segment (`i < seed_split`): the engine's
+/// normal folding, `prefill_chunk()`-sized. Seed segment (`i >= seed_split`):
+/// T=1, mirroring the donor's token-by-token decode fold — see the resumed-
+/// prefill comment in `step_first_body`. `seed_split == tokens.len()` (no
+/// resume seed) reduces to the pre-Option-B behavior exactly.
+fn prefill_span_end(i: usize, chunk: usize, seed_split: usize) -> usize {
+    if i < seed_split {
+        i.saturating_add(chunk).min(seed_split)
+    } else {
+        i + 1
+    }
+}
+
 /// Effective prefill span. Default `usize::MAX` = the whole span in ONE pass (unchanged, fastest).
 ///
 /// `CASCADIA_GEMMA4_FORCE_T1_PREFILL=1` ⇒ 1: fold EVERY token through the same T=1 path. A warm-resumed
@@ -1080,14 +1093,18 @@ impl Gemma4Engine {
         if self.active.is_none() {
             return Ok(Vec::new());
         }
-        let (prefill, tokens) = {
+        let (prefill, tokens, seed_len) = {
             let a = self.active.as_mut().unwrap();
             if !a.prefilled {
                 a.prefilled = true;
                 // warm_prefix is 0 on the cold/default path ⇒ full prompt (unchanged).
-                (true, a.prompt_ids[a.warm_prefix..].to_vec())
+                (
+                    true,
+                    a.prompt_ids[a.warm_prefix..].to_vec(),
+                    a.resume_seed_len,
+                )
             } else {
-                (false, vec![a.last_token as i64])
+                (false, vec![a.last_token as i64], 0)
             }
         };
         let single_stage = self.spec.is_first_stage && self.spec.is_last_stage;
@@ -1110,14 +1127,30 @@ impl Gemma4Engine {
         // different GEMM batch shapes (e.g. 22 vs 93 tokens) over int4 weights, and the rounding delta
         // flips a token ⇒ cross-chain warm != cold. Mirrors qwen36's FORCE_T1_PREFILL.
         let chunk = prefill_chunk();
+        // Option B: a resumed prefill must reproduce the DONOR's compute
+        // pattern — the rendered prompt in the engine's normal (batched)
+        // prefill shape, then the resume SEED folded one token at a time,
+        // exactly as the donor generated it token-by-token. Folding the seed
+        // into the prompt batch changes the int4 GEMM batch shape, and the
+        // rounding delta at the seam flips the first continued token under
+        // greedy (rig 2026-08-27: the alternate gemma4 continued 3 tokens
+        // then bailed to its EOS mode — REGENERATED verdict). Same numerics
+        // class the FORCE_T1_PREFILL knob exists for, but resume needs the
+        // SPLIT shape (all-T=1 would instead diverge the PROMPT segment from
+        // the donor's batched prefill), and needs it unconditionally.
+        let seed_split = if prefill {
+            tokens.len().saturating_sub(seed_len)
+        } else {
+            tokens.len()
+        };
         let mut alpha = std::time::Duration::ZERO;
         let mut wire = std::time::Duration::ZERO;
         let mut next_token: i32;
         let position = self.position;
-        if prefill && tokens.len() > 1 && chunk < tokens.len() {
+        if prefill && tokens.len() > 1 && (chunk < tokens.len() || seed_split < tokens.len()) {
             let mut i = 0usize;
             loop {
-                let end = (i + chunk).min(tokens.len());
+                let end = prefill_span_end(i, chunk, seed_split);
                 let span = &tokens[i..end];
                 let pos = self.position;
                 let ts = std::time::Instant::now();
@@ -2363,5 +2396,37 @@ mod tests {
                 panic!("expected ShardRejected for non-adjacent KV sharing, but load() succeeded")
             }
         }
+    }
+    #[test]
+    fn prefill_spans_without_seed_match_the_old_folding() {
+        // chunk = usize::MAX (default single-pass): one span over everything.
+        assert_eq!(prefill_span_end(0, usize::MAX, 10), 10);
+        // explicit chunking, no seed: plain min(i+chunk, len).
+        assert_eq!(prefill_span_end(0, 4, 10), 4);
+        assert_eq!(prefill_span_end(4, 4, 10), 8);
+        assert_eq!(prefill_span_end(8, 4, 10), 10);
+    }
+
+    #[test]
+    fn prefill_spans_fold_the_resume_seed_at_t1() {
+        // 10 tokens, last 3 are the seed: prompt in one MAX-chunk span, then
+        // three T=1 spans — the donor's exact compute pattern.
+        let (chunk, split, len) = (usize::MAX, 7, 10);
+        let mut i = 0;
+        let mut spans = Vec::new();
+        while i < len {
+            let end = prefill_span_end(i, chunk, split);
+            spans.push((i, end));
+            i = end;
+        }
+        assert_eq!(spans, vec![(0, 7), (7, 8), (8, 9), (9, 10)]);
+    }
+
+    #[test]
+    fn prefill_spans_warm_covered_seed_is_all_t1() {
+        // warm_prefix ate into the seed: seed_split saturates to 0 ⇒ every
+        // remaining token folds at T=1.
+        assert_eq!(prefill_span_end(0, usize::MAX, 0), 1);
+        assert_eq!(prefill_span_end(1, usize::MAX, 0), 2);
     }
 }

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -396,6 +396,11 @@ struct ActiveTask {
     last_text: String,
     prefilled: bool,
     last_token: i32,
+    /// Option B: leading entries of `generated` that are the resume seed. The
+    /// kv_coord capture key must SKIP them — `prompt_ids` already carries the
+    /// resume ids, so counting the seed again keys the blob at a depth that
+    /// never matches the fed sequence (same defect dist_spec fixed).
+    resume_seed_len: usize,
     /// Issue-34: leading prompt tokens already warm in the OV state (RESTOREd). Prefill feeds only
     /// `prompt_ids[warm_prefix..]`. 0 ⇒ cold (default path unchanged).
     warm_prefix: usize,
@@ -876,8 +881,30 @@ impl Gemma4Engine {
             let mut prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
             // Option B forced-prefix resume: append the already-emitted assistant
             // tokens after the rendered prompt (concat, not replace) so the cold
-            // prefill below carries them as context. No-op when not resuming.
-            cascadia_types::append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
+            // prefill below carries them as context. No-op when not resuming
+            // (`resume_ids()` normalizes a wire-legal `Some([])` too).
+            let resume = task.resume_ids().map(<[i32]>::to_vec);
+            if let Some(r) = resume.as_deref() {
+                // Peer-supplied indices reach native OV prefill — bound them first.
+                let vocab = tok.get_vocab_size(true) as u32;
+                if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                    let id = task.task_id.clone();
+                    return Ok(vec![(
+                        id.clone(),
+                        Chunk::error(id, format!("invalid resume prefix: {e}")),
+                    )]);
+                }
+                // Exhausted budget: finish Length with ZERO new tokens — the old
+                // flow pushed the first token before its length check and
+                // overshot prefix+new past max_tokens.
+                if r.len() >= task.max_tokens.max(1) as usize {
+                    let mut c = Chunk::final_marker(task.task_id.clone(), "");
+                    c.n_tokens = Some(0);
+                    c.finish_reason = Some(cascadia_types::FinishReason::Length);
+                    return Ok(vec![(task.task_id.clone(), c)]);
+                }
+            }
+            cascadia_types::append_resume_ids(&mut prompt_ids, resume.as_deref());
             // Issue-34 warm-resume (gated, single-stage for now — multi-stage needs the RESTORE
             // broadcast). Restore a cached strict-prefix blob and prefill only the suffix; else cold.
             #[cfg_attr(not(feature = "kv_coord"), allow(unused_mut))]
@@ -977,11 +1004,11 @@ impl Gemma4Engine {
             // tokens so the budget check bounds prefix+new (not just new) and
             // the first NEW tail token decodes WITH the prefix as context.
             // Empty seed on a normal turn ⇒ identical to today.
-            let resume_seed: Vec<i32> =
-                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
-                    .into_iter()
-                    .map(|t| t as i32)
-                    .collect();
+            let resume_seed: Vec<i32> = cascadia_types::resume_generated_seed(resume.as_deref())
+                .into_iter()
+                .map(|t| t as i32)
+                .collect();
+            let resume_seed_len = resume_seed.len();
             let resume_last_text = if resume_seed.is_empty() {
                 String::new()
             } else {
@@ -997,6 +1024,7 @@ impl Gemma4Engine {
                 prefilled: false,
                 last_token: 0,
                 warm_prefix,
+                resume_seed_len,
                 started: std::time::Instant::now(),
                 t_alpha_compute: std::time::Duration::ZERO,
                 t_wire: std::time::Duration::ZERO,
@@ -1175,17 +1203,31 @@ impl Gemma4Engine {
         // the whole forced prefix duplicated into the client stream. Same contract
         // as the shim's `advance_emitted` — bounded loss at the seam, never
         // duplication.
-        let delta = match full_text.strip_prefix(active.last_text.as_str()) {
-            Some(d) => d.to_string(),
-            None => {
-                warn!(
-                    task = %active.task.task_id,
-                    "decode diverged from the emitted prefix; re-anchoring (delta dropped)"
-                );
-                String::new()
+        // A trailing U+FFFD means the newest token ends mid-glyph (byte-fallback
+        // BPE): the decode is TRANSIENT, not diverged. Hold — emit nothing and
+        // keep `last_text`, so the next token completes the glyph and the strip
+        // emits it whole. Updating `last_text` here (the old behavior) baked the
+        // replacement char into the anchor, so the completed glyph then failed
+        // strip_prefix and was dropped as a fake divergence.
+        let delta = if full_text.ends_with('\u{FFFD}') {
+            String::new()
+        } else {
+            match full_text.strip_prefix(active.last_text.as_str()) {
+                Some(d) => {
+                    let d = d.to_string();
+                    active.last_text = full_text;
+                    d
+                }
+                None => {
+                    warn!(
+                        task = %active.task.task_id,
+                        "decode diverged from the emitted prefix; re-anchoring (delta dropped)"
+                    );
+                    active.last_text = full_text;
+                    String::new()
+                }
             }
         };
-        active.last_text = full_text;
 
         let max_tokens = active.task.max_tokens.max(1) as usize;
         let is_eos = self.eos_token_ids.contains(&(next_token as u32));
@@ -1230,11 +1272,18 @@ impl Gemma4Engine {
             // + gated. (Multi-stage CAPTURE broadcast added with the control protocol.)
             #[cfg(feature = "kv_coord")]
             {
+                // Skip the resume seed: `prompt_ids` already carries those ids.
                 let full: Vec<i32> = active
                     .prompt_ids
                     .iter()
                     .map(|&t| t as i32)
-                    .chain(active.generated.iter().copied())
+                    .chain(
+                        active
+                            .generated
+                            .iter()
+                            .skip(active.resume_seed_len)
+                            .copied(),
+                    )
                     .collect();
                 // H.1b R2: this turn's namespace, read off THIS task's own state — never off a
                 // plane-asserted value, which describes a pulled entry, not this turn.

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1170,6 +1170,7 @@ impl Gemma4Engine {
                 n_tokens: None,
                 prompt_tokens: None,
                 error: None,
+                token_ids: Vec::new(),
                 finish_reason: None,
             }
         } else {

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -873,7 +873,11 @@ impl Gemma4Engine {
             let enc = tok
                 .encode(task.prompt.clone(), false)
                 .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
-            let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            let mut prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            // Option B forced-prefix resume: append the already-emitted assistant
+            // tokens after the rendered prompt (concat, not replace) so the cold
+            // prefill below carries them as context. No-op when not resuming.
+            cascadia_types::append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
             // Issue-34 warm-resume (gated, single-stage for now — multi-stage needs the RESTORE
             // broadcast). Restore a cached strict-prefix blob and prefill only the suffix; else cold.
             #[cfg_attr(not(feature = "kv_coord"), allow(unused_mut))]
@@ -969,11 +973,27 @@ impl Gemma4Engine {
                 warm_prefix,
                 "gemma4 task active"
             );
+            // Option B: pre-seed `generated` + `last_text` with the resumed
+            // tokens so the budget check bounds prefix+new (not just new) and
+            // the first NEW tail token decodes WITH the prefix as context.
+            // Empty seed on a normal turn ⇒ identical to today.
+            let resume_seed: Vec<i32> =
+                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
+                    .into_iter()
+                    .map(|t| t as i32)
+                    .collect();
+            let resume_last_text = if resume_seed.is_empty() {
+                String::new()
+            } else {
+                let seed_u32: Vec<u32> = resume_seed.iter().map(|&t| t as u32).collect();
+                tok.decode(&seed_u32, true)
+                    .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?
+            };
             self.active = Some(ActiveTask {
                 task,
                 prompt_ids,
-                generated: Vec::new(),
-                last_text: String::new(),
+                generated: resume_seed,
+                last_text: resume_last_text,
                 prefilled: false,
                 last_token: 0,
                 warm_prefix,

--- a/crates/cascadia-engine-openvino/src/gemma4.rs
+++ b/crates/cascadia-engine-openvino/src/gemma4.rs
@@ -1013,8 +1013,20 @@ impl Gemma4Engine {
                 String::new()
             } else {
                 let seed_u32: Vec<u32> = resume_seed.iter().map(|&t| t as u32).collect();
-                tok.decode(&seed_u32, true)
-                    .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?
+                match tok.decode(&seed_u32, true) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        // Attributed like the validation branch above: the task is
+                        // already popped from pending, so a bare Err from step()
+                        // fails whichever queued stream happens to poll while THIS
+                        // task's stream hangs with nothing further.
+                        let id = task.task_id.clone();
+                        return Ok(vec![(
+                            id.clone(),
+                            Chunk::error(id, format!("resume seed decode failed: {e}")),
+                        )]);
+                    }
+                }
             };
             self.active = Some(ActiveTask {
                 task,

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -380,6 +380,15 @@ impl Engine for OvGenaiEngine {
     }
 
     fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
+        // No forced-prefix path in the ov-genai pipelines: accepting a resumed task
+        // would regenerate from scratch and report success on a corrupt "resume".
+        // The embedding backend declines these pre-submit; this is the engine-side
+        // backstop for any caller that misses that guard.
+        if task.resume_ids().is_some() {
+            return Err(EngineError::Backend(
+                "resume_unsupported: ov-genai has no forced-prefix path".to_string(),
+            ));
+        }
         if self.pending.iter().any(|t| t.task_id == task.task_id) {
             return Ok(());
         }
@@ -657,6 +666,15 @@ impl Engine for OvGenaiCbEngine {
     }
 
     fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
+        // No forced-prefix path in the ov-genai pipelines: accepting a resumed task
+        // would regenerate from scratch and report success on a corrupt "resume".
+        // The embedding backend declines these pre-submit; this is the engine-side
+        // backstop for any caller that misses that guard.
+        if task.resume_ids().is_some() {
+            return Err(EngineError::Backend(
+                "resume_unsupported: ov-genai has no forced-prefix path".to_string(),
+            ));
+        }
         if self.active.iter().any(|t| t.task_id == task.task_id) {
             return Ok(());
         }

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -382,8 +382,9 @@ impl Engine for OvGenaiEngine {
     fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
         // No forced-prefix path in the ov-genai pipelines: accepting a resumed task
         // would regenerate from scratch and report success on a corrupt "resume".
-        // The embedding backend declines these pre-submit; this is the engine-side
-        // backstop for any caller that misses that guard.
+        // The enterprise shard backend declines these pre-submit (its
+        // shard_is_ov_genai guard); this is the engine-side backstop for any
+        // caller that misses that guard.
         if task.resume_ids().is_some() {
             return Err(EngineError::Backend(
                 "resume_unsupported: ov-genai has no forced-prefix path".to_string(),
@@ -668,8 +669,9 @@ impl Engine for OvGenaiCbEngine {
     fn submit(&mut self, task: GenerationTask) -> EngineResult<()> {
         // No forced-prefix path in the ov-genai pipelines: accepting a resumed task
         // would regenerate from scratch and report success on a corrupt "resume".
-        // The embedding backend declines these pre-submit; this is the engine-side
-        // backstop for any caller that misses that guard.
+        // The enterprise shard backend declines these pre-submit (its
+        // shard_is_ov_genai guard); this is the engine-side backstop for any
+        // caller that misses that guard.
         if task.resume_ids().is_some() {
             return Err(EngineError::Backend(
                 "resume_unsupported: ov-genai has no forced-prefix path".to_string(),

--- a/crates/cascadia-engine-openvino/src/genai.rs
+++ b/crates/cascadia-engine-openvino/src/genai.rs
@@ -1132,6 +1132,26 @@ mod tests {
         GenerationTask::new(id, "hello").with_max_tokens(max_tokens)
     }
 
+    /// Option B: the CB engine has no forced-prefix path — a resumed submit
+    /// must be declined with the `resume_unsupported:` sentinel in the error,
+    /// BEFORE any request is admitted (silently accepting would regenerate
+    /// from scratch and present it as a resume). Any rewording that drops the
+    /// sentinel silently breaks the scheduler's re-route matching.
+    #[test]
+    fn cb_submit_declines_resumed_task_with_sentinel() {
+        let st = Arc::new(Mutex::new(MockState::default()));
+        let mut e = mock_engine(&st);
+        let mut t = task("t1", 8);
+        t.resume_token_ids = Some(vec![1, 2]);
+        let err = e.submit(t).expect_err("resumed submit must be declined");
+        assert!(
+            err.to_string().contains("resume_unsupported:"),
+            "decline must carry the sentinel the scheduler matches on: {err}"
+        );
+        // Nothing was admitted.
+        assert!(e.active.is_empty());
+    }
+
     /// The B1 fix: a step that progressed the batch without producing a token
     /// must still report progress, or the runner's no-progress guard kills a
     /// perfectly healthy request mid-prefill. n_tokens must be an explicit 0 —

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -42,3 +42,16 @@ pub(crate) fn timeout_knob_lock() -> std::sync::MutexGuard<'static, ()> {
     static L: std::sync::Mutex<()> = std::sync::Mutex::new(());
     L.lock().unwrap_or_else(|e| e.into_inner())
 }
+
+/// Exclusive id bound for `validate_resume_ids`: max assigned id + 1 — NOT
+/// `get_vocab_size(true)`, which returns the ENTRY COUNT and under-counts the
+/// bound on a sparse vocab (added tokens with gapped ids), wrongly rejecting
+/// legitimate resume ids. Falls back to the count for an empty vocab map.
+pub(crate) fn resume_vocab_bound(tok: &tokenizers::Tokenizer) -> u32 {
+    tok.get_vocab(true)
+        .values()
+        .max()
+        .map(|&m| m.saturating_add(1))
+        .unwrap_or(0)
+        .max(tok.get_vocab_size(true) as u32)
+}

--- a/crates/cascadia-engine-openvino/src/lib.rs
+++ b/crates/cascadia-engine-openvino/src/lib.rs
@@ -31,3 +31,14 @@ pub use genai::{OvGenaiBuilder, OvGenaiCbEngine, OvGenaiEngine};
 pub use qwen36::{Qwen36Builder, Qwen36Engine};
 pub use rotary::{ModelTextConfig, RopeScalingConfig, Rotary};
 pub use runtime::{OvRuntimeBuilder, OvRuntimeEngine};
+
+/// Tests that touch the process-global activation-timeout knob (or read a
+/// value derived from it under a precondition) must hold this lock: three
+/// runtime.rs tests set it to 1 s and back while gemma4's ceiling test asserts
+/// the budget exceeds the ceiling — racing them made the full-workspace suite
+/// flake with "transport budget (10s) must exceed the ceiling".
+#[cfg(test)]
+pub(crate) fn timeout_knob_lock() -> std::sync::MutexGuard<'static, ()> {
+    static L: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    L.lock().unwrap_or_else(|e| e.into_inner())
+}

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1555,7 +1555,11 @@ impl Qwen36Engine {
                     if reanchored {
                         warn!(task = %task_id, "decode diverged from the emitted prefix; re-anchored (delta dropped)");
                     }
-                    vec![(task_id.clone(), Chunk::token(task_id, next as i64, delta))]
+                    vec![(
+                        task_id.clone(),
+                        Chunk::token(task_id, next as i64, delta)
+                            .with_token_ids(vec![next as i64]),
+                    )]
                 }
                 Err(e) => {
                     warn!(task = %task_id, error = %e, "pipeline decode failed");
@@ -2201,7 +2205,11 @@ impl Qwen36Engine {
                     if reanchored {
                         warn!(task = %task_id, "decode diverged from the emitted prefix; re-anchored (delta dropped)");
                     }
-                    vec![(task_id.clone(), Chunk::token(task_id, next as i64, delta))]
+                    vec![(
+                        task_id.clone(),
+                        Chunk::token(task_id, next as i64, delta)
+                            .with_token_ids(vec![next as i64]),
+                    )]
                 }
                 Err(e) => {
                     warn!(task = %task_id, error = %e, "decode failed");

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1284,10 +1284,14 @@ impl Qwen36Engine {
             let resume_emitted = if resume_gen_ids.is_empty() {
                 0
             } else {
-                tokenizer
-                    .decode(&resume_gen_ids, true)
-                    .unwrap_or_default()
-                    .len()
+                match tokenizer.decode(&resume_gen_ids, true) {
+                    Ok(s) => s.len(),
+                    Err(e) => {
+                        warn!(task = %task.task_id, error = %e, "resume seed decode failed");
+                        let reason = format!("resume seed decode failed: {e}");
+                        return vec![(task.task_id.clone(), Chunk::error(task.task_id, reason))];
+                    }
+                }
             };
             let max_tokens = if task.max_tokens > 0 {
                 task.max_tokens
@@ -1981,10 +1985,14 @@ impl Qwen36Engine {
             let resume_emitted = if resume_gen_ids.is_empty() {
                 0
             } else {
-                tokenizer
-                    .decode(&resume_gen_ids, true)
-                    .unwrap_or_default()
-                    .len()
+                match tokenizer.decode(&resume_gen_ids, true) {
+                    Ok(s) => s.len(),
+                    Err(e) => {
+                        warn!(task = %task.task_id, error = %e, "resume seed decode failed");
+                        let reason = format!("resume seed decode failed: {e}");
+                        return vec![(task.task_id.clone(), Chunk::error(task.task_id, reason))];
+                    }
+                }
             };
             let max_tokens = if task.max_tokens > 0 {
                 task.max_tokens

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1257,7 +1257,10 @@ impl Qwen36Engine {
             // prefill below carries them as context. No-op when not resuming.
             {
                 let mut prompt_ids_i64: Vec<i64> = prompt_ids.iter().map(|&u| u as i64).collect();
-                cascadia_types::append_resume_ids(&mut prompt_ids_i64, task.resume_token_ids.as_deref());
+                cascadia_types::append_resume_ids(
+                    &mut prompt_ids_i64,
+                    task.resume_token_ids.as_deref(),
+                );
                 prompt_ids = prompt_ids_i64.into_iter().map(|t| t as u32).collect();
             }
             // An empty prompt leaves next_token None through prefill and would
@@ -1951,7 +1954,10 @@ impl Qwen36Engine {
             // prefill below carries them as context. No-op when not resuming.
             {
                 let mut prompt_ids_i64: Vec<i64> = prompt_ids.iter().map(|&u| u as i64).collect();
-                cascadia_types::append_resume_ids(&mut prompt_ids_i64, task.resume_token_ids.as_deref());
+                cascadia_types::append_resume_ids(
+                    &mut prompt_ids_i64,
+                    task.resume_token_ids.as_deref(),
+                );
                 prompt_ids = prompt_ids_i64.into_iter().map(|t| t as u32).collect();
             }
             // An empty prompt leaves logits empty and would fabricate token 0

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
-use cascadia_ov_genai_shim::{DType, PluginConfig, Runtime};
+use cascadia_ov_genai_shim::{advance_emitted, DType, PluginConfig, Runtime};
 use cascadia_transport::{
     ActivationClient, ActivationServer, DType as WireDType, Tensor as WireTensor, TransportError,
     MAX_RAW_BYTES,
@@ -637,8 +637,16 @@ struct ActiveTask {
     /// Pipeline rank 0: next token returned by the downstream argmax.
     next_token: Option<u32>,
     gen_ids: Vec<u32>,
-    /// Byte length of the decoded prefix already emitted as chunks.
-    emitted: usize,
+    /// Bytes already handed to the client (the seed's decoded bytes on a
+    /// resumed turn). Deltas come from the shim's `advance_emitted`, which
+    /// holds back an unresolved U+FFFD run and RE-ANCHORS on a diverged
+    /// re-decode — the old byte-offset arithmetic silently duplicated or
+    /// dropped seam text when a diverged decode landed on a char boundary.
+    emitted: Vec<u8>,
+    /// Option B: leading entries of `gen_ids` that are the resume seed. The
+    /// kv_coord capture key must SKIP them — `prompt_ids` already carries the
+    /// resume ids (same defect dist_spec fixed).
+    resume_seed_len: usize,
     max_tokens: usize,
     started: Instant,
     /// Pipeline rank 0: per-frame FORWARD→TOKEN round-trip times for
@@ -851,10 +859,13 @@ impl Qwen36Engine {
         // it. Keyed by the full sequence (session-resume). Gated + best-effort (stub ⇒ no-op).
         #[cfg(feature = "kv_coord")]
         {
+            // Skip the resume seed: `prompt_ids` already carries those ids, so
+            // counting them again keys the blob at a depth that never matches
+            // the fed sequence (same defect dist_spec fixed).
             let tokens: Vec<i32> = t
                 .prompt_ids
                 .iter()
-                .chain(t.gen_ids.iter())
+                .chain(t.gen_ids.iter().skip(t.resume_seed_len))
                 .map(|&u| u as i32)
                 .collect();
             // Pipeline head: broadcast CAPTURE so every downstream rank snapshots its slice under the
@@ -1255,12 +1266,20 @@ impl Qwen36Engine {
             // Option B forced-prefix resume: append the already-emitted assistant
             // tokens after the rendered prompt (concat, not replace) so the cold
             // prefill below carries them as context. No-op when not resuming.
+            // `resume_ids()` normalizes `Some([])`; validation bounds peer-supplied
+            // indices before they reach native prefill (and makes the u32 casts safe).
+            let resume = task.resume_ids().map(<[i32]>::to_vec);
+            if let Some(r) = resume.as_deref() {
+                let vocab = tokenizer.get_vocab_size(true) as u32;
+                if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                    let id = task.task_id.clone();
+                    let c = Chunk::error(id.clone(), format!("invalid resume prefix: {e}"));
+                    return vec![(id, c)];
+                }
+            }
             {
                 let mut prompt_ids_i64: Vec<i64> = prompt_ids.iter().map(|&u| u as i64).collect();
-                cascadia_types::append_resume_ids(
-                    &mut prompt_ids_i64,
-                    task.resume_token_ids.as_deref(),
-                );
+                cascadia_types::append_resume_ids(&mut prompt_ids_i64, resume.as_deref());
                 prompt_ids = prompt_ids_i64.into_iter().map(|t| t as u32).collect();
             }
             // An empty prompt leaves next_token None through prefill and would
@@ -1276,16 +1295,16 @@ impl Qwen36Engine {
             // Option B: pre-seed `gen_ids` + `emitted` with the resumed tokens so the
             // budget check bounds prefix+new (not just new) and the first NEW tail
             // token's delta decode starts after the prefix text. Empty on a normal turn.
-            let resume_gen_ids: Vec<u32> =
-                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
-                    .into_iter()
-                    .map(|t| t as u32)
-                    .collect();
-            let resume_emitted = if resume_gen_ids.is_empty() {
-                0
+            let resume_gen_ids: Vec<u32> = cascadia_types::resume_generated_seed(resume.as_deref())
+                .into_iter()
+                .map(|t| t as u32)
+                .collect();
+            let resume_seed_len = resume_gen_ids.len();
+            let resume_emitted: Vec<u8> = if resume_gen_ids.is_empty() {
+                Vec::new()
             } else {
                 match tokenizer.decode(&resume_gen_ids, true) {
-                    Ok(s) => s.len(),
+                    Ok(s) => s.into_bytes(),
                     Err(e) => {
                         warn!(task = %task.task_id, error = %e, "resume seed decode failed");
                         let reason = format!("resume seed decode failed: {e}");
@@ -1380,6 +1399,7 @@ impl Qwen36Engine {
                 next_token: None,
                 gen_ids: resume_gen_ids,
                 emitted: resume_emitted,
+                resume_seed_len,
                 max_tokens,
                 started: Instant::now(),
                 wire_ms: Vec::new(),
@@ -1527,13 +1547,14 @@ impl Qwen36Engine {
                         .decode(self.active.as_ref().unwrap().gen_ids.as_slice(), true)
                         .unwrap_or_default();
                     let t = self.active.as_mut().unwrap();
-                    let delta = if full.ends_with('\u{FFFD}') {
-                        String::new()
-                    } else {
-                        let d = full.get(t.emitted..).unwrap_or("").to_string();
-                        t.emitted = full.len();
-                        d
-                    };
+                    // Shim `advance_emitted`: FFFD-run holdback + starts_with
+                    // re-anchor, one implementation shared with ov-runtime so
+                    // the two cannot drift.
+                    let (delta, reanchored) =
+                        advance_emitted(&mut t.emitted, full.as_bytes(), true);
+                    if reanchored {
+                        warn!(task = %task_id, "decode diverged from the emitted prefix; re-anchored (delta dropped)");
+                    }
                     vec![(task_id.clone(), Chunk::token(task_id, next as i64, delta))]
                 }
                 Err(e) => {
@@ -1956,12 +1977,20 @@ impl Qwen36Engine {
             // Option B forced-prefix resume: append the already-emitted assistant
             // tokens after the rendered prompt (concat, not replace) so the cold
             // prefill below carries them as context. No-op when not resuming.
+            // `resume_ids()` normalizes `Some([])`; validation bounds peer-supplied
+            // indices before they reach native prefill (and makes the u32 casts safe).
+            let resume = task.resume_ids().map(<[i32]>::to_vec);
+            if let Some(r) = resume.as_deref() {
+                let vocab = tokenizer.get_vocab_size(true) as u32;
+                if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                    let id = task.task_id.clone();
+                    let c = Chunk::error(id.clone(), format!("invalid resume prefix: {e}"));
+                    return vec![(id, c)];
+                }
+            }
             {
                 let mut prompt_ids_i64: Vec<i64> = prompt_ids.iter().map(|&u| u as i64).collect();
-                cascadia_types::append_resume_ids(
-                    &mut prompt_ids_i64,
-                    task.resume_token_ids.as_deref(),
-                );
+                cascadia_types::append_resume_ids(&mut prompt_ids_i64, resume.as_deref());
                 prompt_ids = prompt_ids_i64.into_iter().map(|t| t as u32).collect();
             }
             // An empty prompt leaves logits empty and would fabricate token 0
@@ -1977,16 +2006,16 @@ impl Qwen36Engine {
             // Option B: pre-seed `gen_ids` + `emitted` with the resumed tokens so the
             // budget check bounds prefix+new (not just new) and the first NEW tail
             // token's delta decode starts after the prefix text. Empty on a normal turn.
-            let resume_gen_ids: Vec<u32> =
-                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
-                    .into_iter()
-                    .map(|t| t as u32)
-                    .collect();
-            let resume_emitted = if resume_gen_ids.is_empty() {
-                0
+            let resume_gen_ids: Vec<u32> = cascadia_types::resume_generated_seed(resume.as_deref())
+                .into_iter()
+                .map(|t| t as u32)
+                .collect();
+            let resume_seed_len = resume_gen_ids.len();
+            let resume_emitted: Vec<u8> = if resume_gen_ids.is_empty() {
+                Vec::new()
             } else {
                 match tokenizer.decode(&resume_gen_ids, true) {
-                    Ok(s) => s.len(),
+                    Ok(s) => s.into_bytes(),
                     Err(e) => {
                         warn!(task = %task.task_id, error = %e, "resume seed decode failed");
                         let reason = format!("resume seed decode failed: {e}");
@@ -2043,6 +2072,7 @@ impl Qwen36Engine {
                 next_token: None,
                 gen_ids: resume_gen_ids,
                 emitted: resume_emitted,
+                resume_seed_len,
                 max_tokens,
                 started: Instant::now(),
                 wire_ms: Vec::new(),
@@ -2163,13 +2193,14 @@ impl Qwen36Engine {
                         .decode(self.active.as_ref().unwrap().gen_ids.as_slice(), true)
                         .unwrap_or_default();
                     let t = self.active.as_mut().unwrap();
-                    let delta = if full.ends_with('\u{FFFD}') {
-                        String::new()
-                    } else {
-                        let d = full.get(t.emitted..).unwrap_or("").to_string();
-                        t.emitted = full.len();
-                        d
-                    };
+                    // Shim `advance_emitted`: FFFD-run holdback + starts_with
+                    // re-anchor, one implementation shared with ov-runtime so
+                    // the two cannot drift.
+                    let (delta, reanchored) =
+                        advance_emitted(&mut t.emitted, full.as_bytes(), true);
+                    if reanchored {
+                        warn!(task = %task_id, "decode diverged from the emitted prefix; re-anchored (delta dropped)");
+                    }
                     vec![(task_id.clone(), Chunk::token(task_id, next as i64, delta))]
                 }
                 Err(e) => {
@@ -2780,7 +2811,8 @@ mod tests {
             logits: Vec::new(),
             next_token: Some(5),
             gen_ids: vec![5],
-            emitted: 0,
+            emitted: Vec::new(),
+            resume_seed_len: 0,
             max_tokens: 16,
             started: Instant::now(),
             wire_ms: Vec::new(),

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1270,7 +1270,7 @@ impl Qwen36Engine {
             // indices before they reach native prefill (and makes the u32 casts safe).
             let resume = task.resume_ids().map(<[i32]>::to_vec);
             if let Some(r) = resume.as_deref() {
-                let vocab = tokenizer.get_vocab_size(true) as u32;
+                let vocab = crate::resume_vocab_bound(tokenizer);
                 if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
                     let id = task.task_id.clone();
                     let c = Chunk::error(id.clone(), format!("invalid resume prefix: {e}"));
@@ -1557,8 +1557,7 @@ impl Qwen36Engine {
                     }
                     vec![(
                         task_id.clone(),
-                        Chunk::token(task_id, next as i64, delta)
-                            .with_token_ids(vec![next as i64]),
+                        Chunk::token(task_id, next as i64, delta).with_token_ids(vec![next as i64]),
                     )]
                 }
                 Err(e) => {
@@ -1985,7 +1984,7 @@ impl Qwen36Engine {
             // indices before they reach native prefill (and makes the u32 casts safe).
             let resume = task.resume_ids().map(<[i32]>::to_vec);
             if let Some(r) = resume.as_deref() {
-                let vocab = tokenizer.get_vocab_size(true) as u32;
+                let vocab = crate::resume_vocab_bound(tokenizer);
                 if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
                     let id = task.task_id.clone();
                     let c = Chunk::error(id.clone(), format!("invalid resume prefix: {e}"));
@@ -2207,8 +2206,7 @@ impl Qwen36Engine {
                     }
                     vec![(
                         task_id.clone(),
-                        Chunk::token(task_id, next as i64, delta)
-                            .with_token_ids(vec![next as i64]),
+                        Chunk::token(task_id, next as i64, delta).with_token_ids(vec![next as i64]),
                     )]
                 }
                 Err(e) => {

--- a/crates/cascadia-engine-openvino/src/qwen36.rs
+++ b/crates/cascadia-engine-openvino/src/qwen36.rs
@@ -1252,6 +1252,14 @@ impl Qwen36Engine {
                     prompt_ids.extend(e.get_ids());
                 }
             }
+            // Option B forced-prefix resume: append the already-emitted assistant
+            // tokens after the rendered prompt (concat, not replace) so the cold
+            // prefill below carries them as context. No-op when not resuming.
+            {
+                let mut prompt_ids_i64: Vec<i64> = prompt_ids.iter().map(|&u| u as i64).collect();
+                cascadia_types::append_resume_ids(&mut prompt_ids_i64, task.resume_token_ids.as_deref());
+                prompt_ids = prompt_ids_i64.into_iter().map(|t| t as u32).collect();
+            }
             // An empty prompt leaves next_token None through prefill and would
             // panic the decode branch (`expect`); reject at admission.
             if prompt_ids.is_empty() {
@@ -1262,6 +1270,22 @@ impl Qwen36Engine {
                 );
                 return vec![(task.task_id, e)];
             }
+            // Option B: pre-seed `gen_ids` + `emitted` with the resumed tokens so the
+            // budget check bounds prefix+new (not just new) and the first NEW tail
+            // token's delta decode starts after the prefix text. Empty on a normal turn.
+            let resume_gen_ids: Vec<u32> =
+                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
+                    .into_iter()
+                    .map(|t| t as u32)
+                    .collect();
+            let resume_emitted = if resume_gen_ids.is_empty() {
+                0
+            } else {
+                tokenizer
+                    .decode(&resume_gen_ids, true)
+                    .unwrap_or_default()
+                    .len()
+            };
             let max_tokens = if task.max_tokens > 0 {
                 task.max_tokens
             } else {
@@ -1347,8 +1371,8 @@ impl Qwen36Engine {
                 step: warm_prefix,
                 logits: Vec::new(),
                 next_token: None,
-                gen_ids: Vec::new(),
-                emitted: 0,
+                gen_ids: resume_gen_ids,
+                emitted: resume_emitted,
                 max_tokens,
                 started: Instant::now(),
                 wire_ms: Vec::new(),
@@ -1922,6 +1946,14 @@ impl Qwen36Engine {
                     prompt_ids.extend(e.get_ids());
                 }
             }
+            // Option B forced-prefix resume: append the already-emitted assistant
+            // tokens after the rendered prompt (concat, not replace) so the cold
+            // prefill below carries them as context. No-op when not resuming.
+            {
+                let mut prompt_ids_i64: Vec<i64> = prompt_ids.iter().map(|&u| u as i64).collect();
+                cascadia_types::append_resume_ids(&mut prompt_ids_i64, task.resume_token_ids.as_deref());
+                prompt_ids = prompt_ids_i64.into_iter().map(|t| t as u32).collect();
+            }
             // An empty prompt leaves logits empty and would fabricate token 0
             // (garbage decode); reject at admission to match the pipeline path.
             if prompt_ids.is_empty() {
@@ -1932,6 +1964,22 @@ impl Qwen36Engine {
                 );
                 return vec![(task.task_id, e)];
             }
+            // Option B: pre-seed `gen_ids` + `emitted` with the resumed tokens so the
+            // budget check bounds prefix+new (not just new) and the first NEW tail
+            // token's delta decode starts after the prefix text. Empty on a normal turn.
+            let resume_gen_ids: Vec<u32> =
+                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
+                    .into_iter()
+                    .map(|t| t as u32)
+                    .collect();
+            let resume_emitted = if resume_gen_ids.is_empty() {
+                0
+            } else {
+                tokenizer
+                    .decode(&resume_gen_ids, true)
+                    .unwrap_or_default()
+                    .len()
+            };
             let max_tokens = if task.max_tokens > 0 {
                 task.max_tokens
             } else {
@@ -1979,8 +2027,8 @@ impl Qwen36Engine {
                 step: warm_prefix,
                 logits: Vec::new(),
                 next_token: None,
-                gen_ids: Vec::new(),
-                emitted: 0,
+                gen_ids: resume_gen_ids,
+                emitted: resume_emitted,
                 max_tokens,
                 started: Instant::now(),
                 wire_ms: Vec::new(),

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -3049,6 +3049,7 @@ impl OvRuntimeEngine {
                 n_tokens: None,
                 prompt_tokens: None,
                 error: None,
+                token_ids: Vec::new(),
                 // ov-runtime doesn't yet distinguish length vs stop here; the
                 // API falls back to "stop" (unchanged behavior). #14 follow-up.
                 finish_reason: None,

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2302,6 +2302,22 @@ impl OvRuntimeEngine {
                 break;
             };
             let task = self.pending.remove(0);
+            // Option B: the packed path has no forced-prefix support — it neither
+            // appends `resume_token_ids` to the prompt nor seeds `generated`/`emitted`.
+            // Admitting a resume task here would regenerate the turn FROM SCRATCH and
+            // report success, i.e. silently hand the client a different completion than
+            // the prefix it already received. Refuse loudly so the scheduler can surface
+            // or re-route it, rather than being told the resume succeeded.
+            // (Unreachable at the `packed_slots = 0` default; guards enabling it.)
+            if task
+                .resume_token_ids
+                .as_ref()
+                .is_some_and(|r| !r.is_empty())
+            {
+                return Err(EngineError::Backend(
+                    "resume (Option B forced prefix) is unsupported on packed slots".into(),
+                ));
+            }
             let tok = self
                 .tokenizer
                 .clone()

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2804,7 +2804,9 @@ impl OvRuntimeEngine {
             // the next chunk (BPE splitting a glyph) would otherwise count 0.
             return Ok(Some((
                 task_id.clone(),
-                Chunk::token(task_id, token as i64, delta).with_n_tokens(1),
+                Chunk::token(task_id, token as i64, delta)
+                    .with_n_tokens(1)
+                    .with_token_ids(vec![token as i64]),
             )));
         }
         let n_tokens = t.generated.len() as u32;
@@ -3121,6 +3123,7 @@ impl OvRuntimeEngine {
             }
         } else {
             Chunk::token(task_id.clone(), next_token as i64, delta)
+                .with_token_ids(vec![next_token as i64])
         };
 
         if is_final {

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2236,8 +2236,20 @@ impl OvRuntimeEngine {
                 String::new()
             } else {
                 let seed_u32: Vec<u32> = resume_seed.iter().map(|&t| t as u32).collect();
-                tok.decode(&seed_u32, true)
-                    .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?
+                match tok.decode(&seed_u32, true) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        // Attributed like the validation branch above: the task is
+                        // already popped from pending, so a bare Err from step()
+                        // fails whichever queued stream happens to poll while THIS
+                        // task's stream hangs with nothing further.
+                        let id = task.task_id.clone();
+                        return Ok(vec![(
+                            id.clone(),
+                            Chunk::error(id, format!("resume seed decode failed: {e}")),
+                        )]);
+                    }
+                }
             };
             self.active = Some(ActiveTask {
                 task,

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -6373,6 +6373,7 @@ mod tests {
     #[tokio::test]
     async fn a_wait_that_only_discards_reports_the_discards() {
         let (client, mut server) = loopback().await;
+        let _knob = crate::timeout_knob_lock();
         cascadia_transport::set_activation_timeout_secs(1);
         // Three frames, none of them echoing the seq we are waiting on.
         for s in [11u32, 12, 13] {
@@ -6397,6 +6398,7 @@ mod tests {
     #[tokio::test]
     async fn a_silent_wait_says_no_frame_arrived() {
         let (client, _server) = loopback().await;
+        let _knob = crate::timeout_knob_lock();
         cascadia_transport::set_activation_timeout_secs(1);
         let downstream = Arc::new(tokio::sync::Mutex::new(client));
         let err = recv_token_seq_checked(&downstream, 7, false)
@@ -6519,6 +6521,7 @@ mod tests {
         // Silent peer → the bounded frame-start elapses → TimedOut.
         let (client, _server) = loopback().await;
         let downstream = Arc::new(tokio::sync::Mutex::new(client));
+        let _knob = crate::timeout_knob_lock();
         cascadia_transport::set_activation_timeout_secs(1);
         let err = recv_token_seq_checked(&downstream, 0, false)
             .await

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2096,7 +2096,11 @@ impl OvRuntimeEngine {
             let enc = tok
                 .encode(task.prompt.clone(), false)
                 .map_err(|e| EngineError::Backend(format!("tokenizer encode: {e}")))?;
-            let prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            let mut prompt_ids: Vec<i64> = enc.get_ids().iter().map(|&u| u as i64).collect();
+            // Option B forced-prefix resume: append the already-emitted assistant
+            // tokens after the rendered prompt (concat, not replace) so the cold
+            // prefill below carries them as context. No-op when not resuming.
+            cascadia_types::append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
             // Issue-34 warm-resume: if a pulled/cached KV blob covers a strict prefix of this
             // prompt, restore it and prefill only the suffix. Gated + best-effort — off-rig
             // set_state_blob returns Stub, so this stays cold. Only the stateful (non-static) path.
@@ -2182,11 +2186,33 @@ impl OvRuntimeEngine {
                 warm_prefix,
                 "task active (ov-runtime)"
             );
+            // Option B: pre-seed `generated` + `emitted` with the resumed tokens
+            // so the budget check bounds prefix+new (not just new) and the first
+            // NEW tail token decodes WITH the prefix as context. Seeding `emitted`
+            // with the DECODED PREFIX BYTES is what keeps the client stream a
+            // single continuous completion: `advance_emitted` only hands over
+            // `full[emitted.len()..]`, so the forced prefix is never re-emitted.
+            // A prefix that is not a byte-prefix of the re-decode (SentencePiece
+            // merge at the seam) hits that fn's re-anchor arm and degrades to a
+            // resync instead of corrupting. Empty seed on a normal turn ⇒
+            // identical to today.
+            let resume_seed: Vec<i32> =
+                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
+                    .into_iter()
+                    .map(|t| t as i32)
+                    .collect();
+            let resume_last_text = if resume_seed.is_empty() {
+                String::new()
+            } else {
+                let seed_u32: Vec<u32> = resume_seed.iter().map(|&t| t as u32).collect();
+                tok.decode(&seed_u32, true)
+                    .map_err(|e| EngineError::Backend(format!("tokenizer decode: {e}")))?
+            };
             self.active = Some(ActiveTask {
                 task,
                 prompt_ids,
-                generated: Vec::new(),
-                emitted: Vec::new(),
+                generated: resume_seed,
+                emitted: resume_last_text.into_bytes(),
                 prefilled: false,
                 last_token: 0,
                 warm_prefix,

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2342,13 +2342,18 @@ impl OvRuntimeEngine {
             // or re-route it, rather than being told the resume succeeded.
             // (Unreachable at the `packed_slots = 0` default; guards enabling it.)
             if task.resume_ids().is_some() {
-                // Attributed to the refused task: a bare Err from step() fails
-                // whichever packed stream happened to poll and leaves THIS task
-                // hanging with no error chunk (review finding).
-                return Err(EngineError::Backend(
-                    "resume (Option B forced prefix) is unsupported on packed slots".into(),
-                )
-                .for_task(task.task_id));
+                // Declined as THIS task's error chunk, sentinel-prefixed: the
+                // scheduler matches `resume_unsupported:` with starts_with on
+                // the chunk reason to re-route instead of surfacing a fault,
+                // and an engine-level Err would fail the other packed streams.
+                out.push((
+                    task.task_id.clone(),
+                    Chunk::error(
+                        task.task_id,
+                        "resume_unsupported: packed slots have no forced-prefix path".to_string(),
+                    ),
+                ));
+                continue;
             }
             let tok = self
                 .tokenizer

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -2112,7 +2112,7 @@ impl OvRuntimeEngine {
                 // Peer-supplied indices go straight into native prefill; an
                 // out-of-range id is an OV embedding gather crash, not a typed
                 // error — bound them here.
-                let vocab = tok.get_vocab_size(true) as u32;
+                let vocab = crate::resume_vocab_bound(&tok);
                 if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
                     let id = task.task_id.clone();
                     return Ok(vec![(

--- a/crates/cascadia-engine-openvino/src/runtime.rs
+++ b/crates/cascadia-engine-openvino/src/runtime.rs
@@ -1412,6 +1412,12 @@ struct ActiveTask {
     /// pulled/cached KV blob). The prefill feeds only `prompt_ids[warm_prefix..]`. 0 ⇒ cold (full
     /// prefill), so the default path is unchanged.
     warm_prefix: usize,
+    /// Option B: how many leading entries of `generated` are the resume seed.
+    /// The kv_coord capture key must SKIP them — `prompt_ids` already carries
+    /// the resume ids (appended before prefill), so counting the seed again
+    /// would key the blob at an inflated depth that never matches the real
+    /// fed sequence (dist_spec fixed the same defect; this mirrors it).
+    resume_seed_len: usize,
     /// Wall-clock when the task became active. Used to compute the
     /// final tok/s the engine prints in its `task done` log line.
     started: std::time::Instant,
@@ -2100,7 +2106,32 @@ impl OvRuntimeEngine {
             // Option B forced-prefix resume: append the already-emitted assistant
             // tokens after the rendered prompt (concat, not replace) so the cold
             // prefill below carries them as context. No-op when not resuming.
-            cascadia_types::append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
+            // `resume_ids()` normalizes a wire-legal `Some([])` to "not resuming".
+            let resume = task.resume_ids().map(<[i32]>::to_vec);
+            if let Some(r) = resume.as_deref() {
+                // Peer-supplied indices go straight into native prefill; an
+                // out-of-range id is an OV embedding gather crash, not a typed
+                // error — bound them here.
+                let vocab = tok.get_vocab_size(true) as u32;
+                if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                    let id = task.task_id.clone();
+                    return Ok(vec![(
+                        id.clone(),
+                        Chunk::error(id, format!("invalid resume prefix: {e}")),
+                    )]);
+                }
+                // Budget already exhausted by the prefix (total = prefix + new
+                // must equal max_tokens): finish Length with ZERO new tokens.
+                // The old flow sampled the first token before its length check
+                // and overshot the budget by one on peer-supplied input.
+                if r.len() >= task.max_tokens.max(1) as usize {
+                    let mut c = Chunk::final_marker(task.task_id.clone(), "");
+                    c.n_tokens = Some(0);
+                    c.finish_reason = Some(cascadia_types::FinishReason::Length);
+                    return Ok(vec![(task.task_id.clone(), c)]);
+                }
+            }
+            cascadia_types::append_resume_ids(&mut prompt_ids, resume.as_deref());
             // Issue-34 warm-resume: if a pulled/cached KV blob covers a strict prefix of this
             // prompt, restore it and prefill only the suffix. Gated + best-effort — off-rig
             // set_state_blob returns Stub, so this stays cold. Only the stateful (non-static) path.
@@ -2196,11 +2227,11 @@ impl OvRuntimeEngine {
             // merge at the seam) hits that fn's re-anchor arm and degrades to a
             // resync instead of corrupting. Empty seed on a normal turn ⇒
             // identical to today.
-            let resume_seed: Vec<i32> =
-                cascadia_types::resume_generated_seed(task.resume_token_ids.as_deref())
-                    .into_iter()
-                    .map(|t| t as i32)
-                    .collect();
+            let resume_seed: Vec<i32> = cascadia_types::resume_generated_seed(resume.as_deref())
+                .into_iter()
+                .map(|t| t as i32)
+                .collect();
+            let resume_seed_len = resume_seed.len();
             let resume_last_text = if resume_seed.is_empty() {
                 String::new()
             } else {
@@ -2216,6 +2247,7 @@ impl OvRuntimeEngine {
                 prefilled: false,
                 last_token: 0,
                 warm_prefix,
+                resume_seed_len,
                 started: std::time::Instant::now(),
                 t_alpha_compute: std::time::Duration::ZERO,
                 t_wire: std::time::Duration::ZERO,
@@ -2309,14 +2341,14 @@ impl OvRuntimeEngine {
             // the prefix it already received. Refuse loudly so the scheduler can surface
             // or re-route it, rather than being told the resume succeeded.
             // (Unreachable at the `packed_slots = 0` default; guards enabling it.)
-            if task
-                .resume_token_ids
-                .as_ref()
-                .is_some_and(|r| !r.is_empty())
-            {
+            if task.resume_ids().is_some() {
+                // Attributed to the refused task: a bare Err from step() fails
+                // whichever packed stream happened to poll and leaves THIS task
+                // hanging with no error chunk (review finding).
                 return Err(EngineError::Backend(
                     "resume (Option B forced prefix) is unsupported on packed slots".into(),
-                ));
+                )
+                .for_task(task.task_id));
             }
             let tok = self
                 .tokenizer
@@ -3111,7 +3143,10 @@ impl OvRuntimeEngine {
             #[cfg(feature = "kv_coord")]
             {
                 let mut full: Vec<i32> = active.prompt_ids.iter().map(|&t| t as i32).collect();
-                full.extend_from_slice(&active.generated);
+                // Skip the resume seed: `prompt_ids` already carries those ids.
+                full.extend_from_slice(
+                    &active.generated[active.resume_seed_len.min(active.generated.len())..],
+                );
                 // H.1b R2: the namespace this turn belongs to, read off THIS task's own state —
                 // never off a plane-asserted value, which describes a pulled entry, not this turn.
                 let tenant = active.task.tenant.clone();

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -2126,10 +2126,15 @@ impl SparseMoEEngine {
         }
         let downstream = self.active.as_ref().unwrap().downstream.clone();
         let cfg = self.active.as_ref().unwrap().cfg.clone();
-        let history = self.active.as_ref().unwrap().history.clone();
+        // Take, not clone: a per-token clone of the growing history is O(n^2)
+        // memcpy over the turn. forward only reads the slice; put it back on
+        // success (the Err arm drops the whole slot, history with it).
+        let history = std::mem::take(&mut self.active.as_mut().unwrap().history);
         match self.forward_one_token_first(&history, &cfg, &downstream, true) {
             Ok(tok_back) => {
-                self.active.as_mut().unwrap().next = tok_back;
+                let a = self.active.as_mut().unwrap();
+                a.history = history;
+                a.next = tok_back;
                 vec![(id, token_chunk)]
             }
             Err(e) => {
@@ -5243,6 +5248,10 @@ impl<R: StagedRunner> PipelineEngine<R> {
         };
         let mut token_chunk = Chunk::token(id.clone(), next, delta);
         token_chunk.n_tokens = Some(1);
+        // Splicer poison bypass (spec §4.1, same stamp as the sparse/ovmoe
+        // decode paths): token_id==0 with empty token_ids reads as id-less and
+        // makes the stream resume-ineligible; token 0 is a legal sample.
+        token_chunk.token_ids = vec![next];
 
         let (gen_len, max_new, is_eos, pos, max_seq) = {
             let a = self.active.as_ref().unwrap();

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -3285,7 +3285,15 @@ impl SparseMoEEngine {
                             .map_err(|e| format!("send_restore: {e}"))?;
                         recv_restore_verdict(down).await
                     })
-                    .unwrap_or(false)
+                    .unwrap_or_else(|e| {
+                        // Verdict-0 cold fallback is the designed outcome, but the
+                        // CAUSE must not vanish — mirror the OvMoe handler's warn.
+                        warn!(
+                            rank = self.rank,
+                            epoch, "downstream restore chain failed: {e}"
+                        );
+                        false
+                    })
                 } else {
                     // No downstream socket: verdict-true only when this genuinely
                     // IS the last rank — mirror of the OvMoe handler, so the two

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1657,7 +1657,16 @@ impl SparseMoEEngine {
             if full_text.as_bytes().starts_with(prefix_text.as_bytes()) {
                 full_text.get(prefix_text.len()..).unwrap_or("").to_string()
             } else {
-                warn!(task = %task.task_id, "resume seam diverged; re-anchoring (tail delta dropped)");
+                // Whole-turn path: re-anchoring here withholds the ENTIRE
+                // tail text, and the final below still reads as a clean
+                // success (token_ids carries the real ids for id-based
+                // splicing). This event is the only signal of that, so it
+                // is structured, not just prose.
+                tracing::warn!(target: "cascadia::engine",
+                    event = "resume_seam_diverged_whole_turn",
+                    task = %task.task_id,
+                    full_len = full_text.len(), prefix_len = prefix_text.len(),
+                    "resume seam diverged; whole-turn tail TEXT withheld, ids still surfaced");
                 String::new()
             }
         } else {
@@ -1731,17 +1740,14 @@ impl SparseMoEEngine {
                 }
             }
         };
-        if prompt_ids.is_empty() {
-            return Some(vec![(
-                task.task_id.clone(),
-                Chunk::final_marker(task.task_id, ""),
-            )]);
-        }
         // Option B forced-prefix resume: append the already-emitted assistant
         // tokens after the rendered prompt (concat, not replace) and seed the
         // streaming accumulator from them — the distributed prefill loop
         // below is agnostic to id origin, so the appended ids prefill
-        // naturally. `Ok(None)` on a plain (non-resume) turn.
+        // naturally. `Ok(None)` on a plain (non-resume) turn. Runs BEFORE the
+        // empty-prompt early return so a resumed task with an empty rendered
+        // prompt streams its seed instead of getting a success-shaped final
+        // with the forced prefix silently ignored.
         let mut seed_opt = match self
             .tokenizer
             .as_ref()
@@ -1754,9 +1760,15 @@ impl SparseMoEEngine {
                 return Some(vec![(id.clone(), Chunk::error(id, e))]);
             }
         };
-        if seed_opt.is_some() {
+        if prompt_ids.is_empty() {
+            return Some(vec![(
+                task.task_id.clone(),
+                Chunk::final_marker(task.task_id, ""),
+            )]);
+        }
+        if let Some(seed) = seed_opt.as_ref() {
             info!(task = %task.task_id, event = "resume_admitted",
-                  seed_len = seed_opt.as_ref().unwrap().seed_len,
+                  seed_len = seed.seed_len,
                   "Option B resume admitted (multi-stage, streamed)");
         }
         // Non-resume keeps the base contract: max_tokens == 0 still yields one
@@ -3855,13 +3867,13 @@ impl OvMoeEngine {
                 )]);
             }
         };
-        if prompt_ids.is_empty() {
-            return Some(vec![(id.clone(), Chunk::final_marker(id, ""))]);
-        }
         // Option B forced-prefix resume: append the already-emitted assistant
         // tokens after the rendered prompt (concat, not replace) and seed the
         // streaming accumulator from them. `prepare_resume` works in i64 —
-        // OvMoe's prompt ids are u32, so round-trip at this boundary.
+        // OvMoe's prompt ids are u32, so round-trip at this boundary. Runs
+        // BEFORE the empty-prompt early return so a resumed task with an
+        // empty rendered prompt streams its seed instead of getting a
+        // success-shaped final with the forced prefix silently ignored.
         let mut prompt64: Vec<i64> = prompt_ids.iter().map(|&t| i64::from(t)).collect();
         let mut seed_opt = match self
             .tokenizer
@@ -3875,9 +3887,12 @@ impl OvMoeEngine {
                 return Some(vec![(id.clone(), Chunk::error(id, e))]);
             }
         };
-        if seed_opt.is_some() {
+        if prompt64.is_empty() {
+            return Some(vec![(id.clone(), Chunk::final_marker(id, ""))]);
+        }
+        if let Some(seed) = seed_opt.as_ref() {
             info!(task = %id, event = "resume_admitted",
-                  seed_len = seed_opt.as_ref().unwrap().seed_len,
+                  seed_len = seed.seed_len,
                   "Option B resume admitted (MiniMax-M2 pipeline-parallel, streamed)");
         }
         let prompt_ids: Vec<u32> = prompt64.iter().map(|&t| t as u32).collect(); // validated in-vocab

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1416,13 +1416,37 @@ impl SparseMoEEngine {
         // Option B forced-prefix resume: append the already-emitted assistant
         // tokens after the rendered prompt (concat, not replace) so prefill
         // below carries them as context/KV history. No-op when not resuming.
-        append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
-        let max_new = resume_max_new(task.max_tokens, task.resume_token_ids.as_deref());
+        // `resume_ids()` normalizes a wire-legal `Some([])` to "not resuming" —
+        // the old `is_some()` predicate forced greedy decode on such a turn.
+        let resume = task.resume_ids().map(<[i32]>::to_vec);
+        if let Some(r) = resume.as_deref() {
+            // Peer-supplied indices reach native prefill; bound them first
+            // (also makes the u32 casts below safe).
+            let vocab = tokenizer.get_vocab_size(true) as u32;
+            if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                let id = task.task_id.clone();
+                return vec![(
+                    id.clone(),
+                    Chunk::error(id, format!("invalid resume prefix: {e}")),
+                )];
+            }
+        }
+        append_resume_ids(&mut prompt_ids, resume.as_deref());
+        // Non-resume keeps the base contract: max_tokens == 0 still yields one
+        // token (`.max(1)`, matching gemma4/qwen36/ov-runtime). Only a RESUMED
+        // turn may land at zero new tokens (budget exhausted by the prefix) —
+        // review found this branch had silently flipped the plain max_tokens=0
+        // behavior from 1 token to 0.
+        let max_new = if resume.is_some() {
+            resume_max_new(task.max_tokens, resume.as_deref())
+        } else {
+            task.max_tokens.max(1) as usize
+        };
         let mut sampling_cfg = sampling_from_task(&task);
         // Option B: a resumed turn MUST decode greedily — sampling would let
         // the continuation diverge from what the client already has. temperature
         // <= 0.0 takes the deterministic argmax path in `sampling::sample`.
-        if task.resume_token_ids.is_some() {
+        if resume.is_some() {
             sampling_cfg.temperature = 0.0;
         }
         if max_new == 0 {
@@ -1492,13 +1516,48 @@ impl SparseMoEEngine {
         // ("hello" + "▁world" -> "helloworld" instead of "hello world").
         // Decode prefix+tail together and slice off the prefix's decoded
         // bytes so the tail keeps its seam spacing.
-        let text = if let Some(resume) = task.resume_token_ids.as_deref() {
-            let prefix_u32: Vec<u32> = resume.iter().map(|&i| i as u32).collect();
-            let prefix_text = tokenizer.decode(&prefix_u32, true).unwrap_or_default();
+        let text = if let Some(r) = resume.as_deref() {
+            let prefix_u32: Vec<u32> = r.iter().map(|&i| i as u32).collect();
+            // Propagate decode errors — `unwrap_or_default()` on the PREFIX
+            // decode made the slice offset 0, re-emitting the entire forced
+            // prefix to the client (the exact defect dist_spec's comment warns
+            // about); on the FULL decode it silently dropped the whole tail.
+            let prefix_text = match tokenizer.decode(&prefix_u32, true) {
+                Ok(t) => t,
+                Err(e) => {
+                    let id = task.task_id.clone();
+                    return vec![(
+                        id.clone(),
+                        Chunk::error(id, format!("resume seed decode failed: {e}")),
+                    )];
+                }
+            };
             let mut full_u32 = prefix_u32;
             full_u32.extend(generated.iter().map(|&i| i as u32));
-            let full_text = tokenizer.decode(&full_u32, true).unwrap_or_default();
-            full_text.get(prefix_text.len()..).unwrap_or("").to_string()
+            let full_text = match tokenizer.decode(&full_u32, true) {
+                Ok(t) => t,
+                Err(e) => {
+                    let id = task.task_id.clone();
+                    return vec![(
+                        id.clone(),
+                        Chunk::error(id, format!("resume tail decode failed: {e}")),
+                    )];
+                }
+            };
+            // Divergence guard: the blind byte-offset slice assumes the prefix
+            // decode is a byte-prefix of the full decode. A byte-level seam
+            // (chain A held back a partial UTF-8 char whose token IS in the
+            // prefix) breaks that: U+FFFD bytes in `prefix_text` resolve to
+            // different bytes in `full_text`, and an unlucky boundary silently
+            // re-emits prefix bytes or drops seam text. Re-anchor instead —
+            // emit only what provably follows the prefix (same contract as the
+            // shim's `advance_emitted`).
+            if full_text.as_bytes().starts_with(prefix_text.as_bytes()) {
+                full_text.get(prefix_text.len()..).unwrap_or("").to_string()
+            } else {
+                warn!(task = %task.task_id, "resume seam diverged; re-anchoring (tail delta dropped)");
+                String::new()
+            }
         } else {
             let ids_u32: Vec<u32> = generated.iter().map(|&i| i as u32).collect();
             let mut t = tokenizer
@@ -1555,13 +1614,43 @@ impl SparseMoEEngine {
         // tokens after the rendered prompt (concat, not replace) — the
         // distributed prefill loop below is agnostic to id origin, so the
         // appended ids prefill naturally. No-op when not resuming.
-        append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
-
-        let max_new = resume_max_new(task.max_tokens, task.resume_token_ids.as_deref());
+        // `resume_ids()` normalizes a wire-legal `Some([])` to "not resuming" —
+        // the old `is_some()` predicate forced greedy decode on such a turn.
+        let resume = task.resume_ids().map(<[i32]>::to_vec);
+        if let Some(r) = resume.as_deref() {
+            // Peer-supplied indices reach native prefill; bound them first
+            // (also makes the u32 casts below safe).
+            // `tok` above is scoped to the prompt_ids block; re-borrow. The
+            // else-branch there already returned when the tokenizer is absent,
+            // so unwrap_or(0) is unreachable-but-safe.
+            let vocab = self
+                .tokenizer
+                .as_ref()
+                .map(|t| t.get_vocab_size(true))
+                .unwrap_or(0) as u32;
+            if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+                let id = task.task_id.clone();
+                return vec![(
+                    id.clone(),
+                    Chunk::error(id, format!("invalid resume prefix: {e}")),
+                )];
+            }
+        }
+        append_resume_ids(&mut prompt_ids, resume.as_deref());
+        // Non-resume keeps the base contract: max_tokens == 0 still yields one
+        // token (`.max(1)`, matching gemma4/qwen36/ov-runtime). Only a RESUMED
+        // turn may land at zero new tokens (budget exhausted by the prefix) —
+        // review found this branch had silently flipped the plain max_tokens=0
+        // behavior from 1 token to 0.
+        let max_new = if resume.is_some() {
+            resume_max_new(task.max_tokens, resume.as_deref())
+        } else {
+            task.max_tokens.max(1) as usize
+        };
         let mut sampling_cfg = sampling_from_task(&task);
         // Option B: force greedy decode on a resumed turn so the continuation
         // is deterministic (see step_single_stage for rationale).
-        if task.resume_token_ids.is_some() {
+        if resume.is_some() {
             sampling_cfg.temperature = 0.0;
         }
         if max_new == 0 {
@@ -1786,13 +1875,48 @@ impl SparseMoEEngine {
         // Option B §17: see step_single_stage for why a resumed turn must
         // decode prefix+tail together (preserves the seam space that a
         // tail-only decode would strip at sequence-start).
-        let text = if let Some(resume) = task.resume_token_ids.as_deref() {
-            let prefix_u32: Vec<u32> = resume.iter().map(|&i| i as u32).collect();
-            let prefix_text = tokenizer.decode(&prefix_u32, true).unwrap_or_default();
+        let text = if let Some(r) = resume.as_deref() {
+            let prefix_u32: Vec<u32> = r.iter().map(|&i| i as u32).collect();
+            // Propagate decode errors — `unwrap_or_default()` on the PREFIX
+            // decode made the slice offset 0, re-emitting the entire forced
+            // prefix to the client (the exact defect dist_spec's comment warns
+            // about); on the FULL decode it silently dropped the whole tail.
+            let prefix_text = match tokenizer.decode(&prefix_u32, true) {
+                Ok(t) => t,
+                Err(e) => {
+                    let id = task.task_id.clone();
+                    return vec![(
+                        id.clone(),
+                        Chunk::error(id, format!("resume seed decode failed: {e}")),
+                    )];
+                }
+            };
             let mut full_u32 = prefix_u32;
             full_u32.extend(result_tokens.iter().map(|&i| i as u32));
-            let full_text = tokenizer.decode(&full_u32, true).unwrap_or_default();
-            full_text.get(prefix_text.len()..).unwrap_or("").to_string()
+            let full_text = match tokenizer.decode(&full_u32, true) {
+                Ok(t) => t,
+                Err(e) => {
+                    let id = task.task_id.clone();
+                    return vec![(
+                        id.clone(),
+                        Chunk::error(id, format!("resume tail decode failed: {e}")),
+                    )];
+                }
+            };
+            // Divergence guard: the blind byte-offset slice assumes the prefix
+            // decode is a byte-prefix of the full decode. A byte-level seam
+            // (chain A held back a partial UTF-8 char whose token IS in the
+            // prefix) breaks that: U+FFFD bytes in `prefix_text` resolve to
+            // different bytes in `full_text`, and an unlucky boundary silently
+            // re-emits prefix bytes or drops seam text. Re-anchor instead —
+            // emit only what provably follows the prefix (same contract as the
+            // shim's `advance_emitted`).
+            if full_text.as_bytes().starts_with(prefix_text.as_bytes()) {
+                full_text.get(prefix_text.len()..).unwrap_or("").to_string()
+            } else {
+                warn!(task = %task.task_id, "resume seam diverged; re-anchoring (tail delta dropped)");
+                String::new()
+            }
         } else {
             let ids_u32: Vec<u32> = result_tokens.iter().map(|&i| i as u32).collect();
             let mut t = tokenizer

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1098,8 +1098,20 @@ fn worker_should_report_disconnect(peer_disconnected: bool, already_reported: bo
 /// (split out, same as `prefill_reply_budget` below, purely so a test can pin
 /// "prefill exceeds per-token" against the real function instead of a
 /// disconnected literal). Pure, for testing.
+/// Hard ceiling on the decode-phase token-reply wait, independent of the
+/// operator-tunable `recv_timeout` — mirror of ov-runtime's issue-#40
+/// `TOKEN_RECV_DEADLINE_CEILING`. The rig certs legitimately export
+/// `CASCADIA_ACTIVATION_TIMEOUT_SECS=600` for slow cold prefills; uncapped,
+/// that became THIS budget, and a 600 s bound never beats the gateway's 180 s
+/// inter-token deadline — the tail-kill stall surfaced as a gateway Stall
+/// with nothing for the resume splicer to rescue (rig 2026-08-28, sparse-moe
+/// resume cert at 021a14c2: the bound was armed but had not elapsed). A token
+/// REPLY of an active generation has a tight real deadline regardless of how
+/// slow prefill is allowed to be.
+const TOKEN_RECV_DEADLINE_CEILING: std::time::Duration = std::time::Duration::from_secs(120);
+
 fn per_token_reply_budget(recv_timeout: std::time::Duration) -> std::time::Duration {
-    recv_timeout
+    recv_timeout.min(TOKEN_RECV_DEADLINE_CEILING)
 }
 
 /// Safety margin the clamped prefill budget must stay under the frame-idle
@@ -6336,6 +6348,22 @@ mod tests {
             prefill_reply_budget(recv_timeout, None),
             std::time::Duration::from_secs(600)
         );
+    }
+
+    #[test]
+    fn per_token_budget_beats_the_gateway_inter_token_deadline() {
+        // The rig resume certs export CASCADIA_ACTIVATION_TIMEOUT_SECS=600
+        // for slow cold prefills. The DECODE reply bound must stay under the
+        // gateway's 180 s inter-token deadline anyway, or a dead downstream
+        // stalls to a gateway Stall with nothing for the resume splicer to
+        // rescue (rig 2026-08-28: 600 s armed-but-unelapsed == the pre-fix
+        // signature, byte for byte).
+        let rig = std::time::Duration::from_secs(600);
+        assert_eq!(per_token_reply_budget(rig), TOKEN_RECV_DEADLINE_CEILING);
+        assert!(per_token_reply_budget(rig) < std::time::Duration::from_secs(180));
+        // The default stays untouched below the ceiling.
+        let dflt = std::time::Duration::from_secs(60);
+        assert_eq!(per_token_reply_budget(dflt), dflt);
     }
 
     #[test]

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1003,6 +1003,19 @@ pub struct ResumeSeed {
     pub seed_text: String,
 }
 
+/// Exclusive id bound for `validate_resume_ids`: max assigned id + 1 — NOT
+/// `get_vocab_size(true)`, which returns the ENTRY COUNT and under-counts the
+/// bound on a sparse vocab (added tokens with gapped ids), wrongly rejecting
+/// legitimate resume ids. Falls back to the count for an empty vocab map.
+fn resume_vocab_bound(tok: &tokenizers::Tokenizer) -> u32 {
+    tok.get_vocab(true)
+        .values()
+        .max()
+        .map(|&m| m.saturating_add(1))
+        .unwrap_or(0)
+        .max(tok.get_vocab_size(true) as u32)
+}
+
 #[doc(hidden)]
 pub fn prepare_resume(
     task: &GenerationTask,
@@ -1012,7 +1025,7 @@ pub fn prepare_resume(
     let Some(r) = task.resume_ids() else {
         return Ok(None);
     };
-    let vocab = tokenizer.get_vocab_size(true) as u32;
+    let vocab = resume_vocab_bound(tokenizer);
     cascadia_types::validate_resume_ids(r, Some(vocab))
         .map_err(|e| format!("invalid resume prefix: {e}"))?;
     cascadia_types::append_resume_ids(prompt_ids_i64, Some(r));
@@ -1511,7 +1524,7 @@ impl SparseMoEEngine {
         if let Some(r) = resume.as_deref() {
             // Peer-supplied indices reach native prefill; bound them first
             // (also makes the u32 casts below safe).
-            let vocab = tokenizer.get_vocab_size(true) as u32;
+            let vocab = resume_vocab_bound(tokenizer);
             if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
                 let id = task.task_id.clone();
                 return vec![(

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -2765,6 +2765,13 @@ impl SparseMoEEngine {
     #[cfg(feature = "kv_coord")]
     fn capture_under_epoch(&mut self, tenant: &str, epoch: u64, tokens: Vec<i32>) {
         if !self.kv_prefix_cache.enabled() {
+            // The CAPTURE handler acks upstream regardless, so a skip here is otherwise invisible:
+            // the head believes every stage captured while this rank stored nothing and every
+            // later GET for its slice answers `get_none`.
+            warn!(
+                rank = self.rank,
+                epoch, "kv capture skipped: prefix cache disabled (capacity 0) — ack still sent"
+            );
             return;
         }
         let snap = match self.runner.snapshot_kv() {
@@ -2797,6 +2804,8 @@ impl SparseMoEEngine {
             g.captures
                 .insert(epoch, (tenant.to_string(), tokens.clone(), snap.clone()));
         }
+        tracing::info!(target: "cascadia::kv", event = "kv_capture_stored",
+            rank = self.rank, epoch, n_tokens = tokens.len(), past_seq_len = snap.past_seq_len);
         self.kv_capture
             .insert(epoch, (tenant.to_string(), tokens, snap));
     }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1461,13 +1461,30 @@ impl SparseMoEEngine {
             }
         };
         let n_tokens = generated.len() as u32;
-        let ids_u32: Vec<u32> = generated.iter().map(|&i| i as u32).collect();
-        let mut text = tokenizer
-            .decode(&ids_u32, true)
-            .unwrap_or_else(|_| String::new());
-        if let Some(stripped) = text.strip_prefix(&task.prompt) {
-            text = stripped.trim_start().to_string();
-        }
+        // Option B §17: decoding `generated` in isolation puts the first new
+        // token at sequence-start, so SentencePiece/Metaspace strips its
+        // leading space — fine for a fresh turn, but on a resumed turn the
+        // tail CONTINUES the prefix and that dropped space corrupts the seam
+        // ("hello" + "▁world" -> "helloworld" instead of "hello world").
+        // Decode prefix+tail together and slice off the prefix's decoded
+        // bytes so the tail keeps its seam spacing.
+        let text = if let Some(resume) = task.resume_token_ids.as_deref() {
+            let prefix_u32: Vec<u32> = resume.iter().map(|&i| i as u32).collect();
+            let prefix_text = tokenizer.decode(&prefix_u32, true).unwrap_or_default();
+            let mut full_u32 = prefix_u32;
+            full_u32.extend(generated.iter().map(|&i| i as u32));
+            let full_text = tokenizer.decode(&full_u32, true).unwrap_or_default();
+            full_text.get(prefix_text.len()..).unwrap_or("").to_string()
+        } else {
+            let ids_u32: Vec<u32> = generated.iter().map(|&i| i as u32).collect();
+            let mut t = tokenizer
+                .decode(&ids_u32, true)
+                .unwrap_or_else(|_| String::new());
+            if let Some(stripped) = t.strip_prefix(&task.prompt) {
+                t = stripped.trim_start().to_string();
+            }
+            t
+        };
         let elapsed = started.elapsed().as_secs_f64();
         info!(
             task = %task.task_id,
@@ -1722,7 +1739,6 @@ impl SparseMoEEngine {
         }
 
         let n_tokens = result_tokens.len() as u32;
-        let ids_u32: Vec<u32> = result_tokens.iter().map(|&i| i as u32).collect();
         let Some(tokenizer) = self.tokenizer.as_ref() else {
             warn!("tokenizer disappeared mid-task");
             return vec![(
@@ -1730,12 +1746,26 @@ impl SparseMoEEngine {
                 Chunk::error(task.task_id, "tokenizer disappeared mid-task".to_string()),
             )];
         };
-        let mut text = tokenizer
-            .decode(&ids_u32, true)
-            .unwrap_or_else(|_| String::new());
-        if let Some(stripped) = text.strip_prefix(&task.prompt) {
-            text = stripped.trim_start().to_string();
-        }
+        // Option B §17: see step_single_stage for why a resumed turn must
+        // decode prefix+tail together (preserves the seam space that a
+        // tail-only decode would strip at sequence-start).
+        let text = if let Some(resume) = task.resume_token_ids.as_deref() {
+            let prefix_u32: Vec<u32> = resume.iter().map(|&i| i as u32).collect();
+            let prefix_text = tokenizer.decode(&prefix_u32, true).unwrap_or_default();
+            let mut full_u32 = prefix_u32;
+            full_u32.extend(result_tokens.iter().map(|&i| i as u32));
+            let full_text = tokenizer.decode(&full_u32, true).unwrap_or_default();
+            full_text.get(prefix_text.len()..).unwrap_or("").to_string()
+        } else {
+            let ids_u32: Vec<u32> = result_tokens.iter().map(|&i| i as u32).collect();
+            let mut t = tokenizer
+                .decode(&ids_u32, true)
+                .unwrap_or_else(|_| String::new());
+            if let Some(stripped) = t.strip_prefix(&task.prompt) {
+                t = stripped.trim_start().to_string();
+            }
+            t
+        };
         let elapsed = started.elapsed().as_secs_f64();
         info!(
             task = %task.task_id,

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -2150,12 +2150,26 @@ impl SparseMoEEngine {
             a.generated.push(next_u);
             a.history.push(next);
         }
-        let full = self
+        // A decode Err must NOT fall through as "" — utf8_safe_delta would
+        // reset `emitted` to 0 and the next successful decode would re-emit
+        // the whole turn (on a resumed turn: the forced prefix). Terminal
+        // error chunk, same shape as the forward-failure arm below.
+        let full = match self
             .tokenizer
             .as_ref()
             .unwrap()
             .decode(&self.active.as_ref().unwrap().generated, true)
-            .unwrap_or_default();
+        {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(task = %id, "mid-stream decode failed; surfacing error: {e}");
+                self.active = None;
+                return vec![(
+                    id.clone(),
+                    Chunk::error(id, format!("mid-stream decode failed: {e}")),
+                )];
+            }
+        };
         let delta = {
             let a = self.active.as_mut().unwrap();
             // One-shot Option-B seam guard (mirror of the single-stage
@@ -3976,12 +3990,26 @@ impl OvMoeEngine {
             let a = self.active_ov.as_mut().unwrap();
             a.generated.push(next_u);
         }
-        let full = self
+        // A decode Err must NOT fall through as "" — utf8_safe_delta would
+        // reset `emitted` to 0 and the next successful decode would re-emit
+        // the whole turn (on a resumed turn: the forced prefix). Terminal
+        // error chunk, same shape as the forward-failure arm below.
+        let full = match self
             .tokenizer
             .as_ref()
             .unwrap()
             .decode(&self.active_ov.as_ref().unwrap().generated, true)
-            .unwrap_or_default();
+        {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(task = %id, "mid-stream decode failed; surfacing error: {e}");
+                self.active_ov = None;
+                return vec![(
+                    id.clone(),
+                    Chunk::error(id, format!("mid-stream decode failed: {e}")),
+                )];
+            }
+        };
         let delta = {
             let a = self.active_ov.as_mut().unwrap();
             // One-shot Option-B seam guard (mirror of the single-stage

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1884,53 +1884,87 @@ impl SparseMoEEngine {
             // cache (warm-pull degrades to cold) and never affects the already-complete served output.
             #[cfg(feature = "kv_coord")]
             if self.kv_prefix_cache.enabled() && !result_tokens.is_empty() {
-                let mut full_tokens: Vec<i32> = prompt_ids.iter().map(|&t| t as i32).collect();
-                full_tokens.extend(result_tokens.iter().map(|&t| t as i32));
-                let epoch = crate::kv_coordination::synth_epoch(&full_tokens);
-                // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and the only
-                // ceiling otherwise is the transport frame-idle default — reached before this turn's
-                // already-complete chunks are returned. Timeout ⇒ capture skipped, turn delivered.
-                let acked = self.block_on(async {
-                    match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
-                        send_capture(&downstream, epoch, &full_tokens, &task.tenant)
-                            .await
-                            .map_err(|e| format!("send_capture: {e}"))?;
-                        match recv_kind_client(&downstream).await {
-                            Ok(Some(FrameKind::CaptureAck)) => {
-                                recv_capture_ack_body_client(&downstream)
-                                    .await
-                                    .map(|_| ())
-                                    .map_err(|e| format!("recv_capture_ack: {e}"))
+                // Snapshot FIRST and key the epoch over `full_tokens[..depth]` — the prefix the KV
+                // actually covers. Test-before-push EOS semantics leave the final sampled token
+                // un-pushed, so the turn's token vector runs one LONGER than the KV: an epoch over
+                // the full vector can never match a later NEGOTIATE's offer epoch (computed over
+                // `tokens[..past_seq_len]`), and every worker GET answers `get_none`. Mirrors the
+                // OvMoe multi-stage site, which had this right.
+                match self.runner.snapshot_kv() {
+                    Ok(snap) => {
+                        let depth = snap.past_seq_len;
+                        let mut full_tokens: Vec<i32> =
+                            prompt_ids.iter().map(|&t| t as i32).collect();
+                        full_tokens.extend(result_tokens.iter().map(|&t| t as i32));
+                        if depth >= 1 && depth <= full_tokens.len() {
+                            let captured: Vec<i32> = full_tokens[..depth].to_vec();
+                            let epoch = crate::kv_coordination::synth_epoch(&captured);
+                            // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and
+                            // the only ceiling otherwise is the transport frame-idle default —
+                            // reached before this turn's already-complete chunks are returned.
+                            // Timeout ⇒ capture skipped, turn delivered.
+                            let acked = self.block_on(async {
+                                match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
+                                    send_capture(&downstream, epoch, &captured, &task.tenant)
+                                        .await
+                                        .map_err(|e| format!("send_capture: {e}"))?;
+                                    match recv_kind_client(&downstream).await {
+                                        Ok(Some(FrameKind::CaptureAck)) => {
+                                            recv_capture_ack_body_client(&downstream)
+                                                .await
+                                                .map(|_| ())
+                                                .map_err(|e| format!("recv_capture_ack: {e}"))
+                                        }
+                                        Ok(Some(other)) => {
+                                            Err(format!("expected CaptureAck, got {other:?}"))
+                                        }
+                                        Ok(None) => {
+                                            Err("downstream closed during capture".to_string())
+                                        }
+                                        Err(e) => Err(format!("recv_kind (capture): {e}")),
+                                    }
+                                })
+                                .await
+                                {
+                                    Ok(r) => r,
+                                    Err(_) => {
+                                        // Same hazard recv_token_reply drops the socket for: the
+                                        // peer is usually alive and its CaptureAck (no sequence
+                                        // number) lands after we stopped waiting — a reused
+                                        // connection hands it to the NEXT exchange as its reply.
+                                        downstream.lock().await.close().await;
+                                        Err(format!(
+                                            "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
+                                             connection dropped to avoid reading the late ack as \
+                                             the next exchange's reply"
+                                        ))
+                                    }
+                                }
+                            });
+                            match acked {
+                                Ok(()) => {
+                                    let fp = self.runner.fingerprint();
+                                    let prompt64: Vec<i64> =
+                                        captured.iter().map(|&t| i64::from(t)).collect();
+                                    // Mirror into the holder cache so a busy engine still serves
+                                    // this prefix.
+                                    self.kv_share
+                                        .lock()
+                                        .unwrap_or_else(|e| e.into_inner())
+                                        .prefix
+                                        .insert(prompt64.clone(), &fp, snap.clone());
+                                    self.kv_prefix_cache.insert(prompt64, &fp, snap);
+                                }
+                                Err(e) => {
+                                    warn!(task = %task.task_id, "kv multi-stage capture skipped: {e}")
+                                }
                             }
-                            Ok(Some(other)) => Err(format!("expected CaptureAck, got {other:?}")),
-                            Ok(None) => Err("downstream closed during capture".into()),
-                            Err(e) => Err(format!("recv_kind (capture): {e}")),
-                        }
-                    })
-                    .await
-                    {
-                        Ok(r) => r,
-                        Err(_) => Err(format!(
-                            "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}"
-                        )),
-                    }
-                });
-                match acked {
-                    Ok(()) => {
-                        if let Ok(snap) = self.runner.snapshot_kv() {
-                            let fp = self.runner.fingerprint();
-                            let prompt64: Vec<i64> =
-                                full_tokens.iter().map(|&t| i64::from(t)).collect();
-                            // Mirror into the holder cache so a busy engine still serves this prefix.
-                            self.kv_share
-                                .lock()
-                                .unwrap_or_else(|e| e.into_inner())
-                                .prefix
-                                .insert(prompt64.clone(), &fp, snap.clone());
-                            self.kv_prefix_cache.insert(prompt64, &fp, snap);
+                        } else {
+                            warn!(task = %task.task_id, depth, full_len = full_tokens.len(),
+                                "kv capture skipped: KV depth outside token range");
                         }
                     }
-                    Err(e) => warn!(task = %task.task_id, "kv multi-stage capture skipped: {e}"),
+                    Err(e) => warn!(task = %task.task_id, "kv capture: snapshot_kv failed: {e}"),
                 }
             }
 
@@ -2179,62 +2213,83 @@ impl SparseMoEEngine {
         let should_capture = capture && n_new > 0;
         #[cfg(feature = "kv_coord")]
         if should_capture && self.kv_prefix_cache.enabled() {
-            let mut full_tokens: Vec<i32> = a.prompt_ids.iter().map(|&t| t as i32).collect();
-            full_tokens.extend(a.generated[a.resume_seed_len..].iter().map(|&t| t as i32));
-            let epoch = crate::kv_coordination::synth_epoch(&full_tokens);
-            // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and the only
-            // ceiling otherwise is the transport frame-idle default — reached before this turn's
-            // already-complete chunks are returned. Timeout ⇒ capture skipped, turn delivered.
-            let acked = self.block_on(async {
-                match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
-                    send_capture(&a.downstream, epoch, &full_tokens, &a.tenant)
-                        .await
-                        .map_err(|e| format!("send_capture: {e}"))?;
-                    match recv_kind_client(&a.downstream).await {
-                        Ok(Some(FrameKind::CaptureAck)) => {
-                            recv_capture_ack_body_client(&a.downstream)
-                                .await
-                                .map(|_| ())
-                                .map_err(|e| format!("recv_capture_ack: {e}"))
+            // Snapshot FIRST and key the epoch over `full_tokens[..depth]` — the prefix the KV
+            // actually covers. Test-before-push EOS semantics leave the final sampled token
+            // un-pushed, so the turn's token vector runs one LONGER than the KV: an epoch over the
+            // full vector can never match a later NEGOTIATE's offer epoch (computed over
+            // `tokens[..past_seq_len]`), and every worker GET answers `get_none`. Mirrors the OvMoe
+            // multi-stage site, which had this right.
+            match self.runner.snapshot_kv() {
+                Ok(snap) => {
+                    let depth = snap.past_seq_len;
+                    let mut full_tokens: Vec<i32> =
+                        a.prompt_ids.iter().map(|&t| t as i32).collect();
+                    full_tokens.extend(a.generated[a.resume_seed_len..].iter().map(|&t| t as i32));
+                    if depth >= 1 && depth <= full_tokens.len() {
+                        let captured: Vec<i32> = full_tokens[..depth].to_vec();
+                        let epoch = crate::kv_coordination::synth_epoch(&captured);
+                        // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and
+                        // the only ceiling otherwise is the transport frame-idle default — reached
+                        // before this turn's already-complete chunks are returned. Timeout ⇒
+                        // capture skipped, turn delivered.
+                        let acked = self.block_on(async {
+                            match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
+                                send_capture(&a.downstream, epoch, &captured, &a.tenant)
+                                    .await
+                                    .map_err(|e| format!("send_capture: {e}"))?;
+                                match recv_kind_client(&a.downstream).await {
+                                    Ok(Some(FrameKind::CaptureAck)) => {
+                                        recv_capture_ack_body_client(&a.downstream)
+                                            .await
+                                            .map(|_| ())
+                                            .map_err(|e| format!("recv_capture_ack: {e}"))
+                                    }
+                                    Ok(Some(other)) => {
+                                        Err(format!("expected CaptureAck, got {other:?}"))
+                                    }
+                                    Ok(None) => Err("downstream closed during capture".into()),
+                                    Err(e) => Err(format!("recv_kind (capture): {e}")),
+                                }
+                            })
+                            .await
+                            {
+                                Ok(r) => r,
+                                Err(_) => {
+                                    // Same hazard recv_token_reply drops the socket for: the
+                                    // peer is usually alive and its CaptureAck (no sequence
+                                    // number) lands after we stopped waiting — a reused
+                                    // connection hands it to the NEXT exchange as its reply.
+                                    a.downstream.lock().await.close().await;
+                                    Err(format!(
+                                        "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
+                                         connection dropped to avoid reading the late ack as \
+                                         the next exchange's reply"
+                                    ))
+                                }
+                            }
+                        });
+                        match acked {
+                            Ok(()) => {
+                                let fp = self.runner.fingerprint();
+                                let prompt64: Vec<i64> =
+                                    captured.iter().map(|&t| i64::from(t)).collect();
+                                // Mirror into the holder cache so a busy engine still serves this
+                                // prefix.
+                                self.kv_share
+                                    .lock()
+                                    .unwrap_or_else(|e| e.into_inner())
+                                    .prefix
+                                    .insert(prompt64.clone(), &fp, snap.clone());
+                                self.kv_prefix_cache.insert(prompt64, &fp, snap);
+                            }
+                            Err(e) => warn!(task = %a.id, "kv multi-stage capture skipped: {e}"),
                         }
-                        Ok(Some(other)) => Err(format!("expected CaptureAck, got {other:?}")),
-                        Ok(None) => Err("downstream closed during capture".into()),
-                        Err(e) => Err(format!("recv_kind (capture): {e}")),
-                    }
-                })
-                .await
-                {
-                    Ok(r) => r,
-                    Err(_) => {
-                        // Same hazard recv_token_reply drops the socket for: the peer is
-                        // usually alive and its CaptureAck (no sequence number) lands after
-                        // we stopped waiting — a reused connection hands it to the NEXT
-                        // exchange as its reply.
-                        a.downstream.lock().await.close().await;
-                        Err(format!(
-                            "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
-                             connection dropped to avoid reading the late ack as the next \
-                             exchange's reply"
-                        ))
+                    } else {
+                        warn!(task = %a.id, depth, full_len = full_tokens.len(),
+                            "kv capture skipped: KV depth outside token range");
                     }
                 }
-            });
-            match acked {
-                Ok(()) => {
-                    if let Ok(snap) = self.runner.snapshot_kv() {
-                        let fp = self.runner.fingerprint();
-                        let prompt64: Vec<i64> =
-                            full_tokens.iter().map(|&t| i64::from(t)).collect();
-                        // Mirror into the holder cache so a busy engine still serves this prefix.
-                        self.kv_share
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .prefix
-                            .insert(prompt64.clone(), &fp, snap.clone());
-                        self.kv_prefix_cache.insert(prompt64, &fp, snap);
-                    }
-                }
-                Err(e) => warn!(task = %a.id, "kv multi-stage capture skipped: {e}"),
+                Err(e) => warn!(task = %a.id, "kv capture: snapshot_kv failed: {e}"),
             }
         }
         let elapsed = a.started.elapsed().as_secs_f64();

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1350,8 +1350,8 @@ impl Engine for SparseMoEEngine {
         // loop (architectural follow-up).
         if self.active.as_ref().is_some_and(|a| &a.id == task_id) {
             self.active = None; // free the slot; a zombie here never trips the
-                                 // runner's empty-step guard (lib.rs:1006 counts
-                                 // produced before the cancelled-filter)
+                                // runner's empty-step guard (lib.rs:1006 counts
+                                // produced before the cancelled-filter)
         }
         self.pending.retain(|t| &t.task_id != task_id);
     }
@@ -2137,7 +2137,10 @@ impl SparseMoEEngine {
                 self.active = None;
                 vec![
                     (id.clone(), token_chunk),
-                    (id.clone(), Chunk::error(id, format!("decode forward failed: {e}"))),
+                    (
+                        id.clone(),
+                        Chunk::error(id, format!("decode forward failed: {e}")),
+                    ),
                 ]
             }
         }
@@ -3266,6 +3269,30 @@ const OV_MAX_PENDING: usize = 64;
 ///   upstream. The wire protocol is the engine-agnostic [`crate::dist`]
 ///   one the K2.6 path uses (Forward / Reset / Token frames). No
 ///   spec-decode (M2 sends only per-token Forward frames).
+/// In-flight OvMoe (MiniMax-M2) multi-stage generation, streamed one token
+/// per `step()`. Mirrors `SparseActive`, but `forward_one_token_first` here
+/// takes `(token, pos)` rather than a `history` slice, so we track `pos`
+/// directly instead of replaying history.
+struct OvMoeActive {
+    id: TaskId,
+    downstream: Arc<TokioMutex<ActivationClient>>,
+    cfg: crate::sampling::SamplingConfig,
+    eos: Vec<u32>,
+    max_new: usize,
+    started: Instant,
+    /// Generated ids INCLUDING the resume seed (positions [0, seed_len)).
+    /// OvMoe INCLUDES EOS in this accumulator (push-then-test).
+    generated: Vec<u32>,
+    emitted: usize,
+    resume_seed_len: usize,
+    /// The token to feed on the next decode_step (sampled by the last rank).
+    next: i64,
+    pos: usize,
+    /// prompt ++ resume-prefix (already includes the appended seed).
+    prompt_ids: Vec<u32>,
+    tenant: String,
+}
+
 pub struct OvMoeEngine {
     runner: OvMoeRunner,
     tokenizer: Option<Tokenizer>,
@@ -3318,6 +3345,8 @@ pub struct OvMoeEngine {
     /// `step()` — so it only parks bytes here and the recv loop drains them at `RESTORE`.
     #[cfg(feature = "kv_coord")]
     kv_handoff_mailbox: std::sync::Arc<cascadia_engine::kv_handoff::KvHandoffMailbox>,
+    /// In-flight multi-stage generation, streamed one token per `step()`.
+    active_ov: Option<OvMoeActive>,
 }
 
 impl OvMoeEngine {
@@ -3368,6 +3397,7 @@ impl OvMoeEngine {
             kv_handoff_mailbox: std::sync::Arc::new(
                 cascadia_engine::kv_handoff::KvHandoffMailbox::new(),
             ),
+            active_ov: None,
         }
     }
 
@@ -3431,6 +3461,21 @@ impl OvMoeEngine {
             let e = Chunk::error(task.task_id.clone(), "engine has no tokenizer".to_string());
             return vec![(task.task_id, e)];
         };
+        if task.resume_ids().is_some() {
+            // Option B: this path has no resume implementation — silently dropping
+            // the prefix would regenerate from scratch and the gateway would splice
+            // that after the client's prefix (spec §4.2). Decline; the scheduler's
+            // B6 retry excludes this peer and re-routes.
+            let id = task.task_id.clone();
+            return vec![(
+                id.clone(),
+                Chunk::error(
+                    id,
+                    "resume_unsupported: minimax single-stage has no forced-prefix path"
+                        .to_string(),
+                ),
+            )];
+        }
         let started = Instant::now();
         let prompt_ids: Vec<u32> = match tok.encode(task.prompt.as_str(), true) {
             Ok(enc) => enc.get_ids().to_vec(),
@@ -3536,24 +3581,47 @@ impl OvMoeEngine {
         })
     }
 
-    /// Rank-0 pipeline driver: tokenize, reset the ring, drive prefill +
-    /// decode one token per wire round-trip, decode, emit one final chunk.
+    /// Rank 0 driver: token-streaming state machine (mirrors
+    /// `SparseMoEEngine::step_first`/`begin_generation_sparse`/
+    /// `decode_step_sparse`) — one active task at a time; queued tasks wait
+    /// in `pending`. Streamed replacement for the deleted whole-turn
+    /// pipeline driver.
     fn step_first(&mut self) -> Vec<(TaskId, Chunk)> {
+        if self.active_ov.is_none() {
+            if let Some(terminal) = self.begin_generation_ovmoe() {
+                return terminal;
+            }
+        }
+        self.decode_step_ovmoe()
+    }
+
+    /// Admit the next pending task and drive it through prefill. Only the
+    /// LAST prefill step samples a token (others go as ForwardNoSample so
+    /// discarded prefill tokens never pollute the last rank's penalty
+    /// history), so prefill is unavoidably whole-turn work; decode after that
+    /// streams one token per `step()` via `decode_step_ovmoe`. Returns `Some`
+    /// for every terminal outcome that doesn't reach decode (errors, empty
+    /// prompt, the zero-budget resume case); `None` means `self.active_ov` is
+    /// now armed.
+    fn begin_generation_ovmoe(&mut self) -> Option<Vec<(TaskId, Chunk)>> {
         let task = match self.pending.pop_front() {
             Some(t) => t,
-            None => return Vec::new(),
+            None => return Some(Vec::new()),
         };
         #[cfg(feature = "kv_coord")]
         self.kv_set_turn_tenant(&task.tenant);
         let id = task.task_id.clone();
         let Some(downstream) = self.transport.downstream.clone() else {
             warn!(task = %id, "rank 0 has no downstream; cannot drive pipeline");
-            return vec![(id.clone(), Chunk::error(id, "rank 0 missing downstream"))];
+            return Some(vec![(
+                id.clone(),
+                Chunk::error(id, "rank 0 missing downstream"),
+            )]);
         };
         if self.tokenizer.is_none() {
             warn!(task = %id, "MiniMax-M2 rank 0 has no tokenizer");
             let e = Chunk::error(id.clone(), "engine has no tokenizer".to_string());
-            return vec![(id, e)];
+            return Some(vec![(id, e)]);
         }
         let started = Instant::now();
         let prompt_ids: Vec<u32> = match self
@@ -3565,24 +3633,68 @@ impl OvMoeEngine {
             Ok(enc) => enc.get_ids().to_vec(),
             Err(e) => {
                 warn!(task = %id, "tokenizer encode failed: {e}");
-                return vec![(
+                return Some(vec![(
                     id.clone(),
                     Chunk::error(id, format!("tokenizer encode failed: {e}")),
-                )];
+                )]);
             }
         };
         if prompt_ids.is_empty() {
-            return vec![(id.clone(), Chunk::final_marker(id, ""))];
+            return Some(vec![(id.clone(), Chunk::final_marker(id, ""))]);
         }
-        let max_new = task.max_tokens.max(1) as usize;
-        let cfg = sampling_from_task(&task);
+        // Option B forced-prefix resume: append the already-emitted assistant
+        // tokens after the rendered prompt (concat, not replace) and seed the
+        // streaming accumulator from them. `prepare_resume` works in i64 —
+        // OvMoe's prompt ids are u32, so round-trip at this boundary.
+        let mut prompt64: Vec<i64> = prompt_ids.iter().map(|&t| i64::from(t)).collect();
+        let mut seed_opt = match self
+            .tokenizer
+            .as_ref()
+            .map(|t| prepare_resume(&task, t, &mut prompt64))
+            .unwrap() // tokenizer presence already checked above
+        {
+            Ok(s) => s,
+            Err(e) => {
+                let id = task.task_id.clone();
+                return Some(vec![(id.clone(), Chunk::error(id, e))]);
+            }
+        };
+        if seed_opt.is_some() {
+            info!(task = %id, event = "resume_admitted",
+                  seed_len = seed_opt.as_ref().unwrap().seed_len,
+                  "Option B resume admitted (MiniMax-M2 pipeline-parallel, streamed)");
+        }
+        let prompt_ids: Vec<u32> = prompt64.iter().map(|&t| t as u32).collect(); // validated in-vocab
+
+        // Non-resume keeps the base contract: max_tokens == 0 still yields one
+        // token (`.max(1)`). Only a RESUMED turn may land at zero new tokens
+        // (budget exhausted by the prefix).
+        let max_new = if seed_opt.is_some() {
+            resume_max_new(task.max_tokens, task.resume_ids())
+        } else {
+            task.max_tokens.max(1) as usize
+        };
+        let mut cfg = sampling_from_task(&task);
+        // Option B: a resumed turn MUST decode greedily — sampling would let
+        // the continuation diverge from what the client already has.
+        if seed_opt.is_some() {
+            cfg.temperature = 0.0;
+        }
+        if max_new == 0 {
+            // Budget exhausted by the resume prefix. The decode loop below pushes
+            // BEFORE testing (spec §4.2): entering it would emit one token.
+            let mut chunk = Chunk::final_marker(id.clone(), "");
+            chunk.n_tokens = Some(0);
+            chunk.finish_reason = Some(FinishReason::Length);
+            return Some(vec![(id, chunk)]);
+        }
         let eos = self.runner.eos_token_ids().to_vec();
 
         // Reset KV across the whole pipeline before the new generation.
         self.runner.reset();
         if let Err(e) = self.block_on(send_reset(&downstream)) {
             warn!(task = %id, "send_reset failed: {e}");
-            return vec![(id.clone(), Chunk::error(id, format!("reset: {e}")))];
+            return Some(vec![(id.clone(), Chunk::error(id, format!("reset: {e}")))]);
         }
 
         // Issue-34 consume (§8): same-chain warm-resume. On a kv-prefix-cache hit, restore the head's
@@ -3619,10 +3731,10 @@ impl OvMoeEngine {
                         self.runner.reset();
                         if let Err(e) = self.block_on(send_reset(&downstream)) {
                             warn!(task = %id, "cold-fallback send_reset: {e}");
-                            return vec![(
+                            return Some(vec![(
                                 id.clone(),
                                 Chunk::error(id, format!("cold-fallback send_reset: {e}")),
-                            )];
+                            )]);
                         }
                         0
                     }
@@ -3635,13 +3747,15 @@ impl OvMoeEngine {
         #[cfg(not(feature = "kv_coord"))]
         let warm_prefix: usize = 0;
 
-        // Prefill: feed every prompt token past the warm-resumed prefix. The
-        // sample produced after the LAST prompt token is the first generated
-        // token — matching `OvMoeRunner::generate_timed`. Intermediate steps go
-        // as ForwardNoSample so their discarded tokens never enter the last
-        // rank's penalty history (see FrameKind::ForwardNoSample). The cache
-        // lookup guarantees `warm_prefix < prompt_ids.len()`, so a suffix token
-        // always follows.
+        // Prefill: feed every prompt token past the warm-resumed prefix
+        // (which now includes the appended resume prefix — the prefill loop
+        // is agnostic to id origin, so it force-prefills the resume ids
+        // naturally). The sample produced after the LAST prompt token is the
+        // first generated token — matching `OvMoeRunner::generate_timed`.
+        // Intermediate steps go as ForwardNoSample so their discarded tokens
+        // never enter the last rank's penalty history (see
+        // FrameKind::ForwardNoSample). The cache lookup guarantees
+        // `warm_prefix < prompt_ids.len()`, so a suffix token always follows.
         let mut pos = warm_prefix;
         let mut next: i64 = -1;
         let n_prompt = prompt_ids.len();
@@ -3651,31 +3765,118 @@ impl OvMoeEngine {
                 Ok(tok_back) => next = tok_back,
                 Err(e) => {
                     warn!(task = %id, "prefill forward failed: {e}");
-                    return vec![(id.clone(), Chunk::error(id, e))];
+                    return Some(vec![(id.clone(), Chunk::error(id, e))]);
                 }
             }
             pos += 1;
         }
 
-        // Decode: like generate_timed, push the token then stop on max_new
-        // or EOS (the EOS token is included in the output).
-        let mut generated: Vec<u32> = Vec::with_capacity(max_new);
-        loop {
-            let next_u = next as u32;
-            generated.push(next_u);
-            if generated.len() >= max_new || eos.contains(&next_u) {
-                break;
-            }
-            match self.forward_one_token_first(next_u, pos, &cfg, &downstream, true) {
-                Ok(tok_back) => next = tok_back,
-                Err(e) => {
-                    warn!(task = %id, "decode forward failed; emitting partial output: {e}");
-                    break;
-                }
-            }
-            pos += 1;
-        }
+        // Non-spec path: PREFILL ONLY. `next` is the first generated token
+        // (stashed below); `decode_step_ovmoe` pushes it (OvMoe INCLUDES
+        // EOS — push-then-test) and drives every token after on the
+        // following `step()` calls.
+        let (generated, emitted, resume_seed_len) = match seed_opt.take() {
+            Some(s) => (s.generated_u32, s.emitted, s.seed_len),
+            None => (Vec::with_capacity(max_new), 0usize, 0usize),
+        };
+        self.active_ov = Some(OvMoeActive {
+            id: id.clone(),
+            downstream,
+            cfg,
+            eos,
+            max_new,
+            started,
+            generated,
+            emitted,
+            resume_seed_len,
+            next,
+            pos,
+            prompt_ids,
+            tenant: task.tenant.clone(),
+        });
+        None
+    }
 
+    /// Emit one token from the in-flight task, or finalize when it ends.
+    /// OvMoe INCLUDES the EOS token (push-then-test, old monolithic decode
+    /// loop's `generated.push(next_u)` BEFORE the `eos.contains` check) —
+    /// deliberately the opposite order from `decode_step_sparse`'s exclusion.
+    fn decode_step_ovmoe(&mut self) -> Vec<(TaskId, Chunk)> {
+        let (id, next) = {
+            let a = self.active_ov.as_ref().unwrap();
+            (a.id.clone(), a.next)
+        };
+        let next_u = next as u32;
+        {
+            let a = self.active_ov.as_mut().unwrap();
+            a.generated.push(next_u);
+        }
+        let full = self
+            .tokenizer
+            .as_ref()
+            .unwrap()
+            .decode(&self.active_ov.as_ref().unwrap().generated, true)
+            .unwrap_or_default();
+        let delta = {
+            let a = self.active_ov.as_mut().unwrap();
+            utf8_safe_delta(&full, &mut a.emitted)
+        };
+        let mut token_chunk = Chunk::token(id.clone(), next, delta);
+        token_chunk.n_tokens = Some(1);
+        // Splicer poison bypass (spec §4.1): token_id==0 with empty token_ids
+        // reads as id-less; stamp the single id explicitly.
+        token_chunk.token_ids = vec![next];
+        let (gen_new, max_new, is_eos, pos) = {
+            let a = self.active_ov.as_ref().unwrap();
+            (
+                a.generated.len() - a.resume_seed_len,
+                a.max_new,
+                a.eos.contains(&next_u),
+                a.pos,
+            )
+        };
+        if gen_new >= max_new || is_eos {
+            let mut out = vec![(id, token_chunk)];
+            out.extend(self.finalize_ovmoe(true));
+            return out;
+        }
+        let downstream = self.active_ov.as_ref().unwrap().downstream.clone();
+        let cfg = self.active_ov.as_ref().unwrap().cfg.clone();
+        match self.forward_one_token_first(next_u, pos, &cfg, &downstream, true) {
+            Ok(tok_back) => {
+                let a = self.active_ov.as_mut().unwrap();
+                a.next = tok_back;
+                a.pos += 1;
+                vec![(id, token_chunk)]
+            }
+            Err(e) => {
+                // Same rationale as decode_step_sparse: an error chunk, never a
+                // final (a final would trip the scheduler's saw_final latch and
+                // permanently block the resume) — deliberate divergence from the
+                // old break-to-partial-success decode loop above. No capture;
+                // clear the slot.
+                warn!(task = %id, "decode forward failed; surfacing error for resume: {e}");
+                self.active_ov = None;
+                vec![
+                    (id.clone(), token_chunk),
+                    (
+                        id.clone(),
+                        Chunk::error(id, format!("decode forward failed: {e}")),
+                    ),
+                ]
+            }
+        }
+    }
+
+    /// Finalize the in-flight task: best-effort whole-chain KV capture (so a
+    /// forced move can warm-resume this turn), then the empty final marker.
+    /// `capture` lets a caller skip the KV round-trip on an already-dead
+    /// chain; every current call site passes `true`.
+    fn finalize_ovmoe(&mut self, capture: bool) -> Vec<(TaskId, Chunk)> {
+        let Some(a) = self.active_ov.take() else {
+            return Vec::new();
+        };
+        let n_new = (a.generated.len() - a.resume_seed_len) as u32;
         // Issue-34 §8: capture the post-turn KV across the whole chain so a later request extending
         // this sequence can warm-resume. Snapshot the head's slice FIRST to learn the true KV depth —
         // the final sampled token is never fed, so depth == (prompt + generated) - 1 — and key the
@@ -3685,15 +3886,19 @@ impl OvMoeEngine {
         // snapshots its slice under E and acks up; the head's single ack ⇒ every stage captured. Then
         // seed the head's prefix cache. Best-effort: any error skips the cache (warm-pull degrades to
         // cold) and never touches the already-served output.
+        // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
+        // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
+        let should_capture = capture && n_new > 0;
         #[cfg(feature = "kv_coord")]
-        if self.kv_prefix_cache.enabled() && !generated.is_empty() {
+        if should_capture && self.kv_prefix_cache.enabled() {
             match self.runner.snapshot_kv() {
                 Ok(snap) => {
                     let depth = snap.past_seq_len;
-                    let mut full_tokens: Vec<i32> = prompt_ids.iter().map(|&t| t as i32).collect();
-                    full_tokens.extend(generated.iter().map(|&t| t as i32));
+                    let mut full_tokens: Vec<i32> =
+                        a.prompt_ids.iter().map(|&t| t as i32).collect();
+                    full_tokens.extend(a.generated[a.resume_seed_len..].iter().map(|&t| t as i32));
                     tracing::debug!(target: "cascadia::kv", event = "ovmoe_ms_capture_attempt",
-                        depth, full_len = full_tokens.len(), gen = generated.len(),
+                        depth, full_len = full_tokens.len(), gen = n_new,
                         in_range = (depth >= 1 && depth <= full_tokens.len()));
                     if depth >= 1 && depth <= full_tokens.len() {
                         let captured: Vec<i32> = full_tokens[..depth].to_vec();
@@ -3702,12 +3907,12 @@ impl OvMoeEngine {
                         // peer errors on CaptureV2 without acking; never withhold the turn.
                         let acked = self.block_on(async {
                             match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
-                                send_capture(&downstream, epoch, &captured, &task.tenant)
+                                send_capture(&a.downstream, epoch, &captured, &a.tenant)
                                     .await
                                     .map_err(|e| format!("send_capture: {e}"))?;
-                                match recv_kind_client(&downstream).await {
+                                match recv_kind_client(&a.downstream).await {
                                     Ok(Some(FrameKind::CaptureAck)) => {
-                                        recv_capture_ack_body_client(&downstream)
+                                        recv_capture_ack_body_client(&a.downstream)
                                             .await
                                             .map(|_| ())
                                             .map_err(|e| format!("recv_capture_ack: {e}"))
@@ -3726,7 +3931,7 @@ impl OvMoeEngine {
                                     // Close on elapse — the late CaptureAck has no sequence
                                     // number, so a reused connection would hand it to the
                                     // next exchange as its reply.
-                                    downstream.lock().await.close().await;
+                                    a.downstream.lock().await.close().await;
                                     Err(format!(
                                         "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
                                          connection dropped to avoid reading the late ack as \
@@ -3754,34 +3959,27 @@ impl OvMoeEngine {
                                     "mirrored multi-stage capture into holder");
                                 self.kv_prefix_cache.insert(captured64, &fp, snap);
                             }
-                            Err(e) => warn!(task = %id, "kv multi-stage capture skipped: {e}"),
+                            Err(e) => warn!(task = %a.id, "kv multi-stage capture skipped: {e}"),
                         }
                     }
                 }
-                Err(e) => warn!(task = %id, "kv capture: snapshot_kv failed: {e}"),
+                Err(e) => warn!(task = %a.id, "kv capture: snapshot_kv failed: {e}"),
             }
         }
 
-        let n_tokens = generated.len() as u32;
-        let text = self
-            .tokenizer
-            .as_ref()
-            .unwrap()
-            .decode(&generated, true)
-            .unwrap_or_default();
-        let elapsed = started.elapsed().as_secs_f64();
+        let elapsed = a.started.elapsed().as_secs_f64();
         info!(
-            task = %id,
-            tokens = n_tokens,
+            task = %a.id,
+            tokens = n_new,
             total = self.total,
             elapsed_s = elapsed,
-            tok_s = if elapsed > 0.0 { n_tokens as f64 / elapsed } else { 0.0 },
-            "task done (MiniMax-M2 pipeline-parallel)"
+            tok_s = if elapsed > 0.0 { f64::from(n_new) / elapsed } else { 0.0 },
+            "task done (MiniMax-M2 pipeline-parallel, streamed)"
         );
-        let mut chunk = Chunk::final_marker(id.clone(), text);
-        chunk.n_tokens = Some(n_tokens);
-        chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
-        vec![(id, chunk)]
+        let mut chunk = Chunk::final_marker(a.id.clone(), "");
+        chunk.n_tokens = Some(0);
+        chunk.finish_reason = Some(finish_reason_for(n_new as usize, a.max_new));
+        vec![(a.id, chunk)]
     }
 
     /// Snapshot this rank's KV under `epoch` for a later RESTORE. Bounded by the prefix-cache
@@ -4244,8 +4442,12 @@ impl Engine for OvMoeEngine {
     }
 
     fn cancel(&mut self, task_id: &TaskId) {
-        // Same as the dense sparse-MoE engine: drop queued tasks; an in-flight
-        // monolithic generation runs to its step boundary.
+        // Same as SparseMoEEngine: drop queued tasks; free the active slot if
+        // it belongs to this task (a zombie here never trips the runner's
+        // empty-step guard — produced is counted before the cancelled-filter).
+        if self.active_ov.as_ref().is_some_and(|a| &a.id == task_id) {
+            self.active_ov = None;
+        }
         self.pending.retain(|t| &t.task_id != task_id);
     }
 

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -997,6 +997,10 @@ pub struct ResumeSeed {
     pub generated_u32: Vec<u32>,
     pub emitted: usize,
     pub seed_len: usize,
+    /// Decoded prefix text, kept for the streamed paths' one-shot seam
+    /// divergence check (the growing decode may render the seam region
+    /// differently than the prefix-only decode that seeded `emitted`).
+    pub seed_text: String,
 }
 
 #[doc(hidden)]
@@ -1020,6 +1024,7 @@ pub fn prepare_resume(
         emitted: prefix_text.len(),
         seed_len: generated_u32.len(),
         generated_u32,
+        seed_text: prefix_text,
     }))
 }
 
@@ -1155,6 +1160,9 @@ struct SparseActive {
     /// Seeded to the resume prefix's decoded byte length on a resumed turn.
     emitted: usize,
     resume_seed_len: usize,
+    /// One-shot seam divergence check for a resumed turn: the decoded prefix
+    /// text `emitted` was seeded from. Taken on the first delta; `None` after.
+    seam_check: Option<String>,
     /// The token to emit on the next decode_step (sampled by the last rank).
     next: i64,
     /// Only read by the finalize-time KV capture path (kv_coord).
@@ -1590,7 +1598,7 @@ impl SparseMoEEngine {
             }
         };
         let n_tokens = generated.len() as u32;
-        // Option B §17: decoding `generated` in isolation puts the first new
+        // Resumed-turn seam: decoding `generated` in isolation puts the first new
         // token at sequence-start, so SentencePiece/Metaspace strips its
         // leading space — fine for a fresh turn, but on a resumed turn the
         // tail CONTINUES the prefix and that dropped space corrupts the seam
@@ -2097,9 +2105,9 @@ impl SparseMoEEngine {
             return Some(vec![(task.task_id, chunk)]);
         }
 
-        let (generated, emitted, resume_seed_len) = match seed_opt.take() {
-            Some(s) => (s.generated_u32, s.emitted, s.seed_len),
-            None => (Vec::with_capacity(max_new), 0usize, 0usize),
+        let (generated, emitted, resume_seed_len, seam_check) = match seed_opt.take() {
+            Some(s) => (s.generated_u32, s.emitted, s.seed_len, Some(s.seed_text)),
+            None => (Vec::with_capacity(max_new), 0usize, 0usize, None),
         };
         self.active = Some(SparseActive {
             id: task.task_id.clone(),
@@ -2111,6 +2119,7 @@ impl SparseMoEEngine {
             history,
             generated,
             emitted,
+            seam_check,
             resume_seed_len,
             next: token_back,
             prompt_ids,
@@ -2149,11 +2158,24 @@ impl SparseMoEEngine {
             .unwrap_or_default();
         let delta = {
             let a = self.active.as_mut().unwrap();
+            // One-shot Option-B seam guard (mirror of the single-stage
+            // divergence guard): `emitted` was seeded from decode(prefix)
+            // alone, and a BPE merge across the seam can make the growing
+            // decode render those bytes differently — a blind byte-offset
+            // then re-emits prefix bytes or garbles the seam. Diverged ⇒
+            // warn and drop this step's delta (cursor jumps to the current
+            // end); later tokens stream normally.
+            if let Some(seed) = a.seam_check.take() {
+                if !full.as_bytes().starts_with(seed.as_bytes()) {
+                    warn!(task = %a.id, "resume seam diverged; re-anchoring (seam delta dropped)");
+                    a.emitted = full.len();
+                }
+            }
             utf8_safe_delta(&full, &mut a.emitted)
         };
         let mut token_chunk = Chunk::token(id.clone(), next, delta);
         token_chunk.n_tokens = Some(1);
-        // Splicer poison bypass (spec §4.1): token_id==0 with empty token_ids
+        // Splicer poison bypass (id-less chunks read as resume-ineligible): token_id==0 with empty token_ids
         // reads as id-less; stamp the single id explicitly.
         token_chunk.token_ids = vec![next];
         let (gen_new, max_new) = {
@@ -2179,7 +2201,7 @@ impl SparseMoEEngine {
                 vec![(id, token_chunk)]
             }
             Err(e) => {
-                // Spec §4.1: a mid-decode forward failure is the chain-death signal
+                // A mid-decode forward failure is the chain-death signal
                 // Option B splices on. Emitting a final marker here would trip the
                 // scheduler's saw_final latch and permanently block the resume —
                 // surface an ERROR chunk instead (deliberate divergence from
@@ -2214,7 +2236,7 @@ impl SparseMoEEngine {
         // head's single ack means every stage captured. Then the head seeds its own prefix cache so a
         // later NEGOTIATE maps the prefix → E. Best-effort: any transport/snapshot error just skips the
         // cache (warm-pull degrades to cold) and never affects the already-complete served output.
-        // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
+        // The capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
         // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
         #[cfg_attr(not(feature = "kv_coord"), allow(unused_variables))]
         let should_capture = capture && n_new > 0;
@@ -3251,7 +3273,10 @@ impl SparseMoEEngine {
                     })
                     .unwrap_or(false)
                 } else {
-                    true
+                    // No downstream socket: verdict-true only when this genuinely
+                    // IS the last rank — mirror of the OvMoe handler, so the two
+                    // never disagree on the all-or-nothing verdict.
+                    self.is_last()
                 };
                 self.block_on(send_restore_ack_upstream(
                     upstream,
@@ -3419,6 +3444,8 @@ struct OvMoeActive {
     generated: Vec<u32>,
     emitted: usize,
     resume_seed_len: usize,
+    /// One-shot seam divergence check for a resumed turn (see `SparseActive`).
+    seam_check: Option<String>,
     /// The token to feed on the next decode_step (sampled by the last rank).
     next: i64,
     pos: usize,
@@ -3601,8 +3628,8 @@ impl OvMoeEngine {
         if task.resume_ids().is_some() {
             // Option B: this path has no resume implementation — silently dropping
             // the prefix would regenerate from scratch and the gateway would splice
-            // that after the client's prefix (spec §4.2). Decline; the scheduler's
-            // B6 retry excludes this peer and re-routes.
+            // that after the client's prefix (silent regeneration presented as a resume). Decline; the caller
+            // excludes this peer and re-routes.
             let id = task.task_id.clone();
             return vec![(
                 id.clone(),
@@ -3819,7 +3846,7 @@ impl OvMoeEngine {
         }
         if max_new == 0 {
             // Budget exhausted by the resume prefix. The decode loop below pushes
-            // BEFORE testing (spec §4.2): entering it would emit one token.
+            // BEFORE testing (silent regeneration presented as a resume): entering it would emit one token.
             let mut chunk = Chunk::final_marker(id.clone(), "");
             chunk.n_tokens = Some(0);
             chunk.finish_reason = Some(FinishReason::Length);
@@ -3912,9 +3939,9 @@ impl OvMoeEngine {
         // (stashed below); `decode_step_ovmoe` pushes it (OvMoe INCLUDES
         // EOS — push-then-test) and drives every token after on the
         // following `step()` calls.
-        let (generated, emitted, resume_seed_len) = match seed_opt.take() {
-            Some(s) => (s.generated_u32, s.emitted, s.seed_len),
-            None => (Vec::with_capacity(max_new), 0usize, 0usize),
+        let (generated, emitted, resume_seed_len, seam_check) = match seed_opt.take() {
+            Some(s) => (s.generated_u32, s.emitted, s.seed_len, Some(s.seed_text)),
+            None => (Vec::with_capacity(max_new), 0usize, 0usize, None),
         };
         self.active_ov = Some(OvMoeActive {
             id: id.clone(),
@@ -3925,6 +3952,7 @@ impl OvMoeEngine {
             started,
             generated,
             emitted,
+            seam_check,
             resume_seed_len,
             next,
             pos,
@@ -3956,11 +3984,24 @@ impl OvMoeEngine {
             .unwrap_or_default();
         let delta = {
             let a = self.active_ov.as_mut().unwrap();
+            // One-shot Option-B seam guard (mirror of the single-stage
+            // divergence guard): `emitted` was seeded from decode(prefix)
+            // alone, and a BPE merge across the seam can make the growing
+            // decode render those bytes differently — a blind byte-offset
+            // then re-emits prefix bytes or garbles the seam. Diverged ⇒
+            // warn and drop this step's delta (cursor jumps to the current
+            // end); later tokens stream normally.
+            if let Some(seed) = a.seam_check.take() {
+                if !full.as_bytes().starts_with(seed.as_bytes()) {
+                    warn!(task = %a.id, "resume seam diverged; re-anchoring (seam delta dropped)");
+                    a.emitted = full.len();
+                }
+            }
             utf8_safe_delta(&full, &mut a.emitted)
         };
         let mut token_chunk = Chunk::token(id.clone(), next, delta);
         token_chunk.n_tokens = Some(1);
-        // Splicer poison bypass (spec §4.1): token_id==0 with empty token_ids
+        // Splicer poison bypass (id-less chunks read as resume-ineligible): token_id==0 with empty token_ids
         // reads as id-less; stamp the single id explicitly.
         token_chunk.token_ids = vec![next];
         let (gen_new, max_new, is_eos, pos) = {
@@ -4023,7 +4064,7 @@ impl OvMoeEngine {
         // snapshots its slice under E and acks up; the head's single ack ⇒ every stage captured. Then
         // seed the head's prefix cache. Best-effort: any error skips the cache (warm-pull degrades to
         // cold) and never touches the already-served output.
-        // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
+        // The capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
         // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
         #[cfg_attr(not(feature = "kv_coord"), allow(unused_variables))]
         let should_capture = capture && n_new > 0;
@@ -4126,6 +4167,13 @@ impl OvMoeEngine {
     #[cfg(feature = "kv_coord")]
     fn capture_under_epoch(&mut self, tenant: &str, epoch: u64, tokens: Vec<i32>) {
         if !self.kv_prefix_cache.enabled() {
+            // The CAPTURE handler acks upstream regardless, so a skip here is
+            // otherwise invisible: the head believes every stage captured while
+            // this rank stored nothing and every later GET answers `get_none`.
+            warn!(
+                rank = self.rank,
+                epoch, "kv capture skipped: prefix cache disabled (capacity 0) — ack still sent"
+            );
             return;
         }
         let snap = match self.runner.snapshot_kv() {
@@ -5144,6 +5192,21 @@ impl<R: StagedRunner> PipelineEngine<R> {
             Some(t) => t,
             None => return Some(Vec::new()),
         };
+        // No forced-prefix path here: silently ignoring the ids would regenerate
+        // from scratch and the caller would splice that after the client's
+        // already-received prefix as if it were the resumed tail. Decline with the
+        // sentinel first chunk so the caller excludes this peer and re-routes —
+        // same shape as the MiniMax single-stage decline above.
+        if task.resume_ids().is_some() {
+            let id = task.task_id.clone();
+            return Some(vec![(
+                id.clone(),
+                Chunk::error(
+                    id,
+                    "resume_unsupported: pipeline engine has no forced-prefix path".to_string(),
+                ),
+            )]);
+        }
         let id = task.task_id.clone();
         let Some(downstream) = self.transport.downstream.clone() else {
             warn!(task = %id, "rank 0 has no downstream; cannot drive pipeline");
@@ -5370,7 +5433,7 @@ impl<R: StagedRunner> PipelineEngine<R> {
         };
         let mut token_chunk = Chunk::token(id.clone(), next, delta);
         token_chunk.n_tokens = Some(1);
-        // Splicer poison bypass (spec §4.1, same stamp as the sparse/ovmoe
+        // Splicer poison bypass (same stamp as the sparse/ovmoe
         // decode paths): token_id==0 with empty token_ids reads as id-less and
         // makes the stream resume-ineligible; token 0 is a legal sample.
         token_chunk.token_ids = vec![next];

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -20,7 +20,8 @@ use cascadia_engine::{Builder, Engine, EngineError, EngineResult, LoadStream};
 use cascadia_ov_genai_shim::PluginConfig;
 use cascadia_transport::{ActivationClient, ActivationServer};
 use cascadia_types::{
-    Chunk, FinishReason, GenerationTask, LoadProgress, PeerLayout, ShardSpec, TaskId,
+    append_resume_ids, Chunk, FinishReason, GenerationTask, LoadProgress, PeerLayout, ShardSpec,
+    TaskId,
 };
 use futures::stream;
 use tokenizers::Tokenizer;
@@ -1389,7 +1390,7 @@ impl SparseMoEEngine {
             }
         };
         let started = std::time::Instant::now();
-        let prompt_ids: Vec<i64> = match tokenizer.encode(task.prompt.as_str(), true) {
+        let mut prompt_ids: Vec<i64> = match tokenizer.encode(task.prompt.as_str(), true) {
             Ok(enc) => enc.get_ids().iter().map(|&u| u as i64).collect(),
             Err(e) => {
                 warn!(task = %task.task_id, "tokenizer encode failed: {e}");
@@ -1400,8 +1401,18 @@ impl SparseMoEEngine {
                 return vec![(task.task_id, final_chunk)];
             }
         };
+        // Option B forced-prefix resume: append the already-emitted assistant
+        // tokens after the rendered prompt (concat, not replace) so prefill
+        // below carries them as context/KV history. No-op when not resuming.
+        append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
         let max_new = task.max_tokens.max(1) as usize;
-        let sampling_cfg = sampling_from_task(&task);
+        let mut sampling_cfg = sampling_from_task(&task);
+        // Option B: a resumed turn MUST decode greedily — sampling would let
+        // the continuation diverge from what the client already has. temperature
+        // <= 0.0 takes the deterministic argmax path in `sampling::sample`.
+        if task.resume_token_ids.is_some() {
+            sampling_cfg.temperature = 0.0;
+        }
         // Choose generate path: spec-decode if configured (and the
         // sampling config is greedy — the spec-decode helper falls
         // back to plain generate on temp>0 anyway, but this keeps the
@@ -1467,6 +1478,7 @@ impl SparseMoEEngine {
         );
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
+        chunk.token_ids = generated;
         chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
         vec![(task.task_id.clone(), chunk)]
     }
@@ -1481,7 +1493,7 @@ impl SparseMoEEngine {
         #[cfg(feature = "kv_coord")]
         self.kv_set_turn_tenant(&task.tenant);
         let started = std::time::Instant::now();
-        let prompt_ids: Vec<i64> = {
+        let mut prompt_ids: Vec<i64> = {
             let Some(tok) = self.tokenizer.as_ref() else {
                 warn!(task = %task.task_id, "rank-0 engine has no tokenizer");
                 let e = Chunk::error(task.task_id.clone(), "engine has no tokenizer".to_string());
@@ -1498,9 +1510,19 @@ impl SparseMoEEngine {
                 }
             }
         };
+        // Option B forced-prefix resume: append the already-emitted assistant
+        // tokens after the rendered prompt (concat, not replace) — the
+        // distributed prefill loop below is agnostic to id origin, so the
+        // appended ids prefill naturally. No-op when not resuming.
+        append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
 
         let max_new = task.max_tokens.max(1) as usize;
-        let sampling_cfg = sampling_from_task(&task);
+        let mut sampling_cfg = sampling_from_task(&task);
+        // Option B: force greedy decode on a resumed turn so the continuation
+        // is deterministic (see step_single_stage for rationale).
+        if task.resume_token_ids.is_some() {
+            sampling_cfg.temperature = 0.0;
+        }
         let downstream = match self.transport.downstream.clone() {
             Some(d) => d,
             None => {
@@ -1726,6 +1748,7 @@ impl SparseMoEEngine {
         );
         let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
         chunk.n_tokens = Some(n_tokens);
+        chunk.token_ids = result_tokens;
         chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
         vec![(task.task_id.clone(), chunk)]
     }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1916,96 +1916,13 @@ impl SparseMoEEngine {
                 }
             };
 
-            // Issue-34 Task 1.3 (§8): capture the full post-turn sequence's KV across the whole chain so
-            // a forced move can warm-resume. The head mints E = synth_epoch(full tokens) and broadcasts
-            // CAPTURE(E, tokens) downstream; each stage snapshots its slice under E and acks back up; the
-            // head's single ack means every stage captured. Then the head seeds its own prefix cache so a
-            // later NEGOTIATE maps the prefix → E. Best-effort: any transport/snapshot error just skips the
-            // cache (warm-pull degrades to cold) and never affects the already-complete served output.
+            // Issue-34 (§8): whole-chain KV capture so a forced move can
+            // warm-resume this turn — see `capture_multi_stage`.
             #[cfg(feature = "kv_coord")]
             if self.kv_prefix_cache.enabled() && !result_tokens.is_empty() {
-                // Snapshot FIRST and key the epoch over `full_tokens[..depth]` — the prefix the KV
-                // actually covers. Test-before-push EOS semantics leave the final sampled token
-                // un-pushed, so the turn's token vector runs one LONGER than the KV: an epoch over
-                // the full vector can never match a later NEGOTIATE's offer epoch (computed over
-                // `tokens[..past_seq_len]`), and every worker GET answers `get_none`. Mirrors the
-                // OvMoe multi-stage site, which had this right.
-                match self.runner.snapshot_kv() {
-                    Ok(snap) => {
-                        let depth = snap.past_seq_len;
-                        let mut full_tokens: Vec<i32> =
-                            prompt_ids.iter().map(|&t| t as i32).collect();
-                        full_tokens.extend(result_tokens.iter().map(|&t| t as i32));
-                        if depth >= 1 && depth <= full_tokens.len() {
-                            let captured: Vec<i32> = full_tokens[..depth].to_vec();
-                            let epoch = crate::kv_coordination::synth_epoch(&captured);
-                            // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and
-                            // the only ceiling otherwise is the transport frame-idle default —
-                            // reached before this turn's already-complete chunks are returned.
-                            // Timeout ⇒ capture skipped, turn delivered.
-                            let acked = self.block_on(async {
-                                match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
-                                    send_capture(&downstream, epoch, &captured, &task.tenant)
-                                        .await
-                                        .map_err(|e| format!("send_capture: {e}"))?;
-                                    match recv_kind_client(&downstream).await {
-                                        Ok(Some(FrameKind::CaptureAck)) => {
-                                            recv_capture_ack_body_client(&downstream)
-                                                .await
-                                                .map(|_| ())
-                                                .map_err(|e| format!("recv_capture_ack: {e}"))
-                                        }
-                                        Ok(Some(other)) => {
-                                            Err(format!("expected CaptureAck, got {other:?}"))
-                                        }
-                                        Ok(None) => {
-                                            Err("downstream closed during capture".to_string())
-                                        }
-                                        Err(e) => Err(format!("recv_kind (capture): {e}")),
-                                    }
-                                })
-                                .await
-                                {
-                                    Ok(r) => r,
-                                    Err(_) => {
-                                        // Same hazard recv_token_reply drops the socket for: the
-                                        // peer is usually alive and its CaptureAck (no sequence
-                                        // number) lands after we stopped waiting — a reused
-                                        // connection hands it to the NEXT exchange as its reply.
-                                        downstream.lock().await.close().await;
-                                        Err(format!(
-                                            "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
-                                             connection dropped to avoid reading the late ack as \
-                                             the next exchange's reply"
-                                        ))
-                                    }
-                                }
-                            });
-                            match acked {
-                                Ok(()) => {
-                                    let fp = self.runner.fingerprint();
-                                    let prompt64: Vec<i64> =
-                                        captured.iter().map(|&t| i64::from(t)).collect();
-                                    // Mirror into the holder cache so a busy engine still serves
-                                    // this prefix.
-                                    self.kv_share
-                                        .lock()
-                                        .unwrap_or_else(|e| e.into_inner())
-                                        .prefix
-                                        .insert(prompt64.clone(), &fp, snap.clone());
-                                    self.kv_prefix_cache.insert(prompt64, &fp, snap);
-                                }
-                                Err(e) => {
-                                    warn!(task = %task.task_id, "kv multi-stage capture skipped: {e}")
-                                }
-                            }
-                        } else {
-                            warn!(task = %task.task_id, depth, full_len = full_tokens.len(),
-                                "kv capture skipped: KV depth outside token range");
-                        }
-                    }
-                    Err(e) => warn!(task = %task.task_id, "kv capture: snapshot_kv failed: {e}"),
-                }
+                let mut full_tokens: Vec<i32> = prompt_ids.iter().map(|&t| t as i32).collect();
+                full_tokens.extend(result_tokens.iter().map(|&t| t as i32));
+                self.capture_multi_stage(&downstream, &task.tenant, &task.task_id, &full_tokens);
             }
 
             let n_tokens = result_tokens.len() as u32;
@@ -2259,6 +2176,106 @@ impl SparseMoEEngine {
         }
     }
 
+    /// Issue-34 Task 1.3 (§8): best-effort whole-chain KV capture of a
+    /// completed turn. The head snapshots its own slice, mints
+    /// E = synth_epoch(covered prefix), broadcasts CAPTURE(E, tokens)
+    /// downstream (each stage snapshots under E and acks up — one head-side
+    /// ack means every stage captured), then seeds its prefix cache so a
+    /// later NEGOTIATE maps the prefix → E. Best-effort: any error skips the
+    /// cache (warm-pull degrades to cold) and never affects the served
+    /// output. Shared by the spec-decode burst path and the streamed
+    /// finalize — they previously carried verbatim ~90-line copies, and the
+    /// duplicated timeout arm is exactly where a rebase misgraft landed once.
+    #[cfg(feature = "kv_coord")]
+    fn capture_multi_stage(
+        &mut self,
+        downstream: &Arc<TokioMutex<ActivationClient>>,
+        tenant: &str,
+        task_id: &TaskId,
+        full_tokens: &[i32],
+    ) {
+        // Snapshot FIRST and key the epoch over `full_tokens[..depth]` — the
+        // prefix the KV actually covers. The length-capped streamed path
+        // pushes its final sampled token without ever feeding it, so the
+        // turn's token vector can run one LONGER than the KV (an
+        // EOS-terminated turn — whose un-pushed token is the un-fed EOS —
+        // lands exactly equal): an epoch over the full vector then never
+        // matches a later NEGOTIATE's offer epoch (computed over
+        // `tokens[..past_seq_len]`) and every worker GET answers `get_none`.
+        // Mirrors the OvMoe multi-stage site.
+        match self.runner.snapshot_kv() {
+            Ok(snap) => {
+                let depth = snap.past_seq_len;
+                if depth >= 1 && depth <= full_tokens.len() {
+                    let captured: Vec<i32> = full_tokens[..depth].to_vec();
+                    let epoch = crate::kv_coordination::synth_epoch(&captured);
+                    // Bounded: an older peer that meets CaptureV2 errors WITHOUT
+                    // acking, and the only ceiling otherwise is the transport
+                    // frame-idle default — reached before this turn's
+                    // already-complete chunks are returned. Timeout ⇒ capture
+                    // skipped, turn delivered (the connection is dropped, so the
+                    // NEXT turn on this chain pays the reconnect).
+                    let acked = self.block_on(async {
+                        match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
+                            send_capture(downstream, epoch, &captured, tenant)
+                                .await
+                                .map_err(|e| format!("send_capture: {e}"))?;
+                            match recv_kind_client(downstream).await {
+                                Ok(Some(FrameKind::CaptureAck)) => {
+                                    recv_capture_ack_body_client(downstream)
+                                        .await
+                                        .map(|_| ())
+                                        .map_err(|e| format!("recv_capture_ack: {e}"))
+                                }
+                                Ok(Some(other)) => {
+                                    Err(format!("expected CaptureAck, got {other:?}"))
+                                }
+                                Ok(None) => Err("downstream closed during capture".to_string()),
+                                Err(e) => Err(format!("recv_kind (capture): {e}")),
+                            }
+                        })
+                        .await
+                        {
+                            Ok(r) => r,
+                            Err(_) => {
+                                // Same hazard recv_token_reply drops the socket for: the
+                                // peer is usually alive and its CaptureAck (no sequence
+                                // number) lands after we stopped waiting — a reused
+                                // connection hands it to the NEXT exchange as its reply.
+                                downstream.lock().await.close().await;
+                                Err(format!(
+                                    "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
+                                     connection dropped to avoid reading the late ack as \
+                                     the next exchange's reply"
+                                ))
+                            }
+                        }
+                    });
+                    match acked {
+                        Ok(()) => {
+                            let fp = self.runner.fingerprint();
+                            let prompt64: Vec<i64> =
+                                captured.iter().map(|&t| i64::from(t)).collect();
+                            // Mirror into the holder cache so a busy engine still
+                            // serves this prefix.
+                            self.kv_share
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .prefix
+                                .insert(prompt64.clone(), &fp, snap.clone());
+                            self.kv_prefix_cache.insert(prompt64, &fp, snap);
+                        }
+                        Err(e) => warn!(task = %task_id, "kv multi-stage capture skipped: {e}"),
+                    }
+                } else {
+                    warn!(task = %task_id, depth, full_len = full_tokens.len(),
+                        "kv capture skipped: KV depth outside token range");
+                }
+            }
+            Err(e) => warn!(task = %task_id, "kv capture: snapshot_kv failed: {e}"),
+        }
+    }
+
     /// Finalize the in-flight task: best-effort whole-chain KV capture (so a
     /// forced move can warm-resume this turn), then the empty final marker.
     /// `capture` lets a caller skip the KV round-trip on an already-dead
@@ -2269,96 +2286,17 @@ impl SparseMoEEngine {
             return Vec::new();
         };
         let n_new = (a.generated.len() - a.resume_seed_len) as u32;
-        // Issue-34 Task 1.3 (§8): capture the full post-turn sequence's KV across the whole chain so
-        // a forced move can warm-resume. The head mints E = synth_epoch(full tokens) and broadcasts
-        // CAPTURE(E, tokens) downstream; each stage snapshots its slice under E and acks back up; the
-        // head's single ack means every stage captured. Then the head seeds its own prefix cache so a
-        // later NEGOTIATE maps the prefix → E. Best-effort: any transport/snapshot error just skips the
-        // cache (warm-pull degrades to cold) and never affects the already-complete served output.
-        // The capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
-        // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
+        // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids`
+        // already contains the appended resume prefix, so slicing `generated`
+        // at `resume_seed_len` prevents double-counting it. Capture mechanics
+        // in `capture_multi_stage`.
         #[cfg_attr(not(feature = "kv_coord"), allow(unused_variables))]
         let should_capture = capture && n_new > 0;
         #[cfg(feature = "kv_coord")]
         if should_capture && self.kv_prefix_cache.enabled() {
-            // Snapshot FIRST and key the epoch over `full_tokens[..depth]` — the prefix the KV
-            // actually covers. Test-before-push EOS semantics leave the final sampled token
-            // un-pushed, so the turn's token vector runs one LONGER than the KV: an epoch over the
-            // full vector can never match a later NEGOTIATE's offer epoch (computed over
-            // `tokens[..past_seq_len]`), and every worker GET answers `get_none`. Mirrors the OvMoe
-            // multi-stage site, which had this right.
-            match self.runner.snapshot_kv() {
-                Ok(snap) => {
-                    let depth = snap.past_seq_len;
-                    let mut full_tokens: Vec<i32> =
-                        a.prompt_ids.iter().map(|&t| t as i32).collect();
-                    full_tokens.extend(a.generated[a.resume_seed_len..].iter().map(|&t| t as i32));
-                    if depth >= 1 && depth <= full_tokens.len() {
-                        let captured: Vec<i32> = full_tokens[..depth].to_vec();
-                        let epoch = crate::kv_coordination::synth_epoch(&captured);
-                        // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and
-                        // the only ceiling otherwise is the transport frame-idle default — reached
-                        // before this turn's already-complete chunks are returned. Timeout ⇒
-                        // capture skipped, turn delivered.
-                        let acked = self.block_on(async {
-                            match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
-                                send_capture(&a.downstream, epoch, &captured, &a.tenant)
-                                    .await
-                                    .map_err(|e| format!("send_capture: {e}"))?;
-                                match recv_kind_client(&a.downstream).await {
-                                    Ok(Some(FrameKind::CaptureAck)) => {
-                                        recv_capture_ack_body_client(&a.downstream)
-                                            .await
-                                            .map(|_| ())
-                                            .map_err(|e| format!("recv_capture_ack: {e}"))
-                                    }
-                                    Ok(Some(other)) => {
-                                        Err(format!("expected CaptureAck, got {other:?}"))
-                                    }
-                                    Ok(None) => Err("downstream closed during capture".into()),
-                                    Err(e) => Err(format!("recv_kind (capture): {e}")),
-                                }
-                            })
-                            .await
-                            {
-                                Ok(r) => r,
-                                Err(_) => {
-                                    // Same hazard recv_token_reply drops the socket for: the
-                                    // peer is usually alive and its CaptureAck (no sequence
-                                    // number) lands after we stopped waiting — a reused
-                                    // connection hands it to the NEXT exchange as its reply.
-                                    a.downstream.lock().await.close().await;
-                                    Err(format!(
-                                        "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
-                                         connection dropped to avoid reading the late ack as \
-                                         the next exchange's reply"
-                                    ))
-                                }
-                            }
-                        });
-                        match acked {
-                            Ok(()) => {
-                                let fp = self.runner.fingerprint();
-                                let prompt64: Vec<i64> =
-                                    captured.iter().map(|&t| i64::from(t)).collect();
-                                // Mirror into the holder cache so a busy engine still serves this
-                                // prefix.
-                                self.kv_share
-                                    .lock()
-                                    .unwrap_or_else(|e| e.into_inner())
-                                    .prefix
-                                    .insert(prompt64.clone(), &fp, snap.clone());
-                                self.kv_prefix_cache.insert(prompt64, &fp, snap);
-                            }
-                            Err(e) => warn!(task = %a.id, "kv multi-stage capture skipped: {e}"),
-                        }
-                    } else {
-                        warn!(task = %a.id, depth, full_len = full_tokens.len(),
-                            "kv capture skipped: KV depth outside token range");
-                    }
-                }
-                Err(e) => warn!(task = %a.id, "kv capture: snapshot_kv failed: {e}"),
-            }
+            let mut full_tokens: Vec<i32> = a.prompt_ids.iter().map(|&t| t as i32).collect();
+            full_tokens.extend(a.generated[a.resume_seed_len..].iter().map(|&t| t as i32));
+            self.capture_multi_stage(&a.downstream, &a.tenant, &a.id, &full_tokens);
         }
         let elapsed = a.started.elapsed().as_secs_f64();
         info!(task = %a.id, tokens = n_new, elapsed_s = elapsed,

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -6077,6 +6077,72 @@ mod tests {
         assert_eq!(resume_max_new(8, Some(&prefix)), 0);
     }
 
+    /// Minimal `StagedRunner` for tests that never reach a forward pass.
+    struct StubRunner;
+    impl StagedRunner for StubRunner {
+        fn arch_name(&self) -> &'static str {
+            "stub"
+        }
+        fn hidden_size(&self) -> usize {
+            8
+        }
+        fn max_seq(&self) -> usize {
+            32
+        }
+        fn eos_token_ids(&self) -> &[u32] {
+            &[]
+        }
+        fn reset(&mut self) {}
+        fn embed_token(&self, _token: u32) -> Vec<f32> {
+            vec![0.0; 8]
+        }
+        fn forward_layers(
+            &mut self,
+            hidden: Vec<f32>,
+            _pos: usize,
+            _token: Option<u32>,
+        ) -> Vec<f32> {
+            hidden
+        }
+        fn head_logits(&self, _hidden: &[f32]) -> Vec<f32> {
+            vec![0.0]
+        }
+    }
+
+    /// The staged shells (glm5 / dsv4) have no forced-prefix path: a resumed
+    /// task must be declined with the sentinel FIRST chunk, never silently
+    /// regenerated — the caller would splice the regeneration after the
+    /// client's prefix as a fake resumed tail. Un-gated (no model dir): the
+    /// decline fires before any runner or transport work.
+    #[test]
+    fn pipeline_engine_declines_seeded_task_with_sentinel_first_chunk() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let mut eng = PipelineEngine::new(
+            StubRunner,
+            None,
+            StageTransport {
+                upstream: None,
+                downstream: None,
+            },
+            rt.handle().clone(),
+            0,
+            2,
+            None,
+        );
+        let mut task = GenerationTask::new("t", "hi").with_max_tokens(4);
+        task.resume_token_ids = Some(vec![3]);
+        eng.pending.push_back(task);
+        let chunks = eng.begin_generation().expect("decline is terminal");
+        assert_eq!(chunks.len(), 1, "decline must be the FIRST and only chunk");
+        let reason = chunks[0].1.error.as_deref().expect("error chunk");
+        assert!(
+            reason.starts_with("resume_unsupported:"),
+            "sentinel must PREFIX the reason (callers match with starts_with): {reason}"
+        );
+    }
+
     #[test]
     fn even_moe_split_uniform() {
         assert_eq!(even_moe_split(60, 0, 2), (1, 31));

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -971,6 +971,18 @@ fn utf8_safe_delta(full: &str, emitted: &mut usize) -> String {
     d
 }
 
+/// Option B resume budget: total (prefix + new) must equal `max_tokens`, the
+/// same invariant the streaming engines enforce by seeding their `generated`
+/// accumulator with the K resume ids. sparse-moe's generate helpers always
+/// start `generated` EMPTY (single-shot decode, no seedable accumulator), so
+/// this subtracts K from the caller's budget instead — the opposite lever,
+/// same total-length result. Saturating, no `.max(1)`: an exhausted budget
+/// (K >= max_tokens) must yield exactly zero new tokens.
+fn resume_max_new(max_tokens: u32, resume_token_ids: Option<&[i32]>) -> usize {
+    let already = resume_token_ids.map_or(0, |v| v.len());
+    (max_tokens as usize).saturating_sub(already)
+}
+
 fn sampling_from_task(task: &GenerationTask) -> crate::sampling::SamplingConfig {
     let s = &task.sampling;
     crate::sampling::SamplingConfig {
@@ -1405,13 +1417,25 @@ impl SparseMoEEngine {
         // tokens after the rendered prompt (concat, not replace) so prefill
         // below carries them as context/KV history. No-op when not resuming.
         append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
-        let max_new = task.max_tokens.max(1) as usize;
+        let max_new = resume_max_new(task.max_tokens, task.resume_token_ids.as_deref());
         let mut sampling_cfg = sampling_from_task(&task);
         // Option B: a resumed turn MUST decode greedily — sampling would let
         // the continuation diverge from what the client already has. temperature
         // <= 0.0 takes the deterministic argmax path in `sampling::sample`.
         if task.resume_token_ids.is_some() {
             sampling_cfg.temperature = 0.0;
+        }
+        if max_new == 0 {
+            // Budget already exhausted by the resume prefix. Both generate
+            // helpers unconditionally sample one token off the last prefill
+            // step regardless of `max_tokens`, so we must not call them at
+            // all — the only way to guarantee zero new tokens here.
+            let elapsed = started.elapsed().as_secs_f64();
+            info!(task = %task.task_id, elapsed_s = elapsed, "task done (single-stage, resume budget exhausted)");
+            let mut chunk = Chunk::final_marker(task.task_id.clone(), "");
+            chunk.n_tokens = Some(0);
+            chunk.finish_reason = Some(FinishReason::Length);
+            return vec![(task.task_id, chunk)];
         }
         // Choose generate path: spec-decode if configured (and the
         // sampling config is greedy — the spec-decode helper falls
@@ -1533,12 +1557,25 @@ impl SparseMoEEngine {
         // appended ids prefill naturally. No-op when not resuming.
         append_resume_ids(&mut prompt_ids, task.resume_token_ids.as_deref());
 
-        let max_new = task.max_tokens.max(1) as usize;
+        let max_new = resume_max_new(task.max_tokens, task.resume_token_ids.as_deref());
         let mut sampling_cfg = sampling_from_task(&task);
         // Option B: force greedy decode on a resumed turn so the continuation
         // is deterministic (see step_single_stage for rationale).
         if task.resume_token_ids.is_some() {
             sampling_cfg.temperature = 0.0;
+        }
+        if max_new == 0 {
+            // Budget already exhausted by the resume prefix. Both
+            // drive_generation_first and drive_generation_first_spec
+            // unconditionally sample one token off the last prefill step
+            // regardless of max_new, so we must not drive generation at all
+            // — the only way to guarantee zero new tokens here.
+            let elapsed = started.elapsed().as_secs_f64();
+            info!(task = %task.task_id, elapsed_s = elapsed, "task done (rank-0 driver, resume budget exhausted)");
+            let mut chunk = Chunk::final_marker(task.task_id.clone(), "");
+            chunk.n_tokens = Some(0);
+            chunk.finish_reason = Some(FinishReason::Length);
+            return vec![(task.task_id, chunk)];
         }
         let downstream = match self.transport.downstream.clone() {
             Some(d) => d,
@@ -5279,6 +5316,31 @@ mod tests {
         // A final decode identical to the last (e.g. an EOS skipped by
         // skip_special_tokens) yields an empty delta.
         assert_eq!(utf8_safe_delta("The quick brown", &mut emitted), "");
+    }
+
+    #[test]
+    fn resume_max_new_is_unchanged_when_not_resuming() {
+        assert_eq!(resume_max_new(256, None), 256);
+    }
+
+    #[test]
+    fn resume_max_new_subtracts_prefix_len() {
+        assert_eq!(resume_max_new(256, Some(&[1, 2, 3])), 253);
+    }
+
+    /// Mirrors the mock engine's `resume_at_full_budget_emits_zero_new_tokens`
+    /// contract: a resume prefix that already meets/exceeds max_tokens must
+    /// leave zero budget for new tokens (not `.max(1)`'d back up to 1).
+    #[test]
+    fn resume_max_new_at_full_budget_is_zero() {
+        let prefix: Vec<i32> = (0..8).collect();
+        assert_eq!(resume_max_new(8, Some(&prefix)), 0);
+    }
+
+    #[test]
+    fn resume_max_new_saturates_when_prefix_exceeds_budget() {
+        let prefix: Vec<i32> = (0..10).collect();
+        assert_eq!(resume_max_new(8, Some(&prefix)), 0);
     }
 
     #[test]

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -983,6 +983,43 @@ fn resume_max_new(max_tokens: u32, resume_token_ids: Option<&[i32]>) -> usize {
     (max_tokens as usize).saturating_sub(already)
 }
 
+/// Option B resume seed for a streaming path. Normalizes/validates the wire
+/// prefix, appends it to the prompt ids (concat, not replace), and returns the
+/// accumulator seed. `Ok(None)` = not resuming (including wire-legal
+/// `Some([])`). `emitted` is the BYTE LENGTH of the decoded prefix — the value
+/// `utf8_safe_delta` needs so the first streamed delta starts exactly after
+/// the prefix text.
+#[doc(hidden)]
+pub struct ResumeSeed {
+    pub generated_u32: Vec<u32>,
+    pub emitted: usize,
+    pub seed_len: usize,
+}
+
+#[doc(hidden)]
+pub fn prepare_resume(
+    task: &GenerationTask,
+    tokenizer: &tokenizers::Tokenizer,
+    prompt_ids_i64: &mut Vec<i64>,
+) -> Result<Option<ResumeSeed>, String> {
+    let Some(r) = task.resume_ids() else {
+        return Ok(None);
+    };
+    let vocab = tokenizer.get_vocab_size(true) as u32;
+    cascadia_types::validate_resume_ids(r, Some(vocab))
+        .map_err(|e| format!("invalid resume prefix: {e}"))?;
+    cascadia_types::append_resume_ids(prompt_ids_i64, Some(r));
+    let generated_u32: Vec<u32> = r.iter().map(|&i| i as u32).collect();
+    let prefix_text = tokenizer
+        .decode(&generated_u32, true)
+        .map_err(|e| format!("resume seed decode failed: {e}"))?;
+    Ok(Some(ResumeSeed {
+        emitted: prefix_text.len(),
+        seed_len: generated_u32.len(),
+        generated_u32,
+    }))
+}
+
 fn sampling_from_task(task: &GenerationTask) -> crate::sampling::SamplingConfig {
     let s = &task.sampling;
     crate::sampling::SamplingConfig {

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -2989,16 +2989,25 @@ impl SparseMoEEngine {
         // nothing stashed and a bare RESTORE restores the rank from its own capture. Logged either
         // way — a bare RESTORE and a never-stashed slice are otherwise indistinguishable.
         let carried = self.kv_downstream.remove(&epoch);
-        tracing::info!(target: "cascadia::kv", event = "kv_carry_send", epoch,
-            carried = carried.is_some(), bytes = carried.as_ref().map_or(0, |b| b.len()),
+        // `frame` names what is actually SENT: an oversized blob degrades to a
+        // bare RESTORE (deliberate clean cold), and logging carried=true alone
+        // would claim a carry that never went out.
+        let oversized = carried
+            .as_ref()
+            .is_some_and(|b| b.len() > crate::dist::MAX_RESTORE_BLOB_BYTES as usize);
+        let frame = match (&carried, oversized) {
+            (Some(_), false) => "carry",
+            (Some(_), true) => "bare_oversized",
+            (None, _) => "bare",
+        };
+        tracing::info!(target: "cascadia::kv", event = "kv_carry_send", epoch, frame,
+            bytes = carried.as_ref().map_or(0, |b| b.len()),
             stashed_epochs = self.kv_downstream.len());
         let verdict = self.block_on(async {
             match &carried {
-                Some(blob) if blob.len() <= crate::dist::MAX_RESTORE_BLOB_BYTES as usize => {
-                    send_restore_carry(&down, epoch, blob)
-                        .await
-                        .map_err(|e| format!("send_restore_carry: {e}"))?
-                }
+                Some(blob) if !oversized => send_restore_carry(&down, epoch, blob)
+                    .await
+                    .map_err(|e| format!("send_restore_carry: {e}"))?,
                 // None, or an oversized blob (guards the u32 len field + the peer's recv alloc) ⇒
                 // bare RESTORE ⇒ the moved-to tail misses the foreign epoch ⇒ deliberate clean cold.
                 _ => send_restore(&down, epoch)
@@ -3285,12 +3294,20 @@ impl SparseMoEEngine {
                 let (epoch, blob) = self
                     .block_on(recv_restore_carry_body_server(upstream))
                     .map_err(|e| format!("recv_restore_carry: {e}"))?;
-                let local_ok = match crate::kv_coordination::blob_decode(&blob) {
-                    Some(snap) => self.runner.restore_kv(&snap).is_ok(),
-                    None => false,
+                // Differentiate the two failure classes: wire corruption
+                // (decode) vs an apply failure (restore) — this is the one
+                // path where the blob crossed chains, so shape/version skew
+                // is the most likely and the least diagnosable.
+                let (local_ok, fail) = match crate::kv_coordination::blob_decode(&blob) {
+                    Some(snap) => match self.runner.restore_kv(&snap) {
+                        Ok(()) => (true, String::new()),
+                        Err(e) => (false, format!("restore: {e:?}")),
+                    },
+                    None => (false, "decode".to_string()),
                 };
                 tracing::info!(target: "cascadia::kv", event = "sparse_tail_restore_carried",
-                    rank = self.rank, epoch, ok = local_ok, blob_len = blob.len());
+                    rank = self.rank, epoch, ok = local_ok, blob_len = blob.len(),
+                    reason = %fail);
                 let down_ok = if let Some(down) = downstream.as_ref() {
                     self.block_on(async {
                         send_restore(down, epoch)
@@ -4281,17 +4298,25 @@ impl OvMoeEngine {
         let carried = self.kv_downstream.remove(&epoch);
         // Whether a downstream slice is riding along is the difference between a warm tail and a
         // cold one, and every site that could drop it was previously silent — a bare RESTORE and a
-        // never-stashed slice look identical from the logs.
-        tracing::info!(target: "cascadia::kv", event = "kv_carry_send", epoch,
-            carried = carried.is_some(), bytes = carried.as_ref().map_or(0, |b| b.len()),
+        // never-stashed slice look identical from the logs. `frame` names what is actually SENT:
+        // an oversized blob degrades to a bare RESTORE (deliberate clean cold), and logging
+        // carried=true alone would claim a carry that never went out.
+        let oversized = carried
+            .as_ref()
+            .is_some_and(|b| b.len() > crate::dist::MAX_RESTORE_BLOB_BYTES as usize);
+        let frame = match (&carried, oversized) {
+            (Some(_), false) => "carry",
+            (Some(_), true) => "bare_oversized",
+            (None, _) => "bare",
+        };
+        tracing::info!(target: "cascadia::kv", event = "kv_carry_send", epoch, frame,
+            bytes = carried.as_ref().map_or(0, |b| b.len()),
             stashed_epochs = self.kv_downstream.len());
         let verdict = self.block_on(async {
             match &carried {
-                Some(blob) if blob.len() <= crate::dist::MAX_RESTORE_BLOB_BYTES as usize => {
-                    send_restore_carry(&down, epoch, blob)
-                        .await
-                        .map_err(|e| format!("send_restore_carry: {e}"))?
-                }
+                Some(blob) if !oversized => send_restore_carry(&down, epoch, blob)
+                    .await
+                    .map_err(|e| format!("send_restore_carry: {e}"))?,
                 // None, or an oversized blob (guards the u32 len field + the peer's recv alloc) ⇒ bare
                 // RESTORE ⇒ the moved-to tail misses the foreign epoch ⇒ deliberate clean cold.
                 _ => send_restore(&down, epoch)
@@ -4441,12 +4466,20 @@ impl OvMoeEngine {
         let (epoch, blob) = self
             .block_on(recv_restore_carry_body_server(upstream))
             .map_err(|e| format!("recv_restore_carry: {e}"))?;
-        let local_ok = match crate::ov_kv_coordination::ov_blob_decode(&blob) {
-            Some(snap) => self.runner.restore_kv(&snap).is_ok(),
-            None => false,
+        // Differentiate the two failure classes: wire corruption (decode) vs
+        // an apply failure (restore) — this is the one path where the blob
+        // crossed chains, so shape/version skew is the most likely and the
+        // least diagnosable. Mirror of the SparseMoE handler.
+        let (local_ok, fail) = match crate::ov_kv_coordination::ov_blob_decode(&blob) {
+            Some(snap) => match self.runner.restore_kv(&snap) {
+                Ok(()) => (true, String::new()),
+                Err(e) => (false, format!("restore: {e:?}")),
+            },
+            None => (false, "decode".to_string()),
         };
         tracing::info!(target: "cascadia::kv", event = "ovmoe_tail_restore_carried",
-            rank = self.rank, epoch, ok = local_ok, blob_len = blob.len());
+            rank = self.rank, epoch, ok = local_ok, blob_len = blob.len(),
+            reason = %fail);
         let down_ok = if self.is_last() {
             true
         } else if let Some(down) = downstream {
@@ -4886,11 +4919,16 @@ impl cascadia_engine::KvCoordination for OvMoeEngine {
             return if same { Ok(()) } else { Err(()) };
         }
         let cap = self.kv_prefix_cache.capacity().max(1);
-        while self.kv_downstream.len() >= cap && !self.kv_downstream.contains_key(&epoch) {
+        // (`epoch` is never already present here — the collision guard above
+        // returned for that case.) Eviction silently downgrades the dropped
+        // epoch's future cross-chain restore to cold, so it must be visible.
+        while self.kv_downstream.len() >= cap {
             let Some(k) = self.kv_downstream.keys().next().copied() else {
                 break;
             };
             self.kv_downstream.remove(&k);
+            tracing::warn!(target: "cascadia::kv", event = "kv_carry_stash_evicted",
+                evicted_epoch = k, for_epoch = epoch, cap);
         }
         self.kv_downstream.insert(epoch, blob);
         Ok(())

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -933,6 +933,7 @@ impl Builder for SparseMoEBuilder {
             kv_handoff_mailbox: std::sync::Arc::new(
                 cascadia_engine::kv_handoff::KvHandoffMailbox::new(),
             ),
+            active: None,
         }))
     }
 }
@@ -1133,6 +1134,31 @@ const MAX_PENDING_TASKS: usize = 8;
 /// dist_spec uses for the same situation.
 const WORKER_BACKOFF: Duration = Duration::from_millis(200);
 
+/// In-flight multi-stage generation on rank 0 (one at a time; queued tasks
+/// wait in `pending`). This is the streamed replacement for the deleted
+/// whole-turn `drive_generation_first`.
+struct SparseActive {
+    id: TaskId,
+    downstream: Arc<TokioMutex<ActivationClient>>,
+    cfg: crate::sampling::SamplingConfig,
+    eos: Vec<i64>,
+    max_new: usize,
+    started: std::time::Instant,
+    /// prompt ++ resume-prefix ++ generated — `forward_one_token_first`
+    /// derives past_seq_len from this, so warm-skipped tokens are pushed too.
+    history: Vec<i64>,
+    /// Generated ids INCLUDING the resume seed (positions [0, seed_len)).
+    generated: Vec<u32>,
+    /// Byte length of decoded output already streamed (utf8_safe_delta cursor).
+    /// Seeded to the resume prefix's decoded byte length on a resumed turn.
+    emitted: usize,
+    resume_seed_len: usize,
+    /// The token to emit on the next decode_step (sampled by the last rank).
+    next: i64,
+    prompt_ids: Vec<i64>,
+    tenant: String,
+}
+
 pub struct SparseMoEEngine {
     pub(crate) runner: Runner,
     pub(crate) tokenizer: Option<Tokenizer>,
@@ -1202,6 +1228,8 @@ pub struct SparseMoEEngine {
     /// `step()` — so it only parks bytes here and the recv loop drains them at `RESTORE`.
     #[cfg(feature = "kv_coord")]
     pub(crate) kv_handoff_mailbox: std::sync::Arc<cascadia_engine::kv_handoff::KvHandoffMailbox>,
+    /// In-flight multi-stage generation, streamed one token per `step()`.
+    active: Option<SparseActive>,
 }
 
 impl SparseMoEEngine {
@@ -1320,6 +1348,11 @@ impl Engine for SparseMoEEngine {
         // cannot interrupt one already decoding. Mid-generation interruption
         // would need an out-of-mutex cancel token threaded into the decode
         // loop (architectural follow-up).
+        if self.active.as_ref().is_some_and(|a| &a.id == task_id) {
+            self.active = None; // free the slot; a zombie here never trips the
+                                 // runner's empty-step guard (lib.rs:1006 counts
+                                 // produced before the cancelled-filter)
+        }
         self.pending.retain(|t| &t.task_id != task_id);
     }
 
@@ -1620,12 +1653,31 @@ impl SparseMoEEngine {
         vec![(task.task_id.clone(), chunk)]
     }
 
-    /// Rank 0 driver: tokenize, drive prefill + decode through the
-    /// transport pipeline, return one final chunk for the task.
+    /// Rank 0 driver: token-streaming state machine (PipelineEngine pattern,
+    /// see `decode_step` below) — one active task at a time; queued tasks
+    /// wait in `pending`. This is the streamed replacement for the deleted
+    /// whole-turn `drive_generation_first`.
     fn step_first(&mut self) -> Vec<(TaskId, Chunk)> {
+        if self.active.is_none() {
+            if let Some(terminal) = self.begin_generation_sparse() {
+                return terminal;
+            }
+        }
+        self.decode_step_sparse()
+    }
+
+    /// Admit the next pending task and drive it through prefill. Only the
+    /// LAST prefill step samples a token (the others discard their sample so
+    /// the last rank's rep-penalty history isn't poisoned by prompt tokens),
+    /// so prefill is unavoidably whole-turn work; decode after that streams
+    /// one token per `step()` via `decode_step_sparse`. Returns `Some` for
+    /// every terminal outcome that doesn't reach decode (errors, the
+    /// zero-budget resume case, spec-decode's burst path, EOS on the very
+    /// first generated token); `None` means `self.active` is now armed.
+    fn begin_generation_sparse(&mut self) -> Option<Vec<(TaskId, Chunk)>> {
         let task = match self.pending.pop_front() {
             Some(t) => t,
-            None => return Vec::new(),
+            None => return Some(Vec::new()),
         };
         #[cfg(feature = "kv_coord")]
         self.kv_set_turn_tenant(&task.tenant);
@@ -1634,86 +1686,80 @@ impl SparseMoEEngine {
             let Some(tok) = self.tokenizer.as_ref() else {
                 warn!(task = %task.task_id, "rank-0 engine has no tokenizer");
                 let e = Chunk::error(task.task_id.clone(), "engine has no tokenizer".to_string());
-                return vec![(task.task_id, e)];
+                return Some(vec![(task.task_id, e)]);
             };
             match tok.encode(task.prompt.as_str(), true) {
                 Ok(enc) => enc.get_ids().iter().map(|&u| u as i64).collect(),
                 Err(e) => {
                     warn!(task = %task.task_id, "tokenizer encode failed: {e}");
-                    return vec![(
+                    return Some(vec![(
                         task.task_id.clone(),
                         Chunk::error(task.task_id, format!("tokenizer encode failed: {e}")),
-                    )];
+                    )]);
                 }
             }
         };
         // Option B forced-prefix resume: append the already-emitted assistant
-        // tokens after the rendered prompt (concat, not replace) — the
-        // distributed prefill loop below is agnostic to id origin, so the
-        // appended ids prefill naturally. No-op when not resuming.
-        // `resume_ids()` normalizes a wire-legal `Some([])` to "not resuming" —
-        // the old `is_some()` predicate forced greedy decode on such a turn.
-        let resume = task.resume_ids().map(<[i32]>::to_vec);
-        if let Some(r) = resume.as_deref() {
-            // Peer-supplied indices reach native prefill; bound them first
-            // (also makes the u32 casts below safe).
-            // `tok` above is scoped to the prompt_ids block; re-borrow. The
-            // else-branch there already returned when the tokenizer is absent,
-            // so unwrap_or(0) is unreachable-but-safe.
-            let vocab = self
-                .tokenizer
-                .as_ref()
-                .map(|t| t.get_vocab_size(true))
-                .unwrap_or(0) as u32;
-            if let Err(e) = cascadia_types::validate_resume_ids(r, Some(vocab)) {
+        // tokens after the rendered prompt (concat, not replace) and seed the
+        // streaming accumulator from them — the distributed prefill loop
+        // below is agnostic to id origin, so the appended ids prefill
+        // naturally. `Ok(None)` on a plain (non-resume) turn.
+        let mut seed_opt = match self
+            .tokenizer
+            .as_ref()
+            .map(|t| prepare_resume(&task, t, &mut prompt_ids))
+            .unwrap() // tokenizer presence already checked above
+        {
+            Ok(s) => s,
+            Err(e) => {
                 let id = task.task_id.clone();
-                return vec![(
-                    id.clone(),
-                    Chunk::error(id, format!("invalid resume prefix: {e}")),
-                )];
+                return Some(vec![(id.clone(), Chunk::error(id, e))]);
             }
+        };
+        if seed_opt.is_some() {
+            info!(task = %task.task_id, event = "resume_admitted",
+                  seed_len = seed_opt.as_ref().unwrap().seed_len,
+                  "Option B resume admitted (multi-stage, streamed)");
         }
-        append_resume_ids(&mut prompt_ids, resume.as_deref());
         // Non-resume keeps the base contract: max_tokens == 0 still yields one
         // token (`.max(1)`, matching gemma4/qwen36/ov-runtime). Only a RESUMED
         // turn may land at zero new tokens (budget exhausted by the prefix) —
         // review found this branch had silently flipped the plain max_tokens=0
         // behavior from 1 token to 0.
-        let max_new = if resume.is_some() {
-            resume_max_new(task.max_tokens, resume.as_deref())
+        let max_new = if seed_opt.is_some() {
+            resume_max_new(task.max_tokens, task.resume_ids())
         } else {
             task.max_tokens.max(1) as usize
         };
         let mut sampling_cfg = sampling_from_task(&task);
         // Option B: force greedy decode on a resumed turn so the continuation
         // is deterministic (see step_single_stage for rationale).
-        if resume.is_some() {
+        if seed_opt.is_some() {
             sampling_cfg.temperature = 0.0;
         }
         if max_new == 0 {
-            // Budget already exhausted by the resume prefix. Both
-            // drive_generation_first and drive_generation_first_spec
-            // unconditionally sample one token off the last prefill step
-            // regardless of max_new, so we must not drive generation at all
-            // — the only way to guarantee zero new tokens here.
+            // Budget already exhausted by the resume prefix. The prefill loop
+            // below unconditionally samples one token off the last prefill
+            // step regardless of max_new, so we must not drive generation at
+            // all — the only way to guarantee zero new tokens here.
             let elapsed = started.elapsed().as_secs_f64();
             info!(task = %task.task_id, elapsed_s = elapsed, "task done (rank-0 driver, resume budget exhausted)");
             let mut chunk = Chunk::final_marker(task.task_id.clone(), "");
             chunk.n_tokens = Some(0);
             chunk.finish_reason = Some(FinishReason::Length);
-            return vec![(task.task_id, chunk)];
+            return Some(vec![(task.task_id, chunk)]);
         }
         let downstream = match self.transport.downstream.clone() {
             Some(d) => d,
             None => {
                 warn!("rank 0 has no downstream peer in multi-stage mode");
-                return vec![(
+                return Some(vec![(
                     task.task_id.clone(),
                     Chunk::error(
                         task.task_id,
                         "rank 0 has no downstream peer in multi-stage mode".to_string(),
                     ),
-                )];
+                )]);
             }
         };
 
@@ -1721,26 +1767,40 @@ impl SparseMoEEngine {
         self.runner.reset_kv();
         if let Err(e) = self.block_on(send_reset(&downstream)) {
             warn!(task = %task.task_id, "send_reset: {e}");
-            return vec![(
+            return Some(vec![(
                 task.task_id.clone(),
                 Chunk::error(task.task_id, format!("send_reset: {e}")),
-            )];
+            )]);
         }
 
-        // Drive the full generation. result_tokens collects new tokens
-        // generated AFTER the prompt (we discard the prefill responses).
         // If spec-decode is enabled AND we're greedy (temp==0), use the
-        // batched ForwardBatch path; otherwise fall back to the
-        // per-token Forward driver.
+        // batched ForwardBatch path; otherwise fall back to the per-token
+        // Forward driver (streamed below).
         let use_spec =
             self.spec_decode_k.map(|k| k > 0).unwrap_or(false) && sampling_cfg.temperature <= 0.0;
+        if use_spec && seed_opt.is_some() {
+            // Spec-decode verifies K tokens per round and stays burst (spec §3.2);
+            // it cannot honor a forced prefix mid-round. Decline BEFORE any chunk so
+            // the scheduler's first-frame peek sees the sentinel (B6 retry).
+            let id = task.task_id.clone();
+            return Some(vec![(
+                id.clone(),
+                Chunk::error(
+                    id,
+                    format!(
+                        "resume_unsupported: spec-decode path cannot force-prefix (task {})",
+                        task.task_id
+                    ),
+                ),
+            )]);
+        }
 
         // Issue-34 consume (§8): SAME-CHAIN warm-resume. On a kv-prefix-cache hit, restore the head's
         // own rank-0 slice and RESTORE the whole downstream chain (all-or-nothing); on success skip
         // re-prefilling the matched prefix (`warm_prefix`). Any rank short ⇒ discard: re-RESET local +
         // downstream and cold-run. Runs after the admission RESET above and before generation (rule §2).
         // Inert unless kv_coord + cache enabled + a hit on the non-spec path; `warm_prefix == 0` leaves
-        // `drive_generation_first` byte-identical to the cold path. Spec-decode stays cold (parity with
+        // the prefill loop byte-identical to the cold path. Spec-decode stays cold (parity with
         // the single-stage cache bypass).
         #[cfg(feature = "kv_coord")]
         let warm_prefix: usize = if !use_spec && self.kv_prefix_cache.enabled() {
@@ -1770,13 +1830,13 @@ impl SparseMoEEngine {
                         self.runner.reset_kv();
                         if let Err(e) = self.block_on(send_reset(&downstream)) {
                             warn!(task = %task.task_id, "cold-fallback send_reset: {e}");
-                            return vec![(
+                            return Some(vec![(
                                 task.task_id.clone(),
                                 Chunk::error(
                                     task.task_id,
                                     format!("cold-fallback send_reset: {e}"),
                                 ),
-                            )];
+                            )]);
                         }
                         0
                     }
@@ -1789,14 +1849,16 @@ impl SparseMoEEngine {
         #[cfg(not(feature = "kv_coord"))]
         let warm_prefix: usize = 0;
 
-        let result_tokens = if use_spec {
+        // Spec-decode: unchanged burst path (seed_opt is guaranteed None here
+        // — the decline above already returned for a resumed+spec turn).
+        if use_spec {
             let k = self.spec_decode_k.unwrap();
             info!(
                 task = %task.task_id,
                 draft_k = k,
                 "using n-gram speculative decode (pipeline-parallel)"
             );
-            match self.drive_generation_first_spec(
+            let result_tokens = match self.drive_generation_first_spec(
                 &prompt_ids,
                 max_new,
                 k as usize,
@@ -1806,56 +1868,316 @@ impl SparseMoEEngine {
                 Ok(g) => g,
                 Err(e) => {
                     warn!(task = %task.task_id, "rank-0 spec-decode driver failed: {e}");
-                    return vec![(
+                    return Some(vec![(
                         task.task_id.clone(),
                         Chunk::error(
                             task.task_id,
                             format!("rank-0 spec-decode driver failed: {e}"),
                         ),
-                    )];
+                    )]);
                 }
-            }
-        } else {
-            match self.drive_generation_first(
-                &prompt_ids,
-                max_new,
-                &sampling_cfg,
-                &downstream,
-                warm_prefix,
-            ) {
-                Ok(g) => g,
-                Err(e) => {
-                    warn!(task = %task.task_id, "rank-0 driver failed: {e}");
-                    return vec![(
-                        task.task_id.clone(),
-                        Chunk::error(task.task_id, format!("rank-0 driver failed: {e}")),
-                    )];
-                }
-            }
-        };
+            };
 
+            // Issue-34 Task 1.3 (§8): capture the full post-turn sequence's KV across the whole chain so
+            // a forced move can warm-resume. The head mints E = synth_epoch(full tokens) and broadcasts
+            // CAPTURE(E, tokens) downstream; each stage snapshots its slice under E and acks back up; the
+            // head's single ack means every stage captured. Then the head seeds its own prefix cache so a
+            // later NEGOTIATE maps the prefix → E. Best-effort: any transport/snapshot error just skips the
+            // cache (warm-pull degrades to cold) and never affects the already-complete served output.
+            #[cfg(feature = "kv_coord")]
+            if self.kv_prefix_cache.enabled() && !result_tokens.is_empty() {
+                let mut full_tokens: Vec<i32> = prompt_ids.iter().map(|&t| t as i32).collect();
+                full_tokens.extend(result_tokens.iter().map(|&t| t as i32));
+                let epoch = crate::kv_coordination::synth_epoch(&full_tokens);
+                // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and the only
+                // ceiling otherwise is the transport frame-idle default — reached before this turn's
+                // already-complete chunks are returned. Timeout ⇒ capture skipped, turn delivered.
+                let acked = self.block_on(async {
+                    match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
+                        send_capture(&downstream, epoch, &full_tokens, &task.tenant)
+                            .await
+                            .map_err(|e| format!("send_capture: {e}"))?;
+                        match recv_kind_client(&downstream).await {
+                            Ok(Some(FrameKind::CaptureAck)) => {
+                                recv_capture_ack_body_client(&downstream)
+                                    .await
+                                    .map(|_| ())
+                                    .map_err(|e| format!("recv_capture_ack: {e}"))
+                            }
+                            Ok(Some(other)) => Err(format!("expected CaptureAck, got {other:?}")),
+                            Ok(None) => Err("downstream closed during capture".into()),
+                            Err(e) => Err(format!("recv_kind (capture): {e}")),
+                        }
+                    })
+                    .await
+                    {
+                        Ok(r) => r,
+                        Err(_) => Err(format!(
+                            "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}"
+                        )),
+                    }
+                });
+                match acked {
+                    Ok(()) => {
+                        if let Ok(snap) = self.runner.snapshot_kv() {
+                            let fp = self.runner.fingerprint();
+                            let prompt64: Vec<i64> =
+                                full_tokens.iter().map(|&t| i64::from(t)).collect();
+                            // Mirror into the holder cache so a busy engine still serves this prefix.
+                            self.kv_share
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .prefix
+                                .insert(prompt64.clone(), &fp, snap.clone());
+                            self.kv_prefix_cache.insert(prompt64, &fp, snap);
+                        }
+                    }
+                    Err(e) => warn!(task = %task.task_id, "kv multi-stage capture skipped: {e}"),
+                }
+            }
+
+            let n_tokens = result_tokens.len() as u32;
+            let Some(tokenizer) = self.tokenizer.as_ref() else {
+                warn!("tokenizer disappeared mid-task");
+                return Some(vec![(
+                    task.task_id.clone(),
+                    Chunk::error(task.task_id, "tokenizer disappeared mid-task".to_string()),
+                )]);
+            };
+            let ids_u32: Vec<u32> = result_tokens.iter().map(|&i| i as u32).collect();
+            let mut text = tokenizer
+                .decode(&ids_u32, true)
+                .unwrap_or_else(|_| String::new());
+            if let Some(stripped) = text.strip_prefix(&task.prompt) {
+                text = stripped.trim_start().to_string();
+            }
+            let elapsed = started.elapsed().as_secs_f64();
+            info!(
+                task = %task.task_id,
+                tokens = n_tokens,
+                elapsed_s = elapsed,
+                tok_s = if elapsed > 0.0 { n_tokens as f64 / elapsed } else { 0.0 },
+                rank = self.rank,
+                total = self.total,
+                "task done (rank-0 driver)"
+            );
+            let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
+            chunk.n_tokens = Some(n_tokens);
+            chunk.token_ids = result_tokens;
+            chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
+            return Some(vec![(task.task_id.clone(), chunk)]);
+        }
+
+        // Non-spec path: PREFILL ONLY. The very last prompt token's sampled
+        // reply becomes the first generated token, stashed in `active.next`
+        // — `decode_step_sparse` emits it (and drives every token after) on
+        // the following `step()` calls.
+        let eos: Vec<i64> = self
+            .runner
+            .manifest
+            .eos_token_ids
+            .iter()
+            .map(|&x| x as i64)
+            .collect();
+        let mut history: Vec<i64> = Vec::with_capacity(prompt_ids.len() + max_new);
+
+        info!(
+            prompt_len = prompt_ids.len(),
+            warm_prefix, "prefill (token-by-token, distributed)"
+        );
+        // Streamed-prefill sync window: every N intermediate tokens go as a
+        // blocking ForwardNoSample (which acks) instead of a one-way
+        // ForwardPrefill. This bounds the number of un-acked frames in flight
+        // so rank 0's single final recv can't exceed the transport frame-idle
+        // ceiling on a very long prompt, and it surfaces a mid-prefill failure
+        // within one window rather than only at the very end.
+        const PREFILL_SYNC_EVERY: usize = 256;
+        let mut token_back: i64 = -1;
+        for (i, &t) in prompt_ids.iter().enumerate() {
+            history.push(t);
+            if i < warm_prefix {
+                // KV already restored for this token; skip its forward but keep `history` growing so
+                // `forward_one_token_first`'s `past_seq_len` stays correct. The prefix-cache `lookup`
+                // guarantees `warm_prefix < prompt_ids.len()`, so a suffix token always follows.
+                continue;
+            }
+            if i + 1 == prompt_ids.len() {
+                // Last prompt token: a sampling Forward; the token it returns
+                // is the first generated token.
+                match self.forward_one_token_first(&history, &sampling_cfg, &downstream, true) {
+                    Ok(t) => token_back = t,
+                    Err(e) => {
+                        return Some(vec![(
+                            task.task_id.clone(),
+                            Chunk::error(task.task_id, format!("prefill final step {i}: {e}")),
+                        )]);
+                    }
+                }
+            } else if (i + 1) % PREFILL_SYNC_EVERY == 0 {
+                // Periodic blocking sync (discards the dummy Token(-1) ack).
+                if let Err(e) =
+                    self.forward_one_token_first(&history, &sampling_cfg, &downstream, false)
+                {
+                    return Some(vec![(
+                        task.task_id.clone(),
+                        Chunk::error(task.task_id, format!("prefill sync step {i}: {e}")),
+                    )]);
+                }
+            } else {
+                // Intermediate prompt tokens stream one-way (no ack) so they
+                // pipeline through the ranks — the compute overlaps instead of
+                // one blocking round-trip each. See FrameKind::ForwardPrefill.
+                if let Err(e) =
+                    self.forward_prefill_step_first(&history, &sampling_cfg, &downstream)
+                {
+                    return Some(vec![(
+                        task.task_id.clone(),
+                        Chunk::error(task.task_id, format!("prefill stream step {i}: {e}")),
+                    )]);
+                }
+            }
+        }
+
+        // SparseMoE EXCLUDES the EOS token: `active` is not set yet at this
+        // point, so an EOS on the very first generated token can't route
+        // through `finalize_sparse` — build the empty final inline (old
+        // behavior: empty `generated` → 0-token final; capture skipped, same
+        // as the old block's `!result_tokens.is_empty()` gate).
+        if eos.contains(&token_back) {
+            let mut chunk = Chunk::final_marker(task.task_id.clone(), "");
+            chunk.n_tokens = Some(0);
+            chunk.finish_reason = Some(finish_reason_for(0, max_new));
+            return Some(vec![(task.task_id, chunk)]);
+        }
+
+        let (generated, emitted, resume_seed_len) = match seed_opt.take() {
+            Some(s) => (s.generated_u32, s.emitted, s.seed_len),
+            None => (Vec::with_capacity(max_new), 0usize, 0usize),
+        };
+        self.active = Some(SparseActive {
+            id: task.task_id.clone(),
+            downstream,
+            cfg: sampling_cfg,
+            eos,
+            max_new,
+            started,
+            history,
+            generated,
+            emitted,
+            resume_seed_len,
+            next: token_back,
+            prompt_ids,
+            tenant: task.tenant.clone(),
+        });
+        None
+    }
+
+    /// Emit one token from the in-flight task, or finalize when it ends.
+    /// Adapted from `PipelineEngine::decode_step` with SparseMoE's EOS
+    /// EXCLUSION (test BEFORE push, emit nothing for it) and history-based
+    /// forward (`forward_one_token_first` derives `past_seq_len` from
+    /// `history.len()`, not a separate `pos` counter).
+    fn decode_step_sparse(&mut self) -> Vec<(TaskId, Chunk)> {
+        let (id, next) = {
+            let a = self.active.as_ref().unwrap();
+            (a.id.clone(), a.next)
+        };
+        // SparseMoE EXCLUDES the EOS token (runner.rs, old decode loop): test
+        // BEFORE push, emit nothing for it, finalize with what we have.
+        let is_eos = self.active.as_ref().unwrap().eos.contains(&next);
+        if is_eos {
+            return self.finalize_sparse(true);
+        }
+        let next_u = next as u32;
+        {
+            let a = self.active.as_mut().unwrap();
+            a.generated.push(next_u);
+            a.history.push(next);
+        }
+        let full = self
+            .tokenizer
+            .as_ref()
+            .unwrap()
+            .decode(&self.active.as_ref().unwrap().generated, true)
+            .unwrap_or_default();
+        let delta = {
+            let a = self.active.as_mut().unwrap();
+            utf8_safe_delta(&full, &mut a.emitted)
+        };
+        let mut token_chunk = Chunk::token(id.clone(), next, delta);
+        token_chunk.n_tokens = Some(1);
+        // Splicer poison bypass (spec §4.1): token_id==0 with empty token_ids
+        // reads as id-less; stamp the single id explicitly.
+        token_chunk.token_ids = vec![next];
+        let (gen_new, max_new) = {
+            let a = self.active.as_ref().unwrap();
+            (a.generated.len() - a.resume_seed_len, a.max_new)
+        };
+        if gen_new >= max_new {
+            let mut out = vec![(id, token_chunk)];
+            out.extend(self.finalize_sparse(true));
+            return out;
+        }
+        let downstream = self.active.as_ref().unwrap().downstream.clone();
+        let cfg = self.active.as_ref().unwrap().cfg.clone();
+        let history = self.active.as_ref().unwrap().history.clone();
+        match self.forward_one_token_first(&history, &cfg, &downstream, true) {
+            Ok(tok_back) => {
+                self.active.as_mut().unwrap().next = tok_back;
+                vec![(id, token_chunk)]
+            }
+            Err(e) => {
+                // Spec §4.1: a mid-decode forward failure is the chain-death signal
+                // Option B splices on. Emitting a final marker here would trip the
+                // scheduler's saw_final latch and permanently block the resume —
+                // surface an ERROR chunk instead (deliberate divergence from
+                // PipelineEngine's partial-final, which predates Option B). No
+                // capture; clear the slot.
+                warn!(task = %id, "decode forward failed; surfacing error for resume: {e}");
+                self.active = None;
+                vec![
+                    (id.clone(), token_chunk),
+                    (id.clone(), Chunk::error(id, format!("decode forward failed: {e}"))),
+                ]
+            }
+        }
+    }
+
+    /// Finalize the in-flight task: best-effort whole-chain KV capture (so a
+    /// forced move can warm-resume this turn), then the empty final marker.
+    /// `capture` lets a caller skip the KV round-trip on an already-dead
+    /// chain (mirrors `PipelineEngine::finalize_pipeline`'s `cache` flag);
+    /// every current call site passes `true`.
+    fn finalize_sparse(&mut self, capture: bool) -> Vec<(TaskId, Chunk)> {
+        let Some(a) = self.active.take() else {
+            return Vec::new();
+        };
+        let n_new = (a.generated.len() - a.resume_seed_len) as u32;
         // Issue-34 Task 1.3 (§8): capture the full post-turn sequence's KV across the whole chain so
         // a forced move can warm-resume. The head mints E = synth_epoch(full tokens) and broadcasts
         // CAPTURE(E, tokens) downstream; each stage snapshots its slice under E and acks back up; the
         // head's single ack means every stage captured. Then the head seeds its own prefix cache so a
         // later NEGOTIATE maps the prefix → E. Best-effort: any transport/snapshot error just skips the
         // cache (warm-pull degrades to cold) and never affects the already-complete served output.
+        // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
+        // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
+        let should_capture = capture && n_new > 0;
         #[cfg(feature = "kv_coord")]
-        if self.kv_prefix_cache.enabled() && !result_tokens.is_empty() {
-            let mut full_tokens: Vec<i32> = prompt_ids.iter().map(|&t| t as i32).collect();
-            full_tokens.extend(result_tokens.iter().map(|&t| t as i32));
+        if should_capture && self.kv_prefix_cache.enabled() {
+            let mut full_tokens: Vec<i32> = a.prompt_ids.iter().map(|&t| t as i32).collect();
+            full_tokens.extend(a.generated[a.resume_seed_len..].iter().map(|&t| t as i32));
             let epoch = crate::kv_coordination::synth_epoch(&full_tokens);
             // Bounded: an older peer that meets CaptureV2 errors WITHOUT acking, and the only
             // ceiling otherwise is the transport frame-idle default — reached before this turn's
             // already-complete chunks are returned. Timeout ⇒ capture skipped, turn delivered.
             let acked = self.block_on(async {
                 match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
-                    send_capture(&downstream, epoch, &full_tokens, &task.tenant)
+                    send_capture(&a.downstream, epoch, &full_tokens, &a.tenant)
                         .await
                         .map_err(|e| format!("send_capture: {e}"))?;
-                    match recv_kind_client(&downstream).await {
+                    match recv_kind_client(&a.downstream).await {
                         Ok(Some(FrameKind::CaptureAck)) => {
-                            recv_capture_ack_body_client(&downstream)
+                            recv_capture_ack_body_client(&a.downstream)
                                 .await
                                 .map(|_| ())
                                 .map_err(|e| format!("recv_capture_ack: {e}"))
@@ -1873,7 +2195,7 @@ impl SparseMoEEngine {
                         // usually alive and its CaptureAck (no sequence number) lands after
                         // we stopped waiting — a reused connection hands it to the NEXT
                         // exchange as its reply.
-                        downstream.lock().await.close().await;
+                        a.downstream.lock().await.close().await;
                         Err(format!(
                             "capture ack timed out after {CAPTURE_ACK_TIMEOUT:?}; \
                              connection dropped to avoid reading the late ack as the next \
@@ -1897,174 +2219,17 @@ impl SparseMoEEngine {
                         self.kv_prefix_cache.insert(prompt64, &fp, snap);
                     }
                 }
-                Err(e) => warn!(task = %task.task_id, "kv multi-stage capture skipped: {e}"),
+                Err(e) => warn!(task = %a.id, "kv multi-stage capture skipped: {e}"),
             }
         }
-
-        let n_tokens = result_tokens.len() as u32;
-        let Some(tokenizer) = self.tokenizer.as_ref() else {
-            warn!("tokenizer disappeared mid-task");
-            return vec![(
-                task.task_id.clone(),
-                Chunk::error(task.task_id, "tokenizer disappeared mid-task".to_string()),
-            )];
-        };
-        // Option B §17: see step_single_stage for why a resumed turn must
-        // decode prefix+tail together (preserves the seam space that a
-        // tail-only decode would strip at sequence-start).
-        let text = if let Some(r) = resume.as_deref() {
-            let prefix_u32: Vec<u32> = r.iter().map(|&i| i as u32).collect();
-            // Propagate decode errors — `unwrap_or_default()` on the PREFIX
-            // decode made the slice offset 0, re-emitting the entire forced
-            // prefix to the client (the exact defect dist_spec's comment warns
-            // about); on the FULL decode it silently dropped the whole tail.
-            let prefix_text = match tokenizer.decode(&prefix_u32, true) {
-                Ok(t) => t,
-                Err(e) => {
-                    let id = task.task_id.clone();
-                    return vec![(
-                        id.clone(),
-                        Chunk::error(id, format!("resume seed decode failed: {e}")),
-                    )];
-                }
-            };
-            let mut full_u32 = prefix_u32;
-            full_u32.extend(result_tokens.iter().map(|&i| i as u32));
-            let full_text = match tokenizer.decode(&full_u32, true) {
-                Ok(t) => t,
-                Err(e) => {
-                    let id = task.task_id.clone();
-                    return vec![(
-                        id.clone(),
-                        Chunk::error(id, format!("resume tail decode failed: {e}")),
-                    )];
-                }
-            };
-            // Divergence guard: the blind byte-offset slice assumes the prefix
-            // decode is a byte-prefix of the full decode. A byte-level seam
-            // (chain A held back a partial UTF-8 char whose token IS in the
-            // prefix) breaks that: U+FFFD bytes in `prefix_text` resolve to
-            // different bytes in `full_text`, and an unlucky boundary silently
-            // re-emits prefix bytes or drops seam text. Re-anchor instead —
-            // emit only what provably follows the prefix (same contract as the
-            // shim's `advance_emitted`).
-            if full_text.as_bytes().starts_with(prefix_text.as_bytes()) {
-                full_text.get(prefix_text.len()..).unwrap_or("").to_string()
-            } else {
-                warn!(task = %task.task_id, "resume seam diverged; re-anchoring (tail delta dropped)");
-                String::new()
-            }
-        } else {
-            let ids_u32: Vec<u32> = result_tokens.iter().map(|&i| i as u32).collect();
-            let mut t = tokenizer
-                .decode(&ids_u32, true)
-                .unwrap_or_else(|_| String::new());
-            if let Some(stripped) = t.strip_prefix(&task.prompt) {
-                t = stripped.trim_start().to_string();
-            }
-            t
-        };
-        let elapsed = started.elapsed().as_secs_f64();
-        info!(
-            task = %task.task_id,
-            tokens = n_tokens,
-            elapsed_s = elapsed,
-            tok_s = if elapsed > 0.0 { n_tokens as f64 / elapsed } else { 0.0 },
-            rank = self.rank,
-            total = self.total,
-            "task done (rank-0 driver)"
-        );
-        let mut chunk = Chunk::final_marker(task.task_id.clone(), text);
-        chunk.n_tokens = Some(n_tokens);
-        chunk.token_ids = result_tokens;
-        chunk.finish_reason = Some(finish_reason_for(n_tokens as usize, max_new));
-        vec![(task.task_id.clone(), chunk)]
-    }
-
-    /// Rank 0 generation loop. For each prompt token + each decode
-    /// step: embed → forward through my shells → send hidden
-    /// downstream → recv sampled token back. Discards prefill samples
-    /// except the last (which becomes the first generated token).
-    fn drive_generation_first(
-        &mut self,
-        prompt_ids: &[i64],
-        max_new: usize,
-        cfg: &crate::sampling::SamplingConfig,
-        downstream: &Arc<TokioMutex<ActivationClient>>,
-        // Issue-34 (§8): count of leading prompt tokens whose KV is already in the chain's restored
-        // caches (same-chain warm-resume). Those tokens are pushed into `history` for the past_seq_len
-        // accounting but NOT forwarded. `0` on every cold path ⇒ the loop below is byte-identical.
-        warm_prefix: usize,
-    ) -> Result<Vec<i64>, String> {
-        let hidden = self.runner.manifest.hidden_size as usize;
-        let eos: Vec<i64> = self
-            .runner
-            .manifest
-            .eos_token_ids
-            .iter()
-            .map(|&x| x as i64)
-            .collect();
-        let mut history: Vec<i64> = Vec::with_capacity(prompt_ids.len() + max_new);
-        let mut generated: Vec<i64> = Vec::with_capacity(max_new);
-
-        // Prefill: feed each prompt token; the very last response from
-        // last-rank becomes the first generated token.
-        info!(
-            prompt_len = prompt_ids.len(),
-            warm_prefix, "prefill (token-by-token, distributed)"
-        );
-        // Streamed-prefill sync window: every N intermediate tokens go as a
-        // blocking ForwardNoSample (which acks) instead of a one-way
-        // ForwardPrefill. This bounds the number of un-acked frames in flight
-        // so rank 0's single final recv can't exceed the transport frame-idle
-        // ceiling on a very long prompt, and it surfaces a mid-prefill failure
-        // within one window rather than only at the very end.
-        const PREFILL_SYNC_EVERY: usize = 256;
-        for (i, &t) in prompt_ids.iter().enumerate() {
-            history.push(t);
-            if i < warm_prefix {
-                // KV already restored for this token; skip its forward but keep `history` growing so
-                // `forward_one_token_first`'s `past_seq_len` stays correct. The prefix-cache `lookup`
-                // guarantees `warm_prefix < prompt_ids.len()`, so a suffix token always follows.
-                continue;
-            }
-            if i + 1 == prompt_ids.len() {
-                // Last prompt token: a sampling Forward; the token it returns
-                // is the first generated token.
-                let token_back = self
-                    .forward_one_token_first(&history, cfg, downstream, true)
-                    .map_err(|e| format!("prefill final step {i}: {e}"))?;
-                if eos.contains(&token_back) {
-                    return Ok(generated);
-                }
-                generated.push(token_back);
-                history.push(token_back);
-            } else if (i + 1) % PREFILL_SYNC_EVERY == 0 {
-                // Periodic blocking sync (discards the dummy Token(-1) ack).
-                self.forward_one_token_first(&history, cfg, downstream, false)
-                    .map_err(|e| format!("prefill sync step {i}: {e}"))?;
-            } else {
-                // Intermediate prompt tokens stream one-way (no ack) so they
-                // pipeline through the ranks — the compute overlaps instead of
-                // one blocking round-trip each. See FrameKind::ForwardPrefill.
-                self.forward_prefill_step_first(&history, cfg, downstream)
-                    .map_err(|e| format!("prefill stream step {i}: {e}"))?;
-            }
-        }
-
-        // Decode loop.
-        for step_i in 1..max_new {
-            let token_back = self
-                .forward_one_token_first(&history, cfg, downstream, true)
-                .map_err(|e| format!("decode step {step_i}: {e}"))?;
-            if eos.contains(&token_back) {
-                break;
-            }
-            generated.push(token_back);
-            history.push(token_back);
-        }
-        let _ = hidden;
-        Ok(generated)
+        let elapsed = a.started.elapsed().as_secs_f64();
+        info!(task = %a.id, tokens = n_new, elapsed_s = elapsed,
+            tok_s = if elapsed > 0.0 { f64::from(n_new) / elapsed } else { 0.0 },
+            rank = self.rank, total = self.total, "task done (rank-0 driver, streamed)");
+        let mut chunk = Chunk::final_marker(a.id.clone(), "");
+        chunk.n_tokens = Some(0);
+        chunk.finish_reason = Some(finish_reason_for(n_new as usize, a.max_new));
+        vec![(a.id, chunk)]
     }
 
     /// Rank-0 streamed-prefill step: embed + run my shells on the most
@@ -2241,7 +2406,8 @@ impl SparseMoEEngine {
     ///
     /// Greedy-only by construction — temperature > 0 would change the
     /// distribution under greedy acceptance; callers must dispatch the
-    /// non-greedy path to `drive_generation_first` instead.
+    /// non-greedy path to the streamed prefill loop in
+    /// `begin_generation_sparse` instead.
     fn drive_generation_first_spec(
         &mut self,
         prompt_ids: &[i64],

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1140,6 +1140,26 @@ fn prefill_reply_budget(
     }
 }
 
+/// Decode-phase bound on a Forward's owed Token reply. The enterprise bridge
+/// PARKS a dead pipeline leg for re-pair instead of closing the engine-side
+/// loopback socket, so a SIGKILLed downstream never surfaces as a transport
+/// error on this wait — only a deadline can. Unbounded, the wait outlives the
+/// gateway's inter-token budget and the stream dies as a Stall with no error
+/// chunk for the resume splicer to rescue (rig 2026-08-27, sparse-moe +
+/// sparse-moe-k26 resume certs).
+fn decode_reply_deadline() -> std::time::Duration {
+    per_token_reply_budget(cascadia_transport::recv_timeout())
+}
+
+/// Prefill-phase bound for the same wait (widened: a prefill step can follow
+/// a heavy downstream set_state after a warm RESTORE).
+fn prefill_reply_deadline() -> std::time::Duration {
+    prefill_reply_budget(
+        cascadia_transport::recv_timeout(),
+        cascadia_transport::frame_idle_ceiling(),
+    )
+}
+
 /// Hard cap on the pending-task queue. step() processes one task end-to-end
 /// per call, so the OS-level backpressure of returning QueueFull is
 /// preferable to silently accreting tasks the engine will not reach for
@@ -1999,7 +2019,13 @@ impl SparseMoEEngine {
             if i + 1 == prompt_ids.len() {
                 // Last prompt token: a sampling Forward; the token it returns
                 // is the first generated token.
-                match self.forward_one_token_first(&history, &sampling_cfg, &downstream, true) {
+                match self.forward_one_token_first(
+                    &history,
+                    &sampling_cfg,
+                    &downstream,
+                    true,
+                    prefill_reply_deadline(),
+                ) {
                     Ok(t) => token_back = t,
                     Err(e) => {
                         return Some(vec![(
@@ -2010,9 +2036,13 @@ impl SparseMoEEngine {
                 }
             } else if (i + 1) % PREFILL_SYNC_EVERY == 0 {
                 // Periodic blocking sync (discards the dummy Token(-1) ack).
-                if let Err(e) =
-                    self.forward_one_token_first(&history, &sampling_cfg, &downstream, false)
-                {
+                if let Err(e) = self.forward_one_token_first(
+                    &history,
+                    &sampling_cfg,
+                    &downstream,
+                    false,
+                    prefill_reply_deadline(),
+                ) {
                     return Some(vec![(
                         task.task_id.clone(),
                         Chunk::error(task.task_id, format!("prefill sync step {i}: {e}")),
@@ -2155,7 +2185,13 @@ impl SparseMoEEngine {
         // memcpy over the turn. forward only reads the slice; put it back on
         // success (the Err arm drops the whole slot, history with it).
         let history = std::mem::take(&mut self.active.as_mut().unwrap().history);
-        match self.forward_one_token_first(&history, &cfg, &downstream, true) {
+        match self.forward_one_token_first(
+            &history,
+            &cfg,
+            &downstream,
+            true,
+            decode_reply_deadline(),
+        ) {
             Ok(tok_back) => {
                 let a = self.active.as_mut().unwrap();
                 a.history = history;
@@ -2405,6 +2441,7 @@ impl SparseMoEEngine {
         cfg: &crate::sampling::SamplingConfig,
         downstream: &Arc<TokioMutex<ActivationClient>>,
         sample_back: bool,
+        reply_deadline: std::time::Duration,
     ) -> Result<i64, String> {
         let hidden = self.runner.manifest.hidden_size as usize;
         let past_seq_len: u32 = history
@@ -2455,17 +2492,11 @@ impl SparseMoEEngine {
                 .map_err(|e| format!("send_forward_nosample: {e}"))?;
             }
             let send_done_us = wire_t0.elapsed().as_micros() as u64;
-            match recv_kind_client(downstream).await {
-                Ok(Some(FrameKind::Token)) => {
-                    let token = recv_token_body_client(downstream)
-                        .await
-                        .map_err(|e| format!("recv_token: {e}"))?;
-                    Ok((token, send_done_us))
-                }
-                Ok(Some(other)) => Err(format!("unexpected frame after forward: {other:?}")),
-                Ok(None) => Err("downstream closed during recv_kind".into()),
-                Err(e) => Err(format!("recv_kind: {e}")),
-            }
+            // BOUNDED reply wait (closes the connection on elapse — the late
+            // Token would otherwise pair with the next request). See
+            // `decode_reply_deadline` for why a dead peer never errors here.
+            let token = crate::dist::recv_token_reply(downstream, reply_deadline).await?;
+            Ok((token, send_done_us))
         });
         match result {
             Ok((token, send_done_us)) => {
@@ -2529,7 +2560,13 @@ impl SparseMoEEngine {
             // samples; intermediates go as ForwardNoSample so their
             // discarded tokens never pollute the last rank's history.
             let token_back = self
-                .forward_one_token_first(&history, cfg, downstream, i + 1 == prompt_ids.len())
+                .forward_one_token_first(
+                    &history,
+                    cfg,
+                    downstream,
+                    i + 1 == prompt_ids.len(),
+                    prefill_reply_deadline(),
+                )
                 .map_err(|e| format!("spec prefill step {i}: {e}"))?;
             if i + 1 == prompt_ids.len() {
                 if eos.contains(&token_back) {
@@ -2557,7 +2594,13 @@ impl SparseMoEEngine {
             // No proposal → fall back to one standard forward step.
             if drafts.is_empty() {
                 let token_back = self
-                    .forward_one_token_first(&history, cfg, downstream, true)
+                    .forward_one_token_first(
+                        &history,
+                        cfg,
+                        downstream,
+                        true,
+                        decode_reply_deadline(),
+                    )
                     .map_err(|e| format!("spec fallback step: {e}"))?;
                 if eos.contains(&token_back) {
                     break;
@@ -2593,8 +2636,14 @@ impl SparseMoEEngine {
                 // get the next round's prev_correction. Same as the
                 // single-stage path; kept as a single-token Forward so
                 // we don't introduce a 1-token ForwardBatch frame.
-                self.forward_one_token_first(&history, cfg, downstream, true)
-                    .map_err(|e| format!("spec bonus forward (round {n_rounds}): {e}"))?
+                self.forward_one_token_first(
+                    &history,
+                    cfg,
+                    downstream,
+                    true,
+                    decode_reply_deadline(),
+                )
+                .map_err(|e| format!("spec bonus forward (round {n_rounds}): {e}"))?
             };
 
             // Reconciliation: pop rejected drafts from history, then
@@ -2758,16 +2807,35 @@ impl SparseMoEEngine {
             .await
             .map_err(|e| format!("send_forward_batch: {e}"))?;
             let send_done_us = wire_t0.elapsed().as_micros() as u64;
-            match recv_kind_client(downstream).await {
-                Ok(Some(FrameKind::TokenBatch)) => {
-                    let tokens = recv_token_batch_body_client(downstream)
-                        .await
-                        .map_err(|e| format!("recv_token_batch: {e}"))?;
-                    Ok((tokens, send_done_us))
+            // BOUNDED like the single-token reply (and close on elapse for the
+            // same late-pairing hazard) — a parked bridge leg never errors
+            // this recv on its own; see `decode_reply_deadline`.
+            match tokio::time::timeout(decode_reply_deadline(), async {
+                match recv_kind_client(downstream).await {
+                    Ok(Some(FrameKind::TokenBatch)) => {
+                        let tokens = recv_token_batch_body_client(downstream)
+                            .await
+                            .map_err(|e| format!("recv_token_batch: {e}"))?;
+                        Ok((tokens, send_done_us))
+                    }
+                    Ok(Some(other)) => {
+                        Err(format!("unexpected frame after forward_batch: {other:?}"))
+                    }
+                    Ok(None) => Err("downstream closed during recv_kind (batch)".into()),
+                    Err(e) => Err(format!("recv_kind (batch): {e}")),
                 }
-                Ok(Some(other)) => Err(format!("unexpected frame after forward_batch: {other:?}")),
-                Ok(None) => Err("downstream closed during recv_kind (batch)".into()),
-                Err(e) => Err(format!("recv_kind (batch): {e}")),
+            })
+            .await
+            {
+                Ok(r) => r,
+                Err(_) => {
+                    downstream.lock().await.close().await;
+                    Err(format!(
+                        "batch reply timeout after {:?}: downstream silent (dead peer?); \
+                         connection dropped to avoid reading this reply as the next request's",
+                        decode_reply_deadline()
+                    ))
+                }
             }
         });
         match result {
@@ -3727,6 +3795,7 @@ impl OvMoeEngine {
         cfg: &crate::sampling::SamplingConfig,
         downstream: &Arc<TokioMutex<ActivationClient>>,
         sample_back: bool,
+        reply_deadline: std::time::Duration,
     ) -> Result<i64, String> {
         let hidden = self
             .runner
@@ -3747,14 +3816,9 @@ impl OvMoeEngine {
                     .await
                     .map_err(|e| format!("send_forward_nosample: {e}"))?;
             }
-            match recv_kind_client(downstream).await {
-                Ok(Some(FrameKind::Token)) => recv_token_body_client(downstream)
-                    .await
-                    .map_err(|e| format!("recv_token: {e}")),
-                Ok(Some(other)) => Err(format!("rank 0 expected Token, got {other:?}")),
-                Ok(None) => Err("downstream closed before Token".into()),
-                Err(e) => Err(format!("recv_kind: {e}")),
-            }
+            // BOUNDED reply wait — see `decode_reply_deadline` for why a dead
+            // peer never errors this recv on its own (bridge parks the leg).
+            crate::dist::recv_token_reply(downstream, reply_deadline).await
         })
     }
 
@@ -3941,7 +4005,14 @@ impl OvMoeEngine {
         let n_prompt = prompt_ids.len();
         for (i, &t) in prompt_ids.iter().enumerate().skip(warm_prefix) {
             let sample_back = i + 1 == n_prompt;
-            match self.forward_one_token_first(t, pos, &cfg, &downstream, sample_back) {
+            match self.forward_one_token_first(
+                t,
+                pos,
+                &cfg,
+                &downstream,
+                sample_back,
+                prefill_reply_deadline(),
+            ) {
                 Ok(tok_back) => next = tok_back,
                 Err(e) => {
                     warn!(task = %id, "prefill forward failed: {e}");
@@ -4050,7 +4121,14 @@ impl OvMoeEngine {
         }
         let downstream = self.active_ov.as_ref().unwrap().downstream.clone();
         let cfg = self.active_ov.as_ref().unwrap().cfg.clone();
-        match self.forward_one_token_first(next_u, pos, &cfg, &downstream, true) {
+        match self.forward_one_token_first(
+            next_u,
+            pos,
+            &cfg,
+            &downstream,
+            true,
+            decode_reply_deadline(),
+        ) {
             Ok(tok_back) => {
                 let a = self.active_ov.as_mut().unwrap();
                 a.next = tok_back;

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -974,12 +974,12 @@ fn utf8_safe_delta(full: &str, emitted: &mut usize) -> String {
     d
 }
 
-/// Option B resume budget: total (prefix + new) must equal `max_tokens`, the
-/// same invariant the streaming engines enforce by seeding their `generated`
-/// accumulator with the K resume ids. sparse-moe's generate helpers always
-/// start `generated` EMPTY (single-shot decode, no seedable accumulator), so
-/// this subtracts K from the caller's budget instead — the opposite lever,
-/// same total-length result. Saturating, no `.max(1)`: an exhausted budget
+/// Option B resume budget: total (prefix + new) must equal `max_tokens`.
+/// The single-stage whole-turn helper starts `generated` EMPTY, so this
+/// subtracts K from its budget; the streamed begin paths ALSO use this value,
+/// seeding `generated` with the K resume ids and counting
+/// `generated.len() - resume_seed_len` against it — opposite levers, same
+/// total-length result. Saturating, no `.max(1)`: an exhausted budget
 /// (K >= max_tokens) must yield exactly zero new tokens.
 fn resume_max_new(max_tokens: u32, resume_token_ids: Option<&[i32]>) -> usize {
     let already = resume_token_ids.map_or(0, |v| v.len());
@@ -1382,8 +1382,9 @@ impl Engine for SparseMoEEngine {
         // abandoning mid-sequence leaves no stale KV state to clean up here.
         if self.active.as_ref().is_some_and(|a| &a.id == task_id) {
             self.active = None; // free the slot; a zombie here never trips the
-                                // runner's empty-step guard (lib.rs:1006 counts
-                                // produced before the cancelled-filter)
+                                // runner's empty-step guard (cascadia_runner's
+                                // poll loop counts `produced` before filtering
+                                // cancelled task-ids)
         }
         self.pending.retain(|t| &t.task_id != task_id);
     }
@@ -1535,7 +1536,8 @@ impl SparseMoEEngine {
         }
         append_resume_ids(&mut prompt_ids, resume.as_deref());
         // Non-resume keeps the base contract: max_tokens == 0 still yields one
-        // token (`.max(1)`, matching gemma4/qwen36/ov-runtime). Only a RESUMED
+        // token (`.max(1)`, matching gemma4/ov-runtime; qwen36 instead falls back
+        // to its configured max_tokens_default). Only a RESUMED
         // turn may land at zero new tokens (budget exhausted by the prefix) —
         // review found this branch had silently flipped the plain max_tokens=0
         // behavior from 1 token to 0.
@@ -1712,9 +1714,9 @@ impl SparseMoEEngine {
     /// the last rank's rep-penalty history isn't poisoned by prompt tokens),
     /// so prefill is unavoidably whole-turn work; decode after that streams
     /// one token per `step()` via `decode_step_sparse`. Returns `Some` for
-    /// every terminal outcome that doesn't reach decode (errors, the
-    /// zero-budget resume case, spec-decode's burst path, EOS on the very
-    /// first generated token); `None` means `self.active` is now armed.
+    /// every terminal outcome that doesn't reach decode (errors, the empty
+    /// prompt, the zero-budget resume case, spec-decode's burst path, EOS on
+    /// the very first generated token); `None` means `self.active` is armed.
     fn begin_generation_sparse(&mut self) -> Option<Vec<(TaskId, Chunk)>> {
         let task = match self.pending.pop_front() {
             Some(t) => t,
@@ -1772,7 +1774,8 @@ impl SparseMoEEngine {
                   "Option B resume admitted (multi-stage, streamed)");
         }
         // Non-resume keeps the base contract: max_tokens == 0 still yields one
-        // token (`.max(1)`, matching gemma4/qwen36/ov-runtime). Only a RESUMED
+        // token (`.max(1)`, matching gemma4/ov-runtime; qwen36 instead falls back
+        // to its configured max_tokens_default). Only a RESUMED
         // turn may land at zero new tokens (budget exhausted by the prefix) —
         // review found this branch had silently flipped the plain max_tokens=0
         // behavior from 1 token to 0.
@@ -1783,7 +1786,10 @@ impl SparseMoEEngine {
         };
         let mut sampling_cfg = sampling_from_task(&task);
         // Option B: force greedy decode on a resumed turn so the continuation
-        // is deterministic (see step_single_stage for rationale).
+        // is deterministic (see step_single_stage for rationale). Only the
+        // sparse-moe engines need the explicit force — the OV engine family
+        // (ov-runtime/gemma4/qwen36) is argmax-only, so the same invariant
+        // holds there by construction.
         if seed_opt.is_some() {
             sampling_cfg.temperature = 0.0;
         }
@@ -2211,10 +2217,12 @@ impl SparseMoEEngine {
                     let epoch = crate::kv_coordination::synth_epoch(&captured);
                     // Bounded: an older peer that meets CaptureV2 errors WITHOUT
                     // acking, and the only ceiling otherwise is the transport
-                    // frame-idle default — reached before this turn's
-                    // already-complete chunks are returned. Timeout ⇒ capture
-                    // skipped, turn delivered (the connection is dropped, so the
-                    // NEXT turn on this chain pays the reconnect).
+                    // frame-idle default — reached before this turn's terminal
+                    // chunk is returned (the burst path's whole output, the
+                    // streamed path's final marker; token chunks already went
+                    // out). Timeout ⇒ capture skipped, the turn still completes
+                    // (the connection is dropped, so the NEXT turn on this
+                    // chain pays the reconnect).
                     let acked = self.block_on(async {
                         match tokio::time::timeout(CAPTURE_ACK_TIMEOUT, async {
                             send_capture(downstream, epoch, &captured, tenant)
@@ -3237,8 +3245,11 @@ impl SparseMoEEngine {
             )),
             // Issue-34 cross-chain carried-slice restore: the moved-to head pulled THIS rank's
             // slice from the prior chain and ships it inline (this rank has no local capture for a
-            // foreign chain's epoch). Apply, relay a bare RESTORE downstream (deeper ranks own
-            // their own carry frames), ack the all-or-nothing verdict. Mirror of the OvMoe handler.
+            // foreign chain's epoch). Apply, then relay a bare RESTORE downstream and ack the
+            // all-or-nothing verdict. Only the FIRST downstream rank ever receives a carry frame
+            // today — the head's stash rejects a second rank's blob on epoch collision, so a
+            // 3+-stage cross-chain move deliberately degrades to a clean cold (see
+            // `stash_downstream_rank`). Mirror of the OvMoe handler.
             #[cfg(feature = "kv_coord")]
             FrameKind::RestoreCarry => {
                 let (epoch, blob) = self

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -928,6 +928,8 @@ impl Builder for SparseMoEBuilder {
             #[cfg(feature = "kv_coord")]
             kv_capture: std::collections::HashMap::new(),
             #[cfg(feature = "kv_coord")]
+            kv_downstream: std::collections::HashMap::new(),
+            #[cfg(feature = "kv_coord")]
             kv_share,
             #[cfg(feature = "kv_coord")]
             kv_handoff_mailbox: std::sync::Arc::new(
@@ -1221,6 +1223,11 @@ pub struct SparseMoEEngine {
     #[cfg(feature = "kv_coord")]
     pub(crate) kv_capture:
         std::collections::HashMap<u64, (String, Vec<i32>, crate::kv_prefix_cache::KvSnapshot)>,
+    /// Issue-34 cross-chain multi-stage: a DOWNSTREAM rank's pulled slice, staged by
+    /// `stash_downstream_rank` until `forward_restore_downstream` ships it inline via
+    /// RESTORE_CARRY. Epoch-keyed, bounded by the prefix-cache capacity (mirror of OvMoe's).
+    #[cfg(feature = "kv_coord")]
+    pub(crate) kv_downstream: std::collections::HashMap<u64, Vec<u8>>,
     /// Issue-34 Option C (holder mirror): the lock-free snapshot cache the [`crate::kv_coordination::
     /// SparseMoeKvHolder`] serves from. Populated alongside `kv_prefix_cache` / `kv_offers` /
     /// `kv_capture` so a busy engine answers cross-chain KV pulls without the engine lock.
@@ -2928,10 +2935,27 @@ impl SparseMoEEngine {
         let Some(down) = self.transport.downstream.clone() else {
             return true;
         };
+        // One-shot: take the carried blob (if any) before the async send. Cross-chain, the
+        // downstream rank's pulled slice was staged by `stash_downstream_rank`; same-chain there is
+        // nothing stashed and a bare RESTORE restores the rank from its own capture. Logged either
+        // way — a bare RESTORE and a never-stashed slice are otherwise indistinguishable.
+        let carried = self.kv_downstream.remove(&epoch);
+        tracing::info!(target: "cascadia::kv", event = "kv_carry_send", epoch,
+            carried = carried.is_some(), bytes = carried.as_ref().map_or(0, |b| b.len()),
+            stashed_epochs = self.kv_downstream.len());
         let verdict = self.block_on(async {
-            send_restore(&down, epoch)
-                .await
-                .map_err(|e| format!("send_restore: {e}"))?;
+            match &carried {
+                Some(blob) if blob.len() <= crate::dist::MAX_RESTORE_BLOB_BYTES as usize => {
+                    send_restore_carry(&down, epoch, blob)
+                        .await
+                        .map_err(|e| format!("send_restore_carry: {e}"))?
+                }
+                // None, or an oversized blob (guards the u32 len field + the peer's recv alloc) ⇒
+                // bare RESTORE ⇒ the moved-to tail misses the foreign epoch ⇒ deliberate clean cold.
+                _ => send_restore(&down, epoch)
+                    .await
+                    .map_err(|e| format!("send_restore: {e}"))?,
+            }
             // Bounded + close-on-timeout: RESTORE runs at admission, so an unbounded wait
             // here stalls every warm-hit request behind a silent downstream.
             recv_restore_verdict(&down).await
@@ -3203,9 +3227,43 @@ impl SparseMoEEngine {
                 "rank {} received unexpected RESTORE_ACK from upstream",
                 self.rank
             )),
-            // Cross-chain carried-slice restore is an OvMoe-only path; K2.6 sparse-moe never emits it.
+            // Issue-34 cross-chain carried-slice restore: the moved-to head pulled THIS rank's
+            // slice from the prior chain and ships it inline (this rank has no local capture for a
+            // foreign chain's epoch). Apply, relay a bare RESTORE downstream (deeper ranks own
+            // their own carry frames), ack the all-or-nothing verdict. Mirror of the OvMoe handler.
+            #[cfg(feature = "kv_coord")]
+            FrameKind::RestoreCarry => {
+                let (epoch, blob) = self
+                    .block_on(recv_restore_carry_body_server(upstream))
+                    .map_err(|e| format!("recv_restore_carry: {e}"))?;
+                let local_ok = match crate::kv_coordination::blob_decode(&blob) {
+                    Some(snap) => self.runner.restore_kv(&snap).is_ok(),
+                    None => false,
+                };
+                tracing::info!(target: "cascadia::kv", event = "sparse_tail_restore_carried",
+                    rank = self.rank, epoch, ok = local_ok, blob_len = blob.len());
+                let down_ok = if let Some(down) = downstream.as_ref() {
+                    self.block_on(async {
+                        send_restore(down, epoch)
+                            .await
+                            .map_err(|e| format!("send_restore: {e}"))?;
+                        recv_restore_verdict(down).await
+                    })
+                    .unwrap_or(false)
+                } else {
+                    true
+                };
+                self.block_on(send_restore_ack_upstream(
+                    upstream,
+                    epoch,
+                    u8::from(local_ok && down_ok),
+                ))
+                .map_err(|e| format!("send_restore_ack: {e}"))?;
+                Ok(())
+            }
+            #[cfg(not(feature = "kv_coord"))]
             FrameKind::RestoreCarry => Err(format!(
-                "rank {} received RESTORE_CARRY but K2.6 sparse-moe has no carried-slice restore",
+                "rank {} received RESTORE_CARRY but kv_coord is not built",
                 self.rank
             )),
         }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -1155,7 +1155,10 @@ struct SparseActive {
     resume_seed_len: usize,
     /// The token to emit on the next decode_step (sampled by the last rank).
     next: i64,
+    /// Only read by the finalize-time KV capture path (kv_coord).
+    #[cfg_attr(not(feature = "kv_coord"), allow(dead_code))]
     prompt_ids: Vec<i64>,
+    #[cfg_attr(not(feature = "kv_coord"), allow(dead_code))]
     tenant: String,
 }
 
@@ -1342,12 +1345,13 @@ impl Engine for SparseMoEEngine {
     }
 
     fn cancel(&mut self, task_id: &TaskId) {
-        // Drop the queued task. step() runs one task end-to-end and holds the
-        // engine mutex for that whole generation, so cancel() (also &mut self)
-        // runs only between tasks — it prevents a queued task from starting but
-        // cannot interrupt one already decoding. Mid-generation interruption
-        // would need an out-of-mutex cancel token threaded into the decode
-        // loop (architectural follow-up).
+        // Drop it from the queue if it hasn't started. If it's the in-flight
+        // streamed task (rank 0, multi-stage), drop `active` too so decoding
+        // stops at the current token boundary instead of grinding out the rest
+        // of a completion no one will read — an SSE client that disconnects
+        // mid-stream triggers this via `ChunkStream::drop`. The next task's
+        // `begin_generation_sparse` issues a fresh reset + send_reset, so
+        // abandoning mid-sequence leaves no stale KV state to clean up here.
         if self.active.as_ref().is_some_and(|a| &a.id == task_id) {
             self.active = None; // free the slot; a zombie here never trips the
                                 // runner's empty-step guard (lib.rs:1006 counts
@@ -1360,8 +1364,8 @@ impl Engine for SparseMoEEngine {
         if self.total == 1 {
             return Ok(self.step_single_stage());
         }
-        // step_first handles its own errors terminally (final-marker chunk on
-        // the driver), so rank 0 never surfaces an Err here.
+        // step_first handles its own errors terminally (final-marker/error
+        // chunk on the driver), so rank 0 never surfaces an Err here.
         if self.rank == 0 {
             return Ok(self.step_first());
         }
@@ -1699,6 +1703,12 @@ impl SparseMoEEngine {
                 }
             }
         };
+        if prompt_ids.is_empty() {
+            return Some(vec![(
+                task.task_id.clone(),
+                Chunk::final_marker(task.task_id, ""),
+            )]);
+        }
         // Option B forced-prefix resume: append the already-emitted assistant
         // tokens after the rendered prompt (concat, not replace) and seed the
         // streaming accumulator from them — the distributed prefill loop
@@ -1708,7 +1718,7 @@ impl SparseMoEEngine {
             .tokenizer
             .as_ref()
             .map(|t| prepare_resume(&task, t, &mut prompt_ids))
-            .unwrap() // tokenizer presence already checked above
+            .expect("tokenizer presence checked above")
         {
             Ok(s) => s,
             Err(e) => {
@@ -1775,25 +1785,12 @@ impl SparseMoEEngine {
 
         // If spec-decode is enabled AND we're greedy (temp==0), use the
         // batched ForwardBatch path; otherwise fall back to the per-token
-        // Forward driver (streamed below).
-        let use_spec =
-            self.spec_decode_k.map(|k| k > 0).unwrap_or(false) && sampling_cfg.temperature <= 0.0;
-        if use_spec && seed_opt.is_some() {
-            // Spec-decode verifies K tokens per round and stays burst (spec §3.2);
-            // it cannot honor a forced prefix mid-round. Decline BEFORE any chunk so
-            // the scheduler's first-frame peek sees the sentinel (B6 retry).
-            let id = task.task_id.clone();
-            return Some(vec![(
-                id.clone(),
-                Chunk::error(
-                    id,
-                    format!(
-                        "resume_unsupported: spec-decode path cannot force-prefix (task {})",
-                        task.task_id
-                    ),
-                ),
-            )]);
-        }
+        // Forward driver (streamed below). A resumed turn always takes the
+        // per-token streamed driver instead: resumed turns stream so the
+        // forced prefix is honored; spec-decode is an optimization only.
+        let use_spec = self.spec_decode_k.map(|k| k > 0).unwrap_or(false)
+            && sampling_cfg.temperature <= 0.0
+            && seed_opt.is_none();
 
         // Issue-34 consume (§8): SAME-CHAIN warm-resume. On a kv-prefix-cache hit, restore the head's
         // own rank-0 slice and RESTORE the whole downstream chain (all-or-nothing); on success skip
@@ -1850,7 +1847,8 @@ impl SparseMoEEngine {
         let warm_prefix: usize = 0;
 
         // Spec-decode: unchanged burst path (seed_opt is guaranteed None here
-        // — the decline above already returned for a resumed+spec turn).
+        // — `use_spec` requires `seed_opt.is_none()`, so a resumed turn never
+        // reaches this branch).
         if use_spec {
             let k = self.spec_decode_k.unwrap();
             info!(
@@ -2037,6 +2035,14 @@ impl SparseMoEEngine {
                 }
             }
         }
+        if token_back < 0 {
+            // Non-empty prompt (guarded above) but the sampling forward never ran —
+            // the deleted burst driver returned Err here; keep that contract.
+            return Some(vec![(
+                task.task_id.clone(),
+                Chunk::error(task.task_id, "prefill produced no token"),
+            )]);
+        }
 
         // SparseMoE EXCLUDES the EOS token: `active` is not set yet at this
         // point, so an EOS on the very first generated token can't route
@@ -2164,6 +2170,7 @@ impl SparseMoEEngine {
         // cache (warm-pull degrades to cold) and never affects the already-complete served output.
         // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
         // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
+        #[cfg_attr(not(feature = "kv_coord"), allow(unused_variables))]
         let should_capture = capture && n_new > 0;
         #[cfg(feature = "kv_coord")]
         if should_capture && self.kv_prefix_cache.enabled() {
@@ -3288,8 +3295,11 @@ struct OvMoeActive {
     /// The token to feed on the next decode_step (sampled by the last rank).
     next: i64,
     pos: usize,
-    /// prompt ++ resume-prefix (already includes the appended seed).
+    /// prompt ++ resume-prefix (already includes the appended seed). Only
+    /// read by the finalize-time KV capture path (kv_coord).
+    #[cfg_attr(not(feature = "kv_coord"), allow(dead_code))]
     prompt_ids: Vec<u32>,
+    #[cfg_attr(not(feature = "kv_coord"), allow(dead_code))]
     tenant: String,
 }
 
@@ -3651,7 +3661,7 @@ impl OvMoeEngine {
             .tokenizer
             .as_ref()
             .map(|t| prepare_resume(&task, t, &mut prompt64))
-            .unwrap() // tokenizer presence already checked above
+            .expect("tokenizer presence checked above")
         {
             Ok(s) => s,
             Err(e) => {
@@ -3888,6 +3898,7 @@ impl OvMoeEngine {
         // cold) and never touches the already-served output.
         // §4.3.3: the capture key is prompt_ids ++ NEW tokens — `a.prompt_ids` already contains the
         // appended resume prefix, so slicing generated at `resume_seed_len` prevents double-counting it.
+        #[cfg_attr(not(feature = "kv_coord"), allow(unused_variables))]
         let should_capture = capture && n_new > 0;
         #[cfg(feature = "kv_coord")]
         if should_capture && self.kv_prefix_cache.enabled() {

--- a/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
+++ b/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
@@ -479,9 +479,17 @@ impl KvCoordination for SparseMoEEngine {
             }
             (tokens.clone(), snap.clone())
         } else {
+            // Same diagnosability as the share-holder export: a silent None here reads as
+            // `pull_not_found` on the puller with no donor-side trace.
+            tracing::info!(target: "cascadia::kv", event = "kv_serve_capture_miss",
+                epoch = expected_epoch,
+                n_captures = self.kv_capture.len(),
+                held_epochs = ?self.kv_capture.keys().copied().collect::<Vec<u64>>());
             return None;
         };
         if snap.past_seq_len as u32 != expected_len {
+            tracing::info!(target: "cascadia::kv", event = "kv_serve_len_drift",
+                epoch = expected_epoch, got = snap.past_seq_len, want = expected_len);
             return None; // drifted from what was negotiated
         }
         let (manifest, payloads) =
@@ -666,9 +674,17 @@ impl cascadia_engine::KvSnapshotHolder for SparseMoeKvHolder {
             }
             (tokens.clone(), snap.clone())
         } else {
+            // The refusal arms here are otherwise SILENT on the donor — the puller's
+            // `pull_not_found` cannot be told apart from a missing capture vs a length drift.
+            // Log what this holder actually holds so a rig-side miss is diagnosable.
+            tracing::info!(target: "cascadia::kv", event = "kv_serve_capture_miss",
+                epoch = expected_epoch, n_captures = g.captures.len(),
+                held_epochs = ?g.captures.keys().copied().collect::<Vec<u64>>());
             return None;
         };
         if snap.past_seq_len as u32 != expected_len {
+            tracing::info!(target: "cascadia::kv", event = "kv_serve_len_drift",
+                epoch = expected_epoch, got = snap.past_seq_len, want = expected_len);
             return None; // drifted from what was negotiated
         }
         Some(snapshot_to_wire(

--- a/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
+++ b/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
@@ -380,6 +380,21 @@ pub(crate) fn blob_decode(blob: &[u8]) -> Option<KvSnapshot> {
     for _ in 0..n {
         shells.push(r.slice()?);
     }
+    // Cross-check every slice against the declared dims: a corrupt blob claiming
+    // a huge `past_seq_len` over tiny payloads would otherwise reach
+    // `restore_kv`, which grows KV capacity toward the claimed length before its
+    // own per-layer check rejects the mismatch — bounded (`try_reserve_exact`
+    // fails cleanly) but a pile of doubling allocations for nothing. Reject here.
+    let k_len = (num_heads as usize)
+        .checked_mul(past_seq_len)
+        .and_then(|x| x.checked_mul(qk_head_dim as usize))?;
+    let v_len = (num_heads as usize)
+        .checked_mul(past_seq_len)
+        .and_then(|x| x.checked_mul(v_head_dim as usize))?;
+    let dims_ok = |l: &LayerKvSlice| l.past_k.len() == k_len && l.past_v.len() == v_len;
+    if !(layer0.iter().all(dims_ok) && shells.iter().all(dims_ok)) {
+        return None;
+    }
     (r.pos == blob.len()).then_some(KvSnapshot {
         past_seq_len,
         num_heads,
@@ -574,8 +589,8 @@ impl KvCoordination for SparseMoEEngine {
             // Same diagnosability as the share-holder export: a silent None here reads as
             // `pull_not_found` on the puller with no donor-side trace.
             tracing::info!(target: "cascadia::kv", event = "kv_serve_capture_miss",
-                epoch = expected_epoch,
-                n_captures = self.kv_capture.len(),
+                epoch = expected_epoch, n_captures = self.kv_capture.len());
+            tracing::debug!(target: "cascadia::kv",
                 held_epochs = ?self.kv_capture.keys().copied().collect::<Vec<u64>>());
             return None;
         };
@@ -812,7 +827,8 @@ impl cascadia_engine::KvSnapshotHolder for SparseMoeKvHolder {
             // `pull_not_found` cannot be told apart from a missing capture vs a length drift.
             // Log what this holder actually holds so a rig-side miss is diagnosable.
             tracing::info!(target: "cascadia::kv", event = "kv_serve_capture_miss",
-                epoch = expected_epoch, n_captures = g.captures.len(),
+                epoch = expected_epoch, n_captures = g.captures.len());
+            tracing::debug!(target: "cascadia::kv",
                 held_epochs = ?g.captures.keys().copied().collect::<Vec<u64>>());
             return None;
         };
@@ -1186,5 +1202,69 @@ mod tests {
         let (_m, served) = snapshot_to_wire(&[11, 22, 33], &snap(), "peer", 7, 0xE0);
         let slot = slot_of(&[11, 22, 33], &snap(), 7);
         assert_eq!(payload_digest(&served), payload_digest(&slot.payloads));
+    }
+
+    // ── RESTORE_CARRY blob codec (native mirror of the OvMoe round-trip tests) ──
+
+    /// A dims-consistent 2-heads × 3-slots × 2-dim snapshot, with or without layer 0.
+    fn carry_snap(with_layer0: bool) -> KvSnapshot {
+        let slice = |lid: u32| LayerKvSlice {
+            lid,
+            past_k: (0..12).map(|i| i as u16).collect(),
+            past_v: (100..112).map(|i| i as u16).collect(),
+        };
+        KvSnapshot {
+            past_seq_len: 3,
+            num_heads: 2,
+            qk_head_dim: 2,
+            v_head_dim: 2,
+            layer0: with_layer0.then(|| slice(0)),
+            shells: vec![slice(1), slice(2)],
+        }
+    }
+
+    #[test]
+    fn carry_blob_round_trips_with_and_without_layer0() {
+        for with_l0 in [true, false] {
+            let snap = carry_snap(with_l0);
+            let blob = blob_encode(&snap);
+            let back = blob_decode(&blob).expect("round trip");
+            assert_eq!(back.past_seq_len, snap.past_seq_len);
+            assert_eq!(back.num_heads, snap.num_heads);
+            assert_eq!(back.layer0.is_some(), with_l0);
+            assert_eq!(back.shells.len(), 2);
+            let all = |s: &KvSnapshot| -> Vec<u16> {
+                s.layer0
+                    .iter()
+                    .chain(s.shells.iter())
+                    .flat_map(|l| l.past_k.iter().chain(l.past_v.iter()).copied())
+                    .collect()
+            };
+            assert_eq!(all(&back), all(&snap));
+        }
+    }
+
+    #[test]
+    fn carry_blob_rejects_truncated_input() {
+        let blob = blob_encode(&carry_snap(true));
+        for cut in [0, 1, 4, blob.len() / 2, blob.len() - 1] {
+            assert!(blob_decode(&blob[..cut]).is_none(), "cut at {cut} decoded");
+        }
+    }
+
+    #[test]
+    fn carry_blob_rejects_trailing_garbage() {
+        let mut blob = blob_encode(&carry_snap(true));
+        blob.push(0);
+        assert!(blob_decode(&blob).is_none());
+    }
+
+    #[test]
+    fn carry_blob_rejects_dims_payload_mismatch() {
+        // Claim a huge past_seq_len over the same tiny payloads: must be
+        // rejected in decode, before restore_kv burns grow-allocations on it.
+        let mut blob = blob_encode(&carry_snap(true));
+        blob[0..4].copy_from_slice(&1_000_000u32.to_le_bytes());
+        assert!(blob_decode(&blob).is_none());
     }
 }

--- a/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
+++ b/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
@@ -696,11 +696,16 @@ impl KvCoordination for SparseMoEEngine {
             return if same { Ok(()) } else { Err(()) };
         }
         let cap = self.kv_prefix_cache.capacity().max(1);
-        while self.kv_downstream.len() >= cap && !self.kv_downstream.contains_key(&epoch) {
+        // (`epoch` is never already present here — the collision guard above
+        // returned for that case.) Eviction silently downgrades the dropped
+        // epoch's future cross-chain restore to cold, so it must be visible.
+        while self.kv_downstream.len() >= cap {
             let Some(k) = self.kv_downstream.keys().next().copied() else {
                 break;
             };
             self.kv_downstream.remove(&k);
+            tracing::warn!(target: "cascadia::kv", event = "kv_carry_stash_evicted",
+                evicted_epoch = k, for_epoch = epoch, cap);
         }
         self.kv_downstream.insert(epoch, blob);
         Ok(())

--- a/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
+++ b/crates/cascadia-engine-sparse-moe/src/kv_coordination.rs
@@ -298,6 +298,98 @@ fn wire_to_snapshot(manifest: &Manifest, payloads: &[(Vec<u8>, Vec<u8>)]) -> Opt
     })
 }
 
+/// Flat carry-blob codec for RESTORE_CARRY — the native mirror of `ov_kv_coordination`'s
+/// `ov_blob_encode`/`ov_blob_decode`, with bf16-as-u16 words. Only the moved-to head and its own
+/// downstream ranks ever see these bytes (same pinned build both ends), so no versioning field.
+pub(crate) fn blob_encode(snap: &KvSnapshot) -> Vec<u8> {
+    fn put_u32(out: &mut Vec<u8>, v: u32) {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    fn put_u16s(out: &mut Vec<u8>, xs: &[u16]) {
+        put_u32(out, xs.len() as u32);
+        for x in xs {
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+    fn put_slice(out: &mut Vec<u8>, l: &LayerKvSlice) {
+        put_u32(out, l.lid);
+        put_u16s(out, &l.past_k);
+        put_u16s(out, &l.past_v);
+    }
+    let mut out = Vec::new();
+    put_u32(&mut out, snap.past_seq_len as u32);
+    put_u32(&mut out, snap.num_heads);
+    put_u32(&mut out, snap.qk_head_dim);
+    put_u32(&mut out, snap.v_head_dim);
+    put_u32(&mut out, u32::from(snap.layer0.is_some()));
+    if let Some(l0) = &snap.layer0 {
+        put_slice(&mut out, l0);
+    }
+    put_u32(&mut out, snap.shells.len() as u32);
+    for s in &snap.shells {
+        put_slice(&mut out, s);
+    }
+    out
+}
+
+pub(crate) fn blob_decode(blob: &[u8]) -> Option<KvSnapshot> {
+    struct Reader<'a> {
+        b: &'a [u8],
+        pos: usize,
+    }
+    impl Reader<'_> {
+        fn u32(&mut self) -> Option<u32> {
+            let e = self.pos.checked_add(4)?;
+            let v = u32::from_le_bytes(self.b.get(self.pos..e)?.try_into().ok()?);
+            self.pos = e;
+            Some(v)
+        }
+        fn u16s(&mut self) -> Option<Vec<u16>> {
+            let n = self.u32()? as usize;
+            let bytes = n.checked_mul(2)?;
+            let e = self.pos.checked_add(bytes)?;
+            let out = self
+                .b
+                .get(self.pos..e)?
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            self.pos = e;
+            Some(out)
+        }
+        fn slice(&mut self) -> Option<LayerKvSlice> {
+            Some(LayerKvSlice {
+                lid: self.u32()?,
+                past_k: self.u16s()?,
+                past_v: self.u16s()?,
+            })
+        }
+    }
+    let mut r = Reader { b: blob, pos: 0 };
+    let past_seq_len = r.u32()? as usize;
+    let num_heads = r.u32()?;
+    let qk_head_dim = r.u32()?;
+    let v_head_dim = r.u32()?;
+    let layer0 = if r.u32()? == 1 {
+        Some(r.slice()?)
+    } else {
+        None
+    };
+    let n = r.u32()? as usize;
+    let mut shells = Vec::with_capacity(n.min(1024));
+    for _ in 0..n {
+        shells.push(r.slice()?);
+    }
+    (r.pos == blob.len()).then_some(KvSnapshot {
+        past_seq_len,
+        num_heads,
+        qk_head_dim,
+        v_head_dim,
+        layer0,
+        shells,
+    })
+}
+
 /// FNV-1a over every payload byte in wire order, so a donor's serve digest and a consumer's
 /// applied digest are comparable across ranks.
 ///
@@ -554,6 +646,48 @@ impl KvCoordination for SparseMoEEngine {
             .insert_pulled(partner, prefix.clone(), &fp, snap.clone());
         self.kv_prefix_cache
             .insert_pulled(partner, prefix, &fp, snap);
+        Ok(())
+    }
+
+    fn stash_downstream_rank(
+        &mut self,
+        _rank: u16,
+        manifest: &Manifest,
+        payloads: &[(Vec<u8>, Vec<u8>)],
+    ) -> Result<(), ()> {
+        // Issue-34 cross-chain multi-stage: a DOWNSTREAM rank's pulled slice can't be applied on
+        // this (head) rank locally; stash it under the content epoch so `forward_restore_downstream`
+        // ships it inline via RESTORE_CARRY. Decode eagerly so a corrupt pull votes fail here (not
+        // mid-restore). Mirror of the OvMoe impl — without an override the trait default is
+        // `Err(())`, which made every native rank>0 pull vote cold (`pull_rank_fail reason=insert`).
+        let Some(snap) = wire_to_snapshot(manifest, payloads) else {
+            tracing::warn!(target: "cascadia::kv", event = "kv_carry_stash_rejected",
+                reason = "decode", rank = _rank, n_payloads = payloads.len());
+            return Err(());
+        };
+        let blob = blob_encode(&snap);
+        let epoch = synth_epoch(&manifest.token_ids);
+        tracing::info!(target: "cascadia::kv", event = "kv_carry_stash", epoch, rank = _rank,
+            bytes = blob.len(), n_tokens = manifest.token_ids.len());
+        // Same collision guard as OvMoe: with >1 downstream rank one epoch would key two blobs;
+        // reject a colliding DIFFERENT blob so a 3+-stage chain degrades to a clean cold instead of
+        // a wrong-rank restore. A 2-stage chain never collides; a same-blob re-stash is idempotent.
+        if let Some(existing) = self.kv_downstream.get(&epoch) {
+            let same = existing == &blob;
+            if !same {
+                tracing::warn!(target: "cascadia::kv", event = "kv_carry_stash_rejected",
+                    reason = "epoch_collision", epoch, rank = _rank);
+            }
+            return if same { Ok(()) } else { Err(()) };
+        }
+        let cap = self.kv_prefix_cache.capacity().max(1);
+        while self.kv_downstream.len() >= cap && !self.kv_downstream.contains_key(&epoch) {
+            let Some(k) = self.kv_downstream.keys().next().copied() else {
+                break;
+            };
+            self.kv_downstream.remove(&k);
+        }
+        self.kv_downstream.insert(epoch, blob);
         Ok(())
     }
 

--- a/crates/cascadia-engine-sparse-moe/src/lib.rs
+++ b/crates/cascadia-engine-sparse-moe/src/lib.rs
@@ -56,6 +56,8 @@ pub mod staged;
 pub mod tensors;
 
 pub use engine::{SparseMoEBuilder, SparseMoEBuilderConfig, SparseMoEEngine};
+#[doc(hidden)]
+pub use engine::{prepare_resume, ResumeSeed};
 pub use kv_prefix_cache::{KvPrefixCache, KvSnapshot, LayerKvSlice, ModelFingerprint};
 pub use manifest::Manifest;
 pub use ngram_draft::{Draft, DEFAULT_DRAFT_K, MAX_NGRAM, MIN_NGRAM};

--- a/crates/cascadia-engine-sparse-moe/src/lib.rs
+++ b/crates/cascadia-engine-sparse-moe/src/lib.rs
@@ -55,9 +55,9 @@ pub mod spec_decode;
 pub mod staged;
 pub mod tensors;
 
-pub use engine::{SparseMoEBuilder, SparseMoEBuilderConfig, SparseMoEEngine};
 #[doc(hidden)]
 pub use engine::{prepare_resume, ResumeSeed};
+pub use engine::{SparseMoEBuilder, SparseMoEBuilderConfig, SparseMoEEngine};
 pub use kv_prefix_cache::{KvPrefixCache, KvSnapshot, LayerKvSlice, ModelFingerprint};
 pub use manifest::Manifest;
 pub use ngram_draft::{Draft, DEFAULT_DRAFT_K, MAX_NGRAM, MIN_NGRAM};

--- a/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
@@ -93,7 +93,8 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
             wb.connect(PeerLayout::last_of(PeerEndpoint::new("127.0.0.1", port)))
                 .await
                 .map_err(|e| format!("worker connect: {e:?}"))?;
-            wb.load(shard(false, true))
+            let _progress = wb
+                .load(shard(false, true))
                 .await
                 .map_err(|e| format!("worker load: {e:?}"))?;
             Box::new(wb)
@@ -134,7 +135,8 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
         hb.connect(PeerLayout::first_of(PeerEndpoint::new("127.0.0.1", port)))
             .await
             .map_err(|e| format!("head connect: {e:?}"))?;
-        hb.load(shard(true, false))
+        let _progress = hb
+            .load(shard(true, false))
             .await
             .map_err(|e| format!("head load: {e:?}"))?;
         Box::new(hb)

--- a/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
@@ -71,6 +71,21 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
 /// loop return (dropping the engine + its runtime, closing the sockets), so a
 /// test can simulate mid-decode chain death and join the worker thread.
 fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBool>) {
+    let (head, worker, kill, _mute) = two_rank_harness_faultable();
+    (head, worker, kill)
+}
+
+/// `two_rank_harness_killable` plus a MUTE switch: setting it makes the worker
+/// loop spin WITHOUT stepping — its sockets stay open but it never replies.
+/// This is the rig's real mid-decode death shape: the enterprise bridge parks
+/// a dead pipeline leg instead of closing the engine-side loopback, so the
+/// head sees silence, not a transport error (rig 2026-08-27 resume stall).
+fn two_rank_harness_faultable() -> (
+    Box<dyn Engine>,
+    JoinHandle<()>,
+    Arc<AtomicBool>,
+    Arc<AtomicBool>,
+) {
     let dir = model_dir().expect("caller must gate on model_dir() first");
     let port = free_port();
 
@@ -81,6 +96,8 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
     let kill = Arc::new(AtomicBool::new(false));
     let kill_worker = Arc::clone(&kill);
+    let mute = Arc::new(AtomicBool::new(false));
+    let mute_worker = Arc::clone(&mute);
     let worker_dir = dir.clone();
     let worker_thread = std::thread::spawn(move || {
         let worker_rt = tokio::runtime::Runtime::new().expect("worker runtime");
@@ -118,6 +135,11 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
                 // Simulated chain death: return, dropping the engine and its
                 // runtime — sockets close and the head's next forward fails.
                 return;
+            }
+            if mute_worker.load(Ordering::Relaxed) {
+                // Mute: alive, sockets open, never replies.
+                std::thread::sleep(std::time::Duration::from_millis(20));
+                continue;
             }
             let _ = worker.step();
         }
@@ -161,7 +183,7 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
         Err(_) => panic!("worker not ready within 300s"),
     }
 
-    (head, worker_thread, kill)
+    (head, worker_thread, kill, mute)
 }
 
 /// Single-stage (`total == 1`) OV-IR engine, used only to exercise the
@@ -437,4 +459,46 @@ fn mid_decode_chain_death_is_an_error_chunk_never_a_final() {
         }
     }
     assert!(saw_error, "chain death must surface an error chunk");
+}
+
+/// The 2026-08-27 rig stall: a downstream that goes SILENT (socket open, no
+/// replies — the bridge parks dead legs, it does not close them) must surface
+/// an error chunk within the engine's bounded reply deadline, well under the
+/// gateway's 180 s inter-token budget — not hang until the gateway kills the
+/// stream with nothing for the resume splicer to rescue.
+#[test]
+fn mid_decode_silent_worker_errors_within_deadline() {
+    let Some(_dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker, _kill, mute) = two_rank_harness_faultable();
+    head.submit(GenerationTask::new("tmute", "hello").with_max_tokens(400))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..3 {
+        chunks.extend(head.step().unwrap());
+    }
+    assert!(chunks.iter().all(|(_, c)| !c.is_final));
+    mute.store(true, Ordering::Relaxed);
+    let t0 = std::time::Instant::now();
+    let mut saw_error = false;
+    'outer: while t0.elapsed() < std::time::Duration::from_secs(170) {
+        let out = head.step().unwrap();
+        for (_, c) in &out {
+            assert!(
+                c.error.is_some() || !c.is_final,
+                "silent worker must never produce a success-shaped final: {c:?}"
+            );
+            if c.error.is_some() {
+                saw_error = true;
+                break 'outer;
+            }
+        }
+    }
+    assert!(
+        saw_error,
+        "no error chunk within 170s — the bounded reply deadline did not fire \
+         (gateway inter-token budget is 180s; the engine must beat it)"
+    );
 }

--- a/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
@@ -15,6 +15,8 @@
 //! test runtime `step()` tries to re-enter).
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use cascadia_engine::{Builder, Engine};
@@ -61,6 +63,14 @@ fn free_port() -> u16 {
 /// through the real `Engine`/wire path instead of driving `OvMoeRunner`
 /// directly.
 fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
+    let (head, worker, _kill) = two_rank_harness_killable();
+    (head, worker)
+}
+
+/// `two_rank_harness` plus a kill switch: setting the flag makes the worker
+/// loop return (dropping the engine + its runtime, closing the sockets), so a
+/// test can simulate mid-decode chain death and join the worker thread.
+fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBool>) {
     let dir = model_dir().expect("caller must gate on model_dir() first");
     let port = free_port();
 
@@ -69,6 +79,8 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
     // head then blocks in connect for CASCADIA_CONNECT_TIMEOUT_SECS
     // (default 300s) with the real cause invisible.
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let kill = Arc::new(AtomicBool::new(false));
+    let kill_worker = Arc::clone(&kill);
     let worker_dir = dir.clone();
     let worker_thread = std::thread::spawn(move || {
         let worker_rt = tokio::runtime::Runtime::new().expect("worker runtime");
@@ -101,6 +113,11 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
         // Drive the worker for the rest of the test process; no explicit
         // stop signal needed (matches sparse_streaming.rs).
         loop {
+            if kill_worker.load(Ordering::Relaxed) {
+                // Simulated chain death: return, dropping the engine and its
+                // runtime — sockets close and the head's next forward fails.
+                return;
+            }
             let _ = worker.step();
         }
     });
@@ -142,7 +159,7 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
         Err(_) => panic!("worker not ready within 300s"),
     }
 
-    (head, worker_thread)
+    (head, worker_thread, kill)
 }
 
 /// Single-stage (`total == 1`) OV-IR engine, used only to exercise the
@@ -260,7 +277,23 @@ fn resume_seed_streams_continuation_only() {
     }
     // resume_max_new: 6 - 2 = at most 4 NEW tokens; the seed ids are never re-emitted.
     let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    assert!(
+        !toks.is_empty(),
+        "resume must stream at least one continuation token — an empty stream \
+         passes every assertion below vacuously"
+    );
     assert!(toks.len() <= 4);
+    let fin = chunks
+        .iter()
+        .find(|(_, c)| c.is_final)
+        .expect("a final chunk");
+    if fin.1.finish_reason == Some(FinishReason::Length) {
+        assert_eq!(
+            toks.len(),
+            4,
+            "Length final => exactly max_tokens - seed_len interior chunks"
+        );
+    }
     let streamed: String = toks.iter().map(|(_, c)| c.text.as_str()).collect();
     let seed_text = tokenizer.decode(&[3u32, 4], true).unwrap();
     assert!(
@@ -268,7 +301,7 @@ fn resume_seed_streams_continuation_only() {
         "fixture ids must decode to text or the re-emission assertion below is vacuous"
     );
     assert!(
-        !streamed.starts_with(&seed_text) || seed_text.is_empty(),
+        !streamed.starts_with(&seed_text),
         "streamed deltas re-emitted the forced prefix: {streamed:?}"
     );
 }
@@ -301,11 +334,32 @@ fn cancel_mid_decode_clears_active() {
         .unwrap();
     let first = head.step().unwrap(); // begin + first token
     assert!(!first.is_empty());
+    assert!(
+        !first[0].1.is_final,
+        "first step must be an interior token — a final here means no \
+         generation was active and the cancel below tests nothing"
+    );
     head.cancel(&"t4".to_string());
     let after = head.step().unwrap();
     assert!(
         after.is_empty(),
         "cancelled task must emit nothing and free the slot"
+    );
+    // Recovery: the worker was abandoned mid-sequence; the next task's begin
+    // issues a fresh chain reset, so a full turn must still complete cleanly
+    // (protocol desync here is the actual failure cancel risks).
+    head.submit(GenerationTask::new("t5", "hello again").with_max_tokens(3))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..64 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    assert!(
+        chunks.iter().any(|(_, c)| c.is_final && c.error.is_none()),
+        "post-cancel task must complete cleanly: {chunks:?}"
     );
 }
 
@@ -336,4 +390,49 @@ fn single_stage_declines_seeded_task_with_sentinel_first_chunk() {
         reason.starts_with("resume_unsupported:"),
         "sentinel must PREFIX the reason (callers match it with a starts_with check)"
     );
+}
+
+/// The headline Option B invariant: a mid-decode chain death surfaces an
+/// ERROR chunk and NEVER a success-shaped final — a final marker would trip
+/// the scheduler's saw_final latch and permanently block the forced-prefix
+/// rescue. (Deliberate divergence from PipelineEngine's partial-final; see
+/// the decode step's Err arm.) Reverting that arm to the old partial-final
+/// behavior passes every other test in this suite.
+#[test]
+fn mid_decode_chain_death_is_an_error_chunk_never_a_final() {
+    let Some(_dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let (mut head, worker, kill) = two_rank_harness_killable();
+    head.submit(GenerationTask::new("tkill", "hello").with_max_tokens(400))
+        .unwrap();
+    // Stream a few tokens first so the death is genuinely MID-decode.
+    let mut chunks = Vec::new();
+    for _ in 0..3 {
+        chunks.extend(head.step().unwrap());
+    }
+    assert!(
+        chunks.iter().all(|(_, c)| !c.is_final),
+        "budget 400 must not finish within 3 steps: {chunks:?}"
+    );
+    kill.store(true, Ordering::Relaxed);
+    worker.join().expect("worker thread exits on kill");
+    // Keep stepping until the failure surfaces (the in-flight recv trips its
+    // bounded transport timeout first).
+    let mut saw_error = false;
+    'outer: for _ in 0..64 {
+        let out = head.step().unwrap();
+        for (_, c) in &out {
+            assert!(
+                c.error.is_some() || !c.is_final,
+                "chain death must never produce a success-shaped final: {c:?}"
+            );
+            if c.error.is_some() {
+                saw_error = true;
+                break 'outer;
+            }
+        }
+    }
+    assert!(saw_error, "chain death must surface an error chunk");
 }

--- a/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
@@ -1,0 +1,294 @@
+//! Task 3 (issue-34 Option B): `OvMoeEngine`'s multi-stage rank-0 path
+//! converted from a whole-turn burst driver to a per-token streaming state
+//! machine (`begin_generation_ovmoe` / `decode_step_ovmoe` / `finalize_ovmoe`),
+//! plus streamed Option B resume and the single-stage sentinel decline.
+//! Mirrors `tests/sparse_streaming.rs` (Task 2) but drives the OV-IR
+//! (MiniMax-M2) backend over a REAL two-rank loopback transport.
+//!
+//! Gated on `M2_MODEL_DIR` (see `tests/minimax_m2_eval.rs`): the fixture
+//! cannot be committed. CI skips this file; the rig cert is the enforcement
+//! gate for what's below.
+//!
+//! `Engine::step` is SYNC and `block_on`s internally — every test here drives
+//! `head.step()` from a plain `#[test]` thread. A `#[tokio::test]` would
+//! deadlock (the calling thread would already be inside the single-threaded
+//! test runtime `step()` tries to re-enter).
+
+use std::path::PathBuf;
+use std::thread::JoinHandle;
+
+use cascadia_engine::{Builder, Engine};
+use cascadia_engine_sparse_moe::{Manifest, SparseMoEBuilder, SparseMoEBuilderConfig};
+use cascadia_types::{FinishReason, GenerationTask, PeerEndpoint, PeerLayout, ShardSpec};
+
+fn model_dir() -> Option<PathBuf> {
+    std::env::var("M2_MODEL_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn shard(is_first: bool, is_last: bool) -> ShardSpec {
+    ShardSpec {
+        model_id: "m2".into(),
+        // 0/0: `load_staged` treats an unset layer_end as "even split" for
+        // OV-IR shells (engine.rs `is_ov` branch) — no need to compute it here.
+        layer_start: 0,
+        layer_end: 0,
+        total_layers: 0,
+        device: "CPU".into(),
+        is_first_stage: is_first,
+        is_last_stage: is_last,
+        tp_size: 1,
+        tp_rank: 0,
+    }
+}
+
+/// OS-assigned free TCP port. Small bind-then-drop TOCTOU race, acceptable
+/// for a rig-only, non-CI test.
+fn free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = l.local_addr().expect("local_addr").port();
+    drop(l);
+    port
+}
+
+/// Build a live 2-rank OV-IR chain: rank 0 (head, the API-facing driver
+/// under test) and rank 1 (worker/last-stage). Same scaffold as
+/// `tests/sparse_streaming.rs::two_rank_harness`, generalized to the OV-IR
+/// (MiniMax-M2) backend built the way `tests/minimax_m2_eval.rs`'s
+/// `minimax_m2_two_rank_pipeline_matches_hf_reference` builds one, but
+/// through the real `Engine`/wire path instead of driving `OvMoeRunner`
+/// directly.
+fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
+    let dir = model_dir().expect("caller must gate on model_dir() first");
+    let port = free_port();
+
+    let worker_dir = dir.clone();
+    let worker_thread = std::thread::spawn(move || {
+        let worker_rt = tokio::runtime::Runtime::new().expect("worker runtime");
+        let mut worker: Box<dyn Engine> = worker_rt.block_on(async move {
+            let mut wb = SparseMoEBuilder::new(
+                SparseMoEBuilderConfig::new(worker_dir.to_str().expect("utf8 path"), "CPU")
+                    .with_rank(1, 2),
+            );
+            wb.configure_listen("127.0.0.1", port);
+            wb.connect(PeerLayout::last_of(PeerEndpoint::new("127.0.0.1", port)))
+                .await
+                .expect("worker connect");
+            let _progress = wb.load(shard(false, true)).await.expect("worker load");
+            Box::new(wb).build().expect("worker build")
+        });
+        // Drive the worker for the rest of the test process; no explicit
+        // stop signal needed (matches sparse_streaming.rs).
+        loop {
+            let _ = worker.step();
+        }
+    });
+
+    let head_shard_dir = dir.clone();
+    let head_rt = tokio::runtime::Runtime::new().expect("head runtime");
+    let head: Box<dyn Engine> = head_rt.block_on(async move {
+        let mut hb = SparseMoEBuilder::new(
+            SparseMoEBuilderConfig::new(head_shard_dir.to_str().expect("utf8 path"), "CPU")
+                .with_rank(0, 2),
+        );
+        hb.connect(PeerLayout::first_of(PeerEndpoint::new("127.0.0.1", port)))
+            .await
+            .expect("head connect");
+        let _progress = hb.load(shard(true, false)).await.expect("head load");
+        Box::new(hb).build().expect("head build")
+    });
+    std::mem::forget(head_rt);
+
+    (head, worker_thread)
+}
+
+/// Single-stage (`total == 1`) OV-IR engine, used only to exercise the
+/// sentinel decline path — MiniMax-M2 single-stage has no forced-prefix
+/// resume implementation.
+fn single_stage_ovmoe_harness() -> Box<dyn Engine> {
+    let dir = model_dir().expect("caller must gate on model_dir() first");
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let engine: Box<dyn Engine> = rt.block_on(async move {
+        let mut b = SparseMoEBuilder::new(SparseMoEBuilderConfig::new(
+            dir.to_str().expect("utf8 path"),
+            "CPU",
+        ));
+        let _progress = b.load(shard(true, true)).await.expect("load");
+        Box::new(b).build().expect("build")
+    });
+    std::mem::forget(rt);
+    engine
+}
+
+// Streaming shape: interior token chunks + one empty final marker.
+// OvMoe INCLUDES the EOS token in the output (push-then-test), unlike
+// SparseMoE — no separate exclusion assertion needed here, just the shape.
+#[test]
+fn multi_stage_streams_per_token_with_empty_final() {
+    let Some(_dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    head.submit(GenerationTask::new("t1", "hello").with_max_tokens(4))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..64 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    let finals: Vec<_> = chunks.iter().filter(|(_, c)| c.is_final).collect();
+    assert_eq!(finals.len(), 1);
+    assert!(finals[0].1.text.is_empty(), "final marker carries no text");
+    assert_eq!(finals[0].1.n_tokens, Some(0));
+    let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    assert!(!toks.is_empty(), "interior token chunks must exist");
+    for (_, c) in &toks {
+        assert_eq!(c.n_tokens, Some(1));
+        assert_eq!(
+            c.token_ids,
+            vec![c.token_id],
+            "token_ids stamped (poison bypass)"
+        );
+    }
+}
+
+/// OvMoe INCLUDES the EOS token in the output — push-then-test, preserved
+/// from the old monolithic decode loop (`generated.push(next_u)` BEFORE the
+/// `eos.contains(&next_u)` check). Drive with a generous budget so a model
+/// that naturally reaches EOS within it does so; if it does, EOS must be the
+/// LAST interior token chunk (nothing streams after it) and count toward
+/// n_tokens. If the model never reaches EOS within budget, the shape check
+/// alone (exactly one empty final) still holds.
+#[test]
+fn eos_token_is_included_in_output() {
+    let Some(dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let manifest = Manifest::load(&dir).expect("manifest");
+    let eos = manifest.eos_token_ids.clone();
+    let (mut head, _worker) = two_rank_harness();
+    head.submit(GenerationTask::new("teos", "hello").with_max_tokens(64))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..256 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    let finals: Vec<_> = chunks.iter().filter(|(_, c)| c.is_final).collect();
+    assert_eq!(finals.len(), 1);
+    let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    if let Some(pos) = toks
+        .iter()
+        .position(|(_, c)| eos.contains(&(c.token_id as u32)))
+    {
+        assert_eq!(
+            pos,
+            toks.len() - 1,
+            "EOS must be the LAST interior chunk — OvMoe includes it, so nothing streams after"
+        );
+        assert_eq!(finals[0].1.finish_reason, Some(FinishReason::Stop));
+    }
+}
+
+#[test]
+fn resume_seed_streams_continuation_only() {
+    let Some(dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(dir.join("tokenizer.json")).expect("model tokenizer");
+    let (mut head, _worker) = two_rank_harness();
+    let mut task = GenerationTask::new("t2", "hello").with_max_tokens(6);
+    task.resume_token_ids = Some(vec![3, 4]); // in-vocab for the test model
+    head.submit(task).unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..64 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    // resume_max_new: 6 - 2 = at most 4 NEW tokens; the seed ids are never re-emitted.
+    let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    assert!(toks.len() <= 4);
+    let streamed: String = toks.iter().map(|(_, c)| c.text.as_str()).collect();
+    let seed_text = tokenizer.decode(&[3u32, 4], true).unwrap();
+    assert!(
+        !streamed.starts_with(&seed_text) || seed_text.is_empty(),
+        "streamed deltas re-emitted the forced prefix: {streamed:?}"
+    );
+}
+
+#[test]
+fn zero_budget_resume_finals_immediately_length() {
+    let Some(_dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    let mut task = GenerationTask::new("t3", "hello").with_max_tokens(2);
+    task.resume_token_ids = Some(vec![3, 4]); // budget fully consumed by seed
+    head.submit(task).unwrap();
+    let chunks = head.step().unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].1.is_final);
+    assert_eq!(chunks[0].1.n_tokens, Some(0));
+    assert_eq!(chunks[0].1.finish_reason, Some(FinishReason::Length));
+}
+
+#[test]
+fn cancel_mid_decode_clears_active() {
+    let Some(_dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    head.submit(GenerationTask::new("t4", "hello").with_max_tokens(50))
+        .unwrap();
+    let first = head.step().unwrap(); // begin + first token
+    assert!(!first.is_empty());
+    head.cancel(&"t4".to_string());
+    let after = head.step().unwrap();
+    assert!(
+        after.is_empty(),
+        "cancelled task must emit nothing and free the slot"
+    );
+}
+
+/// Single-stage MiniMax-M2 has no forced-prefix resume implementation
+/// (unlike single-stage SparseMoE — see `crates/cascadia-types/src/task.rs`'s
+/// `append_resume_ids`). A resumed task must be declined with the
+/// `resume_unsupported:` sentinel as the FIRST and ONLY chunk, so the
+/// scheduler's B6 retry excludes this peer and re-routes instead of silently
+/// regenerating from scratch.
+#[test]
+fn single_stage_declines_seeded_task_with_sentinel_first_chunk() {
+    let Some(_dir) = model_dir() else {
+        eprintln!("M2_MODEL_DIR not set; skipping");
+        return;
+    };
+    let mut eng = single_stage_ovmoe_harness();
+    let mut task = GenerationTask::new("t", "hi").with_max_tokens(4);
+    task.resume_token_ids = Some(vec![3]);
+    eng.submit(task).unwrap();
+    let chunks = eng.step().unwrap();
+    assert_eq!(chunks.len(), 1, "decline must be the FIRST and only chunk");
+    let c = &chunks[0].1;
+    let reason = c
+        .error
+        .as_deref()
+        .expect("decline is an error chunk (Chunk.error field)");
+    assert!(
+        reason.starts_with("resume_unsupported:"),
+        "sentinel must PREFIX the reason (enterprise starts_with carve-out)"
+    );
+}

--- a/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
@@ -64,10 +64,15 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
     let dir = model_dir().expect("caller must gate on model_dir() first");
     let port = free_port();
 
+    // The worker's startup errors must reach the test: its JoinHandle is
+    // never joined, so a bare `expect` panic there is swallowed and the
+    // head then blocks in connect for CASCADIA_CONNECT_TIMEOUT_SECS
+    // (default 300s) with the real cause invisible.
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
     let worker_dir = dir.clone();
     let worker_thread = std::thread::spawn(move || {
         let worker_rt = tokio::runtime::Runtime::new().expect("worker runtime");
-        let mut worker: Box<dyn Engine> = worker_rt.block_on(async move {
+        let built: Result<Box<dyn Engine>, String> = worker_rt.block_on(async move {
             let mut wb = SparseMoEBuilder::new(
                 SparseMoEBuilderConfig::new(worker_dir.to_str().expect("utf8 path"), "CPU")
                     .with_rank(1, 2),
@@ -75,10 +80,24 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
             wb.configure_listen("127.0.0.1", port);
             wb.connect(PeerLayout::last_of(PeerEndpoint::new("127.0.0.1", port)))
                 .await
-                .expect("worker connect");
-            let _progress = wb.load(shard(false, true)).await.expect("worker load");
-            Box::new(wb).build().expect("worker build")
+                .map_err(|e| format!("worker connect: {e:?}"))?;
+            wb.load(shard(false, true))
+                .await
+                .map_err(|e| format!("worker load: {e:?}"))?;
+            Box::new(wb)
+                .build()
+                .map_err(|e| format!("worker build: {e:?}"))
         });
+        let mut worker = match built {
+            Ok(w) => {
+                let _ = ready_tx.send(Ok(()));
+                w
+            }
+            Err(e) => {
+                let _ = ready_tx.send(Err(e));
+                return;
+            }
+        };
         // Drive the worker for the rest of the test process; no explicit
         // stop signal needed (matches sparse_streaming.rs).
         loop {
@@ -86,20 +105,42 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
         }
     });
 
+    // The worker's accept only unblocks once the head dials in, so the head
+    // MUST be built concurrently — readiness is checked after, not before.
     let head_shard_dir = dir.clone();
     let head_rt = tokio::runtime::Runtime::new().expect("head runtime");
-    let head: Box<dyn Engine> = head_rt.block_on(async move {
+    let head_res: Result<Box<dyn Engine>, String> = head_rt.block_on(async move {
         let mut hb = SparseMoEBuilder::new(
             SparseMoEBuilderConfig::new(head_shard_dir.to_str().expect("utf8 path"), "CPU")
                 .with_rank(0, 2),
         );
         hb.connect(PeerLayout::first_of(PeerEndpoint::new("127.0.0.1", port)))
             .await
-            .expect("head connect");
-        let _progress = hb.load(shard(true, false)).await.expect("head load");
-        Box::new(hb).build().expect("head build")
+            .map_err(|e| format!("head connect: {e:?}"))?;
+        hb.load(shard(true, false))
+            .await
+            .map_err(|e| format!("head load: {e:?}"))?;
+        Box::new(hb)
+            .build()
+            .map_err(|e| format!("head build: {e:?}"))
     });
     std::mem::forget(head_rt);
+    let head = match head_res {
+        Ok(h) => h,
+        Err(e) => {
+            // Surface the worker's failure as the likely root cause.
+            let worker_err = match ready_rx.try_recv() {
+                Ok(Err(w)) => format!(" (worker: {w})"),
+                _ => String::new(),
+            };
+            panic!("head startup failed: {e}{worker_err}");
+        }
+    };
+    match ready_rx.recv_timeout(std::time::Duration::from_secs(300)) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("worker startup failed: {e}"),
+        Err(_) => panic!("worker not ready within 300s"),
+    }
 
     (head, worker_thread)
 }

--- a/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/ovmoe_streaming.rs
@@ -223,6 +223,10 @@ fn resume_seed_streams_continuation_only() {
     let streamed: String = toks.iter().map(|(_, c)| c.text.as_str()).collect();
     let seed_text = tokenizer.decode(&[3u32, 4], true).unwrap();
     assert!(
+        !seed_text.is_empty(),
+        "fixture ids must decode to text or the re-emission assertion below is vacuous"
+    );
+    assert!(
         !streamed.starts_with(&seed_text) || seed_text.is_empty(),
         "streamed deltas re-emitted the forced prefix: {streamed:?}"
     );
@@ -289,6 +293,6 @@ fn single_stage_declines_seeded_task_with_sentinel_first_chunk() {
         .expect("decline is an error chunk (Chunk.error field)");
     assert!(
         reason.starts_with("resume_unsupported:"),
-        "sentinel must PREFIX the reason (enterprise starts_with carve-out)"
+        "sentinel must PREFIX the reason (callers match it with a starts_with check)"
     );
 }

--- a/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
@@ -1,0 +1,75 @@
+use cascadia_engine_sparse_moe::{prepare_resume, ResumeSeed};
+use cascadia_types::task::GenerationTask;
+
+fn test_tokenizer() -> tokenizers::Tokenizer {
+    let p = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/tokenizer_flags/tokenizer.json"
+    );
+    tokenizers::Tokenizer::from_file(p).expect("checked-in fixture")
+}
+
+#[test]
+fn prepare_resume_none_when_not_resuming() {
+    let tok = test_tokenizer();
+    let task = GenerationTask {
+        task_id: "t".to_string(),
+        prompt: "hi".to_string(),
+        max_tokens: 256,
+        temperature: 0.7,
+        logprobs: 0,
+        sampling: Default::default(),
+        enable_thinking: false,
+        trust_remote_code: false,
+        tenant: "".to_string(),
+        resume_token_ids: None,
+    };
+    let mut ids: Vec<i64> = vec![1, 2];
+    let seed = prepare_resume(&task, &tok, &mut ids).unwrap();
+    assert!(seed.is_none());
+    assert_eq!(ids, vec![1, 2], "prompt ids untouched on a plain turn");
+}
+
+#[test]
+fn prepare_resume_seeds_and_appends() {
+    let tok = test_tokenizer();
+    let mut task = GenerationTask {
+        task_id: "t".to_string(),
+        prompt: "hi".to_string(),
+        max_tokens: 256,
+        temperature: 0.7,
+        logprobs: 0,
+        sampling: Default::default(),
+        enable_thinking: false,
+        trust_remote_code: false,
+        tenant: "".to_string(),
+        resume_token_ids: Some(vec![5, 6]),
+    };
+    let mut ids: Vec<i64> = vec![1, 2];
+    let seed = prepare_resume(&task, &tok, &mut ids).unwrap().unwrap();
+    assert_eq!(ids, vec![1, 2, 5, 6], "resume ids appended after the prompt");
+    assert_eq!(seed.generated_u32, vec![5u32, 6]);
+    assert_eq!(seed.seed_len, 2);
+    let prefix_text = tok.decode(&[5, 6], true).unwrap();
+    assert_eq!(seed.emitted, prefix_text.len(), "emitted = prefix byte length");
+}
+
+#[test]
+fn prepare_resume_rejects_out_of_vocab() {
+    let tok = test_tokenizer();
+    let vocab = tok.get_vocab_size(true) as i32;
+    let mut task = GenerationTask {
+        task_id: "t".to_string(),
+        prompt: "hi".to_string(),
+        max_tokens: 256,
+        temperature: 0.7,
+        logprobs: 0,
+        sampling: Default::default(),
+        enable_thinking: false,
+        trust_remote_code: false,
+        tenant: "".to_string(),
+        resume_token_ids: Some(vec![vocab]), // one past the end
+    };
+    let mut ids: Vec<i64> = vec![1];
+    assert!(prepare_resume(&task, &tok, &mut ids).is_err());
+}

--- a/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
@@ -1,4 +1,4 @@
-use cascadia_engine_sparse_moe::{prepare_resume, ResumeSeed};
+use cascadia_engine_sparse_moe::prepare_resume;
 use cascadia_types::task::GenerationTask;
 
 fn test_tokenizer() -> tokenizers::Tokenizer {
@@ -12,18 +12,9 @@ fn test_tokenizer() -> tokenizers::Tokenizer {
 #[test]
 fn prepare_resume_none_when_not_resuming() {
     let tok = test_tokenizer();
-    let task = GenerationTask {
-        task_id: "t".to_string(),
-        prompt: "hi".to_string(),
-        max_tokens: 256,
-        temperature: 0.7,
-        logprobs: 0,
-        sampling: Default::default(),
-        enable_thinking: false,
-        trust_remote_code: false,
-        tenant: "".to_string(),
-        resume_token_ids: None,
-    };
+    let task = GenerationTask::new("t", "hi")
+        .with_max_tokens(256)
+        .with_temperature(0.7);
     let mut ids: Vec<i64> = vec![1, 2];
     let seed = prepare_resume(&task, &tok, &mut ids).unwrap();
     assert!(seed.is_none());
@@ -33,18 +24,10 @@ fn prepare_resume_none_when_not_resuming() {
 #[test]
 fn prepare_resume_seeds_and_appends() {
     let tok = test_tokenizer();
-    let mut task = GenerationTask {
-        task_id: "t".to_string(),
-        prompt: "hi".to_string(),
-        max_tokens: 256,
-        temperature: 0.7,
-        logprobs: 0,
-        sampling: Default::default(),
-        enable_thinking: false,
-        trust_remote_code: false,
-        tenant: "".to_string(),
-        resume_token_ids: Some(vec![5, 6]),
-    };
+    let mut task = GenerationTask::new("t", "hi")
+        .with_max_tokens(256)
+        .with_temperature(0.7);
+    task.resume_token_ids = Some(vec![5, 6]);
     let mut ids: Vec<i64> = vec![1, 2];
     let seed = prepare_resume(&task, &tok, &mut ids).unwrap().unwrap();
     assert_eq!(
@@ -66,18 +49,10 @@ fn prepare_resume_seeds_and_appends() {
 fn prepare_resume_rejects_out_of_vocab() {
     let tok = test_tokenizer();
     let vocab = tok.get_vocab_size(true) as i32;
-    let mut task = GenerationTask {
-        task_id: "t".to_string(),
-        prompt: "hi".to_string(),
-        max_tokens: 256,
-        temperature: 0.7,
-        logprobs: 0,
-        sampling: Default::default(),
-        enable_thinking: false,
-        trust_remote_code: false,
-        tenant: "".to_string(),
-        resume_token_ids: Some(vec![vocab]), // one past the end
-    };
+    let mut task = GenerationTask::new("t", "hi")
+        .with_max_tokens(256)
+        .with_temperature(0.7);
+    task.resume_token_ids = Some(vec![vocab]); // one past the end
     let mut ids: Vec<i64> = vec![1];
     assert!(prepare_resume(&task, &tok, &mut ids).is_err());
 }

--- a/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
@@ -27,32 +27,40 @@ fn prepare_resume_seeds_and_appends() {
     let mut task = GenerationTask::new("t", "hi")
         .with_max_tokens(256)
         .with_temperature(0.7);
-    task.resume_token_ids = Some(vec![5, 6]);
+    // Ids that DECODE in this fixture: 154841/154842 = "<think>"/"</think>",
+    // both `special: false` so they survive skip_special_tokens=true. The
+    // previous ids (5, 6) map to nothing in the WordLevel fixture, decoded to
+    // "", and made the byte-length assertion below a vacuous 0 == 0.
+    task.resume_token_ids = Some(vec![154841, 154842]);
     let mut ids: Vec<i64> = vec![1, 2];
     let seed = prepare_resume(&task, &tok, &mut ids).unwrap().unwrap();
     assert_eq!(
         ids,
-        vec![1, 2, 5, 6],
+        vec![1, 2, 154841, 154842],
         "resume ids appended after the prompt"
     );
-    assert_eq!(seed.generated_u32, vec![5u32, 6]);
+    assert_eq!(seed.generated_u32, vec![154841u32, 154842]);
     assert_eq!(seed.seed_len, 2);
-    let prefix_text = tok.decode(&[5, 6], true).unwrap();
+    // Literal, not the implementation's own expression. The WordLevel decoder
+    // joins tokens with a space: "<think> </think>" = 16 bytes.
     assert_eq!(
         seed.emitted,
-        prefix_text.len(),
+        "<think> </think>".len(),
         "emitted = prefix byte length"
     );
+    assert_eq!(seed.emitted, 16);
 }
 
 #[test]
 fn prepare_resume_rejects_out_of_vocab() {
     let tok = test_tokenizer();
-    let vocab = tok.get_vocab_size(true) as i32;
     let mut task = GenerationTask::new("t", "hi")
         .with_max_tokens(256)
         .with_temperature(0.7);
-    task.resume_token_ids = Some(vec![vocab]); // one past the end
+    // One past the fixture's highest assigned id (154848, "</arg_key>") — the
+    // bound is max_id + 1, NOT get_vocab_size(true) (the entry count, 7 here),
+    // which would wrongly reject every real id in this gapped vocab.
+    task.resume_token_ids = Some(vec![154849]);
     let mut ids: Vec<i64> = vec![1];
     assert!(prepare_resume(&task, &tok, &mut ids).is_err());
 }

--- a/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/prepare_resume.rs
@@ -47,11 +47,19 @@ fn prepare_resume_seeds_and_appends() {
     };
     let mut ids: Vec<i64> = vec![1, 2];
     let seed = prepare_resume(&task, &tok, &mut ids).unwrap().unwrap();
-    assert_eq!(ids, vec![1, 2, 5, 6], "resume ids appended after the prompt");
+    assert_eq!(
+        ids,
+        vec![1, 2, 5, 6],
+        "resume ids appended after the prompt"
+    );
     assert_eq!(seed.generated_u32, vec![5u32, 6]);
     assert_eq!(seed.seed_len, 2);
     let prefix_text = tok.decode(&[5, 6], true).unwrap();
-    assert_eq!(seed.emitted, prefix_text.len(), "emitted = prefix byte length");
+    assert_eq!(
+        seed.emitted,
+        prefix_text.len(),
+        "emitted = prefix byte length"
+    );
 }
 
 #[test]

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -122,6 +122,21 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
 /// loop return (dropping the engine + its runtime, closing the sockets), so a
 /// test can simulate mid-decode chain death and join the worker thread.
 fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBool>) {
+    let (head, worker, kill, _mute) = two_rank_harness_faultable();
+    (head, worker, kill)
+}
+
+/// `two_rank_harness_killable` plus a MUTE switch: setting it makes the worker
+/// loop spin WITHOUT stepping — its sockets stay open but it never replies.
+/// This is the rig's real mid-decode death shape: the enterprise bridge parks
+/// a dead pipeline leg instead of closing the engine-side loopback, so the
+/// head sees silence, not a transport error (rig 2026-08-27 resume stall).
+fn two_rank_harness_faultable() -> (
+    Box<dyn Engine>,
+    JoinHandle<()>,
+    Arc<AtomicBool>,
+    Arc<AtomicBool>,
+) {
     let dir = tiny_dir().expect("caller must gate on tiny_dir() first");
     let manifest = Manifest::load(&dir).expect("manifest");
     let port = free_port();
@@ -133,6 +148,8 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
     let kill = Arc::new(AtomicBool::new(false));
     let kill_worker = Arc::clone(&kill);
+    let mute = Arc::new(AtomicBool::new(false));
+    let mute_worker = Arc::clone(&mute);
     let worker_dir = dir.clone();
     let worker_shard = shard(&manifest, false, true);
     let worker_thread = std::thread::spawn(move || {
@@ -173,6 +190,11 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
                 // Simulated chain death: return, dropping the engine and its
                 // runtime — sockets close and the head's next forward fails.
                 return;
+            }
+            if mute_worker.load(Ordering::Relaxed) {
+                // Mute: alive, sockets open, never replies.
+                std::thread::sleep(std::time::Duration::from_millis(20));
+                continue;
             }
             let _ = worker.step();
         }
@@ -215,7 +237,7 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
         Err(_) => panic!("worker not ready within 300s"),
     }
 
-    (head, worker_thread, kill)
+    (head, worker_thread, kill, mute)
 }
 
 // Streaming shape: interior token chunks + one empty final marker.
@@ -397,4 +419,45 @@ fn mid_decode_chain_death_is_an_error_chunk_never_a_final() {
         }
     }
     assert!(saw_error, "chain death must surface an error chunk");
+}
+
+/// The 2026-08-27 rig stall: a downstream that goes SILENT (socket open, no
+/// replies — the bridge parks dead legs, it does not close them) must surface
+/// an error chunk within the engine's bounded reply deadline, well under the
+/// gateway's 180 s inter-token budget — not hang until the gateway kills the
+/// stream with nothing for the resume splicer to rescue.
+#[test]
+fn mid_decode_silent_worker_errors_within_deadline() {
+    let Some(_dir) = tiny_dir() else {
+        return; // gate already printed why
+    };
+    let (mut head, _worker, _kill, mute) = two_rank_harness_faultable();
+    head.submit(GenerationTask::new("tmute", "hello").with_max_tokens(400))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..3 {
+        chunks.extend(head.step().unwrap());
+    }
+    assert!(chunks.iter().all(|(_, c)| !c.is_final));
+    mute.store(true, Ordering::Relaxed);
+    let t0 = std::time::Instant::now();
+    let mut saw_error = false;
+    'outer: while t0.elapsed() < std::time::Duration::from_secs(170) {
+        let out = head.step().unwrap();
+        for (_, c) in &out {
+            assert!(
+                c.error.is_some() || !c.is_final,
+                "silent worker must never produce a success-shaped final: {c:?}"
+            );
+            if c.error.is_some() {
+                saw_error = true;
+                break 'outer;
+            }
+        }
+    }
+    assert!(
+        saw_error,
+        "no error chunk within 170s — the bounded reply deadline did not fire \
+         (gateway inter-token budget is 180s; the engine must beat it)"
+    );
 }

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -1,0 +1,222 @@
+//! Task 2 (issue-34 Option B): `SparseMoEEngine`'s multi-stage rank-0 path
+//! converted from a whole-turn burst driver to a per-token streaming state
+//! machine (`begin_generation_sparse` / `decode_step_sparse` /
+//! `finalize_sparse`). These tests drive that state machine through
+//! `Engine::step` over a REAL two-rank loopback transport — the same wire
+//! path production uses — so a regression in the splice between prefill and
+//! decode, or in the resume-seed streaming shape, shows up here instead of
+//! only in the rig cert.
+//!
+//! Gated on `K26_TINY_DIR` (see `tests/k26_native_tiny.rs`): the fixture
+//! cannot be committed (~1.4 GiB, K2.6 dims pinned at compile time). CI skips
+//! this file; the rig cert (Task 9) is the enforcement gate for what's below.
+//!
+//! `Engine::step` is SYNC and `block_on`s internally (`engine.rs`'s
+//! `SparseMoEEngine::block_on`) — every test here drives `head.step()` from a
+//! plain `#[test]` thread. A `#[tokio::test]` would deadlock on that
+//! `block_on` (the calling thread would already be inside the single-threaded
+//! test runtime `step()` tries to re-enter).
+
+use std::path::PathBuf;
+use std::thread::JoinHandle;
+
+use cascadia_engine::{Builder, Engine};
+use cascadia_engine_sparse_moe::{Manifest, SparseMoEBuilder, SparseMoEBuilderConfig};
+use cascadia_types::{FinishReason, GenerationTask, PeerEndpoint, PeerLayout, ShardSpec};
+
+fn tiny_dir() -> Option<PathBuf> {
+    std::env::var("K26_TINY_DIR").ok().map(PathBuf::from)
+}
+
+/// `layer_end` covering every MoE layer in the manifest (ids are 1-based) —
+/// same helper as `tests/k26_native_tiny.rs`, duplicated rather than shared
+/// because integration test binaries can't import each other.
+fn moe_end(m: &Manifest) -> u32 {
+    m.moe_layer_ids().last().copied().unwrap_or(0) + 1
+}
+
+fn shard(m: &Manifest, is_first: bool, is_last: bool) -> ShardSpec {
+    ShardSpec {
+        model_id: "k26_tiny".into(),
+        layer_start: 1,
+        layer_end: moe_end(m),
+        total_layers: m.num_layers,
+        device: "CPU".into(),
+        is_first_stage: is_first,
+        is_last_stage: is_last,
+        tp_size: 1,
+        tp_rank: 0,
+    }
+}
+
+/// The model's own tokenizer — needed so the seed-text comparison in
+/// `resume_seed_streams_continuation_only` decodes with the exact vocab the
+/// engine under test uses (the fixed ids in these tests, e.g. `[3, 4]`, are
+/// only guaranteed in-vocab for THIS tokenizer, not any arbitrary one).
+fn test_tokenizer() -> tokenizers::Tokenizer {
+    let dir = tiny_dir().expect("caller must gate on tiny_dir() first");
+    tokenizers::Tokenizer::from_file(dir.join("tokenizer.json")).expect("model tokenizer")
+}
+
+/// OS-assigned free TCP port. Small bind-then-drop TOCTOU race (another
+/// process could grab it before our own bind below), acceptable for a
+/// rig-only, non-CI test.
+fn free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = l.local_addr().expect("local_addr").port();
+    drop(l);
+    port
+}
+
+/// Build a live 2-rank chain: rank 0 (head, the API-facing driver under
+/// test) and rank 1 (worker/last-stage, drives itself off upstream frames)
+/// wired over a real loopback socket — the transport scaffold in
+/// `tests/dsv4_wire_e2e.rs:27-60`, generalized to full `SparseMoEEngine`s
+/// built the way `tests/k26_native_tiny.rs:124-149` builds one.
+///
+/// Each rank gets its OWN tokio runtime (mirrors `packed_wire_stress.rs`'s
+/// DRIVER/RELAY split — one process per rank in production). The worker's
+/// runtime + step loop live on a dedicated thread for the lifetime of the
+/// test process; the head's runtime is intentionally leaked (`mem::forget`)
+/// because `head`'s captured `Handle` must outlive every `head.step()` call
+/// the *caller* makes, and this function has no join point to hand that
+/// lifetime back through the 2-tuple the tests destructure.
+fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
+    let dir = tiny_dir().expect("caller must gate on tiny_dir() first");
+    let manifest = Manifest::load(&dir).expect("manifest");
+    let port = free_port();
+
+    let worker_dir = dir.clone();
+    let worker_shard = shard(&manifest, false, true);
+    let worker_thread = std::thread::spawn(move || {
+        let worker_rt = tokio::runtime::Runtime::new().expect("worker runtime");
+        let mut worker: Box<dyn Engine> = worker_rt.block_on(async move {
+            let mut wb = SparseMoEBuilder::new(
+                SparseMoEBuilderConfig::new(worker_dir.to_str().expect("utf8 path"), "CPU")
+                    .with_rank(1, 2),
+            );
+            wb.configure_listen("127.0.0.1", port);
+            wb.connect(PeerLayout::last_of(PeerEndpoint::new("127.0.0.1", port)))
+                .await
+                .expect("worker connect");
+            let _progress = wb.load(worker_shard).await.expect("worker load");
+            Box::new(wb).build().expect("worker build")
+        });
+        // Drive the worker for the rest of the test process. When the head
+        // side eventually drops (process exit), `step_worker` degrades to
+        // its WORKER_BACKOFF idle loop rather than erroring hard, so this
+        // never needs an explicit stop signal.
+        loop {
+            let _ = worker.step();
+        }
+    });
+
+    let head_shard = shard(&manifest, true, false);
+    let head_rt = tokio::runtime::Runtime::new().expect("head runtime");
+    let head: Box<dyn Engine> = head_rt.block_on(async move {
+        let mut hb = SparseMoEBuilder::new(
+            SparseMoEBuilderConfig::new(dir.to_str().expect("utf8 path"), "CPU").with_rank(0, 2),
+        );
+        hb.connect(PeerLayout::first_of(PeerEndpoint::new("127.0.0.1", port)))
+            .await
+            .expect("head connect");
+        let _progress = hb.load(head_shard).await.expect("head load");
+        Box::new(hb).build().expect("head build")
+    });
+    std::mem::forget(head_rt);
+
+    (head, worker_thread)
+}
+
+// Streaming shape: interior token chunks + one empty final marker.
+// EOS EXCLUSION: the eos token, when sampled, is NOT in the output ids.
+#[test]
+fn multi_stage_streams_per_token_with_empty_final() {
+    let Some(_dir) = tiny_dir() else {
+        eprintln!("K26_TINY_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    head.submit(GenerationTask::new("t1", "hello").with_max_tokens(4))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..64 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    let finals: Vec<_> = chunks.iter().filter(|(_, c)| c.is_final).collect();
+    assert_eq!(finals.len(), 1);
+    assert!(finals[0].1.text.is_empty(), "final marker carries no text");
+    assert_eq!(finals[0].1.n_tokens, Some(0));
+    let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    assert!(!toks.is_empty(), "interior token chunks must exist");
+    for (_, c) in &toks {
+        assert_eq!(c.n_tokens, Some(1));
+        assert_eq!(c.token_ids, vec![c.token_id], "token_ids stamped (poison bypass)");
+    }
+}
+
+#[test]
+fn resume_seed_streams_continuation_only() {
+    let Some(_dir) = tiny_dir() else {
+        eprintln!("K26_TINY_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    let mut task = GenerationTask::new("t2", "hello").with_max_tokens(6);
+    task.resume_token_ids = Some(vec![3, 4]); // in-vocab for the test model
+    head.submit(task).unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..64 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    // resume_max_new: 6 - 2 = at most 4 NEW tokens; the seed ids are never re-emitted.
+    let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    assert!(toks.len() <= 4);
+    // The seed text must NOT re-stream: concatenated deltas start strictly
+    // after the decoded prefix (emitted-cursor seeding).
+    let streamed: String = toks.iter().map(|(_, c)| c.text.as_str()).collect();
+    let seed_text = test_tokenizer().decode(&[3u32, 4], true).unwrap();
+    assert!(
+        !streamed.starts_with(&seed_text) || seed_text.is_empty(),
+        "streamed deltas re-emitted the forced prefix: {streamed:?}"
+    );
+}
+
+#[test]
+fn zero_budget_resume_finals_immediately_length() {
+    let Some(_dir) = tiny_dir() else {
+        eprintln!("K26_TINY_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    let mut task = GenerationTask::new("t3", "hello").with_max_tokens(2);
+    task.resume_token_ids = Some(vec![3, 4]); // budget fully consumed by seed
+    head.submit(task).unwrap();
+    let chunks = head.step().unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].1.is_final);
+    assert_eq!(chunks[0].1.n_tokens, Some(0));
+    assert_eq!(chunks[0].1.finish_reason, Some(FinishReason::Length));
+}
+
+#[test]
+fn cancel_mid_decode_clears_active() {
+    let Some(_dir) = tiny_dir() else {
+        eprintln!("K26_TINY_DIR not set; skipping");
+        return;
+    };
+    let (mut head, _worker) = two_rank_harness();
+    head.submit(GenerationTask::new("t4", "hello").with_max_tokens(50))
+        .unwrap();
+    let first = head.step().unwrap(); // begin + first token
+    assert!(!first.is_empty());
+    head.cancel(&"t4".to_string());
+    let after = head.step().unwrap();
+    assert!(after.is_empty(), "cancelled task must emit nothing and free the slot");
+}

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -23,6 +23,8 @@
 //! test runtime `step()` tries to re-enter).
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use cascadia_engine::{Builder, Engine};
@@ -108,6 +110,14 @@ fn free_port() -> u16 {
 /// the *caller* makes, and this function has no join point to hand that
 /// lifetime back through the 2-tuple the tests destructure.
 fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
+    let (head, worker, _kill) = two_rank_harness_killable();
+    (head, worker)
+}
+
+/// `two_rank_harness` plus a kill switch: setting the flag makes the worker
+/// loop return (dropping the engine + its runtime, closing the sockets), so a
+/// test can simulate mid-decode chain death and join the worker thread.
+fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBool>) {
     let dir = tiny_dir().expect("caller must gate on tiny_dir() first");
     let manifest = Manifest::load(&dir).expect("manifest");
     let port = free_port();
@@ -117,6 +127,8 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
     // head then blocks in connect for CASCADIA_CONNECT_TIMEOUT_SECS
     // (default 300s) with the real cause invisible.
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let kill = Arc::new(AtomicBool::new(false));
+    let kill_worker = Arc::clone(&kill);
     let worker_dir = dir.clone();
     let worker_shard = shard(&manifest, false, true);
     let worker_thread = std::thread::spawn(move || {
@@ -152,6 +164,11 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
         // its WORKER_BACKOFF idle loop rather than erroring hard, so this
         // never needs an explicit stop signal.
         loop {
+            if kill_worker.load(Ordering::Relaxed) {
+                // Simulated chain death: return, dropping the engine and its
+                // runtime — sockets close and the head's next forward fails.
+                return;
+            }
             let _ = worker.step();
         }
     });
@@ -192,7 +209,7 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
         Err(_) => panic!("worker not ready within 300s"),
     }
 
-    (head, worker_thread)
+    (head, worker_thread, kill)
 }
 
 // Streaming shape: interior token chunks + one empty final marker.
@@ -246,7 +263,23 @@ fn resume_seed_streams_continuation_only() {
     }
     // resume_max_new: 6 - 2 = at most 4 NEW tokens; the seed ids are never re-emitted.
     let toks: Vec<_> = chunks.iter().filter(|(_, c)| !c.is_final).collect();
+    assert!(
+        !toks.is_empty(),
+        "resume must stream at least one continuation token — an empty stream \
+         passes every assertion below vacuously"
+    );
     assert!(toks.len() <= 4);
+    let fin = chunks
+        .iter()
+        .find(|(_, c)| c.is_final)
+        .expect("a final chunk");
+    if fin.1.finish_reason == Some(FinishReason::Length) {
+        assert_eq!(
+            toks.len(),
+            4,
+            "Length final => exactly max_tokens - seed_len interior chunks"
+        );
+    }
     // The seed text must NOT re-stream: concatenated deltas start strictly
     // after the decoded prefix (emitted-cursor seeding).
     let streamed: String = toks.iter().map(|(_, c)| c.text.as_str()).collect();
@@ -256,7 +289,7 @@ fn resume_seed_streams_continuation_only() {
         "fixture ids must decode to text or the re-emission assertion below is vacuous"
     );
     assert!(
-        !streamed.starts_with(&seed_text) || seed_text.is_empty(),
+        !streamed.starts_with(&seed_text),
         "streamed deltas re-emitted the forced prefix: {streamed:?}"
     );
 }
@@ -287,10 +320,75 @@ fn cancel_mid_decode_clears_active() {
         .unwrap();
     let first = head.step().unwrap(); // begin + first token
     assert!(!first.is_empty());
+    assert!(
+        !first[0].1.is_final,
+        "first step must be an interior token — a final here means no \
+         generation was active and the cancel below tests nothing"
+    );
     head.cancel(&"t4".to_string());
     let after = head.step().unwrap();
     assert!(
         after.is_empty(),
         "cancelled task must emit nothing and free the slot"
     );
+    // Recovery: the worker was abandoned mid-sequence; the next task's begin
+    // issues a fresh chain reset, so a full turn must still complete cleanly
+    // (protocol desync here is the actual failure cancel risks).
+    head.submit(GenerationTask::new("t5", "hello again").with_max_tokens(3))
+        .unwrap();
+    let mut chunks = Vec::new();
+    for _ in 0..64 {
+        chunks.extend(head.step().unwrap());
+        if chunks.iter().any(|(_, c)| c.is_final) {
+            break;
+        }
+    }
+    assert!(
+        chunks.iter().any(|(_, c)| c.is_final && c.error.is_none()),
+        "post-cancel task must complete cleanly: {chunks:?}"
+    );
+}
+
+/// The headline Option B invariant: a mid-decode chain death surfaces an
+/// ERROR chunk and NEVER a success-shaped final — a final marker would trip
+/// the scheduler's saw_final latch and permanently block the forced-prefix
+/// rescue. (Deliberate divergence from PipelineEngine's partial-final; see
+/// the decode step's Err arm.) Reverting that arm to the old partial-final
+/// behavior passes every other test in this suite.
+#[test]
+fn mid_decode_chain_death_is_an_error_chunk_never_a_final() {
+    let Some(_dir) = tiny_dir() else {
+        return; // gate already printed why
+    };
+    let (mut head, worker, kill) = two_rank_harness_killable();
+    head.submit(GenerationTask::new("tkill", "hello").with_max_tokens(400))
+        .unwrap();
+    // Stream a few tokens first so the death is genuinely MID-decode.
+    let mut chunks = Vec::new();
+    for _ in 0..3 {
+        chunks.extend(head.step().unwrap());
+    }
+    assert!(
+        chunks.iter().all(|(_, c)| !c.is_final),
+        "budget 400 must not finish within 3 steps: {chunks:?}"
+    );
+    kill.store(true, Ordering::Relaxed);
+    worker.join().expect("worker thread exits on kill");
+    // Keep stepping until the failure surfaces (the in-flight recv trips its
+    // bounded transport timeout first).
+    let mut saw_error = false;
+    'outer: for _ in 0..64 {
+        let out = head.step().unwrap();
+        for (_, c) in &out {
+            assert!(
+                c.error.is_some() || !c.is_final,
+                "chain death must never produce a success-shaped final: {c:?}"
+            );
+            if c.error.is_some() {
+                saw_error = true;
+                break 'outer;
+            }
+        }
+    }
+    assert!(saw_error, "chain death must surface an error chunk");
 }

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -154,7 +154,11 @@ fn multi_stage_streams_per_token_with_empty_final() {
     assert!(!toks.is_empty(), "interior token chunks must exist");
     for (_, c) in &toks {
         assert_eq!(c.n_tokens, Some(1));
-        assert_eq!(c.token_ids, vec![c.token_id], "token_ids stamped (poison bypass)");
+        assert_eq!(
+            c.token_ids,
+            vec![c.token_id],
+            "token_ids stamped (poison bypass)"
+        );
     }
 }
 
@@ -218,5 +222,8 @@ fn cancel_mid_decode_clears_active() {
     assert!(!first.is_empty());
     head.cancel(&"t4".to_string());
     let after = head.step().unwrap();
-    assert!(after.is_empty(), "cancelled task must emit nothing and free the slot");
+    assert!(
+        after.is_empty(),
+        "cancelled task must emit nothing and free the slot"
+    );
 }

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -63,6 +63,10 @@ fn moe_end(m: &Manifest) -> u32 {
     m.moe_layer_ids().last().copied().unwrap_or(0) + 1
 }
 
+/// BOTH ranks get the full MoE layer range: these tests target the WIRE path
+/// (streaming shape, resume seams, chain death), not memory economy, and the
+/// tiny fixture makes a duplicate stack cheap. Contrast ovmoe_streaming.rs,
+/// whose 0/0 layer_end gets a real even split for free from `load_staged`.
 fn shard(m: &Manifest, is_first: bool, is_last: bool) -> ShardSpec {
     ShardSpec {
         model_id: "k26_tiny".into(),

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -7,9 +7,14 @@
 //! decode, or in the resume-seed streaming shape, shows up here instead of
 //! only in the rig cert.
 //!
-//! Gated on `K26_TINY_DIR` (see `tests/k26_native_tiny.rs`): the fixture
-//! cannot be committed (~1.4 GiB, K2.6 dims pinned at compile time). CI skips
-//! this file; the hardware cert is the enforcement gate for what's below.
+//! Gated on `K26_TINY_HEAD_DIR`: a K2.6 tiny tree exported WITH
+//! `tools/export_kimi_k26.py --head`, built `--features openvino`. The worker
+//! rank here is a LAST stage, which hard-requires `head/openvino_model.xml`
+//! and a real OV runtime to compile it — deliberately a DIFFERENT env var
+//! from `K26_TINY_DIR`, whose tree `tests/k26_native_tiny.rs` asserts is
+//! head-LESS (one tree cannot satisfy both files). The fixture cannot be
+//! committed (~1.4 GiB, K2.6 dims pinned at compile time). CI skips this
+//! file; the hardware cert is the enforcement gate for what's below.
 //!
 //! `Engine::step` is SYNC and `block_on`s internally (`engine.rs`'s
 //! `SparseMoEEngine::block_on`) — every test here drives `head.step()` from a
@@ -25,7 +30,28 @@ use cascadia_engine_sparse_moe::{Manifest, SparseMoEBuilder, SparseMoEBuilderCon
 use cascadia_types::{FinishReason, GenerationTask, PeerEndpoint, PeerLayout, ShardSpec};
 
 fn tiny_dir() -> Option<PathBuf> {
-    std::env::var("K26_TINY_DIR").ok().map(PathBuf::from)
+    if cfg!(not(feature = "openvino")) {
+        eprintln!(
+            "sparse_streaming: skipping (build with --features openvino — \
+             the last-stage worker compiles the OV head IR)"
+        );
+        return None;
+    }
+    let dir = match std::env::var("K26_TINY_HEAD_DIR") {
+        Ok(d) => PathBuf::from(d),
+        Err(_) => {
+            eprintln!("K26_TINY_HEAD_DIR not set; skipping");
+            return None;
+        }
+    };
+    if !dir.join("head").join("openvino_model.xml").exists() {
+        eprintln!(
+            "K26_TINY_HEAD_DIR tree has no head/openvino_model.xml \
+             (re-export with export_kimi_k26.py --head); skipping"
+        );
+        return None;
+    }
+    Some(dir)
 }
 
 /// `layer_end` covering every MoE layer in the manifest (ids are 1-based) —
@@ -86,11 +112,16 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
     let manifest = Manifest::load(&dir).expect("manifest");
     let port = free_port();
 
+    // The worker's startup errors must reach the test: its JoinHandle is
+    // never joined, so a bare `expect` panic there is swallowed and the
+    // head then blocks in connect for CASCADIA_CONNECT_TIMEOUT_SECS
+    // (default 300s) with the real cause invisible.
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
     let worker_dir = dir.clone();
     let worker_shard = shard(&manifest, false, true);
     let worker_thread = std::thread::spawn(move || {
         let worker_rt = tokio::runtime::Runtime::new().expect("worker runtime");
-        let mut worker: Box<dyn Engine> = worker_rt.block_on(async move {
+        let built: Result<Box<dyn Engine>, String> = worker_rt.block_on(async move {
             let mut wb = SparseMoEBuilder::new(
                 SparseMoEBuilderConfig::new(worker_dir.to_str().expect("utf8 path"), "CPU")
                     .with_rank(1, 2),
@@ -98,10 +129,24 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
             wb.configure_listen("127.0.0.1", port);
             wb.connect(PeerLayout::last_of(PeerEndpoint::new("127.0.0.1", port)))
                 .await
-                .expect("worker connect");
-            let _progress = wb.load(worker_shard).await.expect("worker load");
-            Box::new(wb).build().expect("worker build")
+                .map_err(|e| format!("worker connect: {e:?}"))?;
+            wb.load(worker_shard)
+                .await
+                .map_err(|e| format!("worker load: {e:?}"))?;
+            Box::new(wb)
+                .build()
+                .map_err(|e| format!("worker build: {e:?}"))
         });
+        let mut worker = match built {
+            Ok(w) => {
+                let _ = ready_tx.send(Ok(()));
+                w
+            }
+            Err(e) => {
+                let _ = ready_tx.send(Err(e));
+                return;
+            }
+        };
         // Drive the worker for the rest of the test process. When the head
         // side eventually drops (process exit), `step_worker` degrades to
         // its WORKER_BACKOFF idle loop rather than erroring hard, so this
@@ -111,19 +156,41 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
         }
     });
 
+    // The worker's accept only unblocks once the head dials in, so the head
+    // MUST be built concurrently — readiness is checked after, not before.
     let head_shard = shard(&manifest, true, false);
     let head_rt = tokio::runtime::Runtime::new().expect("head runtime");
-    let head: Box<dyn Engine> = head_rt.block_on(async move {
+    let head_res: Result<Box<dyn Engine>, String> = head_rt.block_on(async move {
         let mut hb = SparseMoEBuilder::new(
             SparseMoEBuilderConfig::new(dir.to_str().expect("utf8 path"), "CPU").with_rank(0, 2),
         );
         hb.connect(PeerLayout::first_of(PeerEndpoint::new("127.0.0.1", port)))
             .await
-            .expect("head connect");
-        let _progress = hb.load(head_shard).await.expect("head load");
-        Box::new(hb).build().expect("head build")
+            .map_err(|e| format!("head connect: {e:?}"))?;
+        hb.load(head_shard)
+            .await
+            .map_err(|e| format!("head load: {e:?}"))?;
+        Box::new(hb)
+            .build()
+            .map_err(|e| format!("head build: {e:?}"))
     });
     std::mem::forget(head_rt);
+    let head = match head_res {
+        Ok(h) => h,
+        Err(e) => {
+            // Surface the worker's failure as the likely root cause.
+            let worker_err = match ready_rx.try_recv() {
+                Ok(Err(w)) => format!(" (worker: {w})"),
+                _ => String::new(),
+            };
+            panic!("head startup failed: {e}{worker_err}");
+        }
+    };
+    match ready_rx.recv_timeout(std::time::Duration::from_secs(300)) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("worker startup failed: {e}"),
+        Err(_) => panic!("worker not ready within 300s"),
+    }
 
     (head, worker_thread)
 }
@@ -133,8 +200,7 @@ fn two_rank_harness() -> (Box<dyn Engine>, JoinHandle<()>) {
 #[test]
 fn multi_stage_streams_per_token_with_empty_final() {
     let Some(_dir) = tiny_dir() else {
-        eprintln!("K26_TINY_DIR not set; skipping");
-        return;
+        return; // gate already printed why
     };
     let (mut head, _worker) = two_rank_harness();
     head.submit(GenerationTask::new("t1", "hello").with_max_tokens(4))
@@ -165,8 +231,7 @@ fn multi_stage_streams_per_token_with_empty_final() {
 #[test]
 fn resume_seed_streams_continuation_only() {
     let Some(_dir) = tiny_dir() else {
-        eprintln!("K26_TINY_DIR not set; skipping");
-        return;
+        return; // gate already printed why
     };
     let (mut head, _worker) = two_rank_harness();
     let mut task = GenerationTask::new("t2", "hello").with_max_tokens(6);
@@ -199,8 +264,7 @@ fn resume_seed_streams_continuation_only() {
 #[test]
 fn zero_budget_resume_finals_immediately_length() {
     let Some(_dir) = tiny_dir() else {
-        eprintln!("K26_TINY_DIR not set; skipping");
-        return;
+        return; // gate already printed why
     };
     let (mut head, _worker) = two_rank_harness();
     let mut task = GenerationTask::new("t3", "hello").with_max_tokens(2);
@@ -216,8 +280,7 @@ fn zero_budget_resume_finals_immediately_length() {
 #[test]
 fn cancel_mid_decode_clears_active() {
     let Some(_dir) = tiny_dir() else {
-        eprintln!("K26_TINY_DIR not set; skipping");
-        return;
+        return; // gate already printed why
     };
     let (mut head, _worker) = two_rank_harness();
     head.submit(GenerationTask::new("t4", "hello").with_max_tokens(50))

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -9,7 +9,7 @@
 //!
 //! Gated on `K26_TINY_DIR` (see `tests/k26_native_tiny.rs`): the fixture
 //! cannot be committed (~1.4 GiB, K2.6 dims pinned at compile time). CI skips
-//! this file; the rig cert (Task 9) is the enforcement gate for what's below.
+//! this file; the hardware cert is the enforcement gate for what's below.
 //!
 //! `Engine::step` is SYNC and `block_on`s internally (`engine.rs`'s
 //! `SparseMoEEngine::block_on`) — every test here drives `head.step()` from a
@@ -186,6 +186,10 @@ fn resume_seed_streams_continuation_only() {
     // after the decoded prefix (emitted-cursor seeding).
     let streamed: String = toks.iter().map(|(_, c)| c.text.as_str()).collect();
     let seed_text = test_tokenizer().decode(&[3u32, 4], true).unwrap();
+    assert!(
+        !seed_text.is_empty(),
+        "fixture ids must decode to text or the re-emission assertion below is vacuous"
+    );
     assert!(
         !streamed.starts_with(&seed_text) || seed_text.is_empty(),
         "streamed deltas re-emitted the forced prefix: {streamed:?}"

--- a/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
+++ b/crates/cascadia-engine-sparse-moe/tests/sparse_streaming.rs
@@ -146,7 +146,8 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
             wb.connect(PeerLayout::last_of(PeerEndpoint::new("127.0.0.1", port)))
                 .await
                 .map_err(|e| format!("worker connect: {e:?}"))?;
-            wb.load(worker_shard)
+            let _progress = wb
+                .load(worker_shard)
                 .await
                 .map_err(|e| format!("worker load: {e:?}"))?;
             Box::new(wb)
@@ -188,7 +189,8 @@ fn two_rank_harness_killable() -> (Box<dyn Engine>, JoinHandle<()>, Arc<AtomicBo
         hb.connect(PeerLayout::first_of(PeerEndpoint::new("127.0.0.1", port)))
             .await
             .map_err(|e| format!("head connect: {e:?}"))?;
-        hb.load(head_shard)
+        let _progress = hb
+            .load(head_shard)
             .await
             .map_err(|e| format!("head load: {e:?}"))?;
         Box::new(hb)

--- a/crates/cascadia-types/src/chunk.rs
+++ b/crates/cascadia-types/src/chunk.rs
@@ -83,11 +83,14 @@ pub struct Chunk {
     /// falls back to `"stop"` (the historical behavior).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<FinishReason>,
-    /// Every generated token-id in this chunk, in order. Multi-token chunks
-    /// (dist-spec spec-rounds, sparse-moe batches) fill this so a resume source
-    /// can accumulate EXACT ids; single-token chunks leave it empty and callers
-    /// fall back to `token_id`. `#[serde(default)]` keeps the wire additive.
-    #[serde(default)]
+    /// Every generated token-id in this chunk, in order, so a resume source can
+    /// accumulate EXACT ids. Engines that know the ids fill it on EVERY chunk —
+    /// including single-token chunks, where `token_id == 0` with an empty vec is
+    /// indistinguishable from an id-less chunk (token 0 is a legal sample).
+    /// Chunks whose text is not token-addressed (whole-turn ov-genai bursts,
+    /// synthetic markers with `token_id = 0`) leave it empty; such streams are
+    /// not resume sources. `#[serde(default)]` keeps the wire additive.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub token_ids: Vec<i64>,
 }
 
@@ -148,6 +151,14 @@ impl Chunk {
     /// Tag the final chunk with why generation stopped (length vs stop).
     pub fn with_finish_reason(mut self, reason: FinishReason) -> Self {
         self.finish_reason = Some(reason);
+        self
+    }
+
+    /// Stamp the exact generated ids this chunk carries (see `token_ids` docs:
+    /// per-token producers stamp every chunk so a legal token-0 sample can't
+    /// read as id-less).
+    pub fn with_token_ids(mut self, ids: Vec<i64>) -> Self {
+        self.token_ids = ids;
         self
     }
 

--- a/crates/cascadia-types/src/chunk.rs
+++ b/crates/cascadia-types/src/chunk.rs
@@ -83,6 +83,12 @@ pub struct Chunk {
     /// falls back to `"stop"` (the historical behavior).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<FinishReason>,
+    /// Every generated token-id in this chunk, in order. Multi-token chunks
+    /// (dist-spec spec-rounds, sparse-moe batches) fill this so a resume source
+    /// can accumulate EXACT ids; single-token chunks leave it empty and callers
+    /// fall back to `token_id`. `#[serde(default)]` keeps the wire additive.
+    #[serde(default)]
+    pub token_ids: Vec<i64>,
 }
 
 impl Chunk {
@@ -97,6 +103,7 @@ impl Chunk {
             prompt_tokens: None,
             error: None,
             finish_reason: None,
+            token_ids: Vec::new(),
         }
     }
 
@@ -111,6 +118,7 @@ impl Chunk {
             prompt_tokens: None,
             error: None,
             finish_reason: None,
+            token_ids: Vec::new(),
         }
     }
 
@@ -128,6 +136,7 @@ impl Chunk {
             prompt_tokens: None,
             error: Some(reason.into()),
             finish_reason: None,
+            token_ids: Vec::new(),
         }
     }
 
@@ -161,5 +170,39 @@ impl Chunk {
     pub fn token_count(&self) -> u32 {
         self.n_tokens
             .unwrap_or(if self.text.is_empty() { 0 } else { 1 })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_token_ids_defaults_empty_and_is_additive() {
+        let c = Chunk {
+            task_id: "t1".to_string(),
+            token_id: 42,
+            text: "hi".to_string(),
+            is_final: false,
+            logprobs: None,
+            n_tokens: None,
+            prompt_tokens: None,
+            error: None,
+            finish_reason: None,
+            token_ids: Vec::new(),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: Chunk = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.token_ids, Vec::<i64>::new());
+
+        // Additivity: a payload encoded WITHOUT the field still decodes,
+        // defaulting to an empty vec.
+        let without_field = serde_json::json!({
+            "task_id": "t1",
+            "token_id": 42,
+            "text": "hi",
+        });
+        let back: Chunk = serde_json::from_value(without_field).unwrap();
+        assert_eq!(back.token_ids, Vec::<i64>::new());
     }
 }

--- a/crates/cascadia-types/src/lib.rs
+++ b/crates/cascadia-types/src/lib.rs
@@ -19,6 +19,4 @@ pub use load::LoadProgress;
 pub use peer::{PeerEndpoint, PeerLayout};
 pub use shard::{ShardPlan, ShardSpec};
 pub use stats::ApiStats;
-pub use task::{
-    append_resume_ids, resume_generated_seed, GenerationTask, SamplingParams, TaskId,
-};
+pub use task::{append_resume_ids, resume_generated_seed, GenerationTask, SamplingParams, TaskId};

--- a/crates/cascadia-types/src/lib.rs
+++ b/crates/cascadia-types/src/lib.rs
@@ -19,4 +19,7 @@ pub use load::LoadProgress;
 pub use peer::{PeerEndpoint, PeerLayout};
 pub use shard::{ShardPlan, ShardSpec};
 pub use stats::ApiStats;
-pub use task::{append_resume_ids, resume_generated_seed, GenerationTask, SamplingParams, TaskId};
+pub use task::{
+    append_resume_ids, resume_generated_seed, validate_resume_ids, GenerationTask, SamplingParams,
+    TaskId,
+};

--- a/crates/cascadia-types/src/lib.rs
+++ b/crates/cascadia-types/src/lib.rs
@@ -19,4 +19,6 @@ pub use load::LoadProgress;
 pub use peer::{PeerEndpoint, PeerLayout};
 pub use shard::{ShardPlan, ShardSpec};
 pub use stats::ApiStats;
-pub use task::{GenerationTask, SamplingParams, TaskId};
+pub use task::{
+    append_resume_ids, resume_generated_seed, GenerationTask, SamplingParams, TaskId,
+};

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -97,8 +97,22 @@ pub struct GenerationTask {
     /// `resume_generated_seed`); one that cannot honor a forced prefix
     /// declines with a `resume_unsupported:`-prefixed error. Either way the
     /// ids are NEVER re-emitted, and never silently ignored.
-    #[serde(default)]
+    ///
+    /// Wire-normalized: a legal `Some([])` payload means "not resuming" and
+    /// deserializes to `None`, so `Some` ⇒ non-empty is a DATA invariant at
+    /// the wire boundary (`resume_ids()` stays the accessor of record — it
+    /// also covers tasks constructed in-process).
+    #[serde(default, deserialize_with = "de_resume_ids")]
     pub resume_token_ids: Option<Vec<i32>>,
+}
+
+/// See `resume_token_ids`: `Some([])` on the wire normalizes to `None`.
+fn de_resume_ids<'de, D>(d: D) -> Result<Option<Vec<i32>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = Option::<Vec<i32>>::deserialize(d)?;
+    Ok(v.filter(|ids| !ids.is_empty()))
 }
 
 fn default_max_tokens() -> u32 {
@@ -219,6 +233,28 @@ mod tests {
         });
         let back: GenerationTask = serde_json::from_value(without_field).unwrap();
         assert_eq!(back.resume_token_ids, None);
+    }
+
+    #[test]
+    fn wire_empty_resume_ids_normalize_to_none() {
+        // A wire-legal `[]` means "not resuming" — the deserializer makes
+        // `Some` ⇒ non-empty a data invariant so no consumer can branch on a
+        // raw `is_some()` and force resume semantics onto a plain turn.
+        let payload = serde_json::json!({
+            "task_id": "t1",
+            "prompt": "hello",
+            "resume_token_ids": [],
+        });
+        let back: GenerationTask = serde_json::from_value(payload).unwrap();
+        assert_eq!(back.resume_token_ids, None);
+
+        let payload = serde_json::json!({
+            "task_id": "t1",
+            "prompt": "hello",
+            "resume_token_ids": [7, 8],
+        });
+        let back: GenerationTask = serde_json::from_value(payload).unwrap();
+        assert_eq!(back.resume_token_ids, Some(vec![7, 8]));
     }
 
     #[test]

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -173,6 +173,7 @@ mod tests {
             sampling: SamplingParams::default(),
             enable_thinking: false,
             trust_remote_code: false,
+            tenant: String::new(),
             resume_token_ids: None,
         };
         let json = serde_json::to_string(&t).unwrap();

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -90,10 +90,31 @@ pub struct GenerationTask {
     /// the two must flip together.
     #[serde(default)]
     pub tenant: String,
+    /// Option B resumable generation: already-emitted assistant token-ids to
+    /// force-prefix. When `Some`, the engine APPENDS these to the rendered
+    /// prompt-ids and pre-seeds `generated` with them — they are NEVER re-emitted.
+    #[serde(default)]
+    pub resume_token_ids: Option<Vec<i32>>,
 }
 
 fn default_max_tokens() -> u32 {
     256
+}
+
+/// Append the caller's already-emitted assistant token-ids to the engine's
+/// rendered prompt-ids. No-op when not resuming. Concatenation, NOT replacement —
+/// the rendered prompt is KEPT as context.
+pub fn append_resume_ids(prompt_ids: &mut Vec<i64>, resume: Option<&[i32]>) {
+    if let Some(r) = resume {
+        prompt_ids.extend(r.iter().map(|&t| t as i64));
+    }
+}
+
+/// Tokens to pre-seed the engine's `generated` accumulator with on a resumed
+/// turn: makes `generated.len() >= max_tokens` bound total = prefix + new, and
+/// makes tail tokens decode WITH the prefix as context. Empty for a normal turn.
+pub fn resume_generated_seed(resume: Option<&[i32]>) -> Vec<i64> {
+    resume.map(|r| r.iter().map(|&t| t as i64).collect()).unwrap_or_default()
 }
 
 impl GenerationTask {
@@ -108,6 +129,7 @@ impl GenerationTask {
             enable_thinking: false,
             trust_remote_code: false,
             tenant: String::new(), // LOCAL_NS — see the field doc
+            resume_token_ids: None,
         }
     }
 
@@ -131,5 +153,52 @@ impl GenerationTask {
     pub fn with_sampling(mut self, sampling: SamplingParams) -> Self {
         self.sampling = sampling;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_token_ids_defaults_none_and_is_additive() {
+        let t = GenerationTask {
+            task_id: "t1".to_string(),
+            prompt: "hello".to_string(),
+            max_tokens: default_max_tokens(),
+            temperature: 0.0,
+            logprobs: 0,
+            sampling: SamplingParams::default(),
+            enable_thinking: false,
+            trust_remote_code: false,
+            resume_token_ids: None,
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let back: GenerationTask = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.resume_token_ids, None);
+
+        // Additivity: a payload encoded WITHOUT the field still decodes,
+        // defaulting to None.
+        let without_field = serde_json::json!({
+            "task_id": "t1",
+            "prompt": "hello",
+        });
+        let back: GenerationTask = serde_json::from_value(without_field).unwrap();
+        assert_eq!(back.resume_token_ids, None);
+    }
+
+    #[test]
+    fn append_resume_ids_concatenates_and_is_noop_when_absent() {
+        let mut ids = vec![1i64, 2, 3];
+        append_resume_ids(&mut ids, None);
+        assert_eq!(ids, vec![1, 2, 3]);
+        append_resume_ids(&mut ids, Some(&[11, 12]));
+        assert_eq!(ids, vec![1, 2, 3, 11, 12]);
+    }
+
+    #[test]
+    fn resume_generated_seed_maps_and_defaults_empty() {
+        assert_eq!(resume_generated_seed(None), Vec::<i64>::new());
+        assert_eq!(resume_generated_seed(Some(&[5, 6, 7])), vec![5i64, 6, 7]);
     }
 }

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -114,7 +114,9 @@ pub fn append_resume_ids(prompt_ids: &mut Vec<i64>, resume: Option<&[i32]>) {
 /// turn: makes `generated.len() >= max_tokens` bound total = prefix + new, and
 /// makes tail tokens decode WITH the prefix as context. Empty for a normal turn.
 pub fn resume_generated_seed(resume: Option<&[i32]>) -> Vec<i64> {
-    resume.map(|r| r.iter().map(|&t| t as i64).collect()).unwrap_or_default()
+    resume
+        .map(|r| r.iter().map(|&t| t as i64).collect())
+        .unwrap_or_default()
 }
 
 impl GenerationTask {

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -91,8 +91,12 @@ pub struct GenerationTask {
     #[serde(default)]
     pub tenant: String,
     /// Option B resumable generation: already-emitted assistant token-ids to
-    /// force-prefix. When `Some`, the engine APPENDS these to the rendered
-    /// prompt-ids and pre-seeds `generated` with them — they are NEVER re-emitted.
+    /// force-prefix. An engine that supports resume APPENDS these to the
+    /// rendered prompt-ids and accounts prefix + new against `max_tokens`
+    /// (by pre-seeding its accumulator or by subtracting — see
+    /// `resume_generated_seed`); one that cannot honor a forced prefix
+    /// declines with a `resume_unsupported:`-prefixed error. Either way the
+    /// ids are NEVER re-emitted, and never silently ignored.
     #[serde(default)]
     pub resume_token_ids: Option<Vec<i32>>,
 }
@@ -146,9 +150,7 @@ impl GenerationTask {
     pub fn resume_ids(&self) -> Option<&[i32]> {
         self.resume_token_ids.as_deref().filter(|r| !r.is_empty())
     }
-}
 
-impl GenerationTask {
     pub fn new(task_id: impl Into<TaskId>, prompt: impl Into<String>) -> Self {
         Self {
             task_id: task_id.into(),

--- a/crates/cascadia-types/src/task.rs
+++ b/crates/cascadia-types/src/task.rs
@@ -119,6 +119,35 @@ pub fn resume_generated_seed(resume: Option<&[i32]>) -> Vec<i64> {
         .unwrap_or_default()
 }
 
+/// Peer-supplied resume ids are indices into the embedding table, so they must
+/// be validated BEFORE any engine feeds them to a native runtime: a negative or
+/// out-of-vocab id is an out-of-range gather in OpenVINO — crash/UB, not a typed
+/// error. `vocab_size: None` skips the upper bound for engines that cannot
+/// cheaply know it; the sign check always applies.
+pub fn validate_resume_ids(ids: &[i32], vocab_size: Option<u32>) -> Result<(), String> {
+    for (i, &id) in ids.iter().enumerate() {
+        if id < 0 {
+            return Err(format!("resume_token_ids[{i}] = {id} is negative"));
+        }
+        if let Some(v) = vocab_size {
+            if id as u32 >= v {
+                return Err(format!("resume_token_ids[{i}] = {id} >= vocab_size {v}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+impl GenerationTask {
+    /// The normalized resume prefix: `Some(&ids)` only when non-empty. Engines
+    /// MUST branch on this, never on `resume_token_ids.is_some()` — a wire-legal
+    /// `Some([])` is "not resuming", and predicate drift here already produced
+    /// one engine forcing greedy decode on a non-resumed turn.
+    pub fn resume_ids(&self) -> Option<&[i32]> {
+        self.resume_token_ids.as_deref().filter(|r| !r.is_empty())
+    }
+}
+
 impl GenerationTask {
     pub fn new(task_id: impl Into<TaskId>, prompt: impl Into<String>) -> Self {
         Self {
@@ -203,5 +232,31 @@ mod tests {
     fn resume_generated_seed_maps_and_defaults_empty() {
         assert_eq!(resume_generated_seed(None), Vec::<i64>::new());
         assert_eq!(resume_generated_seed(Some(&[5, 6, 7])), vec![5i64, 6, 7]);
+    }
+    #[test]
+    fn resume_ids_normalizes_empty_to_none() {
+        let mut t = GenerationTask::new("t", "p");
+        assert_eq!(t.resume_ids(), None);
+        t.resume_token_ids = Some(vec![]);
+        assert_eq!(t.resume_ids(), None, "wire-legal Some([]) is NOT resuming");
+        t.resume_token_ids = Some(vec![7]);
+        assert_eq!(t.resume_ids(), Some(&[7][..]));
+    }
+
+    #[test]
+    fn validate_resume_ids_bounds() {
+        assert!(validate_resume_ids(&[0, 1, 2], Some(3)).is_ok());
+        assert!(
+            validate_resume_ids(&[3], Some(3)).is_err(),
+            ">= vocab rejected"
+        );
+        assert!(
+            validate_resume_ids(&[-1], None).is_err(),
+            "negative always rejected"
+        );
+        assert!(
+            validate_resume_ids(&[i32::MAX], None).is_ok(),
+            "no vocab => only sign-checked"
+        );
     }
 }

--- a/tools/export_kimi_k26.py
+++ b/tools/export_kimi_k26.py
@@ -35,6 +35,11 @@ numerically meaningful (nothing here is — see the module docstring).
 Usage:
     python tools/export_kimi_k26.py --tiny --out /tmp/k26_tiny
     python tools/export_kimi_k26.py --tiny --out /tmp/k26_mid --no-layer0
+    python tools/export_kimi_k26.py --tiny --out /tmp/k26_tiny_head --head
+        # --head also writes head/openvino_model.xml so the tree can serve a
+        # LAST stage (tests/sparse_streaming.rs, K26_TINY_HEAD_DIR). Requires
+        # torch + openvino. Keep --head trees SEPARATE from the head-less tree
+        # K26_TINY_DIR points at: tests/k26_native_tiny.rs asserts head absence.
 """
 
 import argparse
@@ -289,6 +294,16 @@ def main():
         ap.error("only --tiny is implemented; a real K2.6 export is export_shards.py's job")
     if args.experts > N_ROUTED_EXPERTS:
         ap.error(f"--experts must be <= {N_ROUTED_EXPERTS}")
+    if args.head:
+        # write_head_ir imports these lazily, but it runs LAST — after the
+        # multi-GiB shard write — and a missing dep there leaves a tree that
+        # LOOKS complete yet has no head (the runner later rejects it with
+        # MissingFile). Fail in a second instead, like the ap.error checks.
+        import importlib.util
+        for mod in ("torch", "openvino"):
+            if importlib.util.find_spec(mod) is None:
+                ap.error(f"--head requires {mod} (pip install {mod}); "
+                         "refusing to start a multi-GiB export that would fail at the head step")
 
     rng = np.random.default_rng(args.seed)
     os.makedirs(args.out, exist_ok=True)

--- a/tools/export_kimi_k26.py
+++ b/tools/export_kimi_k26.py
@@ -230,6 +230,37 @@ def write_tokenizer(path, vocab_size):
         json.dump(doc, f)
 
 
+def write_head_ir(out_dir, vocab, seed):
+    """head/openvino_model.xml: RMSNorm(HIDDEN) -> Linear(HIDDEN, vocab), random weights.
+
+    The native runner's last stage compiles EXACTLY this file (runner.rs `head_xml`)
+    and asserts the output's last dim == manifest.vocab_size; input is [1,1,HIDDEN]
+    bf16 at input 0 (name-agnostic). Mirrors export_minimax_m2.py's HeadWrapper.
+    Lazy imports: torch/openvino are only needed when --head is given, keeping the
+    default export numpy-only.
+    """
+    import torch
+    import openvino as ov
+
+    torch.manual_seed(seed)
+
+    class Head(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm_w = torch.nn.Parameter(torch.ones(HIDDEN) + 0.01 * torch.randn(HIDDEN))
+            self.lm = torch.nn.Linear(HIDDEN, vocab, bias=False)
+
+        def forward(self, x):  # x: [1,1,HIDDEN]
+            v = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-6) * self.norm_w
+            return self.lm(v)
+
+    head_dir = os.path.join(out_dir, "head")
+    os.makedirs(head_dir, exist_ok=True)
+    m = ov.convert_model(Head().eval(), example_input=torch.zeros((1, 1, HIDDEN)))
+    ov.save_model(m, os.path.join(head_dir, "openvino_model.xml"))
+    print(f"[head] wrote {head_dir}/openvino_model.xml (vocab={vocab})", file=sys.stderr)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--tiny", action="store_true", help="synthetic random-init tree (the only mode)")
@@ -243,6 +274,9 @@ def main():
     ap.add_argument("--no-experts", action="store_true",
                     help="omit expert weights (load-only tree; experts are lazy)")
     ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--head", action="store_true",
+                    help="also emit head/openvino_model.xml (RMSNorm + lm_head as OV IR) so the "
+                         "tree can serve a LAST stage — requires torch + openvino installed")
     args = ap.parse_args()
 
     if not args.tiny:
@@ -294,14 +328,19 @@ def main():
     with open(os.path.join(args.out, "manifest.json"), "w") as f:
         json.dump(manifest, f, indent=2)
 
+    if args.head:
+        write_head_ir(args.out, args.vocab, args.seed)
+
     write_tokenizer(os.path.join(args.out, "tokenizer.json"), args.vocab)
 
     print(f"wrote {args.out}: {w.offset / 2**20:.1f} MiB, "
           f"{len(moe_ids)} MoE shell(s), "
           f"{0 if args.no_experts else args.experts} expert(s)/layer, "
           f"layer0={'no' if args.no_layer0 else 'yes'}", file=sys.stderr)
-    print("NOTE: no head/openvino_model.xml — the native head is OV-IR only, so this "
-          "tree can only be loaded by a non-last stage (see the test).", file=sys.stderr)
+    if not args.head:
+        print("NOTE: no head/openvino_model.xml — the native head is OV-IR only, so this "
+              "tree can only be loaded by a non-last stage (pass --head for a rig-servable tree).",
+              file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/export_kimi_k26.py
+++ b/tools/export_kimi_k26.py
@@ -257,6 +257,12 @@ def write_head_ir(out_dir, vocab, seed):
     head_dir = os.path.join(out_dir, "head")
     os.makedirs(head_dir, exist_ok=True)
     m = ov.convert_model(Head().eval(), example_input=torch.zeros((1, 1, HIDDEN)))
+    # The runner sets input 0 as bf16 (forward_head_last); the f32 trace above would make
+    # OV reject that with ParameterMismatch. Re-type the input tensor to bf16 — OV inserts
+    # the bf16->f32 convert, output logits stay f32 (runner accepts f32/f16/bf16).
+    ppp = ov.preprocess.PrePostProcessor(m)
+    ppp.input(0).tensor().set_element_type(ov.Type.bf16)
+    m = ppp.build()
     ov.save_model(m, os.path.join(head_dir, "openvino_model.xml"))
     print(f"[head] wrote {head_dir}/openvino_model.xml (vocab={vocab})", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

Engine-side support for **forced-prefix resume**: a scheduler that re-dispatches a mid-stream failure to an alternate chain sends the already-emitted token ids as `resume_token_ids`; engines append them to the rendered prompt, seed the `generated` accumulator, force greedy decode, and never re-emit the prefix. Also converts the two remaining burst engines to per-token streaming so a mid-stream window exists on every family, and makes the native K2.6 engine a fully servable chain participant (head IR export + cross-chain KV carry).

## Changes

### Types (`cascadia-types`)
- `GenerationTask.resume_token_ids: Option<Vec<i32>>` — serde-additive; old payloads decode unchanged.
- `resume_ids()` normalizer (wire-legal `Some([])` = not resuming), `validate_resume_ids` (sign + vocab bounds — peer-supplied ids reach native gathers), `append_resume_ids` / `resume_generated_seed` helpers.

### Resume support in every engine family
- **ov-runtime, gemma4, qwen36, dist-spec, sparse-moe (K2.6), MiniMax-M2**: admission validation; budget pre-check (seed ≥ budget → zero-token `Length` final before any decode); KV-capture keys skip the seed; seam handling per path (whole-text re-anchor on burst, seeded byte-cursor on streamed, U+FFFD hold on gemma4, shim `advance_emitted` on qwen36).
- **Mock engine** enforces id-fidelity (seed id at position *i* must be *i*) with a negative test — pins that engines consume the ids, not just their count.

### Per-token streaming for the burst engines
- `SparseMoEEngine` + `OvMoeEngine` multi-stage rank-0 converted from whole-turn burst to `begin/decode/finalize` state machines (same scope `PipelineEngine` shipped; single-stage and spec-decode stay burst, and a resumed turn routes to the streamed driver).
- Mid-decode failure emits an **error chunk**, never a partial-success final — a final marker would latch the stream as complete and block any downstream rescue.
- `token_ids = vec![id]` stamped on every streamed chunk (including `PipelineEngine`) so a legal token-0 sample can't read as id-less.
- `cancel()` clears in-flight state; empty-prompt/`-1` guards; history `mem::take` (was an O(n²) per-token clone).

### Native K2.6 as a servable chain (head IR + cross-chain KV)
- `export_kimi_k26.py --head` writes the RMSNorm + lm_head OV IR a last stage needs — the historical "native can't be a last stage" limitation was only the missing head file. Input re-typed to **bf16** via PrePostProcessor (the runner sets input 0 as bf16; an f32-traced IR fails OV `set_tensor` with `ParameterMismatch` and wedges the head on its single admission slot).
- **Capture epoch keyed over the KV-covered prefix** (`full_tokens[..past_seq_len]`): the native engine's test-before-push EOS semantics leave the final sampled token un-pushed, so the turn's token vector runs one longer than the KV — an epoch over the full vector never matches a later NEGOTIATE's offer epoch and every worker GET answers `get_none`. The OvMoe engine's push-then-test semantics made the two vectors coincide, which is why this only surfaced on the native path. Mirrors the OvMoe capture site, which already truncated.
- **Native carried-slice restore (`RESTORE_CARRY`)**: `stash_downstream_rank` was the trait default `Err(())` — every rank>0 cross-chain pull voted cold. Added the native `KvSnapshot` blob codec, the carry stash (with the same epoch-collision guard as OvMoe), a carry-aware `forward_restore_downstream`, and the worker-side handler (event `sparse_tail_restore_carried`).
- **Donor-side serve diagnostics**: the holder's refusal arms were silent — a puller's `pull_not_found` was indistinguishable from a missing capture, a length drift, or a namespace mismatch. Added `kv_capture_stored`, `kv_serve_capture_miss` (with held epochs), `kv_serve_len_drift`, and a warning when a capacity-0 worker acks a capture it silently skipped.

### Declines
- Paths that cannot honor a forced prefix (MiniMax single-stage) decline with a `resume_unsupported:`-prefixed error as their first chunk, so the caller can exclude and retry.

## How to test

```bash
cargo test --workspace                                       # full suite
cargo test -p cascadia-engine-sparse-moe --features kv_coord # feature lane
cargo test -p cascadia-engine-sparse-moe --test prepare_resume
```

Notes:
- Engine-level streaming/resume integration tests (`tests/sparse_streaming.rs`, `tests/ovmoe_streaming.rs`) are env-gated on model directories (`K26_TINY_DIR` / `M2_MODEL_DIR`) and skip with a message when unset; the hardware cert is the enforcement gate for those paths.
- Per-engine resume unit tests (seed consumption, budget, capture-key skip, seam) live beside each engine and run in the default suite; the mock engine's id-fidelity check has a negative test (`resume_with_wrong_ids_is_rejected`).

## Verification

- Full workspace suite green; sparse-moe crate green on default and `kv_coord` feature lanes.
- Hardware rig (four nodes, two 2-stage chains): resume-cert **PASS on all six engine cells** — ov-runtime 5/5, dist-spec 5/5, qwen36 5/5, gemma4 5/5, MiniMax-M2 sparse-moe 4/4, native K2.6 sparse-moe 4/4 — serving tail killed mid-stream, rescue via forced prefix, no replay fallback, stream reaches `[DONE]`.
- Native K2.6 cross-chain KV move-cert **7/7 bars**, genuinely cross-chain: pull-hit counter +1, tail restored from the head's carried blob (+1), `plane_pulled=true`, and the pulled-KV continuation byte-identical to a cold re-prefill.

### Final-review fix wave

A two-reviewer full-branch pass added: sentinel declines on the remaining resume-incapable paths (`PipelineEngine::begin_generation`, both ov-genai submits — silently ignoring a forced prefix regenerates from scratch and the caller splices it as a fake resume), a one-shot seam-divergence guard on both streamed resume paths (mirror of the burst path's), a dims cross-check + 4 codec tests for the carry blob, verdict-mirror and warn-parity fixes on the carry/capture paths, and comment hygiene. Re-certified on hardware after the wave: resume cert 5/5, plus the native-K2.6 cells whose binaries gained active-path code — KV move-cert 7/7 (first attempt) and resume cert 4/4.

## Deliberate non-goal

**`StagedRunner` unification** (one streaming engine for K2.6 / M2 / glm5 / dsv4) is analyzed and rejected for this PR: the trait's `&self` receivers conflict with OpenVINO's `&mut infer()` (fixing it breaks 12 external call sites), `max_seq()` has no source of truth, and the two wire dialects mutually reject each other's frames. ~4.4k lines of regression risk across certified engines for zero functional gain — every family already streams and resumes. Full analysis in the downstream design spec.
