### PR TITLE
fix(dsv4): read CASCADIA_DSV4_PREFIX_CACHE for the prefix cap, not the glm5 knob

### DIFF
--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -720,9 +720,11 @@ impl Builder for SparseMoEBuilder {
                 runtime_handle,
                 rank,
                 total,
-                // dsv4 has no config-threaded prefix cache; `None` keeps its
-                // existing env-only behaviour byte-for-byte.
-                None,
+                // dsv4 has no config-threaded prefix cache; env-only.
+                dsv4_prefix_cap(
+                    std::env::var("CASCADIA_DSV4_PREFIX_CACHE").ok().as_deref(),
+                    std::env::var("CASCADIA_GLM5_PREFIX_CACHE").ok().as_deref(),
+                ),
             )));
         }
         if let Some(runner) = self.glm_runner {
@@ -745,7 +747,10 @@ impl Builder for SparseMoEBuilder {
                 total,
                 // Same value the per-rank SliceKvCache got, so the rank-0 index
                 // and the per-rank caches stay in lockstep.
-                self.config.prefix_cache_depth.map(|d| d as usize),
+                resolve_prefix_cap(
+                    self.config.prefix_cache_depth.map(|d| d as usize),
+                    "CASCADIA_GLM5_PREFIX_CACHE",
+                ),
             )));
         }
         if let Some(ov) = self.ov_runner {
@@ -2838,11 +2843,47 @@ struct PipeActive {
     hit_context_cap: bool,
 }
 
+fn parse_prefix_cap(raw: &str) -> Option<usize> {
+    raw.trim().parse::<usize>().ok()
+}
+
+/// `explicit` wins; failing that, reads `env_var` by NAME. The caller picks
+/// the name, so an arch-scoped knob (e.g. `CASCADIA_GLM5_PREFIX_CACHE`) can
+/// never reach a different arch's engine. Unset/unparseable → 0 (off).
+fn resolve_prefix_cap(explicit: Option<usize>, env_var: &str) -> usize {
+    explicit
+        .or_else(|| {
+            std::env::var(env_var)
+                .ok()
+                .as_deref()
+                .and_then(parse_prefix_cap)
+        })
+        .unwrap_or(0)
+}
+
+/// dsv4 rank-0 prefix cap from the raw values of `CASCADIA_DSV4_PREFIX_CACHE`
+/// and the legacy `CASCADIA_GLM5_PREFIX_CACHE`. The dsv4 var wins whenever it
+/// is set; the glm5 name is honoured with a deprecation warning only while the
+/// dsv4 var is unset (issue #139). Drop the fallback after one release.
+fn dsv4_prefix_cap(dsv4: Option<&str>, glm5: Option<&str>) -> usize {
+    match (dsv4, glm5) {
+        (Some(raw), _) => parse_prefix_cap(raw).unwrap_or(0),
+        (None, Some(raw)) => {
+            warn!(
+                "CASCADIA_GLM5_PREFIX_CACHE is deprecated for the dsv4 engine; \
+                 set CASCADIA_DSV4_PREFIX_CACHE instead (fallback removed next release)"
+            );
+            parse_prefix_cap(raw).unwrap_or(0)
+        }
+        (None, None) => 0,
+    }
+}
+
 impl<R: StagedRunner> PipelineEngine<R> {
-    /// `prefix_cap`: rank-0 KV-prefix-cache depth. `None` defers to
-    /// `CASCADIA_GLM5_PREFIX_CACHE`, preserving the env-only behaviour. This
-    /// index must stay in lockstep with every rank's `SliceKvCache`, so the
-    /// value threaded here is the same one handed to `StageOpts`.
+    /// `prefix_cap`: rank-0 KV-prefix-cache depth (0 = off), already resolved
+    /// by the caller via `resolve_prefix_cap` / `dsv4_prefix_cap`. This index
+    /// must stay in lockstep with every rank's `SliceKvCache`, so the value
+    /// threaded here is the same one handed to `StageOpts`.
     fn new(
         runner: R,
         tokenizer: Option<Tokenizer>,
@@ -2850,7 +2891,7 @@ impl<R: StagedRunner> PipelineEngine<R> {
         runtime_handle: tokio::runtime::Handle,
         rank: u32,
         total: u32,
-        prefix_cap: Option<usize>,
+        prefix_cap: usize,
     ) -> Self {
         Self {
             runner,
@@ -2867,13 +2908,7 @@ impl<R: StagedRunner> PipelineEngine<R> {
             last_rank_rng_seeded: false,
             prefix_index: Vec::new(),
             prefix_next_key: 0,
-            prefix_cap: prefix_cap
-                .or_else(|| {
-                    std::env::var("CASCADIA_GLM5_PREFIX_CACHE")
-                        .ok()
-                        .and_then(|s| s.trim().parse::<usize>().ok())
-                })
-                .unwrap_or(0),
+            prefix_cap,
             active: None,
         }
     }
@@ -4070,5 +4105,33 @@ mod tests {
             prefill_reply_budget(recv_timeout, Some(ceiling)),
             std::time::Duration::from_secs(600)
         );
+    }
+
+    /// Issue #139: dsv4's prefix cap reads its own `CASCADIA_DSV4_PREFIX_CACHE`
+    /// and only falls back to the glm5-named var while it is unset.
+    #[test]
+    fn dsv4_prefix_cap_new_var_wins_over_legacy() {
+        assert_eq!(dsv4_prefix_cap(Some("3"), Some("7")), 3);
+    }
+
+    #[test]
+    fn dsv4_prefix_cap_honours_legacy_var_when_new_unset() {
+        assert_eq!(dsv4_prefix_cap(None, Some("7")), 7);
+    }
+
+    #[test]
+    fn dsv4_prefix_cap_defaults_off_when_neither_set() {
+        assert_eq!(dsv4_prefix_cap(None, None), 0);
+    }
+
+    #[test]
+    fn dsv4_prefix_cap_unparseable_new_var_does_not_fall_back() {
+        assert_eq!(dsv4_prefix_cap(Some("lots"), Some("7")), 0);
+    }
+
+    #[test]
+    fn dsv4_prefix_cap_trims_whitespace() {
+        assert_eq!(dsv4_prefix_cap(Some(" 5 "), None), 5);
+        assert_eq!(dsv4_prefix_cap(None, Some(" 9\n")), 9);
     }
 }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -4136,4 +4136,31 @@ mod tests {
         assert_eq!(dsv4_prefix_cap(Some(" 5 "), None), 5);
         assert_eq!(dsv4_prefix_cap(None, Some(" 9\n")), 9);
     }
+
+    /// Set-but-empty counts as set (→ off), same as the glm5 var always has:
+    /// falling through to the legacy value would re-create the cross-arch
+    /// bleed for templates that pass every key empty.
+    #[test]
+    fn dsv4_prefix_cap_empty_new_var_is_off_not_fallback() {
+        assert_eq!(dsv4_prefix_cap(Some(""), Some("7")), 0);
+    }
+
+    /// Test-unique var name so this never races another test's env.
+    #[test]
+    fn resolve_prefix_cap_explicit_then_env_then_off() {
+        let k = "CASCADIA_TEST_RESOLVE_PREFIX_CAP_139";
+        std::env::set_var(k, "9");
+        assert_eq!(resolve_prefix_cap(Some(3), k), 3, "explicit wins over env");
+        assert_eq!(
+            resolve_prefix_cap(None, k),
+            9,
+            "env honoured when no explicit"
+        );
+        std::env::set_var(k, " 4\n");
+        assert_eq!(resolve_prefix_cap(None, k), 4, "env value trimmed");
+        std::env::set_var(k, "lots");
+        assert_eq!(resolve_prefix_cap(None, k), 0, "unparseable env → off");
+        std::env::remove_var(k);
+        assert_eq!(resolve_prefix_cap(None, k), 0, "unset → off");
+    }
 }

--- a/crates/cascadia-engine-sparse-moe/src/engine.rs
+++ b/crates/cascadia-engine-sparse-moe/src/engine.rs
@@ -720,7 +720,9 @@ impl Builder for SparseMoEBuilder {
                 runtime_handle,
                 rank,
                 total,
-                // dsv4 has no config-threaded prefix cache; env-only.
+                // dsv4's runner has no prefix hooks yet, so this cap is inert;
+                // resolve it under dsv4's own name anyway so a glm5 setting can
+                // never reach a dsv4 engine (#139).
                 dsv4_prefix_cap(
                     std::env::var("CASCADIA_DSV4_PREFIX_CACHE").ok().as_deref(),
                     std::env::var("CASCADIA_GLM5_PREFIX_CACHE").ok().as_deref(),

--- a/docs/architectures/deepseek-v4.md
+++ b/docs/architectures/deepseek-v4.md
@@ -66,10 +66,6 @@ shorten). The default (Rust mmap expert) decode path was optimized ~2×:
   `ForwardPrefill` frame belongs to the K2.6 sparse-MoE engine and is **not**
   wired into dsv4. The largest prefill win would be a direct node↔node LAN
   rather than a relayed link.
-- **Rank-0 KV-prefix reuse** across turns is capped by
-  `CASCADIA_DSV4_PREFIX_CACHE` (entries; unset/`0` = off). The glm5-named
-  `CASCADIA_GLM5_PREFIX_CACHE` is still honoured as a deprecated fallback for
-  one release and logs a warning when used.
 
 Evaluated and **rejected with measurement** (recorded so they aren't re-tried):
 FP8-e4m3 shell (bit-exact, but `proj` is compute- not bandwidth-bound after the

--- a/docs/architectures/deepseek-v4.md
+++ b/docs/architectures/deepseek-v4.md
@@ -66,6 +66,10 @@ shorten). The default (Rust mmap expert) decode path was optimized ~2×:
   `ForwardPrefill` frame belongs to the K2.6 sparse-MoE engine and is **not**
   wired into dsv4. The largest prefill win would be a direct node↔node LAN
   rather than a relayed link.
+- **Rank-0 KV-prefix reuse** across turns is capped by
+  `CASCADIA_DSV4_PREFIX_CACHE` (entries; unset/`0` = off). The glm5-named
+  `CASCADIA_GLM5_PREFIX_CACHE` is still honoured as a deprecated fallback for
+  one release and logs a warning when used.
 
 Evaluated and **rejected with measurement** (recorded so they aren't re-tried):
 FP8-e4m3 shell (bit-exact, but `proj` is compute- not bandwidth-bound after the


### PR DESCRIPTION
## Summary

Closes #139

The dsv4 engine's rank-0 KV-prefix cap was resolved inside the shared `PipelineEngine::new` by reading the glm5-named `CASCADIA_GLM5_PREFIX_CACHE` whenever the caller passed `None` — and the dsv4 arm always passed `None`. That let a glm5 tuning reach a dsv4 engine sharing the environment, and made the dsv4-scoped name nonexistent.

**Changes**

- `engine.rs`
  - `resolve_prefix_cap(explicit, env_var)` — explicit wins, else reads the *named* var; unset/unparseable → `0` (off). The glm5 arm passes `"CASCADIA_GLM5_PREFIX_CACHE"`; its behaviour is byte-identical to before.
  - `dsv4_prefix_cap(dsv4_raw, glm5_raw)` — `CASCADIA_DSV4_PREFIX_CACHE` wins whenever set (set-but-empty counts as set → off). While it is unset, the legacy glm5 name is honoured with a deprecation `warn!` naming both vars. The shim is one function; drop it after the deprecation window.
  - `PipelineEngine::new` now takes the already-resolved `usize`, so no env read lives in the shared constructor.
- Unit tests (pure / test-unique env name, no cross-test races): new var wins, legacy honoured when new unset, neither → `0`, unparseable new var does not fall back, empty new var is off not fallback, whitespace trimmed; `resolve_prefix_cap` explicit/env/trim/unparseable/unset.

**Scope note — the cap is currently inert for dsv4**

`Dsv4Runner` implements none of the `StagedRunner` prefix hooks (`prefix_cache_enabled` / `restore_prefix` / `cache_prefix` / `supports_batched_prefill` all default to off, `staged.rs`), and every use of `prefix_cap` in the engine is gated on them. So on `main` the bleed in #139 is latent, not live; this PR is the naming/plumbing fix so that it cannot become live when dsv4 grows prefix hooks (or under #121's store-aware default). For that reason the knob is deliberately **not** documented in `docs/architectures/deepseek-v4.md` yet — the PR that wires dsv4 prefix hooks should document it. The dsv4 arm comment states this.

**Verification**

All pass locally (`just check` by-hand equivalent; the e2e crate needs the binary built first):

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets
cargo build -p cascadia
cargo test --workspace --all-targets
```

Focused run for this change (`cascadia-engine-sparse-moe` lib: 101 passed, 7 new; `glm5_prefill_pipeline`, which sets the glm5 var, still green):

```sh
cargo test -p cascadia-engine-sparse-moe
cargo test -p cascadia-engine-sparse-moe --lib prefix_cap
```

CI: stub + cargo-deny green. The ai-pc OpenVINO lane fails with `STATUS_DLL_NOT_FOUND` on the Windows self-hosted runner — same failure on `main` @ `1ea79b8c`, unrelated to this diff.

**Merge shape vs #121 (kimi-k3)**

Both PRs define `resolve_prefix_cap` and change `PipelineEngine::new`. This PR keeps the *caller-resolves* shape (`new` takes a `usize`; no env read in the shared ctor — the root cause named in #139). #121 resolves inside `new` with a 3-arg `resolve_prefix_cap(explicit, env_var, store_enabled)`. Whichever lands second: keep caller-resolves, hoist #121's `resolve_prefix_cap(.., runner.prefix_cache_enabled())` into the build arms (where `runner` is already a local), and pass the resolved `usize`. Conflict is the helper body, the two arm arguments, the `new` signature, and the tests tail — mechanical.

**Follow-up**

- Remove the glm5 fallback + `warn!` after one release.

## Checklist

- [x] `just check` passes locally (see [CONTRIBUTING.md](https://github.com/labscommunity/cascadia/blob/main/CONTRIBUTING.md) for the by-hand equivalent)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …), one logical change per commit
- [ ] If this touches an OV engine: tested on real Intel hardware (say which, and which OpenVINO version) — CI only covers stub mode — N/A: sparse-moe env resolution only, no OV engine code touched; not hardware-tested
